### PR TITLE
Phase 4: conUD daemon skeleton

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 3.
+The repository has completed Phase 4.
 
 Implemented so far:
 
@@ -15,6 +15,8 @@ Implemented so far:
 - CLI identity/dashboard command shell
 - local node identity persistence
 - local config, trust store skeleton, and agent registry skeleton
+- conUD runtime heartbeat/status skeleton
+- `conu start`, `conu stop`, and runtime-aware `conu status`
 - payload-safe status and agent registry reporting
 - payload-safe protocol scaffold
 - daemon and relay placeholder binaries

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -37,6 +37,14 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - The Phase 3 node id is a local runtime identifier only. It is not a secret, not an authentication credential, and not a replacement for future signed/encrypted identity.
 - conU-owned state must not store plaintext private payloads.
 
+## Local Runtime Rules
+
+- Phase 4 runtime health is file-backed: `runtime/status.toml`, `runtime/conud.lock`, and `runtime/stop.request`.
+- `conu start` should launch `conud --serve`; in development, set `CONUD_EXE` when the daemon binary is not beside the CLI binary.
+- `conu stop` requests graceful shutdown by writing a stop request; conUD owns final stopped state and lock cleanup.
+- Treat stale heartbeats as restartable runtime metadata, not proof of a live process.
+- Runtime logs must remain payload-safe and use metadata-only lines such as event, pid, node id, and `payload=not_observed`.
+
 ## Privacy Rules
 
 - Never log plaintext payloads.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 3 is complete. The CLI identity/dashboard shell exists and `conu init` now creates real local state for this runtime.
+Phase 4 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, and `conu start` launches the local `conUD` runtime skeleton.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -39,12 +39,15 @@ node.toml              local node id only, not a secret or auth credential
 config.toml            local runtime config skeleton
 trust.toml             trusted/revoked peer skeleton
 agents/registry.toml   local agent registry skeleton
+runtime/status.toml    conUD heartbeat/status metadata
+runtime/conud.lock     local runtime process lock
+runtime/stop.request   graceful shutdown request file
 sessions/              future runtime sessions
 mailbox/               future encrypted mailbox storage
 logs/                  future payload-safe logs
 ```
 
-No private message payloads or secret keys are stored by Phase 3.
+No private message payloads or secret keys are stored by Phase 4. Runtime logs contain metadata only, such as event name, pid, node id, and `payload=not_observed`.
 
 ## Development
 
@@ -73,9 +76,14 @@ cargo run -p conu-cli -- pair
 cargo run -p conu-cli -- join 482913
 cargo run -p conu-cli -- connect
 cargo run -p conu-cli -- watch
+cargo run -p conu-cli -- start
+cargo run -p conu-cli -- stop
 cargo run -p conud -- --check
+cargo run -p conud -- --once
 cargo run -p conu-relay -- --check
 ```
+
+When running from a development checkout, build `conud` first or set `CONUD_EXE` to the local daemon binary before using `conu start`.
 
 ## Project Memory
 

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -1,10 +1,15 @@
 //! CLI rendering and command dispatch for conU.
 //!
-//! Phase 3 adds local persistent identity and state while keeping daemon, IPC,
-//! relay, and messaging features as honest previews.
+//! Phase 4 adds local persistent identity, state, and conUD runtime detection
+//! while keeping IPC, relay, and messaging features as honest previews.
 
+use std::env;
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
 
+use conu_core::runtime::{self, RuntimeState, RuntimeStatus, StopReport};
 use conu_core::state::{self, InitReport, StateSnapshot};
 
 /// A rendered CLI command result.
@@ -65,7 +70,8 @@ where
         "connect" => render_connect(&args[1..]),
         "watch" => render_watch(&args[1..]),
         "components" => render_components(&args[1..]),
