### PR TITLE
Phase 2: CLI identity and dashboard

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,15 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository is still in planning and project-memory setup.
+The repository has completed Phase 2.
+
+Implemented so far:
+
+- project memory and architecture
+- Rust workspace scaffold
+- CLI identity/dashboard command shell
+- payload-safe protocol scaffold
+- daemon and relay placeholder binaries
 
 Current important files:
 
@@ -33,6 +41,14 @@ crates/
 |- conu-relay/     hosted relay/bootstrap service
 `- conu-sdk/       agent-facing client libraries later
 ```
+
+Current Rust crates:
+
+- `crates/conu-cli`
+- `crates/conud`
+- `crates/conu-core`
+- `crates/conu-protocol`
+- `crates/conu-relay`
 
 ## Non-Negotiable Product Rule
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Agents own the conversation.
 conU owns the connection.
 ```
 
-## Current Phase
+## Current Status
 
-Phase 1: Rust workspace scaffold.
+Phase 2 is complete. The CLI identity and dashboard shell exists; Phase 3 will add real local identity and persistent state.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -38,11 +38,17 @@ rustup toolchain install stable-x86_64-pc-windows-gnu
 cargo +stable-x86_64-pc-windows-gnu test --workspace
 ```
 
-Useful scaffold commands:
+Useful CLI commands:
 
 ```bash
+cargo run -p conu-cli --
+cargo run -p conu-cli -- init
 cargo run -p conu-cli -- status
-cargo run -p conu-cli -- components
+cargo run -p conu-cli -- agents
+cargo run -p conu-cli -- pair
+cargo run -p conu-cli -- join 482913
+cargo run -p conu-cli -- connect
+cargo run -p conu-cli -- watch
 cargo run -p conud -- --check
 cargo run -p conu-relay -- --check
 ```

--- a/crates/conu-cli/Cargo.toml
+++ b/crates/conu-cli/Cargo.toml
@@ -13,5 +13,9 @@ path = "src/main.rs"
 [dependencies]
 conu-core.workspace = true
 
