### PR TITLE
Phase 3: local identity and persistent state

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,13 +6,16 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 2.
+The repository has completed Phase 3.
 
 Implemented so far:
 
 - project memory and architecture
 - Rust workspace scaffold
 - CLI identity/dashboard command shell
+- local node identity persistence
+- local config, trust store skeleton, and agent registry skeleton
+- payload-safe status and agent registry reporting
 - payload-safe protocol scaffold
 - daemon and relay placeholder binaries
 

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -29,6 +29,14 @@ This workspace was first validated on Windows where the default MSVC Rust toolch
 
 Do not add proc-macro/build-script-heavy dependencies unless validation can still run in the active environment or CI.
 
+## Local State Rules
+
+- `CONU_HOME` overrides the default state directory and should be used for smoke checks.
+- Windows defaults to `%APPDATA%\conU`; non-Windows falls back to `$HOME/.conu`.
+- Tests should pass an explicit state home instead of mutating global process environment.
+- The Phase 3 node id is a local runtime identifier only. It is not a secret, not an authentication credential, and not a replacement for future signed/encrypted identity.
+- conU-owned state must not store plaintext private payloads.
+
 ## Privacy Rules
 
 - Never log plaintext payloads.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 2 is complete. The CLI identity and dashboard shell exists; Phase 3 will add real local identity and persistent state.
+Phase 3 is complete. The CLI identity/dashboard shell exists and `conu init` now creates real local state for this runtime.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -22,6 +22,29 @@ The repository currently contains compile-ready crate boundaries for:
 - `conu-relay`: relay/bootstrap scaffold.
 
 This phase is intentionally std-only so the workspace validates on Windows machines that have Rust installed but do not yet have the Visual Studio C++ linker/Windows SDK configured. Production dependencies such as clap, Tokio, tracing, and serde should be introduced in the relevant future phases once linker support is available locally or in CI.
+
+## Local State
+
+`conu init` creates the Phase 3 state store:
+
+```txt
+%APPDATA%\conU\        Windows default
+~/.conu/               Unix fallback
+```
+
+Set `CONU_HOME` to use a different directory for development or smoke checks.
+
+```txt
+node.toml              local node id only, not a secret or auth credential
+config.toml            local runtime config skeleton
+trust.toml             trusted/revoked peer skeleton
+agents/registry.toml   local agent registry skeleton
+sessions/              future runtime sessions
+mailbox/               future encrypted mailbox storage
+logs/                  future payload-safe logs
+```
+
+No private message payloads or secret keys are stored by Phase 3.
 
 ## Development
 
@@ -44,6 +67,7 @@ Useful CLI commands:
 cargo run -p conu-cli --
 cargo run -p conu-cli -- init
 cargo run -p conu-cli -- status
+cargo run -p conu-cli -- status --json
 cargo run -p conu-cli -- agents
 cargo run -p conu-cli -- pair
 cargo run -p conu-cli -- join 482913

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -1,8 +1,11 @@
 //! CLI rendering and command dispatch for conU.
 //!
-//! Phase 2 builds the user-facing command shell only. Commands that need real
-//! identity, daemon, IPC, relay, or persistence are represented as honest
-//! previews and point to their owning future phase.
+//! Phase 3 adds local persistent identity and state while keeping daemon, IPC,
+//! relay, and messaging features as honest previews.
+
+use std::path::PathBuf;
+
+use conu_core::state::{self, InitReport, StateSnapshot};
 
 /// A rendered CLI command result.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,15 +39,27 @@ where
     I: IntoIterator<Item = S>,
     S: Into<String>,
 {
+    run_with_home(args, None)
+}
+
+/// Dispatch a conU CLI invocation with an explicit state home.
+///
+/// This is mostly used by tests and smoke checks so they do not touch a real
+/// user profile.
+pub fn run_with_home<I, S>(args: I, home_override: Option<PathBuf>) -> CliOutput
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
     let args = args.into_iter().map(Into::into).collect::<Vec<_>>();
     let Some(command) = args.first().map(String::as_str) else {
-        return CliOutput::success(render_dashboard());
+        return CliOutput::success(render_dashboard(home_override));
     };
 
     match command {
-        "init" => render_init(&args[1..]),
-        "status" => render_status(&args[1..]),
-        "agents" | "peers" => render_agents(&args[1..]),
+        "init" => render_init(&args[1..], home_override),
+        "status" => render_status(&args[1..], home_override),
+        "agents" | "peers" => render_agents(&args[1..], home_override),
         "pair" => render_pair(&args[1..]),
         "join" => render_join(&args[1..]),
         "connect" => render_connect(&args[1..]),
@@ -60,7 +75,18 @@ where
     }
 }
 