-        "start" => render_reserved_phase("start", "Phase 4", "conUD daemon lifecycle"),
+        "start" => render_start(&args[1..], home_override),
+        "stop" => render_stop(&args[1..], home_override),
         "--help" | "-h" | "help" => CliOutput::success(render_help()),
         "--version" | "-V" => CliOutput::success(format!("conu {}", env!("CARGO_PKG_VERSION"))),
         unknown => CliOutput::failure(
@@ -76,7 +82,8 @@ where
 }
 
 fn render_dashboard(home_override: Option<PathBuf>) -> String {
-    let snapshot = state::read_state(home_override).ok();
+    let snapshot = state::read_state(home_override.clone()).ok();
+    let runtime_status = runtime::read_runtime(home_override).ok();
     let node = snapshot
         .as_ref()
         .and_then(|snapshot| snapshot.node.as_ref())
@@ -85,6 +92,10 @@ fn render_dashboard(home_override: Option<PathBuf>) -> String {
     let state = snapshot
         .as_ref()
         .map(initialization_label)
+        .unwrap_or("unavailable");
+    let runtime_state = runtime_status
+        .as_ref()
+        .map(runtime_state_label)
         .unwrap_or("unavailable");
 
     format!(
@@ -98,7 +109,7 @@ agent-native encrypted overlay
 {}
 
 control room
-  runtime       offline        conUD starts in Phase 4
+  runtime       {runtime_state}
   node          {node}
   state         {state}
   local agents  none           registration arrives in Phase 5
@@ -129,14 +140,18 @@ fn render_init(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
 }
 
 fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
-    let snapshot = match state::read_state(home_override) {
+    let snapshot = match state::read_state(home_override.clone()) {
         Ok(snapshot) => snapshot,
+        Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
+    };
+    let runtime_status = match runtime::read_runtime(home_override) {
+        Ok(status) => status,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
 
     match json_flag(args) {
-        Ok(true) => CliOutput::success(render_status_json(&snapshot)),
-        Ok(false) => CliOutput::success(render_status_text(&snapshot)),
+        Ok(true) => CliOutput::success(render_status_json(&snapshot, &runtime_status)),
+        Ok(false) => CliOutput::success(render_status_text(&snapshot, &runtime_status)),
         Err(error) => error,
     }
 }
@@ -187,14 +202,14 @@ fn render_pair(args: &[String]) -> CliOutput {
             r#"{
   "status": "reserved",
   "phase": "Phase 7",
-  "message": "pairing code generation is not active in Phase 3"
+  "message": "pairing code generation is not active in Phase 4"
 }"#,
         ),
         Ok(false) => CliOutput::success(
             r"conU pair
 
 status: reserved for Phase 7
-code: not generated in Phase 3
+code: not generated in Phase 4
 purpose: create trust between two conUD runtimes",
         ),
         Err(error) => error,
@@ -208,7 +223,7 @@ fn render_join(args: &[String]) -> CliOutput {
                 r#"{
   "status": "reserved",
   "phase": "Phase 7",
-  "message": "join validation is not active in Phase 3"
+  "message": "join validation is not active in Phase 4"
 }"#,
             ),
             Err(error) => error,
@@ -221,7 +236,7 @@ fn render_join(args: &[String]) -> CliOutput {
 
 status: reserved for Phase 7
 code: accepted for command shape only
-action: no trust entry created in Phase 3",
+action: no trust entry created in Phase 4",
         ),
         Err(error) => error,
     }
@@ -279,10 +294,95 @@ fn render_components(args: &[String]) -> CliOutput {
     CliOutput::success(output)
 }
 
-fn render_reserved_phase(command: &str, phase: &str, owner: &str) -> CliOutput {
-    CliOutput::success(format!(
-        "conU {command}\n\nstatus: reserved for {phase}\nowner: {owner}"
-    ))
+fn render_start(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let json = match json_flag(args) {
+        Ok(json) => json,
+        Err(error) => return error,
+    };
+
+    let current = match runtime::read_runtime(home_override.clone()) {
+        Ok(status) => status,
+        Err(error) => return CliOutput::failure(1, format!("conU start failed\n\n{error}")),
+    };
+    if current.is_live() {
+        return CliOutput::success(render_start_report(&current, false, json));
+    }
+
+    let daemon = resolve_conud_executable();
+    let mut command = Command::new(&daemon);
+    command
+        .arg("--serve")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(home) = home_override.as_ref() {
+        command.env("CONU_HOME", home);
+    }
+
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return CliOutput::failure(
+                1,
+                format!(
+                    "conU start failed\n\ncould not launch conUD at {}: {error}\nset CONUD_EXE to the conud binary path if it is not beside conu",
+                    daemon.display()
+                ),
+            );
+        }
+    };
+
+    for _ in 0..30 {
+        thread::sleep(Duration::from_millis(100));
+        match runtime::read_runtime(home_override.clone()) {
+            Ok(status) if status.is_live() => {
+                return CliOutput::success(render_start_report(&status, true, json));
+            }
+            Ok(_) => {}
+            Err(error) => return CliOutput::failure(1, format!("conU start failed\n\n{error}")),
+        }
+    }
+
+    CliOutput::failure(
+        1,
+        format!(
+            "conU start launched pid {} but no fresh conUD heartbeat was detected",
+            child.id()
+        ),
+    )
+}
+
+fn render_stop(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let json = match json_flag(args) {
+        Ok(json) => json,
+        Err(error) => return error,
+    };
+
+    let report = match runtime::request_runtime_stop(home_override.clone()) {
+        Ok(report) => report,
+        Err(error) => return CliOutput::failure(1, format!("conU stop failed\n\n{error}")),
+    };
+
+    if report.requested {
+        for _ in 0..30 {
+            thread::sleep(Duration::from_millis(100));
+            match runtime::read_runtime(home_override.clone()) {
+                Ok(status) if !status.is_live() => {
+                    return CliOutput::success(render_stop_report(
+                        &StopReport {
+                            requested: true,
+                            status,
+                        },
+                        json,
+                    ));
+                }
+                Ok(_) => {}
+                Err(error) => return CliOutput::failure(1, format!("conU stop failed\n\n{error}")),
+            }
+        }
+    }
+
+    CliOutput::success(render_stop_report(&report, json))
 }
 
 fn render_init_report(report: &InitReport) -> String {
@@ -312,7 +412,7 @@ files
 
 next
   conu status
-  conu start     reserved for Phase 4",
+  conu start",
         report.node.node_id,
         report.node.display_name,
         report.paths.home.display(),
@@ -323,7 +423,7 @@ next
     )
 }
 
