### PR TITLE
Phase 5: Local agent gateway

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 4.
+The repository has completed Phase 5.
 
 Implemented so far:
 
@@ -17,7 +17,12 @@ Implemented so far:
 - local config, trust store skeleton, and agent registry skeleton
 - conUD runtime heartbeat/status skeleton
 - `conu start`, `conu stop`, and runtime-aware `conu status`
+- file-backed local IPC gateway under `runtime/ipc/`
+- local agent registration through `conu agents register`
+- local presence heartbeat through `conu agents heartbeat`
+- persisted local agent registry with capability metadata
 - payload-safe status and agent registry reporting
+- payload-safe runtime and agent metadata logs
 - payload-safe protocol scaffold
 - daemon and relay placeholder binaries
 

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -45,6 +45,36 @@ conUD handles:
 - delivery receipts
 - relay fallback
 
+## Phase 5 Implemented Surface
+
+The current local gateway is a file-backed, metadata-only IPC path:
+
+```txt
+runtime/ipc/inbox       submitted requests
+runtime/ipc/processed   accepted requests
+runtime/ipc/rejected    rejected requests and safe reasons
+agents/registry.toml    persisted local agent cards
+logs/agents.log         metadata-only agent events
+```
+
+Supported commands:
+
+```txt
+conu agents register <agent-id> <display-name> [--kind <kind>] [--json]
+conu agents heartbeat <agent-id> [--presence <ready|busy|idle|offline>] [--json]
+conu agents [--json]
+conud --process-ipc
+```
+
+Supported request types:
+
+```txt
+register_agent
+presence_heartbeat
+```
+
+This phase intentionally does not expose `send`, `receive`, streams, rooms, relay discovery, or payload storage. Those start in later phases.
+
 ## Safety
 
 "Full access" means full communication access inside trust boundaries. It does not mean raw filesystem, shell, network, or secret access.

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -45,6 +45,16 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Treat stale heartbeats as restartable runtime metadata, not proof of a live process.
 - Runtime logs must remain payload-safe and use metadata-only lines such as event, pid, node id, and `payload=not_observed`.
 
+## Local Agent Gateway Rules
+
+- Phase 5 local gateway is file-backed and metadata-only: `runtime/ipc/inbox`, `runtime/ipc/processed`, and `runtime/ipc/rejected`.
+- Accepted Phase 5 request types are only `register_agent` and `presence_heartbeat`.
+- Registration may store agent id, display name, kind, node id, presence, last seen time, and capability booleans.
+- Presence heartbeat may update only an already registered local agent.
+- Rejected requests must not echo arbitrary request contents into CLI output, logs, tests, or `.error` files.
+- Agent logs must use metadata-only lines such as event, agent id, and `payload=not_observed`.
+- Do not add message send/receive, payload storage, remote discovery, or relay behavior to the gateway until the relevant later phase.
+
 ## Privacy Rules
 
 - Never log plaintext payloads.

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -13,17 +13,17 @@ plan.md
   future-agent memory, rules, and skills
 ```
 
-## Future Rust Workspace
+## Rust Workspace
 
 ```txt
 crates/conu-cli
   CLI commands, ASCII dashboard, watch animation, user control flow
 
 crates/conud
-  daemon process, local IPC server, session manager, runtime lifecycle
+  daemon process, local gateway processing, session manager, runtime lifecycle
 
 crates/conu-core
-  identity, trust store, route manager, policy engine, shared runtime logic
+  local state, runtime lifecycle, agent registry, gateway processing, future trust/policy logic
 
 crates/conu-protocol
   envelopes, agent cards, control-plane messages, data-plane messages

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 4 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, and `conu start` launches the local `conUD` runtime skeleton.
+Phase 5 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, and local agents can register metadata and presence through the file-backed gateway.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -42,12 +42,35 @@ agents/registry.toml   local agent registry skeleton
 runtime/status.toml    conUD heartbeat/status metadata
 runtime/conud.lock     local runtime process lock
 runtime/stop.request   graceful shutdown request file
+runtime/ipc/inbox/     metadata-only agent gateway requests
+runtime/ipc/processed/ processed gateway requests
+runtime/ipc/rejected/  rejected gateway requests and safe reasons
 sessions/              future runtime sessions
 mailbox/               future encrypted mailbox storage
-logs/                  future payload-safe logs
+logs/conud.log         runtime metadata log
+logs/agents.log        local agent metadata log
 ```
 
-No private message payloads or secret keys are stored by Phase 4. Runtime logs contain metadata only, such as event name, pid, node id, and `payload=not_observed`.
+No private message payloads or secret keys are stored by Phase 5. Runtime and agent logs contain metadata only, such as event name, pid, node id, agent id, and `payload=not_observed`.
+
+## Local Agent Gateway
+
+Phase 5 exposes a local, metadata-only gateway for agent registration and presence:
+
+```bash
+conu agents register agent.codex "Codex Desktop" --kind coding-agent
+conu agents heartbeat agent.codex --presence busy
+conu agents
+conu agents --json
+```
+
+When `conUD` is running, it processes pending requests from `runtime/ipc/inbox/` and moves them to `processed/` or `rejected/`. Without a running daemon, requests remain queued and can be processed manually:
+
+```bash
+conud --process-ipc
+```
+
+This gateway does not send or receive message payloads yet. Opaque local messaging starts in Phase 6.
 
 ## Development
 
@@ -72,6 +95,9 @@ cargo run -p conu-cli -- init
 cargo run -p conu-cli -- status
 cargo run -p conu-cli -- status --json
 cargo run -p conu-cli -- agents
+cargo run -p conu-cli -- agents --json
+cargo run -p conu-cli -- agents register agent.codex "Codex Desktop" --kind coding-agent
+cargo run -p conu-cli -- agents heartbeat agent.codex --presence busy
 cargo run -p conu-cli -- pair
 cargo run -p conu-cli -- join 482913
 cargo run -p conu-cli -- connect
@@ -80,6 +106,7 @@ cargo run -p conu-cli -- start
 cargo run -p conu-cli -- stop
 cargo run -p conud -- --check
 cargo run -p conud -- --once
+cargo run -p conud -- --process-ipc
 cargo run -p conu-relay -- --check
 ```
 

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -1,7 +1,7 @@
 //! CLI rendering and command dispatch for conU.
 //!
-//! Phase 4 adds local persistent identity, state, and conUD runtime detection
-//! while keeping IPC, relay, and messaging features as honest previews.
+//! Phase 5 adds conUD runtime detection and metadata-only local agent
+//! registration.
 
 use std::env;
 use std::path::PathBuf;
@@ -9,6 +9,9 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
+use conu_core::agents::{
+    self, AgentPresence, AgentRegistration, LocalAgentRecord, PresenceHeartbeat,
+};
 use conu_core::runtime::{self, RuntimeState, RuntimeStatus, StopReport};
 use conu_core::state::{self, InitReport, StateSnapshot};
 
@@ -67,7 +70,7 @@ where
         "agents" | "peers" => render_agents(&args[1..], home_override),
         "pair" => render_pair(&args[1..]),
         "join" => render_join(&args[1..]),
-        "connect" => render_connect(&args[1..]),
+        "connect" => render_connect(&args[1..], home_override),
         "watch" => render_watch(&args[1..]),
         "components" => render_components(&args[1..]),
         "start" => render_start(&args[1..], home_override),