+[lib]
+name = "conu_cli"
+path = "src/lib.rs"
+
 [lints]
 workspace = true

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -1,0 +1,409 @@
+//! CLI rendering and command dispatch for conU.
+//!
+//! Phase 2 builds the user-facing command shell only. Commands that need real
+//! identity, daemon, IPC, relay, or persistence are represented as honest
+//! previews and point to their owning future phase.
+
+/// A rendered CLI command result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliOutput {
+    pub code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl CliOutput {
+    fn success(stdout: impl Into<String>) -> Self {
+        Self {
+            code: 0,
+            stdout: finish(stdout.into()),
+            stderr: String::new(),
+        }
+    }
+
+    fn failure(code: i32, stderr: impl Into<String>) -> Self {
+        Self {
+            code,
+            stdout: String::new(),
+            stderr: finish(stderr.into()),
+        }
+    }
+}
+
+/// Dispatch a conU CLI invocation.
+pub fn run<I, S>(args: I) -> CliOutput
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+    let Some(command) = args.first().map(String::as_str) else {
+        return CliOutput::success(render_dashboard());
+    };
+
+    match command {
+        "init" => render_init(&args[1..]),
+        "status" => render_status(&args[1..]),
+        "agents" | "peers" => render_agents(&args[1..]),
+        "pair" => render_pair(&args[1..]),
+        "join" => render_join(&args[1..]),
+        "connect" => render_connect(&args[1..]),
+        "watch" => render_watch(&args[1..]),
+        "components" => render_components(&args[1..]),
+        "start" => render_reserved_phase("start", "Phase 4", "conUD daemon lifecycle"),
+        "--help" | "-h" | "help" => CliOutput::success(render_help()),
+        "--version" | "-V" => CliOutput::success(format!("conu {}", env!("CARGO_PKG_VERSION"))),
+        unknown => CliOutput::failure(
+            2,
+            format!("unknown command: {unknown}\n\n{}", render_help()),
+        ),
+    }
+}
+
+fn render_dashboard() -> String {
+    format!(
+        r"                 __  __
+  ___ ___  _ __ |  \/  |
+ / __/ _ \| '_ \| |\/| |
+| (_| (_) | | | | |  | |
+ \___\___/|_| |_|_|  |_|
+
+agent-native encrypted overlay
+{}
+
+control room
+  runtime       offline        conUD starts in Phase 4
+  node          not initialized identity arrives in Phase 3
+  local agents  none           registration arrives in Phase 5
+  remote peers  none           pairing arrives in Phase 7
+  network       offline        relay arrives in Phase 8
+
+quick commands
+  conu init
+  conu status
+  conu agents
+  conu pair
+  conu join <code>
+  conu connect
+  conu watch",
+        conu_core::PRODUCT_LAW
+    )
+}
+
+fn render_init(args: &[String]) -> CliOutput {
+    if let Some(error) = reject_args(args) {
+        return error;
+    }
+
+    CliOutput::success(
+        r"conU init
+
+status: ready for Phase 3
+action: no files written in Phase 2
+next: Phase 3 will create the local node identity and trust store",
+    )
+}
+
+fn render_status(args: &[String]) -> CliOutput {
+    match json_flag(args) {
+        Ok(true) => CliOutput::success(render_status_json()),
+        Ok(false) => CliOutput::success(
+            r"conU status
+
+runtime
+  conUD         offline
+  local IPC     not available until Phase 4
+  relay         not available until Phase 8
+
+identity
+  node          not initialized
+  trust store   not initialized
+
+agents
+  local         0 registered
+  remote        0 visible
+
+privacy
+  payload view  contents are not displayed by conU",
+        ),
+        Err(error) => error,
+    }
+}
+
+fn render_agents(args: &[String]) -> CliOutput {
+    match json_flag(args) {
+        Ok(true) => CliOutput::success(
+            r#"{
+  "local": [],
+  "remote": [],
+  "status": "agent registration arrives in Phase 5"
+}"#,
+        ),
+        Ok(false) => CliOutput::success(
+            r"conU agents
+
+local agents
+  none registered yet
+
+remote agents
+  none visible yet
+
+next
+  Phase 5: local agent registration
+  Phase 9: remote discovery and presence",
+        ),
+        Err(error) => error,
+    }
+}
+
+fn render_pair(args: &[String]) -> CliOutput {
+    match json_flag(args) {
+        Ok(true) => CliOutput::success(
+            r#"{
+  "status": "reserved",
+  "phase": "Phase 7",
+  "message": "pairing code generation is not active in Phase 2"
+}"#,
+        ),
+        Ok(false) => CliOutput::success(
+            r"conU pair
+
+status: reserved for Phase 7
+code: not generated in Phase 2
+purpose: create trust between two conUD runtimes",
+        ),
+        Err(error) => error,
+    }
+}
+
+fn render_join(args: &[String]) -> CliOutput {
+    if args.iter().any(|arg| arg == "--json") {
+        return match join_code(args) {
+            Ok(_) => CliOutput::success(
+                r#"{
+  "status": "reserved",
+  "phase": "Phase 7",
+  "message": "join validation is not active in Phase 2"
+}"#,
+            ),
+            Err(error) => error,
+        };
+    }
+
+    match join_code(args) {
+        Ok(_) => CliOutput::success(
+            r"conU join
+
+status: reserved for Phase 7
+code: accepted for command shape only
+action: no trust entry created in Phase 2",
+        ),
+        Err(error) => error,
+    }
+}
+
+fn render_connect(args: &[String]) -> CliOutput {
+    if let Some(error) = reject_args(args) {
+        return error;
+    }
+
+    CliOutput::success(
+        r"conU connect
+
+selector
+  source local agent   none registered
+  target remote agent  none visible
+  mode                 message | stream | room | observe
+
+status: waiting for Phase 5 local agents and Phase 9 remote discovery",
+    )
+}
+
+fn render_watch(args: &[String]) -> CliOutput {
+    if let Some(error) = reject_args(args) {
+        return error;
+    }
+
+    CliOutput::success(
+        r"conU watch
+
+transport view
+  local-agent   -> conUD -> encrypted route -> remote conUD -> remote-agent
+  route         inactive
+  latency       n/a
+  streams       0
+  packets       0
+  contents      not displayed
+
+status: live stream animation arrives in Phase 10",
+    )
+}
+
+fn render_components(args: &[String]) -> CliOutput {
+    if let Some(error) = reject_args(args) {
+        return error;
+    }
+
+    let mut output = String::from("conU components\n\n");
+    for component in conu_core::COMPONENTS {
+        output.push_str(component.name);
+        output.push_str("\n  ");
+        output.push_str(component.responsibility);
+        output.push('\n');
+    }
+    CliOutput::success(output)
+}
+
+fn render_reserved_phase(command: &str, phase: &str, owner: &str) -> CliOutput {
+    CliOutput::success(format!(
+        "conU {command}\n\nstatus: reserved for {phase}\nowner: {owner}"
+    ))
+}
+
+fn render_status_json() -> String {
+    r#"{
+  "runtime": {
+    "conud": "offline",
+    "localIpc": "phase_4",
+    "relay": "phase_8"
+  },
+  "identity": {
+    "node": "not_initialized",
+    "trustStore": "not_initialized"
+  },
+  "agents": {
+    "local": 0,
+    "remote": 0
+  },
+  "privacy": {
+    "contentsDisplayed": false
+  }
+}"#
+    .to_string()
+}
+
+fn render_help() -> String {
+    r"conu - agent-native encrypted communication fabric
+
+Usage:
+  conu
+  conu init
+  conu status [--json]
+  conu agents [--json]
+  conu peers [--json]
+  conu pair [--json]
+  conu join <code> [--json]
+  conu connect
+  conu watch
+  conu components
+  conu --help
+  conu --version
+
+Phase 2 builds the CLI control room. Runtime identity, IPC, pairing, relay, and streaming arrive in later phases."
+        .to_string()
+}
+
+fn json_flag(args: &[String]) -> Result<bool, CliOutput> {
+    let mut json = false;
+    for arg in args {
+        if arg == "--json" {
+            json = true;
+        } else {
+            return Err(CliOutput::failure(2, format!("unknown option: {arg}")));
+        }
+    }
+    Ok(json)
+}
+
+fn join_code(args: &[String]) -> Result<&str, CliOutput> {
+    let mut code = None;
+    for arg in args {
+        if arg == "--json" {
+            continue;
+        }
+        if code.is_some() {
+            return Err(CliOutput::failure(2, "usage: conu join <code> [--json]"));
+        }
+        code = Some(arg.as_str());
+    }
+
+    match code {
+        Some(value) if !value.trim().is_empty() => Ok(value),
+        _ => Err(CliOutput::failure(2, "usage: conu join <code> [--json]")),
+    }
+}
+
+fn reject_args(args: &[String]) -> Option<CliOutput> {
+    args.first()
+        .map(|arg| CliOutput::failure(2, format!("unexpected argument: {arg}")))
+}
+
+fn finish(mut output: String) -> String {
+    while output.ends_with('\n') {
+        output.pop();
+    }
+    output.push('\n');
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dashboard_renders_control_room() {
+        let output = run(Vec::<String>::new());
+
+        assert_eq!(output.code, 0);
+        assert!(output.stdout.contains("control room"));
+        assert!(output.stdout.contains("conu init"));
+        assert!(output.stderr.is_empty());
+    }
+
+    #[test]
+    fn phase_two_commands_are_registered() {
+        for command in ["init", "status", "agents", "pair", "connect", "watch"] {
+            let output = run([command]);
+            assert_eq!(output.code, 0, "{command} failed: {}", output.stderr);
+        }
+
+        let join = run(["join", "123456"]);
+        assert_eq!(join.code, 0);
+    }
+
+    #[test]
+    fn status_json_is_machine_readable_shape() {
+        let output = run(["status", "--json"]);
+
+        assert_eq!(output.code, 0);
+        assert!(output.stdout.contains("\"conud\": \"offline\""));
+        assert!(output.stdout.contains("\"contentsDisplayed\": false"));
+    }
+
+    #[test]
+    fn join_requires_a_code() {
+        let output = run(["join"]);
+
+        assert_eq!(output.code, 2);
+        assert!(output.stderr.contains("usage: conu join <code>"));
+    }
+
+    #[test]
+    fn watch_never_prints_message_contents() {
+        let output = run(["watch"]);
+
+        assert_eq!(output.code, 0);
+        assert!(output.stdout.contains("contents      not displayed"));
+        assert!(!output.stdout.contains("Review this code"));
+        assert!(!output.stdout.contains("private message contents"));
+    }
+
+    #[test]
+    fn unknown_command_fails_with_help() {
+        let output = run(["unknown"]);
+
+        assert_eq!(output.code, 2);
+        assert!(output.stderr.contains("unknown command"));
+        assert!(output.stderr.contains("Usage:"));
+    }
+}