-fn render_dashboard() -> String {
+fn render_dashboard(home_override: Option<PathBuf>) -> String {
+    let snapshot = state::read_state(home_override).ok();
+    let node = snapshot
+        .as_ref()
+        .and_then(|snapshot| snapshot.node.as_ref())
+        .map(|node| node.node_id.as_str())
+        .unwrap_or("not initialized");
+    let state = snapshot
+        .as_ref()
+        .map(initialization_label)
+        .unwrap_or("unavailable");
+
     format!(
         r"                 __  __
   ___ ___  _ __ |  \/  |
@@ -73,7 +99,8 @@ agent-native encrypted overlay
 
 control room
   runtime       offline        conUD starts in Phase 4
-  node          not initialized identity arrives in Phase 3
+  node          {node}
+  state         {state}
   local agents  none           registration arrives in Phase 5
   remote peers  none           pairing arrives in Phase 7
   network       offline        relay arrives in Phase 8
@@ -90,60 +117,56 @@ quick commands
     )
 }
 
-fn render_init(args: &[String]) -> CliOutput {
+fn render_init(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     if let Some(error) = reject_args(args) {
         return error;
     }
 
-    CliOutput::success(
-        r"conU init
-
-status: ready for Phase 3
-action: no files written in Phase 2
-next: Phase 3 will create the local node identity and trust store",
-    )
+    match state::init_state(home_override) {
+        Ok(report) => CliOutput::success(render_init_report(&report)),
+        Err(error) => CliOutput::failure(1, format!("conU init failed\n\n{error}")),
+    }
 }
 
-fn render_status(args: &[String]) -> CliOutput {
+fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let snapshot = match state::read_state(home_override) {
+        Ok(snapshot) => snapshot,
+        Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
+    };
+
     match json_flag(args) {
-        Ok(true) => CliOutput::success(render_status_json()),
-        Ok(false) => CliOutput::success(
-            r"conU status
-
-runtime
-  conUD         offline
-  local IPC     not available until Phase 4
-  relay         not available until Phase 8
-
-identity
-  node          not initialized
-  trust store   not initialized
-
-agents
-  local         0 registered
-  remote        0 visible
-
-privacy
-  payload view  contents are not displayed by conU",
-        ),
+        Ok(true) => CliOutput::success(render_status_json(&snapshot)),
+        Ok(false) => CliOutput::success(render_status_text(&snapshot)),
         Err(error) => error,
     }
 }
 
-fn render_agents(args: &[String]) -> CliOutput {
+fn render_agents(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let snapshot = match state::read_state(home_override) {
+        Ok(snapshot) => snapshot,
+        Err(error) => return CliOutput::failure(1, format!("conU agents failed\n\n{error}")),
+    };
+    let registry_state = ready_label(snapshot.agent_registry_exists);
+
     match json_flag(args) {
-        Ok(true) => CliOutput::success(
-            r#"{
+        Ok(true) => CliOutput::success(format!(
+            r#"{{
   "local": [],
   "remote": [],
+  "registry": "{}",
+  "registryPath": "{}",
   "status": "agent registration arrives in Phase 5"
-}"#,
-        ),
-        Ok(false) => CliOutput::success(
+}}"#,
+            registry_state,
+            json_escape(&snapshot.paths.agent_registry.display().to_string())
+        )),
+        Ok(false) => CliOutput::success(format!(
             r"conU agents
 
 local agents
   none registered yet
+  registry      {}
+  path          {}
 
 remote agents
   none visible yet
@@ -151,7 +174,9 @@ remote agents
 next
   Phase 5: local agent registration
   Phase 9: remote discovery and presence",
-        ),
+            registry_state,
+            snapshot.paths.agent_registry.display()
+        )),
         Err(error) => error,
     }
 }
@@ -162,14 +187,14 @@ fn render_pair(args: &[String]) -> CliOutput {
             r#"{
   "status": "reserved",
   "phase": "Phase 7",
-  "message": "pairing code generation is not active in Phase 2"
+  "message": "pairing code generation is not active in Phase 3"
 }"#,
         ),
         Ok(false) => CliOutput::success(
             r"conU pair
 
 status: reserved for Phase 7
-code: not generated in Phase 2
+code: not generated in Phase 3
 purpose: create trust between two conUD runtimes",
         ),
         Err(error) => error,