@@ -83,7 +86,10 @@ where
 
 fn render_dashboard(home_override: Option<PathBuf>) -> String {
     let snapshot = state::read_state(home_override.clone()).ok();
-    let runtime_status = runtime::read_runtime(home_override).ok();
+    let runtime_status = runtime::read_runtime(home_override.clone()).ok();
+    let local_agents = agents::list_local_agents(home_override)
+        .map(|agents| agents.len())
+        .unwrap_or(0);
     let node = snapshot
         .as_ref()
         .and_then(|snapshot| snapshot.node.as_ref())
@@ -112,7 +118,7 @@ control room
   runtime       {runtime_state}
   node          {node}
   state         {state}
-  local agents  none           registration arrives in Phase 5
+  local agents  {local_agents}
   remote peers  none           pairing arrives in Phase 7
   network       offline        relay arrives in Phase 8
 
@@ -120,6 +126,7 @@ quick commands
   conu init
   conu status
   conu agents
+  conu agents register <agent-id> <display-name>
   conu pair
   conu join <code>
   conu connect
@@ -144,42 +151,254 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
         Ok(snapshot) => snapshot,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
-    let runtime_status = match runtime::read_runtime(home_override) {
+    let runtime_status = match runtime::read_runtime(home_override.clone()) {
         Ok(status) => status,
+        Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
+    };
+    let local_agents = match agents::list_local_agents(home_override) {
+        Ok(agents) => agents,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
 
     match json_flag(args) {
-        Ok(true) => CliOutput::success(render_status_json(&snapshot, &runtime_status)),
-        Ok(false) => CliOutput::success(render_status_text(&snapshot, &runtime_status)),
+        Ok(true) => CliOutput::success(render_status_json(
+            &snapshot,
+            &runtime_status,
+            &local_agents,
+        )),
+        Ok(false) => CliOutput::success(render_status_text(
+            &snapshot,
+            &runtime_status,
+            &local_agents,
+        )),
         Err(error) => error,
     }
 }
 
 fn render_agents(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
-    let snapshot = match state::read_state(home_override) {
+    match args.first().map(String::as_str) {
+        Some("register") => render_agent_register(&args[1..], home_override),
+        Some("heartbeat") => render_agent_heartbeat(&args[1..], home_override),
+        _ => render_agents_list(args, home_override),
+    }
+}
+
+fn render_agents_list(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let snapshot = match state::read_state(home_override.clone()) {
         Ok(snapshot) => snapshot,
+        Err(error) => return CliOutput::failure(1, format!("conU agents failed\n\n{error}")),
+    };
+    let local_agents = match agents::list_local_agents(home_override) {
+        Ok(agents) => agents,
         Err(error) => return CliOutput::failure(1, format!("conU agents failed\n\n{error}")),
     };
     let registry_state = ready_label(snapshot.agent_registry_exists);
 
     match json_flag(args) {
-        Ok(true) => CliOutput::success(format!(
+        Ok(true) => CliOutput::success(render_agents_json(
+            &local_agents,
+            registry_state,
+            &snapshot.paths.agent_registry.display().to_string(),
+        )),
+        Ok(false) => CliOutput::success(render_agents_text(
+            &local_agents,
+            registry_state,
+            &snapshot.paths.agent_registry.display().to_string(),
+        )),
+        Err(error) => error,
+    }
+}
+
+fn render_agent_register(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let parsed = match parse_register_args(args) {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    let registration =
+        match AgentRegistration::new(&parsed.agent_id, &parsed.display_name, &parsed.kind) {
+            Ok(registration) => registration,
+            Err(error) => {
+                return CliOutput::failure(2, format!("conU agents register failed\n\n{error}"));
+            }
+        };
+
+    let submission = match agents::submit_registration(home_override.clone(), registration) {
+        Ok(submission) => submission,
+        Err(error) => {
+            return CliOutput::failure(1, format!("conU agents register failed\n\n{error}"));
+        }
+    };
+    let processed = wait_for_agent(home_override.clone(), &parsed.agent_id);
+    let status = if processed { "registered" } else { "queued" };
+
+    if parsed.json {
+        return CliOutput::success(format!(
             r#"{{
-  "local": [],
+  "status": "{}",
+  "agentId": "{}",
+  "requestId": "{}",
+  "processed": {},
+  "contentsDisplayed": false
+}}"#,
+            status,
+            json_escape(&parsed.agent_id),
+            json_escape(&submission.request_id),
+            processed
+        ));
+    }
+
+    CliOutput::success(format!(
+        r"conU agents register
+
+status: {status}
+agent: {}
+name: {}
+kind: {}
+request: {}
+gateway: file IPC
+
+privacy
+  payload view  contents are not displayed by conU",
+        parsed.agent_id, parsed.display_name, parsed.kind, submission.request_id
+    ))
+}
+
+fn render_agent_heartbeat(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let parsed = match parse_heartbeat_args(args) {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    let heartbeat = match PresenceHeartbeat::new(&parsed.agent_id, parsed.presence) {
+        Ok(heartbeat) => heartbeat,
+        Err(error) => {
+            return CliOutput::failure(2, format!("conU agents heartbeat failed\n\n{error}"));
+        }
+    };
+    let submission = match agents::submit_presence_heartbeat(home_override.clone(), heartbeat) {
+        Ok(submission) => submission,
+        Err(error) => {
+            return CliOutput::failure(1, format!("conU agents heartbeat failed\n\n{error}"));
+        }
+    };
+    let processed = wait_for_agent_presence(home_override, &parsed.agent_id, parsed.presence);
+    let status = if processed {
+        "presence updated"
+    } else {
+        "queued"
+    };
+
+    if parsed.json {
+        return CliOutput::success(format!(
+            r#"{{
+  "status": "{}",
+  "agentId": "{}",
+  "presence": "{}",
+  "requestId": "{}",
+  "processed": {},
+  "contentsDisplayed": false
+}}"#,
+            status,
+            json_escape(&parsed.agent_id),
+            parsed.presence.as_str(),
+            json_escape(&submission.request_id),
+            processed
+        ));
+    }
+
+    CliOutput::success(format!(
+        r"conU agents heartbeat
+
+status: {status}
+agent: {}
+presence: {}
+request: {}
+gateway: file IPC
+
+privacy
+  payload view  contents are not displayed by conU",
+        parsed.agent_id,
+        parsed.presence.as_str(),
+        submission.request_id
+    ))
+}
+
+fn render_agents_json(agents: &[LocalAgentRecord], registry: &str, registry_path: &str) -> String {
+    let local_items = agents
+        .iter()
+        .map(|agent| {
+            format!(
+                r#"    {{
+      "agentId": "{}",
+      "displayName": "{}",
+      "kind": "{}",
+      "presence": "{}",
+      "nodeId": "{}",
+      "capabilities": {{
+        "messages": {},
+        "streams": {},
+        "rooms": {},
+        "files": {},
+        "presence": {}
+      }}
+    }}"#,
+                json_escape(&agent.agent_id),
+                json_escape(&agent.display_name),
+                json_escape(&agent.kind),
+                agent.presence.as_str(),
+                json_escape(&agent.node_id),
+                agent.capabilities.messages,
+                agent.capabilities.streams,
+                agent.capabilities.rooms,
+                agent.capabilities.files,
+                agent.capabilities.presence
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let local = if local_items.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{local_items}\n  ]")
+    };
+
+    format!(
+        r#"{{
+  "local": {},
   "remote": [],
   "registry": "{}",
   "registryPath": "{}",
-  "status": "agent registration arrives in Phase 5"
+  "status": "local agent registration active"
 }}"#,
-            registry_state,
-            json_escape(&snapshot.paths.agent_registry.display().to_string())
-        )),
-        Ok(false) => CliOutput::success(format!(
-            r"conU agents
+        local,
+        registry,
+        json_escape(registry_path)
+    )
+}
+
+fn render_agents_text(agents: &[LocalAgentRecord], registry: &str, registry_path: &str) -> String {
+    let local = if agents.is_empty() {
+        "  none registered yet".to_string()
+    } else {
+        agents
+            .iter()
+            .map(|agent| {
+                format!(
+                    "  {}  {}  {}  kind {}",
+                    agent.agent_id,
+                    agent.presence.as_str(),
+                    agent.display_name,
+                    agent.kind
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        r"conU agents
 
 local agents
-  none registered yet
+{local}
   registry      {}
   path          {}
 
@@ -187,13 +406,183 @@ remote agents
   none visible yet
 
 next
-  Phase 5: local agent registration
+  conu agents register <agent-id> <display-name>
+  conu agents heartbeat <agent-id>
   Phase 9: remote discovery and presence",
-            registry_state,
-            snapshot.paths.agent_registry.display()
-        )),
-        Err(error) => error,
+        registry, registry_path
+    )
+}
+
+struct RegisterArgs {
+    agent_id: String,
+    display_name: String,
+    kind: String,
+    json: bool,
+}
+
+struct HeartbeatArgs {
+    agent_id: String,
+    presence: AgentPresence,
+    json: bool,
+}
+
+fn parse_register_args(args: &[String]) -> Result<RegisterArgs, CliOutput> {
+    let mut json = false;
+    let mut kind = "local-agent".to_string();
+    let mut positional = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            "--kind" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(CliOutput::failure(
+                        2,
+                        "usage: conu agents register <agent-id> <display-name> [--kind <kind>] [--json]",
+                    ));
+                };
+                kind = value.clone();
+                index += 2;
+            }
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            value => {
+                positional.push(value.to_string());
+                index += 1;
+            }
+        }
     }