-fn render_status_text(snapshot: &StateSnapshot) -> String {
+fn render_status_text(snapshot: &StateSnapshot, runtime_status: &RuntimeStatus) -> String {
     let node = snapshot
         .node
         .as_ref()
@@ -339,8 +439,10 @@ fn render_status_text(snapshot: &StateSnapshot) -> String {
         r"conU status
 
 runtime
-  conUD         offline
-  local IPC     not available until Phase 4
+  conUD         {}
+  pid           {}
+  health        {}
+  local IPC     reserved for Phase 5
   relay         not available until Phase 8
 
 identity
@@ -358,6 +460,9 @@ agents
 
 privacy
   payload view  contents are not displayed by conU",
+        runtime_state_label(runtime_status),
+        runtime_pid_label(runtime_status),
+        runtime_health_label(runtime_status),
         initialization_label(snapshot),
         node,
         display_name,
@@ -368,7 +473,7 @@ privacy
     )
 }
 
-fn render_status_json(snapshot: &StateSnapshot) -> String {
+fn render_status_json(snapshot: &StateSnapshot, runtime_status: &RuntimeStatus) -> String {
     let node = snapshot
         .node
         .as_ref()
@@ -383,8 +488,11 @@ fn render_status_json(snapshot: &StateSnapshot) -> String {
     format!(
         r#"{{
   "runtime": {{
-    "conud": "offline",
-    "localIpc": "phase_4",
+    "conud": "{}",
+    "pid": {},
+    "heartbeatAgeSecs": {},
+    "localHealth": "{}",
+    "localIpc": "phase_5",
     "relay": "phase_8"
   }},
   "identity": {{
@@ -404,6 +512,10 @@ fn render_status_json(snapshot: &StateSnapshot) -> String {
     "contentsDisplayed": false
   }}
 }}"#,
+        runtime_status.state.as_str(),
+        json_u32(runtime_status.pid),
+        json_u64(runtime_status.heartbeat_age_secs()),
+        json_escape(runtime_health_label(runtime_status)),
         initialization_label(snapshot),
         json_escape(node),
         json_escape(display_name),
@@ -427,12 +539,88 @@ Usage:
   conu join <code> [--json]
   conu connect
   conu watch
+  conu start [--json]
+  conu stop [--json]
   conu components
   conu --help
   conu --version
 
-Phase 3 adds local identity and persistent state. Daemon IPC, pairing, relay, and streaming arrive in later phases."
+Phase 4 adds the conUD daemon skeleton and local runtime heartbeat. Agent IPC, pairing, relay, and streaming arrive in later phases."
         .to_string()
+}
+
+fn render_start_report(status: &RuntimeStatus, launched: bool, json: bool) -> String {
+    if json {
+        return format!(
+            r#"{{
+  "status": "{}",
+  "launched": {},
+  "pid": {},
+  "health": "{}",
+  "contentsDisplayed": false
+}}"#,
+            status.state.as_str(),
+            launched,
+            json_u32(status.pid),
+            json_escape(runtime_health_label(status))
+        );
+    }
+
+    let action = if launched {
+        "launched"
+    } else {
+        "already running"
+    };
+
+    format!(
+        r"conU start
+
+status: {action}
+conUD: {}
+pid: {}
+health: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        runtime_state_label(status),
+        runtime_pid_label(status),
+        runtime_health_label(status)
+    )
+}
+
+fn render_stop_report(report: &StopReport, json: bool) -> String {
+    if json {
+        return format!(
+            r#"{{
+  "requested": {},
+  "status": "{}",
+  "pid": {},
+  "contentsDisplayed": false
+}}"#,
+            report.requested,
+            report.status.state.as_str(),
+            json_u32(report.status.pid)
+        );
+    }
+
+    let action = if report.requested {
+        "stop requested"
+    } else {
+        "not running"
+    };
+
+    format!(
+        r"conU stop
+
+status: {action}
+conUD: {}
+pid: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        runtime_state_label(&report.status),
+        runtime_pid_label(&report.status)
+    )
 }
 
 fn initialization_label(snapshot: &StateSnapshot) -> &'static str {
@@ -449,6 +637,63 @@ fn ready_label(is_ready: bool) -> &'static str {
 
 fn created_label(created: bool) -> &'static str {
     if created { "created" } else { "kept" }