@@ -183,7 +208,7 @@ fn render_join(args: &[String]) -> CliOutput {
                 r#"{
   "status": "reserved",
   "phase": "Phase 7",
-  "message": "join validation is not active in Phase 2"
+  "message": "join validation is not active in Phase 3"
 }"#,
             ),
             Err(error) => error,
@@ -196,7 +221,7 @@ fn render_join(args: &[String]) -> CliOutput {
 
 status: reserved for Phase 7
 code: accepted for command shape only
-action: no trust entry created in Phase 2",
+action: no trust entry created in Phase 3",
         ),
         Err(error) => error,
     }
@@ -260,26 +285,133 @@ fn render_reserved_phase(command: &str, phase: &str, owner: &str) -> CliOutput {
     ))
 }
 
-fn render_status_json() -> String {
-    r#"{
-  "runtime": {
+fn render_init_report(report: &InitReport) -> String {
+    let repaired =
+        report.config_created || report.trust_store_created || report.agent_registry_created;
+    let status = if report.node_created {
+        "created"
+    } else if repaired {
+        "repaired"
+    } else {
+        "already initialized"
+    };
+
+    format!(
+        r"conU init
+
+status: {status}
+node: {}
+name: {}
+state path: {}
+
+files
+  node identity  {}
+  config         {}
+  trust store    {}
+  agent registry {}
+
+next
+  conu status
+  conu start     reserved for Phase 4",
+        report.node.node_id,
+        report.node.display_name,
+        report.paths.home.display(),
+        created_label(report.node_created),
+        created_label(report.config_created),
+        created_label(report.trust_store_created),
+        created_label(report.agent_registry_created)
+    )
+}
+
+fn render_status_text(snapshot: &StateSnapshot) -> String {
+    let node = snapshot
+        .node
+        .as_ref()
+        .map(|node| node.node_id.as_str())
+        .unwrap_or("not initialized");
+    let display_name = snapshot
+        .node
+        .as_ref()
+        .map(|node| node.display_name.as_str())
+        .unwrap_or("not initialized");
+
+    format!(
+        r"conU status
+
+runtime
+  conUD         offline
+  local IPC     not available until Phase 4
+  relay         not available until Phase 8
+
+identity
+  state         {}
+  node          {}
+  name          {}
+  state path    {}
+  config        {}
+  trust store   {}
+
+agents
+  local         0 registered
+  registry      {}
+  remote        0 visible
+
+privacy
+  payload view  contents are not displayed by conU",
+        initialization_label(snapshot),
+        node,
+        display_name,
+        snapshot.paths.home.display(),
+        ready_label(snapshot.config_exists),
+        ready_label(snapshot.trust_store_exists),
+        ready_label(snapshot.agent_registry_exists)
+    )
+}
+
+fn render_status_json(snapshot: &StateSnapshot) -> String {
+    let node = snapshot
+        .node
+        .as_ref()
+        .map(|node| node.node_id.as_str())
+        .unwrap_or("not_initialized");
+    let display_name = snapshot
+        .node
+        .as_ref()
+        .map(|node| node.display_name.as_str())
+        .unwrap_or("not_initialized");
+
+    format!(
+        r#"{{
+  "runtime": {{
     "conud": "offline",
     "localIpc": "phase_4",
     "relay": "phase_8"
-  },
-  "identity": {
-    "node": "not_initialized",
-    "trustStore": "not_initialized"
-  },
-  "agents": {
+  }},
+  "identity": {{
+    "state": "{}",
+    "node": "{}",
+    "displayName": "{}",
+    "statePath": "{}",
+    "config": "{}",
+    "trustStore": "{}"
+  }},
+  "agents": {{
     "local": 0,
+    "registry": "{}",
     "remote": 0
-  },
-  "privacy": {
+  }},
+  "privacy": {{
     "contentsDisplayed": false
-  }
-}"#
-    .to_string()
+  }}
+}}"#,
+        initialization_label(snapshot),
+        json_escape(node),
+        json_escape(display_name),
+        json_escape(&snapshot.paths.home.display().to_string()),
+        ready_label(snapshot.config_exists),
+        ready_label(snapshot.trust_store_exists),
+        ready_label(snapshot.agent_registry_exists)
+    )
 }
 
 fn render_help() -> String {
@@ -299,8 +431,42 @@ Usage:
   conu --help
   conu --version
 
-Phase 2 builds the CLI control room. Runtime identity, IPC, pairing, relay, and streaming arrive in later phases."
+Phase 3 adds local identity and persistent state. Daemon IPC, pairing, relay, and streaming arrive in later phases."
         .to_string()
+}
+
+fn initialization_label(snapshot: &StateSnapshot) -> &'static str {
+    if snapshot.is_initialized() {
+        "initialized"
+    } else {
+        "not_initialized"
+    }
+}
+
+fn ready_label(is_ready: bool) -> &'static str {
+    if is_ready { "ready" } else { "not_initialized" }
+}
+
+fn created_label(created: bool) -> &'static str {
+    if created { "created" } else { "kept" }
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+
+    for character in value.chars() {
+        match character {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            value if value.is_control() => escaped.push_str(&format!("\\u{:04x}", value as u32)),
+            value => escaped.push(value),
+        }
+    }
+
+    escaped
 }
 
 fn json_flag(args: &[String]) -> Result<bool, CliOutput> {
@@ -349,10 +515,12 @@ fn finish(mut output: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn dashboard_renders_control_room() {
-        let output = run(Vec::<String>::new());
+        let output = run_with_home(Vec::<String>::new(), Some(temp_home("dashboard")));
 
         assert_eq!(output.code, 0);
         assert!(output.stdout.contains("control room"));
@@ -361,9 +529,11 @@ mod tests {
     }
 
     #[test]
-    fn phase_two_commands_are_registered() {
+    fn phase_three_commands_are_registered() {
+        let home = temp_home("commands");
+
         for command in ["init", "status", "agents", "pair", "connect", "watch"] {
-            let output = run([command]);
+            let output = run_with_home([command], Some(home.clone()));
             assert_eq!(output.code, 0, "{command} failed: {}", output.stderr);
         }
 
@@ -372,11 +542,46 @@ mod tests {
     }
 
     #[test]
+    fn init_creates_state_and_status_reads_it() {
+        let home = temp_home("init-status");
+
+        let init = run_with_home(["init"], Some(home.clone()));
+        let status = run_with_home(["status"], Some(home));
+
+        assert_eq!(init.code, 0, "{}", init.stderr);
+        assert!(init.stdout.contains("status: created"));
+        assert!(init.stdout.contains("node_"));
+        assert_eq!(status.code, 0, "{}", status.stderr);
+        assert!(status.stdout.contains("state         initialized"));
+        assert!(status.stdout.contains("trust store   ready"));
+    }
+
+    #[test]
+    fn init_is_idempotent() {
+        let home = temp_home("init-idempotent");
+
+        let first = run_with_home(["init"], Some(home.clone()));
+        let second = run_with_home(["init"], Some(home));
+
+        assert_eq!(first.code, 0, "{}", first.stderr);
+        assert_eq!(second.code, 0, "{}", second.stderr);
+        assert!(first.stdout.contains("status: created"));
+        assert!(second.stdout.contains("status: already initialized"));
+        assert!(second.stdout.contains("node identity  kept"));
+    }
+
+    #[test]
     fn status_json_is_machine_readable_shape() {
-        let output = run(["status", "--json"]);
+        let home = temp_home("status-json");
+        let init = run_with_home(["init"], Some(home.clone()));
+        assert_eq!(init.code, 0, "{}", init.stderr);
+
+        let output = run_with_home(["status", "--json"], Some(home));
 
         assert_eq!(output.code, 0);
         assert!(output.stdout.contains("\"conud\": \"offline\""));
+        assert!(output.stdout.contains("\"state\": \"initialized\""));
+        assert!(output.stdout.contains("\"node\": \"node_"));
         assert!(output.stdout.contains("\"contentsDisplayed\": false"));
     }
 
@@ -405,5 +610,14 @@ mod tests {
         assert_eq!(output.code, 2);
         assert!(output.stderr.contains("unknown command"));
         assert!(output.stderr.contains("Usage:"));
+    }
+
+    fn temp_home(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        std::env::temp_dir().join(format!("conu-cli-test-{label}-{}-{nonce}", process::id()))
     }
 }

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -1,5 +1,7 @@
 //! Core conU runtime concepts shared by binaries.
 
+pub mod state;
+
 /// The product invariant every crate should preserve.
 pub const PRODUCT_LAW: &str = "Agents own the conversation. conU owns the connection.";
 

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -1,0 +1,497 @@
+//! Local persistent state for conU.
+//!
+//! Phase 3 keeps this intentionally small and std-only: a locally generated
+//! node id, config, trust store skeleton, and agent registry skeleton. Secret
+//! keys and encrypted payload storage belong to later phases.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::env;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use conu_protocol::PROTOCOL_VERSION;
+
+const NODE_FILE: &str = "node.toml";
+const CONFIG_FILE: &str = "config.toml";
+const TRUST_FILE: &str = "trust.toml";
+const AGENTS_DIR: &str = "agents";
+const AGENT_REGISTRY_FILE: &str = "registry.toml";
+const SESSIONS_DIR: &str = "sessions";
+const MAILBOX_DIR: &str = "mailbox";
+const LOGS_DIR: &str = "logs";
+
+/// Files and folders used by the local conU state store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatePaths {
+    pub home: PathBuf,
+    pub node_identity: PathBuf,
+    pub config: PathBuf,
+    pub trust_store: PathBuf,
+    pub agents_dir: PathBuf,
+    pub agent_registry: PathBuf,
+    pub sessions_dir: PathBuf,
+    pub mailbox_dir: PathBuf,
+    pub logs_dir: PathBuf,
+}
+
+impl StatePaths {
+    /// Resolve conU's local state paths.
+    pub fn resolve(home_override: Option<PathBuf>) -> Result<Self, StateError> {
+        let home = match home_override {
+            Some(path) => path,
+            None => default_home()?,
+        };
+
+        Ok(Self::from_home(home))
+    }
+
+    /// Build state paths from an already resolved home directory.
+    pub fn from_home(home: PathBuf) -> Self {
+        let agents_dir = home.join(AGENTS_DIR);
+
+        Self {
+            node_identity: home.join(NODE_FILE),
+            config: home.join(CONFIG_FILE),
+            trust_store: home.join(TRUST_FILE),
+            agent_registry: agents_dir.join(AGENT_REGISTRY_FILE),
+            agents_dir,
+            sessions_dir: home.join(SESSIONS_DIR),
+            mailbox_dir: home.join(MAILBOX_DIR),
+            logs_dir: home.join(LOGS_DIR),
+            home,
+        }
+    }
+}
+
+/// Local identity for this conUD runtime node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeIdentity {
+    pub node_id: String,
+    pub display_name: String,
+    pub created_at_unix: u64,
+    pub protocol_version: String,
+}
+
+/// Result of creating or reusing local state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitReport {
+    pub paths: StatePaths,
+    pub node: NodeIdentity,
+    pub node_created: bool,
+    pub config_created: bool,
+    pub trust_store_created: bool,
+    pub agent_registry_created: bool,
+}
+
+/// Read-only view of the local state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateSnapshot {
+    pub paths: StatePaths,
+    pub node: Option<NodeIdentity>,
+    pub config_exists: bool,
+    pub trust_store_exists: bool,
+    pub agent_registry_exists: bool,
+}
+
+impl StateSnapshot {
+    /// True once the required Phase 3 state files exist and the node identity parses.
+    pub fn is_initialized(&self) -> bool {
+        self.node.is_some()
+            && self.config_exists
+            && self.trust_store_exists
+            && self.agent_registry_exists
+    }
+}
+
+/// Errors produced while reading or creating local state.
+#[derive(Debug)]
+pub enum StateError {
+    MissingHome,
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidNodeIdentity {
+        path: PathBuf,
+        reason: String,
+    },
+}
+
+impl StateError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for StateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingHome => write!(
+                formatter,
+                "could not resolve a conU state directory; set CONU_HOME"
+            ),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidNodeIdentity { path, reason } => {
+                write!(
+                    formatter,
+                    "invalid node identity at {}: {reason}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for StateError {}
+
+/// Create the local state directory and required Phase 3 files.
+pub fn init_state(home_override: Option<PathBuf>) -> Result<InitReport, StateError> {
+    let paths = StatePaths::resolve(home_override)?;
+    create_layout(&paths)?;
+
+    let (node, node_created) = if paths.node_identity.exists() {
+        (read_node_identity(&paths.node_identity)?, false)
+    } else {
+        let node = NodeIdentity::new(default_display_name(), current_unix_seconds());
+        match write_new_file(&paths.node_identity, &render_node_identity(&node)) {
+            Ok(()) => (node, true),
+            Err(StateError::Io { source, .. }) if source.kind() == io::ErrorKind::AlreadyExists => {
+                (read_node_identity(&paths.node_identity)?, false)
+            }
+            Err(error) => return Err(error),
+        }
+    };
+
+    let config_created = write_if_missing(&paths.config, &render_config(&node))?;
+    let trust_store_created = write_if_missing(&paths.trust_store, &render_trust_store())?;
+    let agent_registry_created = write_if_missing(&paths.agent_registry, &render_agent_registry())?;
+
+    Ok(InitReport {
+        paths,
+        node,
+        node_created,
+        config_created,
+        trust_store_created,
+        agent_registry_created,
+    })
+}
+
+/// Read the current local state without creating missing files.
+pub fn read_state(home_override: Option<PathBuf>) -> Result<StateSnapshot, StateError> {
+    let paths = StatePaths::resolve(home_override)?;
+    let node = match paths.node_identity.exists() {
+        true => Some(read_node_identity(&paths.node_identity)?),
+        false => None,
+    };
+
+    Ok(StateSnapshot {
+        config_exists: paths.config.exists(),
+        trust_store_exists: paths.trust_store.exists(),
+        agent_registry_exists: paths.agent_registry.exists(),
+        paths,
+        node,
+    })
+}
+
+impl NodeIdentity {
+    fn new(display_name: String, created_at_unix: u64) -> Self {
+        Self {
+            node_id: generate_node_id(&display_name, created_at_unix),
+            display_name,
+            created_at_unix,
+            protocol_version: PROTOCOL_VERSION.to_string(),
+        }
+    }
+}
+
+fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
+    for directory in [
+        &paths.home,
+        &paths.agents_dir,
+        &paths.sessions_dir,
+        &paths.mailbox_dir,
+        &paths.logs_dir,
+    ] {
+        fs::create_dir_all(directory)
+            .map_err(|error| StateError::io("create state directory", directory, error))?;
+    }
+
+    Ok(())
+}
+
+fn write_if_missing(path: &Path, contents: &str) -> Result<bool, StateError> {
+    match write_new_file(path, contents) {
+        Ok(()) => Ok(true),
+        Err(StateError::Io { source, .. }) if source.kind() == io::ErrorKind::AlreadyExists => {
+            Ok(false)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn write_new_file(path: &Path, contents: &str) -> Result<(), StateError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| StateError::io("create state file", path, error))?;
+
+    file.write_all(contents.as_bytes())
+        .map_err(|error| StateError::io("write state file", path, error))
+}
+
+fn read_node_identity(path: &Path) -> Result<NodeIdentity, StateError> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| StateError::io("read node identity", path, error))?;
+    let values = parse_key_values(&contents);
+
+    let node_id = required_field(path, &values, "node_id")?;
+    let display_name = required_field(path, &values, "display_name")?;
+    let protocol_version = required_field(path, &values, "protocol_version")?;
+    let created_at_unix = required_field(path, &values, "created_at_unix")?
+        .parse::<u64>()
+        .map_err(|_| StateError::InvalidNodeIdentity {
+            path: path.to_path_buf(),
+            reason: "created_at_unix must be an unsigned integer".to_string(),
+        })?;
+
+    if !node_id.starts_with("node_") {
+        return Err(StateError::InvalidNodeIdentity {
+            path: path.to_path_buf(),
+            reason: "node_id must start with node_".to_string(),
+        });
+    }
+
+    Ok(NodeIdentity {
+        node_id,
+        display_name,
+        created_at_unix,
+        protocol_version,
+    })
+}
+
+fn required_field(
+    path: &Path,
+    values: &HashMap<String, String>,
+    key: &'static str,
+) -> Result<String, StateError> {
+    values
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| StateError::InvalidNodeIdentity {
+            path: path.to_path_buf(),
+            reason: format!("missing {key}"),
+        })
+}
+
+fn parse_key_values(contents: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        values.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    values
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn render_node_identity(node: &NodeIdentity) -> String {
+    format!(
+        "# conU node identity\n# Local node id only. Secret keys are introduced in later phases.\nversion = \"1\"\nnode_id = \"{}\"\ndisplay_name = \"{}\"\ncreated_at_unix = {}\nprotocol_version = \"{}\"\n",
+        escape_file_value(&node.node_id),
+        escape_file_value(&node.display_name),
+        node.created_at_unix,
+        escape_file_value(&node.protocol_version)
+    )
+}
+
+fn render_config(node: &NodeIdentity) -> String {
+    format!(
+        "# conU local config\nversion = \"1\"\nruntime_name = \"{}\"\ndefault_relay = \"\"\n",
+        escape_file_value(&node.display_name)
+    )
+}
+
+fn render_trust_store() -> String {
+    "# conU trust store skeleton\nversion = \"1\"\ntrusted_peers = []\nrevoked_peers = []\n"
+        .to_string()
+}
+
+fn render_agent_registry() -> String {
+    "# conU local agent registry skeleton\nversion = \"1\"\nagents = []\n".to_string()
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn generate_node_id(display_name: &str, created_at_unix: u64) -> String {
+    let mut hasher = DefaultHasher::new();
+    display_name.hash(&mut hasher);
+    created_at_unix.hash(&mut hasher);
+    process::id().hash(&mut hasher);
+    current_unix_nanos().hash(&mut hasher);
+
+    format!("node_{:016x}", hasher.finish())
+}
+
+fn default_display_name() -> String {
+    let raw = env::var("CONU_NODE_NAME")
+        .or_else(|_| env::var("COMPUTERNAME"))
+        .or_else(|_| env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "local-node".to_string());
+
+    sanitize_display_name(&raw)
+}
+
+fn sanitize_display_name(value: &str) -> String {
+    let cleaned = value
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+        .collect::<String>();
+
+    if cleaned.is_empty() {
+        "local-node".to_string()
+    } else {
+        cleaned
+    }
+}
+
+fn default_home() -> Result<PathBuf, StateError> {
+    if let Ok(value) = env::var("CONU_HOME") {
+        if !value.trim().is_empty() {
+            return Ok(PathBuf::from(value));
+        }
+    }
+
+    #[cfg(windows)]
+    if let Ok(value) = env::var("APPDATA") {
+        if !value.trim().is_empty() {
+            return Ok(PathBuf::from(value).join("conU"));
+        }
+    }
+
+    if let Ok(value) = env::var("HOME") {
+        if !value.trim().is_empty() {
+            return Ok(PathBuf::from(value).join(".conu"));
+        }
+    }
+
+    if let Ok(value) = env::var("USERPROFILE") {
+        if !value.trim().is_empty() {
+            return Ok(PathBuf::from(value).join(".conu"));
+        }
+    }
+
+    Err(StateError::MissingHome)
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_creates_required_state_files() {
+        let home = test_home("creates");
+        let report = init_state(Some(home.clone())).expect("state initializes");
+
+        assert!(report.node_created);
+        assert!(report.config_created);
+        assert!(report.trust_store_created);
+        assert!(report.agent_registry_created);
+        assert!(report.node.node_id.starts_with("node_"));
+        assert!(home.join(NODE_FILE).exists());
+        assert!(home.join(CONFIG_FILE).exists());
+        assert!(home.join(TRUST_FILE).exists());
+        assert!(home.join(AGENTS_DIR).join(AGENT_REGISTRY_FILE).exists());
+    }
+
+    #[test]
+    fn init_is_idempotent_and_preserves_node_id() {
+        let home = test_home("idempotent");
+        let first = init_state(Some(home.clone())).expect("first init succeeds");
+        let second = init_state(Some(home)).expect("second init succeeds");
+
+        assert!(first.node_created);
+        assert!(!second.node_created);
+        assert_eq!(first.node.node_id, second.node.node_id);
+        assert!(!second.config_created);
+        assert!(!second.trust_store_created);
+        assert!(!second.agent_registry_created);
+    }
+
+    #[test]
+    fn read_state_reports_initialized_after_init() {
+        let home = test_home("snapshot");
+        init_state(Some(home.clone())).expect("state initializes");
+
+        let snapshot = read_state(Some(home)).expect("state reads");
+
+        assert!(snapshot.is_initialized());
+        assert!(snapshot.node.expect("node").node_id.starts_with("node_"));
+    }
+
+    #[test]
+    fn read_state_does_not_create_missing_files() {
+        let home = test_home("missing");
+        let snapshot = read_state(Some(home.clone())).expect("state reads");
+
+        assert!(!snapshot.is_initialized());
+        assert!(snapshot.node.is_none());
+        assert!(!home.exists());
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        env::temp_dir().join(format!(
+            "conu-state-test-{label}-{}-{}",
+            process::id(),
+            current_unix_nanos()
+        ))
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 3 - Local Identity And Persistent State
+Current phase: Phase 4 - conUD Daemon Skeleton
 Status: not_started
 Last updated: 2026-05-10
 ```
@@ -242,7 +242,7 @@ Next:
 
 ## Phase 3 - Local Identity And Persistent State
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -258,9 +258,55 @@ Deliverables:
 
 Exit criteria:
 
-- `conu init` creates local identity.
-- `conu status` reads identity and config.
-- Re-running init is safe.
+- [x] `conu init` creates local identity.
+- [x] `conu status` reads identity and config.
+- [x] Re-running init is safe.
+
+Completed work:
+
+- Created GitHub issue #5 for Phase 3.
+- Created and pushed branch `codex/phase-3-local-identity`.
+- Added std-only local state management in `conu-core`.
+- Added safe state path resolution with `CONU_HOME`, Windows `%APPDATA%\conU`, and Unix `$HOME/.conu` fallback.
+- Added idempotent creation of `node.toml`, `config.toml`, `trust.toml`, `agents/registry.toml`, and future runtime directories.
+- Added `conu init` integration that creates or repairs Phase 3 state without overwriting existing files.
+- Added `conu status` and `conu status --json` integration that reads persisted identity/config/trust/registry readiness.
+- Added `conu agents --json` registry readiness metadata while keeping actual registration reserved for Phase 5.
+- Added tests for local state creation, idempotency, missing-state reads, CLI status, JSON shape, and watch payload privacy.
+- Updated README, repo overview, and implementation guardrails.
+
+Files changed:
+
+- `README.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `plan.md`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-core/src/state.rs`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- init` passed with isolated `CONU_HOME`.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- init` passed a second time and preserved the same node id.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- status` passed with isolated `CONU_HOME`.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- status --json` passed with isolated `CONU_HOME`.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- agents --json` passed with isolated `CONU_HOME`.
+
+Known gaps:
+
+- Phase 3 node id is a local identifier only, not a cryptographic identity or authentication credential.
+- No private keys, signed identities, encrypted mailbox, or key storage exists yet; those remain Phase 11 hardening work.
+- No real daemon lifecycle exists yet; that remains Phase 4.
+- No local agent registration exists yet; that remains Phase 5.
+- Trust store and agent registry are skeleton files only until pairing/registration phases.
+
+Next:
+
+- Start Phase 4: conUD daemon skeleton with runtime state, health/status detection, graceful shutdown, and payload-safe logs.
 
 ## Phase 4 - conUD Daemon Skeleton
 
@@ -534,4 +580,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 0 completed. User approved implementation and Phase 1 started.
 2026-05-10 - Phase 1 completed. Rust workspace scaffold created and validated with cargo fmt/check/test plus binary smoke commands using stable-x86_64-pc-windows-gnu. Next: Phase 2 CLI identity and dashboard.
 2026-05-10 - Phase 2 completed. CLI dashboard and command shell created with payload-safe outputs, tests, and smoke validation. Next: Phase 3 local identity and persistent state.
+2026-05-10 - Phase 3 completed. Local identity and persistent state added with idempotent init, status reads, tests, and isolated CONU_HOME smoke validation. Next: Phase 4 conUD daemon skeleton.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- Add std-only local state management for node identity, config, trust store skeleton, and agent registry skeleton.
- Wire conu init, conu status, conu status --json, and conu agents --json to the persisted state.
- Update README, repo memory, implementation guardrails, and plan.md for the completed phase.

## Privacy / security
- No message payloads are read, logged, displayed, or stored.
- Phase 3 node id is documented as a local identifier only, not a secret or cryptographic credential.
- Trust and agent registry are skeleton metadata files only.

## Validation
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu test --workspace
- isolated CONU_HOME smoke: init, repeated init, status, status --json, gents --json

Closes #5


___

## **CodeAnt-AI Description**
**Create and read local conU state from disk**

### What Changed
- `conu init` now creates local state files for the runtime node, config, trust store, and agent registry, and shows whether each file was created or already kept
- `conu status` and `conu status --json` now read that saved state and display the node id, runtime name, state path, and readiness of config, trust store, and registry files
- `conu agents` and `conu agents --json` now report the local registry path and whether the registry is ready
- The dashboard, help text, README, and project notes now describe Phase 3 as completed and document the local state location and files

### Impact
`✅ Persistent local identity after init`
`✅ Safer repeated init runs without overwriting existing state`
`✅ Clearer status output for local setup and readiness`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=QlvOMdNzEHR_zEHOuO84KHgoo1SU5d1DDHXunkCdgRo&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