+
+    if positional.len() != 2 {
+        return Err(CliOutput::failure(
+            2,
+            "usage: conu agents register <agent-id> <display-name> [--kind <kind>] [--json]",
+        ));
+    }
+
+    Ok(RegisterArgs {
+        agent_id: positional.remove(0),
+        display_name: positional.remove(0),
+        kind,
+        json,
+    })
+}
+
+fn parse_heartbeat_args(args: &[String]) -> Result<HeartbeatArgs, CliOutput> {
+    let mut json = false;
+    let mut presence = AgentPresence::Ready;
+    let mut agent_id = None;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            "--presence" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(CliOutput::failure(
+                        2,
+                        "usage: conu agents heartbeat <agent-id> [--presence <ready|busy|idle|offline>] [--json]",
+                    ));
+                };
+                presence = parse_presence(value)?;
+                index += 2;
+            }
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            value => {
+                if agent_id.is_some() {
+                    return Err(CliOutput::failure(
+                        2,
+                        "usage: conu agents heartbeat <agent-id> [--presence <ready|busy|idle|offline>] [--json]",
+                    ));
+                }
+                agent_id = Some(value.to_string());
+                index += 1;
+            }
+        }
+    }
+
+    let Some(agent_id) = agent_id else {
+        return Err(CliOutput::failure(
+            2,
+            "usage: conu agents heartbeat <agent-id> [--presence <ready|busy|idle|offline>] [--json]",
+        ));
+    };
+
+    Ok(HeartbeatArgs {
+        agent_id,
+        presence,
+        json,
+    })
+}
+
+fn parse_presence(value: &str) -> Result<AgentPresence, CliOutput> {
+    match value {
+        "ready" => Ok(AgentPresence::Ready),
+        "busy" => Ok(AgentPresence::Busy),
+        "idle" => Ok(AgentPresence::Idle),
+        "offline" => Ok(AgentPresence::Offline),
+        _ => Err(CliOutput::failure(
+            2,
+            "presence must be ready, busy, idle, or offline",
+        )),
+    }
+}
+
+fn wait_for_agent(home_override: Option<PathBuf>, agent_id: &str) -> bool {
+    if !runtime_is_live(home_override.clone()) {
+        return false;
+    }
+
+    for _ in 0..40 {
+        if agents::agent_exists(home_override.clone(), agent_id).unwrap_or(false) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    false
+}
+
+fn wait_for_agent_presence(
+    home_override: Option<PathBuf>,
+    agent_id: &str,
+    presence: AgentPresence,
+) -> bool {
+    if !runtime_is_live(home_override.clone()) {
+        return false;
+    }
+
+    for _ in 0..40 {
+        if agents::list_local_agents(home_override.clone())
+            .map(|agents| {
+                agents
+                    .iter()
+                    .any(|agent| agent.agent_id == agent_id && agent.presence == presence)
+            })
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    false
+}
+
+fn runtime_is_live(home_override: Option<PathBuf>) -> bool {
+    runtime::read_runtime(home_override)
+        .map(|status| status.is_live())
+        .unwrap_or(false)
 }
 
 fn render_pair(args: &[String]) -> CliOutput {
@@ -202,14 +591,14 @@ fn render_pair(args: &[String]) -> CliOutput {
             r#"{
   "status": "reserved",
   "phase": "Phase 7",
-  "message": "pairing code generation is not active in Phase 4"
+  "message": "pairing code generation is not active in Phase 5"
 }"#,
         ),
         Ok(false) => CliOutput::success(
             r"conU pair
 
 status: reserved for Phase 7
-code: not generated in Phase 4
+code: not generated in Phase 5
 purpose: create trust between two conUD runtimes",
         ),
         Err(error) => error,
@@ -223,7 +612,7 @@ fn render_join(args: &[String]) -> CliOutput {
                 r#"{
   "status": "reserved",
   "phase": "Phase 7",
-  "message": "join validation is not active in Phase 4"
+  "message": "join validation is not active in Phase 5"
 }"#,
             ),
             Err(error) => error,
@@ -236,27 +625,44 @@ fn render_join(args: &[String]) -> CliOutput {
 
 status: reserved for Phase 7
 code: accepted for command shape only
-action: no trust entry created in Phase 4",
+action: no trust entry created in Phase 5",
         ),
         Err(error) => error,
     }
 }
 