+}
+
+fn runtime_state_label(status: &RuntimeStatus) -> &'static str {
+    match status.state {
+        RuntimeState::Offline => "offline",
+        RuntimeState::Starting => "starting",
+        RuntimeState::Running => "running",
+        RuntimeState::Stopping => "stopping",
+        RuntimeState::Stopped => "stopped",
+        RuntimeState::Stale => "stale",
+    }
+}
+
+fn runtime_health_label(status: &RuntimeStatus) -> &'static str {
+    match status.state {
+        RuntimeState::Starting | RuntimeState::Running | RuntimeState::Stopping => {
+            "file heartbeat ok"
+        }
+        RuntimeState::Stale => "stale heartbeat",
+        RuntimeState::Offline | RuntimeState::Stopped => "offline",
+    }
+}
+
+fn runtime_pid_label(status: &RuntimeStatus) -> String {
+    status
+        .pid
+        .map(|pid| pid.to_string())
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn json_u32(value: Option<u32>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn json_u64(value: Option<u64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn resolve_conud_executable() -> PathBuf {
+    if let Ok(value) = env::var("CONUD_EXE") {
+        if !value.trim().is_empty() {
+            return PathBuf::from(value);
+        }
+    }
+
+    if let Ok(mut path) = env::current_exe() {
+        path.set_file_name(format!("conud{}", env::consts::EXE_SUFFIX));
+        if path.exists() {
+            return path;
+        }
+    }
+
+    PathBuf::from(format!("conud{}", env::consts::EXE_SUFFIX))
 }
 
 fn json_escape(value: &str) -> String {
@@ -529,10 +774,12 @@ mod tests {
     }
 
     #[test]
-    fn phase_three_commands_are_registered() {
+    fn phase_four_commands_are_registered() {
         let home = temp_home("commands");
 
-        for command in ["init", "status", "agents", "pair", "connect", "watch"] {
+        for command in [
+            "init", "status", "agents", "pair", "connect", "watch", "stop",
+        ] {
             let output = run_with_home([command], Some(home.clone()));
             assert_eq!(output.code, 0, "{command} failed: {}", output.stderr);
         }
@@ -554,6 +801,42 @@ mod tests {
         assert_eq!(status.code, 0, "{}", status.stderr);
         assert!(status.stdout.contains("state         initialized"));
         assert!(status.stdout.contains("trust store   ready"));
+    }
+
+    #[test]
+    fn status_detects_runtime_heartbeat() {
+        let home = temp_home("status-runtime");
+        let _lease = runtime::acquire_runtime(Some(home.clone())).expect("runtime starts");
+
+        let status = run_with_home(["status"], Some(home));
+
+        assert_eq!(status.code, 0, "{}", status.stderr);
+        assert!(status.stdout.contains("conUD         running"));
+        assert!(status.stdout.contains("health        file heartbeat ok"));
+    }
+
+    #[test]
+    fn start_reports_already_running_without_spawning() {
+        let home = temp_home("start-running");
+        let _lease = runtime::acquire_runtime(Some(home.clone())).expect("runtime starts");
+
+        let start = run_with_home(["start"], Some(home));
+
+        assert_eq!(start.code, 0, "{}", start.stderr);
+        assert!(start.stdout.contains("status: already running"));
+    }
+
+    #[test]
+    fn stop_requests_running_runtime() {
+        let home = temp_home("stop-running");
+        let _lease = runtime::acquire_runtime(Some(home.clone())).expect("runtime starts");
+        let stop_path = state::StatePaths::from_home(home.clone()).runtime_stop_request;
+
+        let stop = run_with_home(["stop"], Some(home));
+
+        assert_eq!(stop.code, 0, "{}", stop.stderr);
+        assert!(stop.stdout.contains("status: stop requested"));
+        assert!(stop_path.exists());
     }
 
     #[test]
@@ -580,6 +863,7 @@ mod tests {
 
         assert_eq!(output.code, 0);
         assert!(output.stdout.contains("\"conud\": \"offline\""));
+        assert!(output.stdout.contains("\"localIpc\": \"phase_5\""));
         assert!(output.stdout.contains("\"state\": \"initialized\""));
         assert!(output.stdout.contains("\"node\": \"node_"));
         assert!(output.stdout.contains("\"contentsDisplayed\": false"));

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Core conU runtime concepts shared by binaries.
 
+pub mod runtime;
 pub mod state;
 
 /// The product invariant every crate should preserve.

--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -1,0 +1,595 @@
+//! Local conUD runtime state and heartbeat management.
+//!
+//! Phase 4 uses a file-backed health signal so the CLI can detect a local
+//! runtime without introducing IPC or networking before their dedicated phases.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::state::{self, NodeIdentity, StateError, StatePaths};
+
+const STATUS_VERSION: &str = "1";
+const STALE_AFTER_SECS: u64 = 10;
+const LOCAL_ENDPOINT: &str = "local-ipc:phase-5-pending";
+
+/// High-level state for the local conUD runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeState {
+    Offline,
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+    Stale,
+}
+
+impl RuntimeState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Offline => "offline",
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Stopping => "stopping",
+            Self::Stopped => "stopped",
+            Self::Stale => "stale",
+        }
+    }
+
+    fn from_str(value: &str) -> Self {
+        match value {
+            "starting" => Self::Starting,
+            "running" => Self::Running,
+            "stopping" => Self::Stopping,
+            "stopped" => Self::Stopped,
+            "stale" => Self::Stale,
+            _ => Self::Offline,
+        }
+    }
+
+    pub const fn is_live(self) -> bool {
+        matches!(self, Self::Starting | Self::Running | Self::Stopping)
+    }
+}
+
+/// Runtime metadata visible to the CLI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeStatus {
+    pub state: RuntimeState,
+    pub pid: Option<u32>,
+    pub node_id: Option<String>,
+    pub started_at_unix: Option<u64>,
+    pub heartbeat_at_unix: Option<u64>,
+    pub local_endpoint: String,
+    pub status_path: PathBuf,
+    pub lock_path: PathBuf,
+}
+
+impl RuntimeStatus {
+    /// True when the runtime heartbeat is fresh enough to treat as alive.
+    pub fn is_live(&self) -> bool {
+        self.state.is_live()
+    }
+
+    /// Seconds since the latest heartbeat, if a heartbeat exists.
+    pub fn heartbeat_age_secs(&self) -> Option<u64> {
+        self.heartbeat_at_unix
+            .map(|heartbeat| current_unix_seconds().saturating_sub(heartbeat))
+    }
+}
+
+/// Result of asking conUD to stop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StopReport {
+    pub requested: bool,
+    pub status: RuntimeStatus,
+}
+
+/// An acquired local runtime slot.
+#[derive(Debug)]
+pub struct RuntimeLease {
+    paths: StatePaths,
+    node: NodeIdentity,
+    pid: u32,
+    started_at_unix: u64,
+    stopped: bool,
+}
+
+impl RuntimeLease {
+    /// Return the currently known status for this runtime lease.
+    pub fn status(&self) -> RuntimeStatus {
+        self.build_status(RuntimeState::Running, current_unix_seconds())
+    }
+
+    /// Refresh the heartbeat file.
+    pub fn heartbeat(&self) -> Result<RuntimeStatus, RuntimeError> {
+        let status = self.build_status(RuntimeState::Running, current_unix_seconds());
+        write_status(&self.paths, &status)?;
+        append_log(&self.paths, "heartbeat", self.pid, &self.node.node_id)?;
+        Ok(status)
+    }
+
+    /// True when the CLI has requested a graceful shutdown.
+    pub fn stop_requested(&self) -> bool {
+        self.paths.runtime_stop_request.exists()
+    }
+
+    /// Sleep and heartbeat until a stop request appears.
+    pub fn serve_until_stop(&self, heartbeat_every: Duration) -> Result<(), RuntimeError> {
+        while !self.stop_requested() {
+            self.heartbeat()?;
+            thread::sleep(heartbeat_every);
+        }
+
+        let status = self.build_status(RuntimeState::Stopping, current_unix_seconds());
+        write_status(&self.paths, &status)?;
+        append_log(&self.paths, "stop_requested", self.pid, &self.node.node_id)?;
+        Ok(())
+    }
+
+    /// Stop this runtime and clean up the process lock.
+    pub fn stop(mut self) -> Result<RuntimeStatus, RuntimeError> {
+        self.finish()
+    }
+
+    fn build_status(&self, state: RuntimeState, heartbeat_at_unix: u64) -> RuntimeStatus {
+        RuntimeStatus {
+            state,
+            pid: Some(self.pid),
+            node_id: Some(self.node.node_id.clone()),
+            started_at_unix: Some(self.started_at_unix),
+            heartbeat_at_unix: Some(heartbeat_at_unix),
+            local_endpoint: LOCAL_ENDPOINT.to_string(),
+            status_path: self.paths.runtime_status.clone(),
+            lock_path: self.paths.runtime_lock.clone(),
+        }
+    }
+
+    fn finish(&mut self) -> Result<RuntimeStatus, RuntimeError> {
+        if self.stopped {
+            return read_runtime_from_paths(&self.paths);
+        }
+
+        let status = self.build_status(RuntimeState::Stopped, current_unix_seconds());
+        write_status(&self.paths, &status)?;
+        remove_file_if_exists(&self.paths.runtime_lock)?;
+        remove_file_if_exists(&self.paths.runtime_stop_request)?;
+        append_log(&self.paths, "stopped", self.pid, &self.node.node_id)?;
+        self.stopped = true;
+
+        Ok(status)
+    }
+}
+
+impl Drop for RuntimeLease {
+    fn drop(&mut self) {
+        let _ = self.finish();
+    }
+}
+
+/// Errors produced by the local runtime lifecycle.
+#[derive(Debug)]
+pub enum RuntimeError {
+    State(StateError),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    AlreadyRunning(RuntimeStatus),
+}
+
+impl RuntimeError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::AlreadyRunning(status) => {
+                let pid = status
+                    .pid
+                    .map(|pid| pid.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                write!(formatter, "conUD is already running with pid {pid}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RuntimeError {}
+
+impl From<StateError> for RuntimeError {
+    fn from(error: StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+/// Read the local runtime status without changing it.
+pub fn read_runtime(home_override: Option<PathBuf>) -> Result<RuntimeStatus, RuntimeError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_runtime_from_paths(&paths)
+}
+
+/// Acquire the local conUD runtime slot.
+pub fn acquire_runtime(home_override: Option<PathBuf>) -> Result<RuntimeLease, RuntimeError> {
+    let init = state::init_state(home_override)?;
+    let paths = init.paths;
+    let existing = read_runtime_from_paths(&paths)?;
+
+    if existing.is_live() {
+        return Err(RuntimeError::AlreadyRunning(existing));
+    }
+
+    if existing.state == RuntimeState::Stale || paths.runtime_lock.exists() {
+        clear_runtime_files(&paths)?;
+    }
+
+    let pid = process::id();
+    let started_at_unix = current_unix_seconds();
+    write_lock(&paths, pid, started_at_unix)?;
+    remove_file_if_exists(&paths.runtime_stop_request)?;
+
+    let lease = RuntimeLease {
+        paths,
+        node: init.node,
+        pid,
+        started_at_unix,
+        stopped: false,
+    };
+
+    let starting = lease.build_status(RuntimeState::Starting, started_at_unix);
+    write_status(&lease.paths, &starting)?;
+    append_log(&lease.paths, "started", lease.pid, &lease.node.node_id)?;
+    lease.heartbeat()?;
+
+    Ok(lease)
+}
+
+/// Ask a running local conUD process to shut down gracefully.
+pub fn request_runtime_stop(home_override: Option<PathBuf>) -> Result<StopReport, RuntimeError> {
+    let paths = StatePaths::resolve(home_override)?;
+    fs::create_dir_all(&paths.runtime_dir)
+        .map_err(|error| RuntimeError::io("create runtime directory", &paths.runtime_dir, error))?;
+
+    let status = read_runtime_from_paths(&paths)?;
+    if status.is_live() {
+        let contents = format!("requested_at_unix = {}\n", current_unix_seconds());
+        fs::write(&paths.runtime_stop_request, contents).map_err(|error| {
+            RuntimeError::io(
+                "write runtime stop request",
+                &paths.runtime_stop_request,
+                error,
+            )
+        })?;
+        append_log(
+            &paths,
+            "stop_requested_by_cli",
+            process::id(),
+            status.node_id.as_deref().unwrap_or("unknown"),
+        )?;
+        Ok(StopReport {
+            requested: true,
+            status,
+        })
+    } else if status.state == RuntimeState::Stale {
+        let stopped = RuntimeStatus {
+            state: RuntimeState::Stopped,
+            heartbeat_at_unix: Some(current_unix_seconds()),
+            ..status
+        };
+        clear_runtime_files(&paths)?;
+        write_status(&paths, &stopped)?;
+        Ok(StopReport {
+            requested: false,
+            status: stopped,
+        })
+    } else {
+        Ok(StopReport {
+            requested: false,
+            status,
+        })
+    }
+}
+
+fn read_runtime_from_paths(paths: &StatePaths) -> Result<RuntimeStatus, RuntimeError> {
+    if !paths.runtime_status.exists() {
+        return Ok(offline_status(paths));
+    }
+
+    let contents = fs::read_to_string(&paths.runtime_status)
+        .map_err(|error| RuntimeError::io("read runtime status", &paths.runtime_status, error))?;
+    let values = parse_key_values(&contents);
+    let mut status = RuntimeStatus {
+        state: RuntimeState::from_str(value_or_empty(&values, "state")),
+        pid: parse_u32(values.get("pid")),
+        node_id: values
+            .get("node_id")
+            .cloned()
+            .filter(|value| !value.is_empty()),
+        started_at_unix: parse_u64(values.get("started_at_unix")),
+        heartbeat_at_unix: parse_u64(values.get("heartbeat_at_unix")),
+        local_endpoint: values
+            .get("local_endpoint")
+            .cloned()
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| LOCAL_ENDPOINT.to_string()),
+        status_path: paths.runtime_status.clone(),
+        lock_path: paths.runtime_lock.clone(),
+    };
+
+    if status.state.is_live() && runtime_is_stale(&status) {
+        status.state = RuntimeState::Stale;
+    }
+
+    Ok(status)
+}
+
+fn write_status(paths: &StatePaths, status: &RuntimeStatus) -> Result<(), RuntimeError> {
+    let contents = format!(
+        "version = \"{}\"\nstate = \"{}\"\npid = {}\nnode_id = \"{}\"\nstarted_at_unix = {}\nheartbeat_at_unix = {}\nlocal_endpoint = \"{}\"\n",
+        STATUS_VERSION,
+        status.state.as_str(),
+        status.pid.unwrap_or_default(),
+        escape_file_value(status.node_id.as_deref().unwrap_or("")),
+        status.started_at_unix.unwrap_or_default(),
+        status.heartbeat_at_unix.unwrap_or_default(),
+        escape_file_value(&status.local_endpoint)
+    );
+
+    fs::write(&paths.runtime_status, contents)
+        .map_err(|error| RuntimeError::io("write runtime status", &paths.runtime_status, error))
+}
+
+fn write_lock(paths: &StatePaths, pid: u32, started_at_unix: u64) -> Result<(), RuntimeError> {
+    let contents = format!("pid = {pid}\nstarted_at_unix = {started_at_unix}\n");
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&paths.runtime_lock)
+        .map_err(|error| RuntimeError::io("create runtime lock", &paths.runtime_lock, error))?;
+
+    file.write_all(contents.as_bytes())
+        .map_err(|error| RuntimeError::io("write runtime lock", &paths.runtime_lock, error))
+}
+
+fn append_log(
+    paths: &StatePaths,
+    event: &str,
+    pid: u32,
+    node_id: &str,
+) -> Result<(), RuntimeError> {
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| RuntimeError::io("create log directory", &paths.logs_dir, error))?;
+    let log_path = paths.logs_dir.join("conud.log");
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&log_path)
+        .map_err(|error| RuntimeError::io("open runtime log", &log_path, error))?;
+
+    writeln!(
+        file,
+        "time={} event={} pid={} node={} payload=not_observed",
+        current_unix_seconds(),
+        event,
+        pid,
+        sanitize_log_value(node_id)
+    )
+    .map_err(|error| RuntimeError::io("write runtime log", &log_path, error))
+}
+
+fn runtime_is_stale(status: &RuntimeStatus) -> bool {
+    let Some(heartbeat_at_unix) = status.heartbeat_at_unix else {
+        return true;
+    };
+
+    current_unix_seconds().saturating_sub(heartbeat_at_unix) > STALE_AFTER_SECS
+}
+
+fn offline_status(paths: &StatePaths) -> RuntimeStatus {
+    RuntimeStatus {
+        state: RuntimeState::Offline,
+        pid: None,
+        node_id: None,
+        started_at_unix: None,
+        heartbeat_at_unix: None,
+        local_endpoint: LOCAL_ENDPOINT.to_string(),
+        status_path: paths.runtime_status.clone(),
+        lock_path: paths.runtime_lock.clone(),
+    }
+}
+
+fn clear_runtime_files(paths: &StatePaths) -> Result<(), RuntimeError> {
+    remove_file_if_exists(&paths.runtime_lock)?;
+    remove_file_if_exists(&paths.runtime_stop_request)
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<(), RuntimeError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(RuntimeError::io("remove runtime file", path, error)),
+    }
+}
+
+fn parse_key_values(contents: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        values.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    values
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn value_or_empty<'a>(values: &'a HashMap<String, String>, key: &str) -> &'a str {
+    values.get(key).map(String::as_str).unwrap_or("")
+}
+
+fn parse_u32(value: Option<&String>) -> Option<u32> {
+    value.and_then(|value| value.parse::<u32>().ok())
+}
+
+fn parse_u64(value: Option<&String>) -> Option<u64> {
+    value.and_then(|value| value.parse::<u64>().ok())
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn sanitize_log_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+        .collect()
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acquire_runtime_writes_live_status() {
+        let home = test_home("live");
+        let lease = acquire_runtime(Some(home.clone())).expect("runtime starts");
+        let status = read_runtime(Some(home)).expect("runtime reads");
+
+        assert!(status.is_live());
+        assert_eq!(status.state, RuntimeState::Running);
+        assert_eq!(status.pid, Some(process::id()));
+        assert_eq!(status.node_id, Some(lease.node.node_id.clone()));
+    }
+
+    #[test]
+    fn second_runtime_cannot_start_while_heartbeat_is_fresh() {
+        let home = test_home("already-running");
+        let _lease = acquire_runtime(Some(home.clone())).expect("runtime starts");
+        let error = acquire_runtime(Some(home)).expect_err("second runtime should fail");
+
+        assert!(matches!(error, RuntimeError::AlreadyRunning(_)));
+    }
+
+    #[test]
+    fn stop_request_creates_payload_safe_control_file() {
+        let home = test_home("stop-request");
+        let _lease = acquire_runtime(Some(home.clone())).expect("runtime starts");
+        let report = request_runtime_stop(Some(home.clone())).expect("stop requested");
+        let request = fs::read_to_string(StatePaths::from_home(home).runtime_stop_request)
+            .expect("stop request exists");
+
+        assert!(report.requested);
+        assert!(request.contains("requested_at_unix"));
+        assert!(!request.contains("private message contents"));
+    }
+
+    #[test]
+    fn runtime_log_is_payload_safe() {
+        let home = test_home("payload-safe-log");
+        let lease = acquire_runtime(Some(home.clone())).expect("runtime starts");
+        lease.heartbeat().expect("heartbeat writes");
+        let log = fs::read_to_string(StatePaths::from_home(home).logs_dir.join("conud.log"))
+            .expect("runtime log exists");
+
+        assert!(log.contains("payload=not_observed"));
+        assert!(!log.contains("private message contents"));
+        assert!(!log.contains("Review this code"));
+    }
+
+    #[test]
+    fn stopped_runtime_removes_lock() {
+        let home = test_home("stopped");
+        let lease = acquire_runtime(Some(home.clone())).expect("runtime starts");
+        let paths = StatePaths::from_home(home.clone());
+        let status = lease.stop().expect("runtime stops");
+        let read_back = read_runtime(Some(home)).expect("runtime reads");
+
+        assert_eq!(status.state, RuntimeState::Stopped);
+        assert_eq!(read_back.state, RuntimeState::Stopped);
+        assert!(!paths.runtime_lock.exists());
+    }
+
+    #[test]
+    fn stale_runtime_is_replaced_on_start() {
+        let home = test_home("stale");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let paths = init.paths;
+        fs::write(&paths.runtime_lock, "pid = 123\n").expect("stale lock writes");
+        let stale_status = RuntimeStatus {
+            state: RuntimeState::Running,
+            pid: Some(123),
+            node_id: Some(init.node.node_id),
+            started_at_unix: Some(1),
+            heartbeat_at_unix: Some(1),
+            local_endpoint: LOCAL_ENDPOINT.to_string(),
+            status_path: paths.runtime_status.clone(),
+            lock_path: paths.runtime_lock.clone(),
+        };
+        write_status(&paths, &stale_status).expect("stale status writes");
+
+        let lease = acquire_runtime(Some(home.clone())).expect("runtime replaces stale state");
+        let status = read_runtime(Some(home)).expect("runtime reads");
+
+        assert_eq!(status.state, RuntimeState::Running);
+        assert_eq!(status.pid, Some(process::id()));
+        assert_eq!(status.node_id, Some(lease.node.node_id.clone()));
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "conu-runtime-test-{label}-{}-{}",
+            process::id(),
+            current_unix_nanos()
+        ))
+    }
+}
+
+#[cfg(test)]
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -1,8 +1,8 @@
 //! Local persistent state for conU.
 //!