--- a/crates/conu-cli/src/main.rs
+++ b/crates/conu-cli/src/main.rs
@@ -2,79 +2,14 @@ use std::env;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    let mut args = env::args().skip(1);
-    let command = args.next();
+    let output = conu_cli::run(env::args().skip(1));
 
-    match command.as_deref() {
-        Some("status") => {
-            let json = args.any(|arg| arg == "--json");
-            print_status(json);
-            ExitCode::SUCCESS
-        }
-        Some("components") => {
-            print_components();
-            ExitCode::SUCCESS
-        }
-        Some("--help") | Some("-h") => {
-            print_help();
-            ExitCode::SUCCESS
-        }
-        Some("--version") | Some("-V") => {
-            println!("conu {}", env!("CARGO_PKG_VERSION"));
-            ExitCode::SUCCESS
-        }
-        Some(unknown) => {
-            eprintln!("unknown command: {unknown}");
-            print_help();
-            ExitCode::from(2)
-        }
-        None => {
-            print_banner();
-            ExitCode::SUCCESS
-        }
+    if !output.stdout.is_empty() {
+        print!("{}", output.stdout);
     }
-}
-
-fn print_banner() {
-    println!(
-        r"                 __  __
-  ___ ___  _ __ |  \/  |
- / __/ _ \| '_ \| |\/| |
-| (_| (_) | | | | |  | |
- \___\___/|_| |_|_|  |_|
-
-agent-native encrypted overlay
-{}",
-        conu_core::PRODUCT_LAW
-    );
-}
-
-fn print_status(json: bool) {
-    if json {
-        println!(
-            "{{\n  \"component\": \"conu-cli\",\n  \"status\": \"scaffold_ready\",\n  \"payloadVisibility\": \"opaque\",\n  \"productLaw\": \"{}\"\n}}",
-            conu_core::PRODUCT_LAW
-        );
-    } else {
-        println!("{}", conu_core::scaffold_status("conu-cli"));
+    if !output.stderr.is_empty() {
+        eprint!("{}", output.stderr);
     }
-}
 
-fn print_components() {
-    for component in conu_core::COMPONENTS {
-        println!("{} - {}", component.name, component.responsibility);
-    }
-}
-
-fn print_help() {
-    println!(
-        r"conu - agent-native encrypted communication fabric
-
-Usage:
-  conu
-  conu status [--json]
-  conu components
-  conu --help
-  conu --version"
-    );
+    ExitCode::from(output.code as u8)
 }

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 2 - CLI Identity And Dashboard
+Current phase: Phase 3 - Local Identity And Persistent State
 Status: not_started
 Last updated: 2026-05-10
 ```
@@ -166,7 +166,7 @@ Next:
 
 ## Phase 2 - CLI Identity And Dashboard
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -187,9 +187,58 @@ conu watch
 
 Exit criteria:
 
-- CLI renders cleanly on Windows terminals.
-- No private payload concepts are displayed.
-- Commands have helpful structured output.
+- [x] CLI renders cleanly on Windows terminals.
+- [x] No private payload contents are displayed.
+- [x] Commands have helpful structured output.
+
+Completed work:
+
+- Created GitHub issue #3 for Phase 2.
+- Created and pushed branch `codex/phase-2-cli-dashboard`.
+- Refactored `conu-cli` into a testable library plus thin binary adapter.
+- Added ASCII dashboard for `conu`.
+- Added command shell for `init`, `status`, `agents`, `peers`, `pair`, `join <code>`, `connect`, `watch`, `components`, and reserved `start`.
+- Added text and JSON status/agent outputs where useful.
+- Kept Phase 3+ behavior honest: no persistent identity, trust store, IPC, relay, or real daemon state is created in Phase 2.
+- Added tests for command registration, dashboard rendering, status JSON, join usage, unknown command handling, and watch content privacy.
+- Updated README and repo overview for the completed CLI shell.
+
+Files changed:
+
+- `README.md`
+- `.agents/repo/ABOUT.md`
+- `plan.md`
+- `crates/conu-cli/Cargo.toml`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-cli/src/main.rs`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli --` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- init` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- status --json` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- agents` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- pair` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- join 482913` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- connect` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- watch` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- peers --json` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- start` passed.
+
+Known gaps:
+
+- No real local identity is created; that remains Phase 3.
+- No real daemon lifecycle is implemented; that remains Phase 4.
+- No real local agent registration exists; that remains Phase 5.
+- Pairing/join are command-shape previews only; trust creation remains Phase 7.
+- Watch shows a static transport view only; live animation remains Phase 10.
+
+Next:
+
+- Start Phase 3: local identity, config, trust store skeleton, and safe state path resolution.
 
 ## Phase 3 - Local Identity And Persistent State
 
@@ -484,4 +533,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 0 started. Architecture and agent memory created. Waiting for user approval before implementation.
 2026-05-10 - Phase 0 completed. User approved implementation and Phase 1 started.
 2026-05-10 - Phase 1 completed. Rust workspace scaffold created and validated with cargo fmt/check/test plus binary smoke commands using stable-x86_64-pc-windows-gnu. Next: Phase 2 CLI identity and dashboard.
+2026-05-10 - Phase 2 completed. CLI dashboard and command shell created with payload-safe outputs, tests, and smoke validation. Next: Phase 3 local identity and persistent state.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- Refactor `conu-cli` into a testable library with a thin binary adapter.
- Add the Phase 2 CLI control room: `conu`, `init`, `status`, `agents`, `peers`, `pair`, `join <code>`, `connect`, `watch`, and reserved `start`.
- Keep Phase 3+ features honest: no identity, state, trust store, IPC, relay, or real network behavior is created yet.
- Update README, repo overview, and `plan.md` for completed Phase 2.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu test --workspace`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli --`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- init`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- status --json`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- agents`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- pair`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- join 482913`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- connect`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- watch`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- peers --json`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- start`

## Security / Privacy
- CLI watch/status outputs show state and transport metadata only.
- Message contents, prompt text, reasoning, files, and tool outputs are not displayed.
- Phase 2 does not add storage, logs, relay forwarding, or network transport.

Closes #3


___

## **CodeAnt-AI Description**
**Add the Phase 2 CLI dashboard and command shell**

### What Changed
- The default `conu` screen now shows a control-room dashboard with current phase status and quick commands.
- Added user-facing output for `init`, `status`, `agents`, `peers`, `pair`, `join <code>`, `connect`, `watch`, `components`, and `start`.
- `status`, `agents`, `pair`, and `join` can also return JSON output for machine use.
- The CLI now rejects invalid usage with clear messages and keeps payload contents hidden in status and watch views.

### Impact
`✅ Clearer first-run CLI experience`
`✅ Easier command discovery`
`✅ Fewer accidental payload leaks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=lCoE8VmB0gxdpvFMuserRq_Zbl2nN172GwoKZMn3gzg&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