-fn render_connect(args: &[String]) -> CliOutput {
+fn render_connect(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     if let Some(error) = reject_args(args) {
         return error;
     }
+    let local_agents = agents::list_local_agents(home_override).unwrap_or_default();
+    let local = if local_agents.is_empty() {
+        "none registered".to_string()
+    } else {
+        local_agents
+            .iter()
+            .map(|agent| {
+                format!(
+                    "{} ({}, {})",
+                    agent.agent_id,
+                    agent.presence.as_str(),
+                    agent.kind
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
 
-    CliOutput::success(
+    CliOutput::success(format!(
         r"conU connect
 
 selector
-  source local agent   none registered
+  source local agent   {local}
   target remote agent  none visible
   mode                 message | stream | room | observe
 
-status: waiting for Phase 5 local agents and Phase 9 remote discovery",
-    )
+status: waiting for Phase 6 local messaging and Phase 9 remote discovery",
+    ))
 }
 
 fn render_watch(args: &[String]) -> CliOutput {
@@ -423,7 +829,11 @@ next
     )
 }
 
-fn render_status_text(snapshot: &StateSnapshot, runtime_status: &RuntimeStatus) -> String {
+fn render_status_text(
+    snapshot: &StateSnapshot,
+    runtime_status: &RuntimeStatus,
+    local_agents: &[LocalAgentRecord],
+) -> String {
     let node = snapshot
         .node
         .as_ref()
@@ -442,7 +852,7 @@ runtime
   conUD         {}
   pid           {}
   health        {}
-  local IPC     reserved for Phase 5
+  local IPC     file gateway active
   relay         not available until Phase 8
 
 identity
@@ -454,7 +864,7 @@ identity
   trust store   {}
 
 agents
-  local         0 registered
+  local         {} registered
   registry      {}
   remote        0 visible
 
@@ -469,11 +879,16 @@ privacy
         snapshot.paths.home.display(),
         ready_label(snapshot.config_exists),
         ready_label(snapshot.trust_store_exists),
+        local_agents.len(),
         ready_label(snapshot.agent_registry_exists)
     )
 }
 
-fn render_status_json(snapshot: &StateSnapshot, runtime_status: &RuntimeStatus) -> String {
+fn render_status_json(
+    snapshot: &StateSnapshot,
+    runtime_status: &RuntimeStatus,
+    local_agents: &[LocalAgentRecord],
+) -> String {
     let node = snapshot
         .node
         .as_ref()
@@ -492,7 +907,7 @@ fn render_status_json(snapshot: &StateSnapshot, runtime_status: &RuntimeStatus) 
     "pid": {},
     "heartbeatAgeSecs": {},
     "localHealth": "{}",
-    "localIpc": "phase_5",
+    "localIpc": "file_gateway",
     "relay": "phase_8"
   }},
   "identity": {{
@@ -504,7 +919,7 @@ fn render_status_json(snapshot: &StateSnapshot, runtime_status: &RuntimeStatus) 
     "trustStore": "{}"
   }},
   "agents": {{
-    "local": 0,
+    "local": {},
     "registry": "{}",
     "remote": 0
   }},
@@ -522,6 +937,7 @@ fn render_status_json(snapshot: &StateSnapshot, runtime_status: &RuntimeStatus) 
         json_escape(&snapshot.paths.home.display().to_string()),
         ready_label(snapshot.config_exists),
         ready_label(snapshot.trust_store_exists),
+        local_agents.len(),
         ready_label(snapshot.agent_registry_exists)
     )
 }
@@ -534,6 +950,8 @@ Usage:
   conu init
   conu status [--json]
   conu agents [--json]
+  conu agents register <agent-id> <display-name> [--kind <kind>] [--json]
+  conu agents heartbeat <agent-id> [--presence <ready|busy|idle|offline>] [--json]
   conu peers [--json]
   conu pair [--json]
   conu join <code> [--json]
@@ -545,7 +963,7 @@ Usage:
   conu --help
   conu --version
 
-Phase 4 adds the conUD daemon skeleton and local runtime heartbeat. Agent IPC, pairing, relay, and streaming arrive in later phases."
+Phase 5 adds metadata-only local agent registration through the conUD file gateway. Pairing, relay, messaging, and streaming arrive in later phases."
         .to_string()
 }
 
@@ -774,7 +1192,7 @@ mod tests {
     }
 
     #[test]
-    fn phase_four_commands_are_registered() {
+    fn phase_five_commands_are_registered() {
         let home = temp_home("commands");
 
         for command in [
@@ -786,6 +1204,76 @@ mod tests {
 
         let join = run(["join", "123456"]);
         assert_eq!(join.code, 0);
+    }
+
+    #[test]
+    fn agents_register_queues_metadata_request() {
+        let home = temp_home("agent-register-queued");
+
+        let output = run_with_home(
+            [
+                "agents",
+                "register",
+                "agent.codex",
+                "Codex Desktop",
+                "--kind",
+                "coding-agent",
+            ],
+            Some(home.clone()),
+        );
+
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        assert!(output.stdout.contains("status: queued"));
+        assert!(
+            output
+                .stdout
+                .contains("payload view  contents are not displayed")
+        );
+        assert!(state::StatePaths::from_home(home).ipc_inbox_dir.exists());
+    }
+
+    #[test]
+    fn agents_list_persisted_local_agent() {
+        let home = temp_home("agent-list");
+        let registration = AgentRegistration::new("agent.codex", "Codex Desktop", "coding-agent")
+            .expect("valid registration");
+        agents::submit_registration(Some(home.clone()), registration).expect("request submits");
+        agents::process_gateway_requests(Some(home.clone())).expect("request processes");
+
+        let output = run_with_home(["agents"], Some(home));
+
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        assert!(output.stdout.contains("agent.codex"));
+        assert!(output.stdout.contains("Codex Desktop"));
+        assert!(output.stdout.contains("ready"));
+    }
+
+    #[test]
+    fn agents_json_lists_persisted_local_agent() {
+        let home = temp_home("agent-json");
+        let registration = AgentRegistration::new("agent.codex", "Codex Desktop", "coding-agent")
+            .expect("valid registration");
+        agents::submit_registration(Some(home.clone()), registration).expect("request submits");
+        agents::process_gateway_requests(Some(home.clone())).expect("request processes");
+
+        let output = run_with_home(["agents", "--json"], Some(home));
+
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        assert!(output.stdout.contains("\"agentId\": \"agent.codex\""));
+        assert!(output.stdout.contains("\"displayName\": \"Codex Desktop\""));
+    }
+
+    #[test]
+    fn agents_heartbeat_queues_presence_request() {
+        let home = temp_home("agent-heartbeat");
+        let output = run_with_home(
+            ["agents", "heartbeat", "agent.codex", "--presence", "busy"],
+            Some(home),
+        );
+
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        assert!(output.stdout.contains("status: queued"));
+        assert!(output.stdout.contains("presence: busy"));
     }
 
     #[test]
@@ -863,7 +1351,7 @@ mod tests {
 
         assert_eq!(output.code, 0);
         assert!(output.stdout.contains("\"conud\": \"offline\""));
-        assert!(output.stdout.contains("\"localIpc\": \"phase_5\""));
+        assert!(output.stdout.contains("\"localIpc\": \"file_gateway\""));
         assert!(output.stdout.contains("\"state\": \"initialized\""));
         assert!(output.stdout.contains("\"node\": \"node_"));
         assert!(output.stdout.contains("\"contentsDisplayed\": false"));

--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -1,0 +1,858 @@
+//! Local agent gateway and registry.
+//!
+//! Phase 5 implements metadata-only registration through a file-backed local
+//! gateway. It does not route messages or store agent payloads.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use conu_protocol::AgentCapabilities;
+
+use crate::state::{self, StateError, StatePaths};
+
+const REQUEST_VERSION: &str = "1";
+
+/// Presence state published by a local agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentPresence {
+    Ready,
+    Busy,
+    Idle,
+    Offline,
+}
+
+impl AgentPresence {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Busy => "busy",
+            Self::Idle => "idle",
+            Self::Offline => "offline",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "ready" => Some(Self::Ready),
+            "busy" => Some(Self::Busy),
+            "idle" => Some(Self::Idle),
+            "offline" => Some(Self::Offline),
+            _ => None,
+        }
+    }
+}
+
+/// Metadata a local agent submits to conUD.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentRegistration {
+    pub agent_id: String,
+    pub display_name: String,
+    pub kind: String,
+    pub capabilities: AgentCapabilities,
+}
+
+impl AgentRegistration {
+    pub fn new(
+        agent_id: impl Into<String>,
+        display_name: impl Into<String>,
+        kind: impl Into<String>,
+    ) -> Result<Self, AgentError> {
+        let agent_id = validate_identifier(agent_id.into(), "agent id")?;
+        let display_name = validate_display_name(display_name.into())?;
+        let kind = validate_kind(kind.into())?;
+
+        Ok(Self {
+            agent_id,
+            display_name,
+            kind,
+            capabilities: AgentCapabilities::basic(),
+        })
+    }
+}
+
+/// Metadata a local agent submits to refresh presence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PresenceHeartbeat {
+    pub agent_id: String,
+    pub presence: AgentPresence,
+}
+
+impl PresenceHeartbeat {
+    pub fn new(agent_id: impl Into<String>, presence: AgentPresence) -> Result<Self, AgentError> {
+        Ok(Self {
+            agent_id: validate_identifier(agent_id.into(), "agent id")?,
+            presence,
+        })
+    }
+}
+
+/// Persisted local agent card.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalAgentRecord {
+    pub agent_id: String,
+    pub display_name: String,
+    pub node_id: String,
+    pub kind: String,
+    pub presence: AgentPresence,
+    pub last_seen_unix: u64,
+    pub capabilities: AgentCapabilities,
+}
+
+/// Result of submitting an IPC-style request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewaySubmission {
+    pub request_id: String,
+    pub request_path: PathBuf,
+}
+
+/// Result of conUD processing local gateway requests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayProcessReport {
+    pub processed: usize,
+    pub rejected: usize,
+    pub registered_agents: Vec<String>,
+    pub heartbeat_agents: Vec<String>,
+}
+
+/// Errors produced by local agent gateway and registry operations.
+#[derive(Debug)]
+pub enum AgentError {
+    State(StateError),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidRequest {
+        reason: String,
+    },
+}
+
+impl AgentError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for AgentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidRequest { reason } => write!(formatter, "invalid agent request: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for AgentError {}
+
+impl From<StateError> for AgentError {
+    fn from(error: StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+/// Submit a local agent registration request to the conUD gateway inbox.
+pub fn submit_registration(
+    home_override: Option<PathBuf>,
+    registration: AgentRegistration,
+) -> Result<GatewaySubmission, AgentError> {
+    let init = state::init_state(home_override)?;
+    let request_id = request_id("register");
+    let request_path = init.paths.ipc_inbox_dir.join(format!("{request_id}.req"));
+    let contents = render_registration_request(&request_id, &registration);
+    write_new_file(&request_path, &contents)?;
+
+    Ok(GatewaySubmission {
+        request_id,
+        request_path,
+    })
+}
+
+/// Submit a local agent presence heartbeat request to the conUD gateway inbox.
+pub fn submit_presence_heartbeat(
+    home_override: Option<PathBuf>,
+    heartbeat: PresenceHeartbeat,
+) -> Result<GatewaySubmission, AgentError> {
+    let init = state::init_state(home_override)?;
+    let request_id = request_id("presence");
+    let request_path = init.paths.ipc_inbox_dir.join(format!("{request_id}.req"));
+    let contents = render_presence_request(&request_id, &heartbeat);
+    write_new_file(&request_path, &contents)?;
+
+    Ok(GatewaySubmission {
+        request_id,
+        request_path,
+    })
+}
+
+/// Process pending gateway requests using the default state path resolution.
+pub fn process_gateway_requests(
+    home_override: Option<PathBuf>,
+) -> Result<GatewayProcessReport, AgentError> {
+    let init = state::init_state(home_override)?;
+    process_gateway_requests_from_paths(&init.paths, &init.node.node_id)
+}
+
+/// Process pending gateway requests from already resolved state paths.
+pub fn process_gateway_requests_from_paths(
+    paths: &StatePaths,
+    node_id: &str,
+) -> Result<GatewayProcessReport, AgentError> {
+    fs::create_dir_all(&paths.ipc_inbox_dir)
+        .map_err(|error| AgentError::io("create IPC inbox", &paths.ipc_inbox_dir, error))?;
+    fs::create_dir_all(&paths.ipc_processed_dir).map_err(|error| {
+        AgentError::io(
+            "create IPC processed directory",
+            &paths.ipc_processed_dir,
+            error,
+        )
+    })?;
+    fs::create_dir_all(&paths.ipc_rejected_dir).map_err(|error| {
+        AgentError::io(
+            "create IPC rejected directory",
+            &paths.ipc_rejected_dir,
+            error,
+        )
+    })?;
+
+    let mut report = GatewayProcessReport {
+        processed: 0,
+        rejected: 0,
+        registered_agents: Vec::new(),
+        heartbeat_agents: Vec::new(),
+    };
+
+    for request_path in pending_requests(paths)? {
+        match process_one_request(paths, node_id, &request_path) {
+            Ok(ProcessedRequest::Registered(agent_id)) => {
+                report.processed += 1;
+                report.registered_agents.push(agent_id);
+                move_request(&request_path, &paths.ipc_processed_dir)?;
+            }
+            Ok(ProcessedRequest::Presence(agent_id)) => {
+                report.processed += 1;
+                report.heartbeat_agents.push(agent_id);
+                move_request(&request_path, &paths.ipc_processed_dir)?;
+            }
+            Err(error) => {
+                report.rejected += 1;
+                reject_request(&request_path, &paths.ipc_rejected_dir, &error)?;
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Read the persisted local agent registry.
+pub fn list_local_agents(
+    home_override: Option<PathBuf>,
+) -> Result<Vec<LocalAgentRecord>, AgentError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_registry(&paths)
+}
+
+/// Return true when an agent exists in the persisted registry.
+pub fn agent_exists(home_override: Option<PathBuf>, agent_id: &str) -> Result<bool, AgentError> {
+    Ok(list_local_agents(home_override)?
+        .iter()
+        .any(|agent| agent.agent_id == agent_id))
+}
+
+enum ProcessedRequest {
+    Registered(String),
+    Presence(String),
+}
+
+fn process_one_request(
+    paths: &StatePaths,
+    node_id: &str,
+    request_path: &Path,
+) -> Result<ProcessedRequest, AgentError> {
+    let contents = fs::read_to_string(request_path)
+        .map_err(|error| AgentError::io("read IPC request", request_path, error))?;
+    let values = parse_key_values(&contents);
+
+    if value_or_empty(&values, "version") != REQUEST_VERSION {
+        return Err(AgentError::InvalidRequest {
+            reason: "unsupported request version".to_string(),
+        });
+    }
+
+    match value_or_empty(&values, "type") {
+        "register_agent" => {
+            let registration = registration_from_values(&values)?;
+            upsert_agent(paths, node_id, registration).map(ProcessedRequest::Registered)
+        }
+        "presence_heartbeat" => {
+            let heartbeat = presence_from_values(&values)?;
+            update_presence(paths, heartbeat).map(ProcessedRequest::Presence)
+        }
+        _ => Err(AgentError::InvalidRequest {
+            reason: "unsupported request type".to_string(),
+        }),
+    }
+}
+
+fn upsert_agent(
+    paths: &StatePaths,
+    node_id: &str,
+    registration: AgentRegistration,
+) -> Result<String, AgentError> {
+    let mut agents = read_registry(paths)?;
+    let now = current_unix_seconds();
+    let mut updated = false;
+
+    for agent in &mut agents {
+        if agent.agent_id == registration.agent_id {
+            agent.display_name = registration.display_name.clone();
+            agent.kind = registration.kind.clone();
+            agent.presence = AgentPresence::Ready;
+            agent.last_seen_unix = now;
+            agent.capabilities = registration.capabilities.clone();
+            updated = true;
+            break;
+        }
+    }
+
+    if !updated {
+        agents.push(LocalAgentRecord {
+            agent_id: registration.agent_id.clone(),
+            display_name: registration.display_name,
+            node_id: node_id.to_string(),
+            kind: registration.kind,
+            presence: AgentPresence::Ready,
+            last_seen_unix: now,
+            capabilities: registration.capabilities,
+        });
+    }
+
+    write_registry(paths, &agents)?;
+    append_agent_log(paths, "agent_registered", &registration.agent_id)?;
+
+    Ok(registration.agent_id)
+}
+
+fn update_presence(paths: &StatePaths, heartbeat: PresenceHeartbeat) -> Result<String, AgentError> {
+    let mut agents = read_registry(paths)?;
+    let now = current_unix_seconds();
+    let mut found = false;
+
+    for agent in &mut agents {
+        if agent.agent_id == heartbeat.agent_id {
+            agent.presence = heartbeat.presence;
+            agent.last_seen_unix = now;
+            found = true;
+            break;
+        }
+    }
+
+    if !found {
+        return Err(AgentError::InvalidRequest {
+            reason: format!("unknown local agent {}", heartbeat.agent_id),
+        });
+    }
+
+    write_registry(paths, &agents)?;
+    append_agent_log(paths, "agent_presence", &heartbeat.agent_id)?;
+
+    Ok(heartbeat.agent_id)
+}
+
+fn read_registry(paths: &StatePaths) -> Result<Vec<LocalAgentRecord>, AgentError> {
+    if !paths.agent_registry.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(&paths.agent_registry)
+        .map_err(|error| AgentError::io("read agent registry", &paths.agent_registry, error))?;
+    parse_registry(&contents)
+}
+
+fn write_registry(paths: &StatePaths, agents: &[LocalAgentRecord]) -> Result<(), AgentError> {
+    let mut sorted = agents.to_vec();
+    sorted.sort_by(|left, right| left.agent_id.cmp(&right.agent_id));
+    let mut contents = String::from("# conU local agent registry\nversion = \"1\"\n");
+
+    for agent in sorted {
+        contents.push_str("\n[[agent]]\n");
+        contents.push_str(&format!(
+            "agent_id = \"{}\"\n",
+            escape_file_value(&agent.agent_id)
+        ));
+        contents.push_str(&format!(
+            "display_name = \"{}\"\n",
+            escape_file_value(&agent.display_name)
+        ));
+        contents.push_str(&format!(
+            "node_id = \"{}\"\n",
+            escape_file_value(&agent.node_id)
+        ));
+        contents.push_str(&format!("kind = \"{}\"\n", escape_file_value(&agent.kind)));
+        contents.push_str(&format!("presence = \"{}\"\n", agent.presence.as_str()));
+        contents.push_str(&format!("last_seen_unix = {}\n", agent.last_seen_unix));
+        contents.push_str(&format!("cap_messages = {}\n", agent.capabilities.messages));
+        contents.push_str(&format!("cap_streams = {}\n", agent.capabilities.streams));
+        contents.push_str(&format!("cap_rooms = {}\n", agent.capabilities.rooms));
+        contents.push_str(&format!("cap_files = {}\n", agent.capabilities.files));
+        contents.push_str(&format!("cap_presence = {}\n", agent.capabilities.presence));
+    }
+
+    fs::write(&paths.agent_registry, contents)
+        .map_err(|error| AgentError::io("write agent registry", &paths.agent_registry, error))
+}
+
+fn parse_registry(contents: &str) -> Result<Vec<LocalAgentRecord>, AgentError> {
+    let mut records = Vec::new();
+    let mut current = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty()
+            || line.starts_with('#')
+            || line == "version = \"1\""
+            || line == "agents = []"
+        {
+            continue;
+        }
+
+        if line == "[[agent]]" {
+            if !current.is_empty() {
+                records.push(record_from_values(&current)?);
+                current.clear();
+            }
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        current.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    if !current.is_empty() {
+        records.push(record_from_values(&current)?);
+    }
+
+    Ok(records)
+}
+
+fn record_from_values(values: &HashMap<String, String>) -> Result<LocalAgentRecord, AgentError> {
+    let agent_id = validate_identifier(required(values, "agent_id")?, "agent id")?;
+    let display_name = validate_display_name(required(values, "display_name")?)?;
+    let node_id = validate_identifier(required(values, "node_id")?, "node id")?;
+    let kind = validate_kind(required(values, "kind")?)?;
+    let presence = AgentPresence::from_str(&required(values, "presence")?).ok_or_else(|| {
+        AgentError::InvalidRequest {
+            reason: "presence must be ready, busy, idle, or offline".to_string(),
+        }
+    })?;
+    let last_seen_unix = required(values, "last_seen_unix")?
+        .parse::<u64>()
+        .map_err(|_| AgentError::InvalidRequest {
+            reason: "last_seen_unix must be an unsigned integer".to_string(),
+        })?;
+
+    Ok(LocalAgentRecord {
+        agent_id,
+        display_name,
+        node_id,
+        kind,
+        presence,
+        last_seen_unix,
+        capabilities: AgentCapabilities {
+            messages: parse_bool(values.get("cap_messages")).unwrap_or(true),
+            streams: parse_bool(values.get("cap_streams")).unwrap_or(false),
+            rooms: parse_bool(values.get("cap_rooms")).unwrap_or(false),
+            files: parse_bool(values.get("cap_files")).unwrap_or(false),
+            presence: parse_bool(values.get("cap_presence")).unwrap_or(true),
+        },
+    })
+}
+
+fn registration_from_values(
+    values: &HashMap<String, String>,
+) -> Result<AgentRegistration, AgentError> {
+    let mut registration = AgentRegistration::new(
+        required(values, "agent_id")?,
+        required(values, "display_name")?,
+        values
+            .get("kind")
+            .cloned()
+            .unwrap_or_else(|| "local-agent".to_string()),
+    )?;
+    registration.capabilities = AgentCapabilities {
+        messages: parse_bool(values.get("cap_messages")).unwrap_or(true),
+        streams: parse_bool(values.get("cap_streams")).unwrap_or(false),
+        rooms: parse_bool(values.get("cap_rooms")).unwrap_or(false),
+        files: parse_bool(values.get("cap_files")).unwrap_or(false),
+        presence: parse_bool(values.get("cap_presence")).unwrap_or(true),
+    };
+    Ok(registration)
+}
+
+fn presence_from_values(values: &HashMap<String, String>) -> Result<PresenceHeartbeat, AgentError> {
+    let presence = values
+        .get("presence")
+        .and_then(|value| AgentPresence::from_str(value))
+        .ok_or_else(|| AgentError::InvalidRequest {
+            reason: "presence must be ready, busy, idle, or offline".to_string(),
+        })?;
+    PresenceHeartbeat::new(required(values, "agent_id")?, presence)
+}
+
+fn pending_requests(paths: &StatePaths) -> Result<Vec<PathBuf>, AgentError> {
+    let mut requests = Vec::new();
+
+    for entry in fs::read_dir(&paths.ipc_inbox_dir)
+        .map_err(|error| AgentError::io("read IPC inbox", &paths.ipc_inbox_dir, error))?
+    {
+        let entry = entry
+            .map_err(|error| AgentError::io("read IPC inbox entry", &paths.ipc_inbox_dir, error))?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("req") {
+            requests.push(path);
+        }
+    }
+
+    requests.sort();
+    Ok(requests)
+}
+
+fn move_request(request_path: &Path, target_dir: &Path) -> Result<(), AgentError> {
+    fs::create_dir_all(target_dir)
+        .map_err(|error| AgentError::io("create IPC target directory", target_dir, error))?;
+    let target = target_dir.join(
+        request_path
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("request.req")),
+    );
+    fs::rename(request_path, &target)
+        .map_err(|error| AgentError::io("move IPC request", request_path, error))
+}
+
+fn reject_request(
+    request_path: &Path,
+    target_dir: &Path,
+    error: &AgentError,
+) -> Result<(), AgentError> {
+    fs::create_dir_all(target_dir)
+        .map_err(|error| AgentError::io("create IPC rejected directory", target_dir, error))?;
+    let target = target_dir.join(
+        request_path
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("request.req")),
+    );
+    let error_path = target.with_extension("error");
+    fs::write(&error_path, format!("{error}\n"))
+        .map_err(|error| AgentError::io("write IPC rejection reason", &error_path, error))?;
+    fs::rename(request_path, &target)
+        .map_err(|error| AgentError::io("move rejected IPC request", request_path, error))
+}
+
+fn render_registration_request(request_id: &str, registration: &AgentRegistration) -> String {
+    format!(
+        "version = \"{}\"\ntype = \"register_agent\"\nrequest_id = \"{}\"\nagent_id = \"{}\"\ndisplay_name = \"{}\"\nkind = \"{}\"\ncap_messages = {}\ncap_streams = {}\ncap_rooms = {}\ncap_files = {}\ncap_presence = {}\n",
+        REQUEST_VERSION,
+        escape_file_value(request_id),
+        escape_file_value(&registration.agent_id),
+        escape_file_value(&registration.display_name),
+        escape_file_value(&registration.kind),
+        registration.capabilities.messages,
+        registration.capabilities.streams,
+        registration.capabilities.rooms,
+        registration.capabilities.files,
+        registration.capabilities.presence,
+    )
+}
+
+fn render_presence_request(request_id: &str, heartbeat: &PresenceHeartbeat) -> String {
+    format!(
+        "version = \"{}\"\ntype = \"presence_heartbeat\"\nrequest_id = \"{}\"\nagent_id = \"{}\"\npresence = \"{}\"\n",
+        REQUEST_VERSION,
+        escape_file_value(request_id),
+        escape_file_value(&heartbeat.agent_id),
+        heartbeat.presence.as_str(),
+    )
+}
+
+fn append_agent_log(paths: &StatePaths, event: &str, agent_id: &str) -> Result<(), AgentError> {
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| AgentError::io("create log directory", &paths.logs_dir, error))?;
+    let log_path = paths.logs_dir.join("agents.log");
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&log_path)
+        .map_err(|error| AgentError::io("open agent log", &log_path, error))?;
+
+    writeln!(
+        file,
+        "time={} event={} agent={} payload=not_observed",
+        current_unix_seconds(),
+        event,
+        sanitize_log_value(agent_id)
+    )
+    .map_err(|error| AgentError::io("write agent log", &log_path, error))
+}
+
+fn write_new_file(path: &Path, contents: &str) -> Result<(), AgentError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| AgentError::io("create IPC request", path, error))?;
+
+    file.write_all(contents.as_bytes())
+        .map_err(|error| AgentError::io("write IPC request", path, error))
+}
+
+fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, AgentError> {
+    values
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| AgentError::InvalidRequest {
+            reason: format!("missing {key}"),
+        })
+}
+
+fn validate_identifier(value: String, field: &'static str) -> Result<String, AgentError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(AgentError::InvalidRequest {
+            reason: format!("{field} cannot be empty"),
+        });
+    }
+    if value.len() > 80 {
+        return Err(AgentError::InvalidRequest {
+            reason: format!("{field} is too long"),
+        });
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Err(AgentError::InvalidRequest {
+            reason: format!("{field} must use ASCII letters, numbers, dash, underscore, or dot"),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_display_name(value: String) -> Result<String, AgentError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(AgentError::InvalidRequest {
+            reason: "display name cannot be empty".to_string(),
+        });
+    }
+    if value.len() > 120 {
+        return Err(AgentError::InvalidRequest {
+            reason: "display name is too long".to_string(),
+        });
+    }
+    if value.chars().any(|character| character.is_control()) {
+        return Err(AgentError::InvalidRequest {
+            reason: "display name cannot contain control characters".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_kind(value: String) -> Result<String, AgentError> {
+    let value = if value.trim().is_empty() {
+        "local-agent".to_string()
+    } else {
+        value.trim().to_string()
+    };
+    validate_identifier(value, "agent kind")
+}
+
+fn parse_key_values(contents: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        values.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    values
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn value_or_empty<'a>(values: &'a HashMap<String, String>, key: &str) -> &'a str {
+    values.get(key).map(String::as_str).unwrap_or("")
+}
+
+fn parse_bool(value: Option<&String>) -> Option<bool> {
+    value.and_then(|value| match value.as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    })
+}
+
+fn request_id(prefix: &str) -> String {
+    format!("{}_{}_{}", prefix, process::id(), current_unix_nanos())
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn sanitize_log_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+        .collect()
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registration_request_is_metadata_only() {
+        let home = test_home("metadata");
+        let registration = AgentRegistration::new("agent.codex", "Codex Desktop", "coding-agent")
+            .expect("valid registration");
+
+        let submission = submit_registration(Some(home), registration).expect("request submits");
+        let contents = fs::read_to_string(submission.request_path).expect("request reads");
+
+        assert!(contents.contains("type = \"register_agent\""));
+        assert!(contents.contains("agent_id = \"agent.codex\""));
+        assert!(!contents.contains("private message contents"));
+        assert!(!contents.contains("Review this code"));
+    }
+
+    #[test]
+    fn process_registration_persists_agent() {
+        let home = test_home("register");
+        let registration = AgentRegistration::new("agent.codex", "Codex Desktop", "coding-agent")
+            .expect("valid registration");
+        submit_registration(Some(home.clone()), registration).expect("request submits");
+
+        let report = process_gateway_requests(Some(home.clone())).expect("requests process");
+        let agents = list_local_agents(Some(home)).expect("agents read");
+
+        assert_eq!(report.processed, 1);
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].agent_id, "agent.codex");
+        assert_eq!(agents[0].presence, AgentPresence::Ready);
+    }
+
+    #[test]
+    fn registration_is_idempotent() {
+        let home = test_home("idempotent");
+        let first = AgentRegistration::new("agent.codex", "Codex Desktop", "coding-agent")
+            .expect("valid registration");
+        let second = AgentRegistration::new("agent.codex", "Codex Updated", "coding-agent")
+            .expect("valid registration");
+        submit_registration(Some(home.clone()), first).expect("first request submits");
+        submit_registration(Some(home.clone()), second).expect("second request submits");
+
+        process_gateway_requests(Some(home.clone())).expect("requests process");
+        let agents = list_local_agents(Some(home)).expect("agents read");
+
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].display_name, "Codex Updated");
+    }
+
+    #[test]
+    fn presence_heartbeat_updates_existing_agent() {
+        let home = test_home("presence");
+        let registration = AgentRegistration::new("agent.codex", "Codex Desktop", "coding-agent")
+            .expect("valid registration");
+        submit_registration(Some(home.clone()), registration).expect("registration submits");
+        process_gateway_requests(Some(home.clone())).expect("registration processes");
+        let heartbeat =
+            PresenceHeartbeat::new("agent.codex", AgentPresence::Busy).expect("heartbeat valid");
+        submit_presence_heartbeat(Some(home.clone()), heartbeat).expect("heartbeat submits");
+
+        let report = process_gateway_requests(Some(home.clone())).expect("heartbeat processes");
+        let agents = list_local_agents(Some(home)).expect("agents read");
+
+        assert_eq!(report.processed, 1);
+        assert_eq!(agents[0].presence, AgentPresence::Busy);
+    }
+
+    #[test]
+    fn bad_request_is_rejected_without_payload() {
+        let home = test_home("reject");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let bad = init.paths.ipc_inbox_dir.join("bad.req");
+        fs::write(
+            &bad,
+            "version = \"1\"\ntype = \"secret private message contents\"\n",
+        )
+        .expect("bad request writes");
+
+        let report = process_gateway_requests(Some(home.clone())).expect("requests process");
+        let rejected_dir = StatePaths::from_home(home).ipc_rejected_dir;
+        let rejected = fs::read_dir(&rejected_dir)
+            .expect("rejected dir reads")
+            .count();
+        let error_text =
+            fs::read_to_string(rejected_dir.join("bad.error")).expect("rejection reason reads");
+
+        assert_eq!(report.rejected, 1);
+        assert!(rejected >= 1);
+        assert!(error_text.contains("unsupported request type"));
+        assert!(!error_text.contains("secret private message contents"));
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "conu-agents-test-{label}-{}-{}",
+            process::id(),
+            current_unix_nanos()
+        ))
+    }
+}

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Core conU runtime concepts shared by binaries.
 