-//! Phase 3 keeps this intentionally small and std-only: a locally generated
-//! node id, config, trust store skeleton, and agent registry skeleton. Secret
-//! keys and encrypted payload storage belong to later phases.
+//! Phase 4 keeps this intentionally small and std-only: a locally generated
+//! node id, config, trust store skeleton, agent registry skeleton, and runtime
+//! metadata. Secret keys and encrypted payload storage belong to later phases.
 
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -22,6 +22,7 @@ const CONFIG_FILE: &str = "config.toml";
 const TRUST_FILE: &str = "trust.toml";
 const AGENTS_DIR: &str = "agents";
 const AGENT_REGISTRY_FILE: &str = "registry.toml";
+const RUNTIME_DIR: &str = "runtime";
 const SESSIONS_DIR: &str = "sessions";
 const MAILBOX_DIR: &str = "mailbox";
 const LOGS_DIR: &str = "logs";
@@ -35,6 +36,10 @@ pub struct StatePaths {
     pub trust_store: PathBuf,
     pub agents_dir: PathBuf,
     pub agent_registry: PathBuf,
+    pub runtime_dir: PathBuf,
+    pub runtime_status: PathBuf,
+    pub runtime_lock: PathBuf,
+    pub runtime_stop_request: PathBuf,
     pub sessions_dir: PathBuf,
     pub mailbox_dir: PathBuf,
     pub logs_dir: PathBuf,
@@ -54,6 +59,7 @@ impl StatePaths {
     /// Build state paths from an already resolved home directory.
     pub fn from_home(home: PathBuf) -> Self {
         let agents_dir = home.join(AGENTS_DIR);
+        let runtime_dir = home.join(RUNTIME_DIR);
 
         Self {
             node_identity: home.join(NODE_FILE),
@@ -61,6 +67,10 @@ impl StatePaths {
             trust_store: home.join(TRUST_FILE),
             agent_registry: agents_dir.join(AGENT_REGISTRY_FILE),
             agents_dir,
+            runtime_status: runtime_dir.join("status.toml"),
+            runtime_lock: runtime_dir.join("conud.lock"),
+            runtime_stop_request: runtime_dir.join("stop.request"),
+            runtime_dir,
             sessions_dir: home.join(SESSIONS_DIR),
             mailbox_dir: home.join(MAILBOX_DIR),
             logs_dir: home.join(LOGS_DIR),
@@ -223,6 +233,7 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
     for directory in [
         &paths.home,
         &paths.agents_dir,
+        &paths.runtime_dir,
         &paths.sessions_dir,
         &paths.mailbox_dir,
         &paths.logs_dir,
@@ -450,6 +461,7 @@ mod tests {
         assert!(home.join(CONFIG_FILE).exists());
         assert!(home.join(TRUST_FILE).exists());
         assert!(home.join(AGENTS_DIR).join(AGENT_REGISTRY_FILE).exists());
+        assert!(home.join(RUNTIME_DIR).exists());
     }
 
     #[test]

--- a/crates/conud/src/main.rs
+++ b/crates/conud/src/main.rs
@@ -1,13 +1,17 @@
 use std::env;
 use std::process::ExitCode;
+use std::time::Duration;
 
 fn main() -> ExitCode {
     let mut args = env::args().skip(1);
     match args.next().as_deref() {
         Some("--check") => {
-            println!("{}", conu_core::scaffold_status("conud"));
+            print_check();
             ExitCode::SUCCESS
         }
+        Some("--serve") | None => serve_runtime(),
+        Some("--once") => run_once(),
+        Some("--status") => print_status(),
         Some("--help") | Some("-h") => {
             print_help();
             ExitCode::SUCCESS
@@ -21,20 +25,111 @@ fn main() -> ExitCode {
             print_help();
             ExitCode::from(2)
         }
-        None => {
-            println!("conUD scaffold ready. Local IPC arrives in Phase 4.");
+    }
+}
+
+fn serve_runtime() -> ExitCode {
+    match conu_core::runtime::acquire_runtime(None) {
+        Ok(lease) => {
+            let status = lease.status();
+            println!(
+                "conUD runtime live; pid {}; health {}; payloads not observed",
+                status
+                    .pid
+                    .map(|pid| pid.to_string())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                status.local_endpoint
+            );
+
+            match lease.serve_until_stop(Duration::from_secs(1)) {
+                Ok(()) => match lease.stop() {
+                    Ok(_) => ExitCode::SUCCESS,
+                    Err(error) => {
+                        eprintln!("conUD shutdown failed: {error}");
+                        ExitCode::from(1)
+                    }
+                },
+                Err(error) => {
+                    eprintln!("conUD runtime failed: {error}");
+                    ExitCode::from(1)
+                }
+            }
+        }
+        Err(conu_core::runtime::RuntimeError::AlreadyRunning(status)) => {
+            println!(
+                "conUD already running; pid {}; payloads not observed",
+                status
+                    .pid
+                    .map(|pid| pid.to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+            );
             ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("conUD start failed: {error}");
+            ExitCode::from(1)
         }
     }
 }
 
+fn run_once() -> ExitCode {
+    match conu_core::runtime::acquire_runtime(None) {
+        Ok(lease) => match lease.heartbeat().and_then(|_| lease.stop()) {
+            Ok(status) => {
+                println!(
+                    "conUD one-shot completed; state {}; payloads not observed",
+                    status.state.as_str()
+                );
+                ExitCode::SUCCESS
+            }
+            Err(error) => {
+                eprintln!("conUD one-shot failed: {error}");
+                ExitCode::from(1)
+            }
+        },
+        Err(error) => {
+            eprintln!("conUD one-shot failed: {error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn print_status() -> ExitCode {
+    match conu_core::runtime::read_runtime(None) {
+        Ok(status) => {
+            println!(
+                "conUD status: {}; pid {}; health {}; payloads not observed",
+                status.state.as_str(),
+                status
+                    .pid
+                    .map(|pid| pid.to_string())
+                    .unwrap_or_else(|| "n/a".to_string()),
+                status.local_endpoint
+            );
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("conUD status failed: {error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn print_check() {
+    println!("{}", conu_core::scaffold_status("conud"));
+    println!("runtime: phase 4 heartbeat skeleton ready; payloads not observed");
+}
+
 fn print_help() {
     println!(
-        r"conud - conU local runtime daemon scaffold
+        r"conud - conU local runtime daemon
 
 Usage:
   conud
+  conud --serve
+  conud --once
   conud --check
+  conud --status
   conud --help
   conud --version"
     );

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 4 - conUD Daemon Skeleton
+Current phase: Phase 5 - Local IPC And Agent Registration
 Status: not_started
 Last updated: 2026-05-10
 ```
@@ -310,7 +310,7 @@ Next:
 
 ## Phase 4 - conUD Daemon Skeleton
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -326,9 +326,63 @@ Deliverables:
 
 Exit criteria:
 
-- `conu start` launches runtime.
-- `conu status` detects runtime.
-- Runtime can restart cleanly.
+- [x] `conu start` launches runtime.
+- [x] `conu status` detects runtime.
+- [x] Runtime can restart cleanly.
+
+Completed work:
+
+- Created GitHub issue #7 for Phase 4.
+- Created and pushed branch `codex/phase-4-conud-daemon`.
+- Added std-only `conu_core::runtime` lifecycle module.
+- Added runtime heartbeat/status metadata under `runtime/status.toml`.
+- Added local process lock handling with stale heartbeat replacement.
+- Added graceful shutdown request handling through `runtime/stop.request`.
+- Added payload-safe runtime log lines under `logs/conud.log`.
+- Updated `conud` with `--serve`, `--once`, `--status`, and enhanced `--check`.
+- Wired `conu start` to launch `conud --serve`.
+- Added `conu stop` for graceful shutdown.
+- Updated `conu status`, `conu status --json`, and dashboard output to detect local runtime state.
+- Added tests for runtime acquire, already-running guard, stop request, stopped cleanup, stale replacement, CLI runtime status, start already-running path, and stop request path.
+- Updated README, repo overview, and implementation guardrails.
+
+Files changed:
+
+- `README.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `plan.md`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-core/src/runtime.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conud/src/main.rs`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu build -p conud -p conu-cli` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- init` passed with isolated `CONU_HOME`.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- start` launched `conud --serve` with isolated `CONU_HOME` and `CONUD_EXE`.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- status` detected the running daemon.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- status --json` reported running runtime metadata.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-cli -- stop` requested graceful shutdown and observed stopped state.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conud -- --once` passed.
+- Smoke log review confirmed only metadata lines with `payload=not_observed`.
+
+Known gaps:
+
+- Phase 4 health is file-backed heartbeat metadata, not real IPC.
+- `conu start` needs an installed/sibling `conud` binary or `CONUD_EXE` in development.
+- There is no local agent registration yet; that remains Phase 5.
+- There is no message routing, transport encryption session, relay, or remote discovery yet.
+- Runtime logs are std-only text metadata and do not yet have rotation or structured logging.
+
+Next:
+
+- Start Phase 5: local IPC transport and agent registration with payload-safe agent registry updates.
 
 ## Phase 5 - Local IPC And Agent Registration
 
@@ -581,4 +635,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 1 completed. Rust workspace scaffold created and validated with cargo fmt/check/test plus binary smoke commands using stable-x86_64-pc-windows-gnu. Next: Phase 2 CLI identity and dashboard.
 2026-05-10 - Phase 2 completed. CLI dashboard and command shell created with payload-safe outputs, tests, and smoke validation. Next: Phase 3 local identity and persistent state.
 2026-05-10 - Phase 3 completed. Local identity and persistent state added with idempotent init, status reads, tests, and isolated CONU_HOME smoke validation. Next: Phase 4 conUD daemon skeleton.
+2026-05-10 - Phase 4 completed. conUD daemon skeleton added with start/stop, runtime heartbeat status, stale restart handling, payload-safe logs, tests, and isolated CONU_HOME process smoke. Next: Phase 5 local IPC and agent registration.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- Add std-only conu_core::runtime lifecycle and heartbeat state.
- Add conud --serve, --once, --status, and enhanced --check.
- Wire conu start, conu stop, dashboard, and conu status to local runtime state.
- Update README, repo memory, guardrails, and plan.md for Phase 4 completion.

## Privacy / security
- Runtime files contain process/heartbeat metadata only.
- Runtime logs use metadata-only lines and explicitly record payload=not_observed.
- No payloads are read, logged, displayed, routed, or stored.
- No agent discovery/messaging permissions are introduced in this phase.

## Validation
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu test --workspace
- cargo +stable-x86_64-pc-windows-gnu build -p conud -p conu-cli
- isolated CONU_HOME + CONUD_EXE smoke: init, start, status --json, stop, status, conud --once
- smoke log review confirmed metadata-only payload=not_observed entries

Closes #7


___

## **CodeAnt-AI Description**
**Add local runtime start/stop support and runtime-aware status**

### What Changed
- `conu start` now launches the local `conud` runtime and reports whether it was started or was already running.
- `conu stop` now requests a graceful shutdown and waits for the runtime to reach a stopped state.
- `conu status`, the dashboard, and `conu status --json` now show runtime state, process id, and heartbeat health instead of always showing the runtime as offline.
- `conud` now supports `--serve`, `--once`, `--status`, and a richer `--check` output for local runtime checks.
- Runtime state is stored in local metadata files, and logs stay payload-free with `payload=not_observed`.

### Impact
`✅ Start and stop the local runtime from the CLI`
`✅ Clearer runtime status in the dashboard and status view`
`✅ Fewer failed restarts from stale runtime files`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=S18kL18iKN3D0eD-PINfT5cqqlhihG0asIwsmRmPiPQ&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