+pub mod agents;
 pub mod runtime;
 pub mod state;
 

--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -1,7 +1,7 @@
 //! Local conUD runtime state and heartbeat management.
 //!
-//! Phase 4 uses a file-backed health signal so the CLI can detect a local
-//! runtime without introducing IPC or networking before their dedicated phases.
+//! Phase 5 uses file-backed health and gateway state so the CLI can detect a
+//! local runtime and agents can submit metadata-only registration requests.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -12,11 +12,12 @@ use std::process;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::agents;
 use crate::state::{self, NodeIdentity, StateError, StatePaths};
 
 const STATUS_VERSION: &str = "1";
 const STALE_AFTER_SECS: u64 = 10;
-const LOCAL_ENDPOINT: &str = "local-ipc:phase-5-pending";
+const LOCAL_ENDPOINT: &str = "file-ipc:runtime/ipc/inbox";
 
 /// High-level state for the local conUD runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,6 +124,8 @@ impl RuntimeLease {
     pub fn serve_until_stop(&self, heartbeat_every: Duration) -> Result<(), RuntimeError> {
         while !self.stop_requested() {
             self.heartbeat()?;
+            agents::process_gateway_requests_from_paths(&self.paths, &self.node.node_id)
+                .map_err(RuntimeError::Agent)?;
             thread::sleep(heartbeat_every);
         }
 
@@ -176,6 +179,7 @@ impl Drop for RuntimeLease {
 #[derive(Debug)]
 pub enum RuntimeError {
     State(StateError),
+    Agent(agents::AgentError),
     Io {
         action: &'static str,
         path: PathBuf,
@@ -198,6 +202,7 @@ impl fmt::Display for RuntimeError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::State(error) => write!(formatter, "{error}"),
+            Self::Agent(error) => write!(formatter, "{error}"),
             Self::Io {
                 action,
                 path,
@@ -219,6 +224,12 @@ impl std::error::Error for RuntimeError {}
 impl From<StateError> for RuntimeError {
     fn from(error: StateError) -> Self {
         Self::State(error)
+    }
+}
+
+impl From<agents::AgentError> for RuntimeError {
+    fn from(error: agents::AgentError) -> Self {
+        Self::Agent(error)
     }
 }
 

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -1,8 +1,9 @@
 //! Local persistent state for conU.
 //!
-//! Phase 4 keeps this intentionally small and std-only: a locally generated
-//! node id, config, trust store skeleton, agent registry skeleton, and runtime
-//! metadata. Secret keys and encrypted payload storage belong to later phases.
+//! Phase 5 keeps this intentionally small and std-only: a locally generated
+//! node id, config, trust store skeleton, agent registry, runtime metadata, and
+//! local gateway inbox. Secret keys and encrypted payload storage belong to
+//! later phases.
 
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -23,6 +24,10 @@ const TRUST_FILE: &str = "trust.toml";
 const AGENTS_DIR: &str = "agents";
 const AGENT_REGISTRY_FILE: &str = "registry.toml";
 const RUNTIME_DIR: &str = "runtime";
+const IPC_DIR: &str = "ipc";
+const IPC_INBOX_DIR: &str = "inbox";
+const IPC_PROCESSED_DIR: &str = "processed";
+const IPC_REJECTED_DIR: &str = "rejected";
 const SESSIONS_DIR: &str = "sessions";
 const MAILBOX_DIR: &str = "mailbox";
 const LOGS_DIR: &str = "logs";
@@ -40,6 +45,10 @@ pub struct StatePaths {
     pub runtime_status: PathBuf,
     pub runtime_lock: PathBuf,
     pub runtime_stop_request: PathBuf,
+    pub ipc_dir: PathBuf,
+    pub ipc_inbox_dir: PathBuf,
+    pub ipc_processed_dir: PathBuf,
+    pub ipc_rejected_dir: PathBuf,
     pub sessions_dir: PathBuf,
     pub mailbox_dir: PathBuf,
     pub logs_dir: PathBuf,
@@ -60,6 +69,7 @@ impl StatePaths {
     pub fn from_home(home: PathBuf) -> Self {
         let agents_dir = home.join(AGENTS_DIR);
         let runtime_dir = home.join(RUNTIME_DIR);
+        let ipc_dir = runtime_dir.join(IPC_DIR);
 
         Self {
             node_identity: home.join(NODE_FILE),
@@ -71,6 +81,10 @@ impl StatePaths {
             runtime_lock: runtime_dir.join("conud.lock"),
             runtime_stop_request: runtime_dir.join("stop.request"),
             runtime_dir,
+            ipc_inbox_dir: ipc_dir.join(IPC_INBOX_DIR),
+            ipc_processed_dir: ipc_dir.join(IPC_PROCESSED_DIR),
+            ipc_rejected_dir: ipc_dir.join(IPC_REJECTED_DIR),
+            ipc_dir,
             sessions_dir: home.join(SESSIONS_DIR),
             mailbox_dir: home.join(MAILBOX_DIR),
             logs_dir: home.join(LOGS_DIR),
@@ -234,6 +248,10 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
         &paths.home,
         &paths.agents_dir,
         &paths.runtime_dir,
+        &paths.ipc_dir,
+        &paths.ipc_inbox_dir,
+        &paths.ipc_processed_dir,
+        &paths.ipc_rejected_dir,
         &paths.sessions_dir,
         &paths.mailbox_dir,
         &paths.logs_dir,
@@ -361,7 +379,7 @@ fn render_trust_store() -> String {
 }
 
 fn render_agent_registry() -> String {
-    "# conU local agent registry skeleton\nversion = \"1\"\nagents = []\n".to_string()
+    "# conU local agent registry\nversion = \"1\"\n".to_string()
 }
 
 fn escape_file_value(value: &str) -> String {
@@ -462,6 +480,12 @@ mod tests {
         assert!(home.join(TRUST_FILE).exists());
         assert!(home.join(AGENTS_DIR).join(AGENT_REGISTRY_FILE).exists());
         assert!(home.join(RUNTIME_DIR).exists());
+        assert!(
+            home.join(RUNTIME_DIR)
+                .join(IPC_DIR)
+                .join(IPC_INBOX_DIR)
+                .exists()
+        );
     }
 
     #[test]

--- a/crates/conud/src/main.rs
+++ b/crates/conud/src/main.rs
@@ -11,6 +11,7 @@ fn main() -> ExitCode {
         }
         Some("--serve") | None => serve_runtime(),
         Some("--once") => run_once(),
+        Some("--process-ipc") => process_ipc_once(),
         Some("--status") => print_status(),
         Some("--help") | Some("-h") => {
             print_help();
@@ -74,7 +75,11 @@ fn serve_runtime() -> ExitCode {
 
 fn run_once() -> ExitCode {
     match conu_core::runtime::acquire_runtime(None) {
-        Ok(lease) => match lease.heartbeat().and_then(|_| lease.stop()) {
+        Ok(lease) => match lease.heartbeat().and_then(|_| {
+            conu_core::agents::process_gateway_requests(None)
+                .map_err(conu_core::runtime::RuntimeError::from)?;
+            lease.stop()
+        }) {
             Ok(status) => {
                 println!(
                     "conUD one-shot completed; state {}; payloads not observed",
@@ -89,6 +94,22 @@ fn run_once() -> ExitCode {
         },
         Err(error) => {
             eprintln!("conUD one-shot failed: {error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn process_ipc_once() -> ExitCode {
+    match conu_core::agents::process_gateway_requests(None) {
+        Ok(report) => {
+            println!(
+                "conUD IPC processed {}; rejected {}; payloads not observed",
+                report.processed, report.rejected
+            );
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("conUD IPC processing failed: {error}");
             ExitCode::from(1)
         }
     }
@@ -117,7 +138,7 @@ fn print_status() -> ExitCode {
 
 fn print_check() {
     println!("{}", conu_core::scaffold_status("conud"));
-    println!("runtime: phase 4 heartbeat skeleton ready; payloads not observed");
+    println!("runtime: phase 5 local IPC registration ready; payloads not observed");
 }
 
 fn print_help() {
@@ -128,6 +149,7 @@ Usage:
   conud
   conud --serve
   conud --once
+  conud --process-ipc
   conud --check
   conud --status
   conud --help

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 5 - Local IPC And Agent Registration
+Current phase: Phase 6 - Opaque Envelope Messaging
 Status: not_started
 Last updated: 2026-05-10
 ```
@@ -386,7 +386,7 @@ Next:
 
 ## Phase 5 - Local IPC And Agent Registration
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -394,17 +394,71 @@ Let local agents register with conUD through a local gateway.
 
 Deliverables:
 
-- local IPC transport
-- register agent request
-- agent card model
-- presence heartbeat
-- `conu agents` local list
+- [x] local IPC transport
+- [x] register agent request
+- [x] agent card model
+- [x] presence heartbeat
+- [x] `conu agents` local list
 
 Exit criteria:
 
-- A sample local agent can register.
-- CLI lists local registered agents.
-- Agent identity persists.
+- [x] A sample local agent can register.
+- [x] CLI lists local registered agents.
+- [x] Agent identity persists.
+
+Completed work:
+
+- Created GitHub issue #9 for Phase 5.
+- Created and pushed branch `codex/phase-5-local-ipc-agents`.
+- Added std-only `conu_core::agents` local gateway and registry module.
+- Added file-backed IPC directories under `runtime/ipc/inbox`, `runtime/ipc/processed`, and `runtime/ipc/rejected`.
+- Added metadata-only registration request submission and processing.
+- Added presence heartbeat submission and processing for registered local agents.
+- Persisted local agent records in `agents/registry.toml` with id, display name, node id, kind, presence, last seen time, and capability booleans.
+- Integrated conUD serve loop and `conud --process-ipc` with gateway request processing.
+- Updated `conu agents`, `conu agents --json`, `conu agents register`, and `conu agents heartbeat`.
+- Updated `conu status` and dashboard output with local IPC and local agent count.
+- Added payload-safe `logs/agents.log` metadata lines with `payload=not_observed`.
+- Hardened rejected IPC request errors so arbitrary request contents are not echoed into rejection reasons.
+- Updated README, repo overview, builder guardrails, and agent gateway contract.
+
+Files changed:
+
+- `README.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `plan.md`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-core/src/agents.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-core/src/runtime.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conud/src/main.rs`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu build -p conud -p conu-cli` passed.
+- Direct binary smoke passed with isolated `CONU_HOME`: `conu init`, `conu start`, `conu agents register agent.codex "Codex Desktop" --kind coding-agent`, `conu agents heartbeat agent.codex --presence busy`, `conu status --json`, and `conu stop`.
+- Smoke follow-up confirmed `conu agents --json` showed `presence: busy`.
+- Smoke log review confirmed `logs/agents.log` contains only metadata lines with `payload=not_observed`.
+- `conud --process-ipc` passed after daemon stop with no pending requests.
+- Explicit process check confirmed no `conud` process remained running after smoke.
+
+Known gaps:
+
+- Phase 5 IPC is file-backed for reliability and visibility; it is not yet named pipes, Unix sockets, or binary framed IPC.
+- The gateway only supports registration and presence. Message send/receive starts in Phase 6.
+- Agent capabilities are basic booleans only; policy grants and signed agent cards arrive in later trust/security phases.
+- There is no remote discovery or relay integration yet.
+
+Next:
+
+- Start Phase 6: local opaque envelope messaging with sender/receiver validation, local inbox, and delivery metadata that never displays payload contents.
 
 ## Phase 6 - Opaque Envelope Messaging
 
@@ -636,4 +690,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 2 completed. CLI dashboard and command shell created with payload-safe outputs, tests, and smoke validation. Next: Phase 3 local identity and persistent state.
 2026-05-10 - Phase 3 completed. Local identity and persistent state added with idempotent init, status reads, tests, and isolated CONU_HOME smoke validation. Next: Phase 4 conUD daemon skeleton.
 2026-05-10 - Phase 4 completed. conUD daemon skeleton added with start/stop, runtime heartbeat status, stale restart handling, payload-safe logs, tests, and isolated CONU_HOME process smoke. Next: Phase 5 local IPC and agent registration.
+2026-05-10 - Phase 5 completed. File-backed local IPC gateway added with metadata-only agent registration, presence heartbeat, persisted local agent registry, conUD processing, CLI listing, tests, docs, and isolated CONU_HOME smoke validation. Next: Phase 6 opaque envelope messaging.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- Adds Phase 5 file-backed local IPC gateway for metadata-only agent registration and presence.
- Persists local agent records in `agents/registry.toml` and processes requests from `runtime/ipc/inbox` into processed/rejected folders.
- Wires `conu agents register`, `conu agents heartbeat`, `conu agents --json`, `conud --process-ipc`, runtime processing, docs, and future-agent guardrails.

## Privacy / Security
- No message send/receive path is introduced in Phase 5.
- CLI and logs expose metadata only and keep payload contents hidden.
- Rejected IPC request reasons do not echo arbitrary request contents.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu test --workspace`
- `cargo +stable-x86_64-pc-windows-gnu build -p conud -p conu-cli`
- Direct isolated smoke: `conu init`, `conu start`, `conu agents register`, `conu agents heartbeat`, `conu status --json`, `conu stop`
- Smoke log check confirmed `logs/agents.log` only contains metadata with `payload=not_observed`

Closes #9


___

## **CodeAnt-AI Description**
**Add local agent registration and presence tracking through the file-backed gateway**

### What Changed
- Local agents can now register with conUD and report presence through `conu agents register` and `conu agents heartbeat`
- Registered agents are saved in the local agent registry and now appear in `conu agents`, `conu status`, and the dashboard
- conUD now processes queued gateway requests with `--process-ipc` and during its normal runtime loop
- Rejected requests are moved aside with safe reasons, and logs stay metadata-only without showing request contents
- Help text, docs, and status messages now reflect Phase 5 behavior and the new local gateway paths

### Impact
`✅ Local agent setup from the CLI`
`✅ Clearer visibility into registered agents and presence`
`✅ Fewer lost agent requests while conUD is running or offline`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=DlD8470UzFq95WrdyDkanMp4mN5dq8RG5kr2rfdM2ps&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
