### PR TITLE
Phase 6: Opaque local messaging

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 5.
+The repository has completed Phase 6.
 
 Implemented so far:
 
@@ -21,8 +21,13 @@ Implemented so far:
 - local agent registration through `conu agents register`
 - local presence heartbeat through `conu agents heartbeat`
 - persisted local agent registry with capability metadata
+- local opaque envelope submission through `conu messages send --stdin`
+- local recipient inbox listing through `conu messages inbox`
+- metadata-only delivery receipts through `conu messages receipts`
+- conUD processing for local message delivery
 - payload-safe status and agent registry reporting
 - payload-safe runtime and agent metadata logs
+- payload-safe message delivery metadata logs
 - payload-safe protocol scaffold
 - daemon and relay placeholder binaries
 

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -45,9 +45,9 @@ conUD handles:
 - delivery receipts
 - relay fallback
 
-## Phase 5 Implemented Surface
+## Implemented Surface
 
-The current local gateway is a file-backed, metadata-only IPC path:
+The Phase 5 local agent gateway is a file-backed, metadata-only IPC path:
 
 ```txt
 runtime/ipc/inbox       submitted requests
@@ -73,7 +73,32 @@ register_agent
 presence_heartbeat
 ```
 
-This phase intentionally does not expose `send`, `receive`, streams, rooms, relay discovery, or payload storage. Those start in later phases.
+The Phase 6 local message gateway is a separate file-backed queue and local inbox path:
+
+```txt
+runtime/ipc/messages/inbox       submitted local message requests
+runtime/ipc/messages/processed   metadata-only processed markers
+runtime/ipc/messages/rejected    safe rejection reasons
+messages/inbox/<agent-id>        delivered opaque local envelopes
+messages/receipts                metadata-only delivery receipts
+logs/messages.log                metadata-only delivery events
+```
+
+Supported commands:
+
+```txt
+conu messages send <from-agent> <to-agent> --stdin [--json]
+conu messages inbox <agent-id> [--json]
+conu messages receipts [--json]
+```
+
+Supported request type:
+
+```txt
+send_message
+```
+
+Phase 6 intentionally does not expose remote relay delivery, discovery, streams, rooms, or pub/sub. Those start in later phases.
 
 ## Safety
 

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -53,7 +53,17 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Presence heartbeat may update only an already registered local agent.
 - Rejected requests must not echo arbitrary request contents into CLI output, logs, tests, or `.error` files.
 - Agent logs must use metadata-only lines such as event, agent id, and `payload=not_observed`.
-- Do not add message send/receive, payload storage, remote discovery, or relay behavior to the gateway until the relevant later phase.
+- Do not add message send/receive, payload storage, remote discovery, or relay behavior to the Phase 5 registration inbox; Phase 6+ message work belongs in separate message routing modules and queues.
+
+## Local Message Routing Rules
+
+- Phase 6 local messages use a separate file-backed queue under `runtime/ipc/messages/`.
+- CLI message send must read payload bytes from stdin or a future SDK/gateway API, not from a direct command-line text argument.
+- Sender and recipient must both be registered local agents before conUD delivers an envelope.
+- Recipient inbox files may store opaque payload bytes for local delivery, but all CLI, log, receipt, processed-marker, and rejected-marker surfaces must show metadata only.
+- Rejected message requests must delete the original payload-bearing request and write only a safe reason.
+- Message logs must use metadata-only lines such as envelope id, from, to, byte count, and `payload=not_observed`.
+- Do not add remote message routing, relay forwarding, discovery, streams, or rooms while completing Phase 6.
 
 ## Privacy Rules
 

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -20,10 +20,10 @@ crates/conu-cli
   CLI commands, ASCII dashboard, watch animation, user control flow
 
 crates/conud
-  daemon process, local gateway processing, session manager, runtime lifecycle
+  daemon process, local gateway/message processing, session manager, runtime lifecycle
 
 crates/conu-core
-  local state, runtime lifecycle, agent registry, gateway processing, future trust/policy logic
+  local state, runtime lifecycle, agent registry, local message routing, future trust/policy logic
 
 crates/conu-protocol
   envelopes, agent cards, control-plane messages, data-plane messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "conu-cli"
 version = "0.1.0"
 dependencies = [
  "conu-core",
+ "conu-protocol",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 5 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, and local agents can register metadata and presence through the file-backed gateway.
+Phase 6 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, local agents can register metadata and presence, and registered local agents can exchange opaque message envelopes through conUD.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -45,13 +45,17 @@ runtime/stop.request   graceful shutdown request file
 runtime/ipc/inbox/     metadata-only agent gateway requests
 runtime/ipc/processed/ processed gateway requests
 runtime/ipc/rejected/  rejected gateway requests and safe reasons
+runtime/ipc/messages/  opaque local message request queue
+messages/inbox/        delivered local opaque envelopes by recipient agent
+messages/receipts/     metadata-only local delivery receipts
 sessions/              future runtime sessions
 mailbox/               future encrypted mailbox storage
 logs/conud.log         runtime metadata log
 logs/agents.log        local agent metadata log
+logs/messages.log      local message delivery metadata log
 ```
 
-No private message payloads or secret keys are stored by Phase 5. Runtime and agent logs contain metadata only, such as event name, pid, node id, agent id, and `payload=not_observed`.
+Runtime, agent, and message logs contain metadata only, such as event name, pid, node id, agent id, envelope id, byte count, and `payload=not_observed`. Phase 6 local message payload bytes are stored only as opaque recipient-inbox envelope data; CLI output, receipts, processed markers, rejected markers, and logs do not display message contents. Until encryption hardening lands in Phase 11, agents should prefer already-encrypted payload bytes for sensitive local messages.
 
 ## Local Agent Gateway
 
@@ -70,7 +74,18 @@ When `conUD` is running, it processes pending requests from `runtime/ipc/inbox/`
 conud --process-ipc
 ```
 
-This gateway does not send or receive message payloads yet. Opaque local messaging starts in Phase 6.
+## Local Opaque Messages
+
+Phase 6 adds local-only message delivery between registered agents:
+
+```bash
+conu messages send agent.sender agent.receiver --stdin
+conu messages inbox agent.receiver
+conu messages inbox agent.receiver --json
+conu messages receipts
+```
+
+`conu messages send` reads bytes from stdin so payloads are not placed directly in the command line. When `conUD` is running, delivery is processed automatically. If the runtime is offline, message requests remain queued under `runtime/ipc/messages/inbox/` and can be processed with `conud --process-ipc`.
 
 ## Development
 
@@ -98,6 +113,9 @@ cargo run -p conu-cli -- agents
 cargo run -p conu-cli -- agents --json
 cargo run -p conu-cli -- agents register agent.codex "Codex Desktop" --kind coding-agent
 cargo run -p conu-cli -- agents heartbeat agent.codex --presence busy
+cargo run -p conu-cli -- messages send agent.sender agent.receiver --stdin
+cargo run -p conu-cli -- messages inbox agent.receiver --json
+cargo run -p conu-cli -- messages receipts --json
 cargo run -p conu-cli -- pair
 cargo run -p conu-cli -- join 482913
 cargo run -p conu-cli -- connect

--- a/crates/conu-cli/Cargo.toml
+++ b/crates/conu-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 conu-core.workspace = true
+conu-protocol.workspace = true
 
 [lib]
 name = "conu_cli"

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -1,8 +1,9 @@
 //! CLI rendering and command dispatch for conU.
 //!
-//! Phase 5 adds conUD runtime detection and metadata-only local agent
-//! registration.
+//! Phase 6 adds conUD runtime detection, metadata-only local agent
+//! registration, and local opaque envelope delivery.
 
+use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -12,8 +13,10 @@ use std::time::Duration;
 use conu_core::agents::{
     self, AgentPresence, AgentRegistration, LocalAgentRecord, PresenceHeartbeat,
 };
+use conu_core::messages::{self, DeliveryReceipt, InboxEntry, LocalMessage};
 use conu_core::runtime::{self, RuntimeState, RuntimeStatus, StopReport};
 use conu_core::state::{self, InitReport, StateSnapshot};
+use conu_protocol::OpaquePayload;
 
 /// A rendered CLI command result.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,7 +50,7 @@ where
     I: IntoIterator<Item = S>,
     S: Into<String>,
 {
-    run_with_home(args, None)
+    run_with_home_and_stdin(args, None, Vec::new())
 }
 
 /// Dispatch a conU CLI invocation with an explicit state home.
@@ -55,6 +58,28 @@ where
 /// This is mostly used by tests and smoke checks so they do not touch a real
 /// user profile.
 pub fn run_with_home<I, S>(args: I, home_override: Option<PathBuf>) -> CliOutput
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    run_with_home_and_stdin(args, home_override, Vec::new())
+}
+
+/// Dispatch a conU CLI invocation with explicit stdin bytes.
+pub fn run_with_stdin<I, S>(args: I, stdin_payload: Vec<u8>) -> CliOutput
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    run_with_home_and_stdin(args, None, stdin_payload)
+}
+
+/// Dispatch a conU CLI invocation with explicit state and stdin bytes.
+pub fn run_with_home_and_stdin<I, S>(
+    args: I,
+    home_override: Option<PathBuf>,
+    stdin_payload: Vec<u8>,
+) -> CliOutput
 where
     I: IntoIterator<Item = S>,
     S: Into<String>,
@@ -68,6 +93,7 @@ where
         "init" => render_init(&args[1..], home_override),
         "status" => render_status(&args[1..], home_override),
         "agents" | "peers" => render_agents(&args[1..], home_override),
+        "messages" => render_messages(&args[1..], home_override, stdin_payload),
         "pair" => render_pair(&args[1..]),
         "join" => render_join(&args[1..]),
         "connect" => render_connect(&args[1..], home_override),
@@ -127,6 +153,7 @@ quick commands
   conu status
   conu agents
   conu agents register <agent-id> <display-name>
+  conu messages send <from-agent> <to-agent> --stdin
   conu pair
   conu join <code>
   conu connect
@@ -585,20 +612,410 @@ fn runtime_is_live(home_override: Option<PathBuf>) -> bool {
         .unwrap_or(false)
 }
 
+fn render_messages(
+    args: &[String],
+    home_override: Option<PathBuf>,
+    stdin_payload: Vec<u8>,
+) -> CliOutput {
+    match args.first().map(String::as_str) {
+        Some("send") => render_message_send(&args[1..], home_override, stdin_payload),
+        Some("inbox") => render_message_inbox(&args[1..], home_override),
+        Some("receipts") => render_message_receipts(&args[1..], home_override),
+        _ => CliOutput::failure(2, render_messages_usage()),
+    }
+}
+
+fn render_message_send(
+    args: &[String],
+    home_override: Option<PathBuf>,
+    stdin_payload: Vec<u8>,
+) -> CliOutput {
+    let parsed = match parse_message_send_args(args) {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    if !parsed.stdin {
+        return CliOutput::failure(2, render_messages_usage());
+    }
+    if stdin_payload.is_empty() {
+        return CliOutput::failure(2, "stdin payload is empty");
+    }
+
+    let before = inbox_ids(home_override.clone(), &parsed.to_agent_id);
+    let payload_bytes = stdin_payload.len();
+    let message = match LocalMessage::new(
+        &parsed.from_agent_id,
+        &parsed.to_agent_id,
+        OpaquePayload::from_bytes(stdin_payload),
+    ) {
+        Ok(message) => message,
+        Err(error) => {
+            return CliOutput::failure(2, format!("conU messages send failed\n\n{error}"));
+        }
+    };
+    let submission = match messages::submit_local_message(home_override.clone(), message) {
+        Ok(submission) => submission,
+        Err(error) => {
+            return CliOutput::failure(1, format!("conU messages send failed\n\n{error}"));
+        }
+    };
+    let delivered = wait_for_message_delivery(
+        home_override,
+        &parsed.to_agent_id,
+        before,
+        submission.payload_bytes,
+    );
+    let status = if delivered.is_some() {
+        "delivered"
+    } else {
+        "queued"
+    };
+
+    if parsed.json {
+        let envelope_id = delivered
+            .as_ref()
+            .map(|entry| json_string(&entry.envelope_id))
+            .unwrap_or_else(|| "null".to_string());
+        return CliOutput::success(format!(
+            r#"{{
+  "status": "{}",
+  "fromAgentId": "{}",
+  "toAgentId": "{}",
+  "requestId": "{}",
+  "envelopeId": {},
+  "payloadBytes": {},
+  "contentsDisplayed": false
+}}"#,
+            status,
+            json_escape(&parsed.from_agent_id),
+            json_escape(&parsed.to_agent_id),
+            json_escape(&submission.request_id),
+            envelope_id,
+            payload_bytes
+        ));
+    }
+
+    let envelope_line = delivered
+        .as_ref()
+        .map(|entry| format!("envelope: {}", entry.envelope_id))
+        .unwrap_or_else(|| "envelope: pending".to_string());
+
+    CliOutput::success(format!(
+        r"conU messages send
+
+status: {status}
+from: {}
+to: {}
+request: {}
+{envelope_line}
+bytes: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        parsed.from_agent_id, parsed.to_agent_id, submission.request_id, payload_bytes
+    ))
+}
+
+fn render_message_inbox(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let parsed = match parse_message_inbox_args(args) {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    let entries = match messages::list_agent_inbox(home_override, &parsed.agent_id) {
+        Ok(entries) => entries,
+        Err(error) => {
+            return CliOutput::failure(1, format!("conU messages inbox failed\n\n{error}"));
+        }
+    };
+
+    if parsed.json {
+        return CliOutput::success(render_inbox_json(&parsed.agent_id, &entries));
+    }
+
+    CliOutput::success(render_inbox_text(&parsed.agent_id, &entries))
+}
+
+fn render_message_receipts(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let json = match json_flag(args) {
+        Ok(json) => json,
+        Err(error) => return error,
+    };
+    let receipts = match messages::list_receipts(home_override) {
+        Ok(receipts) => receipts,
+        Err(error) => {
+            return CliOutput::failure(1, format!("conU messages receipts failed\n\n{error}"));
+        }
+    };
+
+    if json {
+        return CliOutput::success(render_receipts_json(&receipts));
+    }
+
+    CliOutput::success(render_receipts_text(&receipts))
+}
+
+fn render_inbox_json(agent_id: &str, entries: &[InboxEntry]) -> String {
+    let messages = entries
+        .iter()
+        .map(|entry| {
+            format!(
+                r#"    {{
+      "envelopeId": "{}",
+      "fromAgentId": "{}",
+      "toAgentId": "{}",
+      "receiptId": "{}",
+      "payloadBytes": {},
+      "deliveredAtUnix": {}
+    }}"#,
+                json_escape(&entry.envelope_id),
+                json_escape(&entry.from_agent_id),
+                json_escape(&entry.to_agent_id),
+                json_escape(&entry.receipt_id),
+                entry.payload_bytes,
+                entry.delivered_at_unix
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let messages = if messages.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{messages}\n  ]")
+    };
+
+    format!(
+        r#"{{
+  "agentId": "{}",
+  "messages": {},
+  "contentsDisplayed": false
+}}"#,
+        json_escape(agent_id),
+        messages
+    )
+}
+
+fn render_inbox_text(agent_id: &str, entries: &[InboxEntry]) -> String {
+    let messages = if entries.is_empty() {
+        "  none delivered yet".to_string()
+    } else {
+        entries
+            .iter()
+            .map(|entry| {
+                format!(
+                    "  {}  from {}  bytes {}  receipt {}",
+                    entry.envelope_id, entry.from_agent_id, entry.payload_bytes, entry.receipt_id
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        r"conU messages inbox
+
+agent: {agent_id}
+messages
+{messages}
+
+privacy
+  payload view  contents are not displayed by conU"
+    )
+}
+
+fn render_receipts_json(receipts: &[DeliveryReceipt]) -> String {
+    let receipts = receipts
+        .iter()
+        .map(|receipt| {
+            format!(
+                r#"    {{
+      "receiptId": "{}",
+      "envelopeId": "{}",
+      "fromAgentId": "{}",
+      "toAgentId": "{}",
+      "status": "{}",
+      "payloadBytes": {},
+      "deliveredAtUnix": {}
+    }}"#,
+                json_escape(&receipt.receipt_id),
+                json_escape(&receipt.envelope_id),
+                json_escape(&receipt.from_agent_id),
+                json_escape(&receipt.to_agent_id),
+                json_escape(&receipt.status),
+                receipt.payload_bytes,
+                receipt.delivered_at_unix
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let receipts = if receipts.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{receipts}\n  ]")
+    };
+
+    format!(
+        r#"{{
+  "receipts": {},
+  "contentsDisplayed": false
+}}"#,
+        receipts
+    )
+}
+
+fn render_receipts_text(receipts: &[DeliveryReceipt]) -> String {
+    let receipts = if receipts.is_empty() {
+        "  none recorded yet".to_string()
+    } else {
+        receipts
+            .iter()
+            .map(|receipt| {
+                format!(
+                    "  {}  {}  {} -> {}  bytes {}",
+                    receipt.receipt_id,
+                    receipt.status,
+                    receipt.from_agent_id,
+                    receipt.to_agent_id,
+                    receipt.payload_bytes
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        r"conU messages receipts
+
+receipts
+{receipts}
+
+privacy
+  payload view  contents are not displayed by conU"
+    )
+}
+
+struct MessageSendArgs {
+    from_agent_id: String,
+    to_agent_id: String,
+    stdin: bool,
+    json: bool,
+}
+
+struct MessageInboxArgs {
+    agent_id: String,
+    json: bool,
+}
+
+fn parse_message_send_args(args: &[String]) -> Result<MessageSendArgs, CliOutput> {
+    let mut json = false;
+    let mut stdin = false;
+    let mut positional = Vec::new();
+
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            "--stdin" => stdin = true,
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            value => positional.push(value.to_string()),
+        }
+    }
+
+    if positional.len() != 2 {
+        return Err(CliOutput::failure(2, render_messages_usage()));
+    }
+
+    Ok(MessageSendArgs {
+        from_agent_id: positional.remove(0),
+        to_agent_id: positional.remove(0),
+        stdin,
+        json,
+    })
+}
+
+fn parse_message_inbox_args(args: &[String]) -> Result<MessageInboxArgs, CliOutput> {
+    let mut json = false;
+    let mut agent_id = None;
+
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            value => {
+                if agent_id.is_some() {
+                    return Err(CliOutput::failure(2, render_messages_usage()));
+                }
+                agent_id = Some(value.to_string());
+            }
+        }
+    }
+
+    let Some(agent_id) = agent_id else {
+        return Err(CliOutput::failure(2, render_messages_usage()));
+    };
+
+    Ok(MessageInboxArgs { agent_id, json })
+}
+
+fn render_messages_usage() -> String {
+    r"usage:
+  conu messages send <from-agent> <to-agent> --stdin [--json]
+  conu messages inbox <agent-id> [--json]
+  conu messages receipts [--json]"
+        .to_string()
+}
+
+fn inbox_ids(home_override: Option<PathBuf>, agent_id: &str) -> HashSet<String> {
+    messages::list_agent_inbox(home_override, agent_id)
+        .map(|entries| {
+            entries
+                .into_iter()
+                .map(|entry| entry.envelope_id)
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn wait_for_message_delivery(
+    home_override: Option<PathBuf>,
+    to_agent_id: &str,
+    before: HashSet<String>,
+    payload_bytes: usize,
+) -> Option<InboxEntry> {
+    if !runtime_is_live(home_override.clone()) {
+        return None;
+    }
+
+    for _ in 0..40 {
+        if let Ok(entries) = messages::list_agent_inbox(home_override.clone(), to_agent_id) {
+            if let Some(entry) = entries.into_iter().find(|entry| {
+                !before.contains(&entry.envelope_id) && entry.payload_bytes == payload_bytes
+            }) {
+                return Some(entry);
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    None
+}
+
 fn render_pair(args: &[String]) -> CliOutput {
     match json_flag(args) {
         Ok(true) => CliOutput::success(
             r#"{
   "status": "reserved",
   "phase": "Phase 7",
-  "message": "pairing code generation is not active in Phase 5"
+  "message": "pairing code generation is not active in Phase 6"
 }"#,
         ),
         Ok(false) => CliOutput::success(
             r"conU pair
 
 status: reserved for Phase 7
-code: not generated in Phase 5
+code: not generated in Phase 6
 purpose: create trust between two conUD runtimes",
         ),
         Err(error) => error,
@@ -612,7 +1029,7 @@ fn render_join(args: &[String]) -> CliOutput {
                 r#"{
   "status": "reserved",
   "phase": "Phase 7",
-  "message": "join validation is not active in Phase 5"
+  "message": "join validation is not active in Phase 6"
 }"#,
             ),
             Err(error) => error,
@@ -625,7 +1042,7 @@ fn render_join(args: &[String]) -> CliOutput {
 
 status: reserved for Phase 7
 code: accepted for command shape only
-action: no trust entry created in Phase 5",
+action: no trust entry created in Phase 6",
         ),
         Err(error) => error,
     }
@@ -661,7 +1078,7 @@ selector
   target remote agent  none visible
   mode                 message | stream | room | observe
 
-status: waiting for Phase 6 local messaging and Phase 9 remote discovery",
+status: local messages use `conu messages send`; interactive connect waits for Phase 9 remote discovery",
     ))
 }
 
@@ -952,6 +1369,9 @@ Usage:
   conu agents [--json]
   conu agents register <agent-id> <display-name> [--kind <kind>] [--json]
   conu agents heartbeat <agent-id> [--presence <ready|busy|idle|offline>] [--json]
+  conu messages send <from-agent> <to-agent> --stdin [--json]
+  conu messages inbox <agent-id> [--json]
+  conu messages receipts [--json]
   conu peers [--json]
   conu pair [--json]
   conu join <code> [--json]
@@ -963,7 +1383,7 @@ Usage:
   conu --help
   conu --version
 
-Phase 5 adds metadata-only local agent registration through the conUD file gateway. Pairing, relay, messaging, and streaming arrive in later phases."
+Phase 6 adds local opaque envelope delivery through conUD. Pairing, relay, remote discovery, and streaming arrive in later phases."
         .to_string()
 }
 
@@ -1132,6 +1552,10 @@ fn json_escape(value: &str) -> String {
     escaped
 }
 
+fn json_string(value: &str) -> String {
+    format!("\"{}\"", json_escape(value))
+}
+
 fn json_flag(args: &[String]) -> Result<bool, CliOutput> {
     let mut json = false;
     for arg in args {
@@ -1192,7 +1616,7 @@ mod tests {
     }
 
     #[test]
-    fn phase_five_commands_are_registered() {
+    fn phase_six_commands_are_registered() {
         let home = temp_home("commands");
 
         for command in [
@@ -1204,6 +1628,8 @@ mod tests {
 
         let join = run(["join", "123456"]);
         assert_eq!(join.code, 0);
+        let receipts = run_with_home(["messages", "receipts"], Some(home));
+        assert_eq!(receipts.code, 0);
     }
 
     #[test]
@@ -1274,6 +1700,96 @@ mod tests {
         assert_eq!(output.code, 0, "{}", output.stderr);
         assert!(output.stdout.contains("status: queued"));
         assert!(output.stdout.contains("presence: busy"));
+    }
+
+    #[test]
+    fn messages_send_queues_opaque_stdin_payload() {
+        let home = temp_home("message-send-queued");
+
+        let output = run_with_home_and_stdin(
+            [
+                "messages",
+                "send",
+                "agent.sender",
+                "agent.receiver",
+                "--stdin",
+            ],
+            Some(home.clone()),
+            b"private message contents".to_vec(),
+        );
+        let request = std::fs::read_dir(state::StatePaths::from_home(home).message_ipc_inbox_dir)
+            .expect("message inbox reads")
+            .next()
+            .expect("message request exists")
+            .expect("message request entry");
+        let request_text = std::fs::read_to_string(request.path()).expect("request reads");
+
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        assert!(output.stdout.contains("status: queued"));
+        assert!(output.stdout.contains("bytes: 24"));
+        assert!(!output.stdout.contains("private message contents"));
+        assert!(request_text.contains("payload_len = 24"));
+        assert!(!request_text.contains("private message contents"));
+    }
+
+    #[test]
+    fn messages_inbox_lists_metadata_without_payload() {
+        let home = temp_home("message-inbox");
+        register_test_agent(&home, "agent.sender");
+        register_test_agent(&home, "agent.receiver");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("message valid");
+        messages::submit_local_message(Some(home.clone()), message).expect("message submits");
+        messages::process_message_requests(Some(home.clone())).expect("message processes");
+
+        let output = run_with_home(["messages", "inbox", "agent.receiver"], Some(home));
+
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        assert!(output.stdout.contains("from agent.sender"));
+        assert!(output.stdout.contains("bytes 24"));
+        assert!(
+            output
+                .stdout
+                .contains("payload view  contents are not displayed")
+        );
+        assert!(!output.stdout.contains("private message contents"));
+    }
+
+    #[test]
+    fn messages_inbox_json_lists_metadata_without_payload() {
+        let home = temp_home("message-inbox-json");
+        register_test_agent(&home, "agent.sender");
+        register_test_agent(&home, "agent.receiver");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes([7, 8, 9]),
+        )
+        .expect("message valid");
+        messages::submit_local_message(Some(home.clone()), message).expect("message submits");
+        messages::process_message_requests(Some(home.clone())).expect("message processes");
+
+        let output = run_with_home(
+            ["messages", "inbox", "agent.receiver", "--json"],
+            Some(home),
+        );
+
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        assert!(output.stdout.contains("\"fromAgentId\": \"agent.sender\""));
+        assert!(output.stdout.contains("\"payloadBytes\": 3"));
+        assert!(output.stdout.contains("\"contentsDisplayed\": false"));
+    }
+
+    #[test]
+    fn messages_send_requires_stdin_flag() {
+        let output = run(["messages", "send", "agent.sender", "agent.receiver"]);
+
+        assert_eq!(output.code, 2);
+        assert!(output.stderr.contains("conu messages send"));
     }
 
     #[test]
@@ -1391,5 +1907,12 @@ mod tests {
             .as_nanos();
 
         std::env::temp_dir().join(format!("conu-cli-test-{label}-{}-{nonce}", process::id()))
+    }
+
+    fn register_test_agent(home: &PathBuf, agent_id: &str) {
+        let registration =
+            AgentRegistration::new(agent_id, agent_id, "test-agent").expect("valid registration");
+        agents::submit_registration(Some(home.clone()), registration).expect("request submits");
+        agents::process_gateway_requests(Some(home.clone())).expect("request processes");
     }
 }

--- a/crates/conu-cli/src/main.rs
+++ b/crates/conu-cli/src/main.rs
@@ -1,8 +1,20 @@
 use std::env;
+use std::io::{self, Read};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    let output = conu_cli::run(env::args().skip(1));
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let stdin_payload = if needs_stdin_payload(&args) {
+        let mut payload = Vec::new();
+        if let Err(error) = io::stdin().read_to_end(&mut payload) {
+            eprintln!("conU failed to read stdin payload: {error}");
+            return ExitCode::from(1);
+        }
+        payload
+    } else {
+        Vec::new()
+    };
+    let output = conu_cli::run_with_stdin(args, stdin_payload);
 
     if !output.stdout.is_empty() {
         print!("{}", output.stdout);
@@ -12,4 +24,14 @@ fn main() -> ExitCode {
     }
 
     ExitCode::from(output.code as u8)
+}
+
+fn needs_stdin_payload(args: &[String]) -> bool {
+    matches!(
+        args,
+        [command, subcommand, ..]
+            if command == "messages"
+                && subcommand == "send"
+                && args.iter().any(|arg| arg == "--stdin")
+    )
 }

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Core conU runtime concepts shared by binaries.
 
 pub mod agents;
+pub mod messages;
 pub mod runtime;
 pub mod state;
 

--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -1,0 +1,929 @@
+//! Local opaque message routing.
+//!
+//! Phase 6 delivers local-only opaque envelopes between registered agents. The
+//! runtime validates identities and stores byte payloads as opaque transport
+//! data, but CLI/log/receipt surfaces expose metadata only.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use conu_protocol::{
+    AgentId, Envelope, EnvelopeKind, OpaquePayload, PROTOCOL_VERSION, ProtocolError,
+};
+
+use crate::agents::{self, AgentError};
+use crate::state::{self, StateError, StatePaths};
+
+const REQUEST_VERSION: &str = "1";
+const MAX_LOCAL_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Opaque local message submitted by an agent.
+#[derive(Clone, PartialEq, Eq)]
+pub struct LocalMessage {
+    pub from_agent_id: String,
+    pub to_agent_id: String,
+    pub payload: OpaquePayload,
+}
+
+impl LocalMessage {
+    pub fn new(
+        from_agent_id: impl Into<String>,
+        to_agent_id: impl Into<String>,
+        payload: OpaquePayload,
+    ) -> Result<Self, MessageError> {
+        validate_payload_size(payload.len())?;
+
+        Ok(Self {
+            from_agent_id: validate_identifier(from_agent_id.into(), "from agent id")?,
+            to_agent_id: validate_identifier(to_agent_id.into(), "to agent id")?,
+            payload,
+        })
+    }
+}
+
+impl fmt::Debug for LocalMessage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalMessage")
+            .field("from_agent_id", &self.from_agent_id)
+            .field("to_agent_id", &self.to_agent_id)
+            .field("payload_len", &self.payload.len())
+            .field("payload", &"<opaque>")
+            .finish()
+    }
+}
+
+/// Result of submitting a local message request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageSubmission {
+    pub request_id: String,
+    pub request_path: PathBuf,
+    pub payload_bytes: usize,
+}
+
+/// Metadata for a delivered local message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InboxEntry {
+    pub envelope_id: String,
+    pub from_agent_id: String,
+    pub to_agent_id: String,
+    pub receipt_id: String,
+    pub delivered_at_unix: u64,
+    pub payload_bytes: usize,
+}
+
+/// Metadata-only delivery receipt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliveryReceipt {
+    pub receipt_id: String,
+    pub envelope_id: String,
+    pub from_agent_id: String,
+    pub to_agent_id: String,
+    pub status: String,
+    pub delivered_at_unix: u64,
+    pub payload_bytes: usize,
+}
+
+/// Result of conUD processing local message requests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageProcessReport {
+    pub delivered: usize,
+    pub rejected: usize,
+    pub envelope_ids: Vec<String>,
+}
+
+/// Errors produced by local message routing.
+#[derive(Debug)]
+pub enum MessageError {
+    State(StateError),
+    Agent(AgentError),
+    Protocol(ProtocolError),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidRequest {
+        reason: String,
+    },
+}
+
+impl MessageError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for MessageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Agent(error) => write!(formatter, "{error}"),
+            Self::Protocol(error) => write!(formatter, "{error}"),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidRequest { reason } => {
+                write!(formatter, "invalid message request: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MessageError {}
+
+impl From<StateError> for MessageError {
+    fn from(error: StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+impl From<AgentError> for MessageError {
+    fn from(error: AgentError) -> Self {
+        Self::Agent(error)
+    }
+}
+
+impl From<ProtocolError> for MessageError {
+    fn from(error: ProtocolError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+/// Submit a local opaque message into the message gateway inbox.
+pub fn submit_local_message(
+    home_override: Option<PathBuf>,
+    message: LocalMessage,
+) -> Result<MessageSubmission, MessageError> {
+    let init = state::init_state(home_override)?;
+    let request_id = request_id("message");
+    let request_path = init
+        .paths
+        .message_ipc_inbox_dir
+        .join(format!("{request_id}.msg"));
+    let contents = render_message_request(&request_id, &message);
+    write_new_file(&request_path, &contents)?;
+
+    Ok(MessageSubmission {
+        request_id,
+        request_path,
+        payload_bytes: message.payload.len(),
+    })
+}
+
+/// Process pending local message requests using default state path resolution.
+pub fn process_message_requests(
+    home_override: Option<PathBuf>,
+) -> Result<MessageProcessReport, MessageError> {
+    let init = state::init_state(home_override)?;
+    process_message_requests_from_paths(&init.paths)
+}
+
+/// Process pending local message requests from already resolved state paths.
+pub fn process_message_requests_from_paths(
+    paths: &StatePaths,
+) -> Result<MessageProcessReport, MessageError> {
+    ensure_message_dirs(paths)?;
+
+    let mut report = MessageProcessReport {
+        delivered: 0,
+        rejected: 0,
+        envelope_ids: Vec::new(),
+    };
+
+    for request_path in pending_message_requests(paths)? {
+        match process_one_message_request(paths, &request_path) {
+            Ok(delivery) => {
+                report.delivered += 1;
+                report.envelope_ids.push(delivery.envelope_id.clone());
+                write_processed_marker(paths, &request_path, &delivery)?;
+                remove_file_if_exists(&request_path)?;
+            }
+            Err(error) => {
+                report.rejected += 1;
+                reject_message_request(paths, &request_path, &error)?;
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// List metadata for messages delivered to a local agent inbox.
+pub fn list_agent_inbox(
+    home_override: Option<PathBuf>,
+    agent_id: &str,
+) -> Result<Vec<InboxEntry>, MessageError> {
+    let agent_id = validate_identifier(agent_id.to_string(), "agent id")?;
+    let paths = StatePaths::resolve(home_override)?;
+    let inbox_dir = paths.message_inbox_dir.join(&agent_id);
+    if !inbox_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(&inbox_dir)
+        .map_err(|error| MessageError::io("read agent message inbox", &inbox_dir, error))?
+    {
+        let entry = entry.map_err(|error| {
+            MessageError::io("read agent message inbox entry", &inbox_dir, error)
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("env") {
+            entries.push(read_inbox_entry(&path)?);
+        }
+    }
+
+    entries.sort_by(|left, right| left.envelope_id.cmp(&right.envelope_id));
+    Ok(entries)
+}
+
+/// Read opaque payload bytes for a delivered local message.
+pub fn read_message_payload(
+    home_override: Option<PathBuf>,
+    agent_id: &str,
+    envelope_id: &str,
+) -> Result<OpaquePayload, MessageError> {
+    let agent_id = validate_identifier(agent_id.to_string(), "agent id")?;
+    let envelope_id = validate_identifier(envelope_id.to_string(), "envelope id")?;
+    let paths = StatePaths::resolve(home_override)?;
+    let path = paths
+        .message_inbox_dir
+        .join(agent_id)
+        .join(format!("{envelope_id}.env"));
+    let contents = fs::read_to_string(&path)
+        .map_err(|error| MessageError::io("read local message", &path, error))?;
+    let values = parse_key_values(&contents);
+    let payload = hex_decode(&required(&values, "payload_hex")?)?;
+
+    Ok(OpaquePayload::from_bytes(payload))
+}
+
+/// List metadata-only local delivery receipts.
+pub fn list_receipts(home_override: Option<PathBuf>) -> Result<Vec<DeliveryReceipt>, MessageError> {
+    let paths = StatePaths::resolve(home_override)?;
+    if !paths.message_receipts_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut receipts = Vec::new();
+    for entry in fs::read_dir(&paths.message_receipts_dir).map_err(|error| {
+        MessageError::io(
+            "read message receipts directory",
+            &paths.message_receipts_dir,
+            error,
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            MessageError::io(
+                "read message receipt entry",
+                &paths.message_receipts_dir,
+                error,
+            )
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("receipt") {
+            receipts.push(read_receipt(&path)?);
+        }
+    }
+
+    receipts.sort_by(|left, right| left.receipt_id.cmp(&right.receipt_id));
+    Ok(receipts)
+}
+
+fn process_one_message_request(
+    paths: &StatePaths,
+    request_path: &Path,
+) -> Result<InboxEntry, MessageError> {
+    let contents = fs::read_to_string(request_path)
+        .map_err(|error| MessageError::io("read message IPC request", request_path, error))?;
+    let values = parse_key_values(&contents);
+
+    if value_or_empty(&values, "version") != REQUEST_VERSION {
+        return Err(MessageError::InvalidRequest {
+            reason: "unsupported request version".to_string(),
+        });
+    }
+    if value_or_empty(&values, "type") != "send_message" {
+        return Err(MessageError::InvalidRequest {
+            reason: "unsupported request type".to_string(),
+        });
+    }
+
+    let payload = OpaquePayload::from_bytes(hex_decode(&required(&values, "payload_hex")?)?);
+    let message = LocalMessage::new(
+        required(&values, "from_agent_id")?,
+        required(&values, "to_agent_id")?,
+        payload,
+    )?;
+
+    validate_agents_can_message(paths, &message.from_agent_id, &message.to_agent_id)?;
+
+    let envelope_id = request_id("env");
+    let envelope = Envelope::new(
+        &envelope_id,
+        AgentId::new(message.from_agent_id.clone())?,
+        AgentId::new(message.to_agent_id.clone())?,
+        EnvelopeKind::Message,
+        message.payload,
+    )?;
+
+    deliver_envelope(paths, envelope)
+}
+
+fn validate_agents_can_message(
+    paths: &StatePaths,
+    from_agent_id: &str,
+    to_agent_id: &str,
+) -> Result<(), MessageError> {
+    let registered = agents::list_local_agents(Some(paths.home.clone()))?;
+    let sender = registered
+        .iter()
+        .find(|agent| agent.agent_id == from_agent_id)
+        .ok_or_else(|| MessageError::InvalidRequest {
+            reason: "sender is not a registered local agent".to_string(),
+        })?;
+    let recipient = registered
+        .iter()
+        .find(|agent| agent.agent_id == to_agent_id)
+        .ok_or_else(|| MessageError::InvalidRequest {
+            reason: "recipient is not a registered local agent".to_string(),
+        })?;
+
+    if !sender.capabilities.messages {
+        return Err(MessageError::InvalidRequest {
+            reason: "sender is not allowed to send messages".to_string(),
+        });
+    }
+    if !recipient.capabilities.messages {
+        return Err(MessageError::InvalidRequest {
+            reason: "recipient is not allowed to receive messages".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn deliver_envelope(paths: &StatePaths, envelope: Envelope) -> Result<InboxEntry, MessageError> {
+    let now = current_unix_seconds();
+    let receipt_id = request_id("rcpt");
+    let inbox_dir = paths.message_inbox_dir.join(envelope.to.as_str());
+    fs::create_dir_all(&inbox_dir)
+        .map_err(|error| MessageError::io("create agent message inbox", &inbox_dir, error))?;
+    fs::create_dir_all(&paths.message_receipts_dir).map_err(|error| {
+        MessageError::io(
+            "create message receipts directory",
+            &paths.message_receipts_dir,
+            error,
+        )
+    })?;
+
+    let entry = InboxEntry {
+        envelope_id: envelope.id.clone(),
+        from_agent_id: envelope.from.as_str().to_string(),
+        to_agent_id: envelope.to.as_str().to_string(),
+        receipt_id,
+        delivered_at_unix: now,
+        payload_bytes: envelope.payload.len(),
+    };
+    let envelope_path = inbox_dir.join(format!("{}.env", entry.envelope_id));
+    write_new_file(&envelope_path, &render_envelope_file(&entry, &envelope))?;
+
+    let receipt = DeliveryReceipt {
+        receipt_id: entry.receipt_id.clone(),
+        envelope_id: entry.envelope_id.clone(),
+        from_agent_id: entry.from_agent_id.clone(),
+        to_agent_id: entry.to_agent_id.clone(),
+        status: "delivered_local".to_string(),
+        delivered_at_unix: now,
+        payload_bytes: entry.payload_bytes,
+    };
+    let receipt_path = paths
+        .message_receipts_dir
+        .join(format!("{}.receipt", receipt.receipt_id));
+    write_new_file(&receipt_path, &render_receipt(&receipt))?;
+    append_message_log(paths, &entry)?;
+
+    Ok(entry)
+}
+
+fn ensure_message_dirs(paths: &StatePaths) -> Result<(), MessageError> {
+    for directory in [
+        &paths.message_ipc_dir,
+        &paths.message_ipc_inbox_dir,
+        &paths.message_ipc_processed_dir,
+        &paths.message_ipc_rejected_dir,
+        &paths.messages_dir,
+        &paths.message_inbox_dir,
+        &paths.message_receipts_dir,
+    ] {
+        fs::create_dir_all(directory)
+            .map_err(|error| MessageError::io("create message directory", directory, error))?;
+    }
+
+    Ok(())
+}
+
+fn pending_message_requests(paths: &StatePaths) -> Result<Vec<PathBuf>, MessageError> {
+    let mut requests = Vec::new();
+
+    for entry in fs::read_dir(&paths.message_ipc_inbox_dir).map_err(|error| {
+        MessageError::io(
+            "read message IPC inbox",
+            &paths.message_ipc_inbox_dir,
+            error,
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            MessageError::io(
+                "read message IPC inbox entry",
+                &paths.message_ipc_inbox_dir,
+                error,
+            )
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("msg") {
+            requests.push(path);
+        }
+    }
+
+    requests.sort();
+    Ok(requests)
+}
+
+fn write_processed_marker(
+    paths: &StatePaths,
+    request_path: &Path,
+    delivery: &InboxEntry,
+) -> Result<(), MessageError> {
+    fs::create_dir_all(&paths.message_ipc_processed_dir).map_err(|error| {
+        MessageError::io(
+            "create message IPC processed directory",
+            &paths.message_ipc_processed_dir,
+            error,
+        )
+    })?;
+    let marker_path = paths
+        .message_ipc_processed_dir
+        .join(replace_extension(request_path, "meta"));
+    let contents = format!(
+        "version = \"{}\"\ntype = \"send_message\"\nrequest_id = \"{}\"\nenvelope_id = \"{}\"\nfrom_agent_id = \"{}\"\nto_agent_id = \"{}\"\nstatus = \"delivered_local\"\npayload_len = {}\npayload_displayed = false\n",
+        REQUEST_VERSION,
+        escape_file_value(&request_stem(request_path)),
+        escape_file_value(&delivery.envelope_id),
+        escape_file_value(&delivery.from_agent_id),
+        escape_file_value(&delivery.to_agent_id),
+        delivery.payload_bytes
+    );
+
+    fs::write(&marker_path, contents).map_err(|error| {
+        MessageError::io("write message IPC processed marker", &marker_path, error)
+    })
+}
+
+fn reject_message_request(
+    paths: &StatePaths,
+    request_path: &Path,
+    error: &MessageError,
+) -> Result<(), MessageError> {
+    fs::create_dir_all(&paths.message_ipc_rejected_dir).map_err(|error| {
+        MessageError::io(
+            "create message IPC rejected directory",
+            &paths.message_ipc_rejected_dir,
+            error,
+        )
+    })?;
+    let error_path = paths
+        .message_ipc_rejected_dir
+        .join(replace_extension(request_path, "error"));
+    fs::write(&error_path, format!("{error}\n")).map_err(|error| {
+        MessageError::io("write message IPC rejection reason", &error_path, error)
+    })?;
+    remove_file_if_exists(request_path)
+}
+
+fn read_inbox_entry(path: &Path) -> Result<InboxEntry, MessageError> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| MessageError::io("read inbox metadata", path, error))?;
+    let values = parse_key_values(&contents);
+
+    Ok(InboxEntry {
+        envelope_id: validate_identifier(required(&values, "envelope_id")?, "envelope id")?,
+        from_agent_id: validate_identifier(required(&values, "from_agent_id")?, "from agent id")?,
+        to_agent_id: validate_identifier(required(&values, "to_agent_id")?, "to agent id")?,
+        receipt_id: validate_identifier(required(&values, "receipt_id")?, "receipt id")?,
+        delivered_at_unix: parse_u64(&required(&values, "delivered_at_unix")?)?,
+        payload_bytes: parse_usize(&required(&values, "payload_len")?)?,
+    })
+}
+
+fn read_receipt(path: &Path) -> Result<DeliveryReceipt, MessageError> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| MessageError::io("read message receipt", path, error))?;
+    let values = parse_key_values(&contents);
+
+    Ok(DeliveryReceipt {
+        receipt_id: validate_identifier(required(&values, "receipt_id")?, "receipt id")?,
+        envelope_id: validate_identifier(required(&values, "envelope_id")?, "envelope id")?,
+        from_agent_id: validate_identifier(required(&values, "from_agent_id")?, "from agent id")?,
+        to_agent_id: validate_identifier(required(&values, "to_agent_id")?, "to agent id")?,
+        status: required(&values, "status")?,
+        delivered_at_unix: parse_u64(&required(&values, "delivered_at_unix")?)?,
+        payload_bytes: parse_usize(&required(&values, "payload_len")?)?,
+    })
+}
+
+fn render_message_request(request_id: &str, message: &LocalMessage) -> String {
+    format!(
+        "version = \"{}\"\ntype = \"send_message\"\nrequest_id = \"{}\"\nfrom_agent_id = \"{}\"\nto_agent_id = \"{}\"\npayload_len = {}\npayload_hex = \"{}\"\n",
+        REQUEST_VERSION,
+        escape_file_value(request_id),
+        escape_file_value(&message.from_agent_id),
+        escape_file_value(&message.to_agent_id),
+        message.payload.len(),
+        hex_encode(message.payload.as_bytes())
+    )
+}
+
+fn render_envelope_file(entry: &InboxEntry, envelope: &Envelope) -> String {
+    format!(
+        "version = \"{}\"\nenvelope_id = \"{}\"\nfrom_agent_id = \"{}\"\nto_agent_id = \"{}\"\nkind = \"message\"\nreceipt_id = \"{}\"\ndelivered_at_unix = {}\npayload_len = {}\npayload_privacy = \"opaque\"\npayload_hex = \"{}\"\n",
+        PROTOCOL_VERSION,
+        escape_file_value(&entry.envelope_id),
+        escape_file_value(&entry.from_agent_id),
+        escape_file_value(&entry.to_agent_id),
+        escape_file_value(&entry.receipt_id),
+        entry.delivered_at_unix,
+        entry.payload_bytes,
+        hex_encode(envelope.payload.as_bytes())
+    )
+}
+
+fn render_receipt(receipt: &DeliveryReceipt) -> String {
+    format!(
+        "version = \"{}\"\nreceipt_id = \"{}\"\nenvelope_id = \"{}\"\nfrom_agent_id = \"{}\"\nto_agent_id = \"{}\"\nstatus = \"{}\"\ndelivered_at_unix = {}\npayload_len = {}\npayload_displayed = false\n",
+        REQUEST_VERSION,
+        escape_file_value(&receipt.receipt_id),
+        escape_file_value(&receipt.envelope_id),
+        escape_file_value(&receipt.from_agent_id),
+        escape_file_value(&receipt.to_agent_id),
+        escape_file_value(&receipt.status),
+        receipt.delivered_at_unix,
+        receipt.payload_bytes
+    )
+}
+
+fn append_message_log(paths: &StatePaths, entry: &InboxEntry) -> Result<(), MessageError> {
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| MessageError::io("create log directory", &paths.logs_dir, error))?;
+    let log_path = paths.logs_dir.join("messages.log");
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&log_path)
+        .map_err(|error| MessageError::io("open message log", &log_path, error))?;
+
+    writeln!(
+        file,
+        "time={} event=message_delivered envelope={} from={} to={} bytes={} payload=not_observed",
+        current_unix_seconds(),
+        sanitize_log_value(&entry.envelope_id),
+        sanitize_log_value(&entry.from_agent_id),
+        sanitize_log_value(&entry.to_agent_id),
+        entry.payload_bytes
+    )
+    .map_err(|error| MessageError::io("write message log", &log_path, error))
+}
+
+fn write_new_file(path: &Path, contents: &str) -> Result<(), MessageError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| MessageError::io("create message file", path, error))?;
+
+    file.write_all(contents.as_bytes())
+        .map_err(|error| MessageError::io("write message file", path, error))
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<(), MessageError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(MessageError::io("remove message IPC request", path, error)),
+    }
+}
+
+fn replace_extension(path: &Path, extension: &str) -> PathBuf {
+    path.file_name()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("request.msg"))
+        .with_extension(extension)
+}
+
+fn request_stem(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("request")
+        .to_string()
+}
+
+fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, MessageError> {
+    values
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| MessageError::InvalidRequest {
+            reason: format!("missing {key}"),
+        })
+}
+
+fn validate_identifier(value: String, field: &'static str) -> Result<String, MessageError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(MessageError::InvalidRequest {
+            reason: format!("{field} cannot be empty"),
+        });
+    }
+    if value.len() > 100 {
+        return Err(MessageError::InvalidRequest {
+            reason: format!("{field} is too long"),
+        });
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Err(MessageError::InvalidRequest {
+            reason: format!("{field} must use ASCII letters, numbers, dash, underscore, or dot"),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_payload_size(bytes: usize) -> Result<(), MessageError> {
+    if bytes > MAX_LOCAL_PAYLOAD_BYTES {
+        return Err(MessageError::InvalidRequest {
+            reason: "payload is too large for the Phase 6 local gateway".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn parse_key_values(contents: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        values.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    values
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn value_or_empty<'a>(values: &'a HashMap<String, String>, key: &str) -> &'a str {
+    values.get(key).map(String::as_str).unwrap_or("")
+}
+
+fn parse_u64(value: &str) -> Result<u64, MessageError> {
+    value
+        .parse::<u64>()
+        .map_err(|_| MessageError::InvalidRequest {
+            reason: "expected unsigned integer".to_string(),
+        })
+}
+
+fn parse_usize(value: &str) -> Result<usize, MessageError> {
+    value
+        .parse::<usize>()
+        .map_err(|_| MessageError::InvalidRequest {
+            reason: "expected unsigned integer".to_string(),
+        })
+}
+
+fn request_id(prefix: &str) -> String {
+    format!("{}_{}_{}", prefix, process::id(), current_unix_nanos())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+
+    encoded
+}
+
+fn hex_decode(value: &str) -> Result<Vec<u8>, MessageError> {
+    let value = value.trim();
+    if value.len() % 2 != 0 {
+        return Err(MessageError::InvalidRequest {
+            reason: "payload_hex must have an even number of characters".to_string(),
+        });
+    }
+
+    let mut bytes = Vec::with_capacity(value.len() / 2);
+    let mut chars = value.as_bytes().chunks_exact(2);
+    for pair in &mut chars {
+        let high = hex_nibble(pair[0])?;
+        let low = hex_nibble(pair[1])?;
+        bytes.push((high << 4) | low);
+    }
+    validate_payload_size(bytes.len())?;
+
+    Ok(bytes)
+}
+
+fn hex_nibble(byte: u8) -> Result<u8, MessageError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(MessageError::InvalidRequest {
+            reason: "payload_hex must contain only hex characters".to_string(),
+        }),
+    }
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn sanitize_log_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+        .collect()
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_request_file_hides_literal_payload() {
+        let home = test_home("request-redaction");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("message is valid");
+
+        let submission =
+            submit_local_message(Some(home), message).expect("message request submits");
+        let contents = fs::read_to_string(submission.request_path).expect("request reads");
+
+        assert!(contents.contains("type = \"send_message\""));
+        assert!(contents.contains("payload_len = 24"));
+        assert!(!contents.contains("private message contents"));
+        assert!(!contents.contains("Review this code"));
+    }
+
+    #[test]
+    fn process_message_delivers_to_recipient_inbox() {
+        let home = test_home("deliver");
+        register_agent(&home, "agent.sender");
+        register_agent(&home, "agent.receiver");
+        let payload = OpaquePayload::from_bytes([1, 2, 3, 4]);
+        let message =
+            LocalMessage::new("agent.sender", "agent.receiver", payload).expect("message valid");
+        submit_local_message(Some(home.clone()), message).expect("message submits");
+
+        let report = process_message_requests(Some(home.clone())).expect("message processes");
+        let inbox = list_agent_inbox(Some(home.clone()), "agent.receiver").expect("inbox reads");
+        let received = read_message_payload(Some(home), "agent.receiver", &inbox[0].envelope_id)
+            .expect("payload reads");
+
+        assert_eq!(report.delivered, 1);
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].from_agent_id, "agent.sender");
+        assert_eq!(inbox[0].payload_bytes, 4);
+        assert_eq!(received.as_bytes(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn unknown_recipient_is_rejected_without_payload() {
+        let home = test_home("reject");
+        register_agent(&home, "agent.sender");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"secret private message contents".to_vec()),
+        )
+        .expect("message valid");
+        submit_local_message(Some(home.clone()), message).expect("message submits");
+
+        let report = process_message_requests(Some(home.clone())).expect("message processes");
+        let paths = StatePaths::from_home(home);
+        let rejected = fs::read_dir(&paths.message_ipc_rejected_dir)
+            .expect("rejected dir reads")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("entries read");
+        let error_text = fs::read_to_string(rejected[0].path()).expect("rejection reason reads");
+
+        assert_eq!(report.rejected, 1);
+        assert!(error_text.contains("recipient is not a registered local agent"));
+        assert!(!error_text.contains("secret private message contents"));
+        assert_eq!(
+            fs::read_dir(&paths.message_ipc_inbox_dir)
+                .expect("inbox reads")
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn delivery_receipt_is_metadata_only() {
+        let home = test_home("receipt");
+        register_agent(&home, "agent.sender");
+        register_agent(&home, "agent.receiver");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("message valid");
+        submit_local_message(Some(home.clone()), message).expect("message submits");
+
+        process_message_requests(Some(home.clone())).expect("message processes");
+        let receipts = list_receipts(Some(home.clone())).expect("receipts read");
+        let receipt_file = fs::read_to_string(
+            fs::read_dir(StatePaths::from_home(home).message_receipts_dir)
+                .expect("receipt dir reads")
+                .next()
+                .expect("receipt exists")
+                .expect("receipt entry")
+                .path(),
+        )
+        .expect("receipt file reads");
+
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].status, "delivered_local");
+        assert_eq!(receipts[0].payload_bytes, 24);
+        assert!(receipt_file.contains("payload_displayed = false"));
+        assert!(!receipt_file.contains("private message contents"));
+    }
+
+    fn register_agent(home: &Path, agent_id: &str) {
+        let registration =
+            agents::AgentRegistration::new(agent_id, agent_id, "test-agent").expect("valid agent");
+        agents::submit_registration(Some(home.to_path_buf()), registration)
+            .expect("registration submits");
+        agents::process_gateway_requests(Some(home.to_path_buf())).expect("registration processes");
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "conu-messages-test-{label}-{}-{}",
+            process::id(),
+            current_unix_nanos()
+        ))
+    }
+}

--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -1,7 +1,8 @@
 //! Local conUD runtime state and heartbeat management.
 //!
-//! Phase 5 uses file-backed health and gateway state so the CLI can detect a
-//! local runtime and agents can submit metadata-only registration requests.
+//! Phase 6 uses file-backed health and gateway state so the CLI can detect a
+//! local runtime, agents can register, and local opaque message requests can be
+//! delivered between registered agents.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -12,8 +13,8 @@ use std::process;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::agents;
 use crate::state::{self, NodeIdentity, StateError, StatePaths};
+use crate::{agents, messages};
 
 const STATUS_VERSION: &str = "1";
 const STALE_AFTER_SECS: u64 = 10;
@@ -126,6 +127,8 @@ impl RuntimeLease {
             self.heartbeat()?;
             agents::process_gateway_requests_from_paths(&self.paths, &self.node.node_id)
                 .map_err(RuntimeError::Agent)?;
+            messages::process_message_requests_from_paths(&self.paths)
+                .map_err(RuntimeError::Message)?;
             thread::sleep(heartbeat_every);
         }
 
@@ -180,6 +183,7 @@ impl Drop for RuntimeLease {
 pub enum RuntimeError {
     State(StateError),
     Agent(agents::AgentError),
+    Message(messages::MessageError),
     Io {
         action: &'static str,
         path: PathBuf,
@@ -203,6 +207,7 @@ impl fmt::Display for RuntimeError {
         match self {
             Self::State(error) => write!(formatter, "{error}"),
             Self::Agent(error) => write!(formatter, "{error}"),
+            Self::Message(error) => write!(formatter, "{error}"),
             Self::Io {
                 action,
                 path,
@@ -230,6 +235,12 @@ impl From<StateError> for RuntimeError {
 impl From<agents::AgentError> for RuntimeError {
     fn from(error: agents::AgentError) -> Self {
         Self::Agent(error)
+    }
+}
+
+impl From<messages::MessageError> for RuntimeError {
+    fn from(error: messages::MessageError) -> Self {
+        Self::Message(error)
     }
 }
 

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -1,9 +1,9 @@
 //! Local persistent state for conU.
 //!
-//! Phase 5 keeps this intentionally small and std-only: a locally generated
-//! node id, config, trust store skeleton, agent registry, runtime metadata, and
-//! local gateway inbox. Secret keys and encrypted payload storage belong to
-//! later phases.
+//! Phase 6 keeps this intentionally small and std-only: a locally generated
+//! node id, config, trust store skeleton, agent registry, runtime metadata,
+//! local gateway inboxes, and local opaque message inboxes. Secret keys and
+//! encrypted remote mailbox storage belong to later phases.
 
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -28,6 +28,9 @@ const IPC_DIR: &str = "ipc";
 const IPC_INBOX_DIR: &str = "inbox";
 const IPC_PROCESSED_DIR: &str = "processed";
 const IPC_REJECTED_DIR: &str = "rejected";
+const MESSAGES_DIR: &str = "messages";
+const MESSAGE_INBOX_DIR: &str = "inbox";
+const MESSAGE_RECEIPTS_DIR: &str = "receipts";
 const SESSIONS_DIR: &str = "sessions";
 const MAILBOX_DIR: &str = "mailbox";
 const LOGS_DIR: &str = "logs";
@@ -49,6 +52,13 @@ pub struct StatePaths {
     pub ipc_inbox_dir: PathBuf,
     pub ipc_processed_dir: PathBuf,
     pub ipc_rejected_dir: PathBuf,
+    pub message_ipc_dir: PathBuf,
+    pub message_ipc_inbox_dir: PathBuf,
+    pub message_ipc_processed_dir: PathBuf,
+    pub message_ipc_rejected_dir: PathBuf,
+    pub messages_dir: PathBuf,
+    pub message_inbox_dir: PathBuf,
+    pub message_receipts_dir: PathBuf,
     pub sessions_dir: PathBuf,
     pub mailbox_dir: PathBuf,
     pub logs_dir: PathBuf,
@@ -70,6 +80,8 @@ impl StatePaths {
         let agents_dir = home.join(AGENTS_DIR);
         let runtime_dir = home.join(RUNTIME_DIR);
         let ipc_dir = runtime_dir.join(IPC_DIR);
+        let message_ipc_dir = ipc_dir.join(MESSAGES_DIR);
+        let messages_dir = home.join(MESSAGES_DIR);
 
         Self {
             node_identity: home.join(NODE_FILE),
@@ -84,7 +96,14 @@ impl StatePaths {
             ipc_inbox_dir: ipc_dir.join(IPC_INBOX_DIR),
             ipc_processed_dir: ipc_dir.join(IPC_PROCESSED_DIR),
             ipc_rejected_dir: ipc_dir.join(IPC_REJECTED_DIR),
+            message_ipc_inbox_dir: message_ipc_dir.join(IPC_INBOX_DIR),
+            message_ipc_processed_dir: message_ipc_dir.join(IPC_PROCESSED_DIR),
+            message_ipc_rejected_dir: message_ipc_dir.join(IPC_REJECTED_DIR),
+            message_ipc_dir,
             ipc_dir,
+            message_inbox_dir: messages_dir.join(MESSAGE_INBOX_DIR),
+            message_receipts_dir: messages_dir.join(MESSAGE_RECEIPTS_DIR),
+            messages_dir,
             sessions_dir: home.join(SESSIONS_DIR),
             mailbox_dir: home.join(MAILBOX_DIR),
             logs_dir: home.join(LOGS_DIR),
@@ -252,6 +271,13 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
         &paths.ipc_inbox_dir,
         &paths.ipc_processed_dir,
         &paths.ipc_rejected_dir,
+        &paths.message_ipc_dir,
+        &paths.message_ipc_inbox_dir,
+        &paths.message_ipc_processed_dir,
+        &paths.message_ipc_rejected_dir,
+        &paths.messages_dir,
+        &paths.message_inbox_dir,
+        &paths.message_receipts_dir,
         &paths.sessions_dir,
         &paths.mailbox_dir,
         &paths.logs_dir,
@@ -483,6 +509,14 @@ mod tests {
         assert!(
             home.join(RUNTIME_DIR)
                 .join(IPC_DIR)
+                .join(IPC_INBOX_DIR)
+                .exists()
+        );
+        assert!(home.join(MESSAGES_DIR).join(MESSAGE_INBOX_DIR).exists());
+        assert!(
+            home.join(RUNTIME_DIR)
+                .join(IPC_DIR)
+                .join(MESSAGES_DIR)
                 .join(IPC_INBOX_DIR)
                 .exists()
         );

--- a/crates/conud/src/main.rs
+++ b/crates/conud/src/main.rs
@@ -78,6 +78,8 @@ fn run_once() -> ExitCode {
         Ok(lease) => match lease.heartbeat().and_then(|_| {
             conu_core::agents::process_gateway_requests(None)
                 .map_err(conu_core::runtime::RuntimeError::from)?;
+            conu_core::messages::process_message_requests(None)
+                .map_err(conu_core::runtime::RuntimeError::from)?;
             lease.stop()
         }) {
             Ok(status) => {
@@ -100,15 +102,25 @@ fn run_once() -> ExitCode {
 }
 
 fn process_ipc_once() -> ExitCode {
-    match conu_core::agents::process_gateway_requests(None) {
-        Ok(report) => {
+    match (
+        conu_core::agents::process_gateway_requests(None),
+        conu_core::messages::process_message_requests(None),
+    ) {
+        (Ok(agent_report), Ok(message_report)) => {
             println!(
-                "conUD IPC processed {}; rejected {}; payloads not observed",
-                report.processed, report.rejected
+                "conUD IPC agents processed {}; agents rejected {}; messages delivered {}; messages rejected {}; payloads not observed",
+                agent_report.processed,
+                agent_report.rejected,
+                message_report.delivered,
+                message_report.rejected
             );
             ExitCode::SUCCESS
         }
-        Err(error) => {
+        (Err(error), _) => {
+            eprintln!("conUD IPC processing failed: {error}");
+            ExitCode::from(1)
+        }
+        (_, Err(error)) => {
             eprintln!("conUD IPC processing failed: {error}");
             ExitCode::from(1)
         }
@@ -138,7 +150,7 @@ fn print_status() -> ExitCode {
 
 fn print_check() {
     println!("{}", conu_core::scaffold_status("conud"));
-    println!("runtime: phase 5 local IPC registration ready; payloads not observed");
+    println!("runtime: phase 6 local opaque messaging ready; payloads not observed");
 }
 
 fn print_help() {

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 6 - Opaque Envelope Messaging
+Current phase: Phase 7 - Pairing And Trust
 Status: not_started
 Last updated: 2026-05-10
 ```
@@ -462,7 +462,7 @@ Next:
 
 ## Phase 6 - Opaque Envelope Messaging
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -470,16 +470,71 @@ Implement local opaque message envelopes and local send/receive routing.
 
 Deliverables:
 
-- envelope type
-- message id
-- sender/receiver validation
-- local inbox
-- delivery receipt skeleton
+- [x] envelope type
+- [x] message id
+- [x] sender/receiver validation
+- [x] local inbox
+- [x] delivery receipt skeleton
 
 Exit criteria:
 
-- One local agent can send an opaque payload to another local agent.
-- CLI can show delivery metadata without showing payload.
+- [x] One local agent can send an opaque payload to another local agent.
+- [x] CLI can show delivery metadata without showing payload.
+
+Completed work:
+
+- Created GitHub issue #11 for Phase 6.
+- Created and pushed branch `codex/phase-6-opaque-messaging`.
+- Added std-only `conu_core::messages` local message routing module.
+- Added file-backed message request queue under `runtime/ipc/messages/`.
+- Added recipient inbox storage under `messages/inbox/<agent-id>/`.
+- Added metadata-only delivery receipts under `messages/receipts/`.
+- Added sender and recipient validation against the local registered agent registry.
+- Added `conu messages send <from-agent> <to-agent> --stdin`.
+- Added `conu messages inbox <agent-id>` and JSON output.
+- Added `conu messages receipts` and JSON output.
+- Wired conUD serve loop, `conud --once`, and `conud --process-ipc` to process local message requests.
+- Added payload-safe `logs/messages.log` metadata lines with `payload=not_observed`.
+- Ensured processed and rejected message request markers do not keep or display payload contents.
+- Updated README, repo overview, builder guardrails, repo map, and agent gateway contract.
+
+Files changed:
+
+- `README.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `plan.md`
+- `crates/conu-cli/Cargo.toml`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-cli/src/main.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-core/src/messages.rs`
+- `crates/conu-core/src/runtime.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conud/src/main.rs`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu build -p conud -p conu-cli` passed.
+- Live isolated `CONU_HOME` smoke passed: `conu init`, `conu start`, two `conu agents register` calls, `conu messages send agent.sender agent.receiver --stdin`, `conu messages inbox agent.receiver --json`, `conu messages receipts --json`, `conu stop`, and `conud --process-ipc`.
+- Smoke confirmed delivery status `delivered`, recipient inbox metadata, `delivered_local` receipt metadata, and `logs/messages.log` with `payload=not_observed`.
+- Explicit process check confirmed no `conud` process remained running after smoke.
+
+Known gaps:
+
+- Phase 6 is local-only; there is no remote relay, remote discovery, pairing, streams, rooms, or pub/sub yet.
+- Message payload bytes are stored as opaque local recipient-inbox envelope data, not displayed or logged. Encryption hardening and encrypted mailbox storage remain Phase 11 work.
+- The CLI can submit from stdin and list metadata, but SDK/MCP receive APIs arrive in Phase 12.
+- File-backed message IPC is intentionally simple; named pipes, Unix sockets, and binary framed IPC remain future production upgrades.
+
+Next:
+
+- Start Phase 7: pairing and trust records between runtimes, including code lifecycle, trust entry persistence, and revocation/listing groundwork.
 
 ## Phase 7 - Pairing And Trust
 
@@ -691,4 +746,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 3 completed. Local identity and persistent state added with idempotent init, status reads, tests, and isolated CONU_HOME smoke validation. Next: Phase 4 conUD daemon skeleton.
 2026-05-10 - Phase 4 completed. conUD daemon skeleton added with start/stop, runtime heartbeat status, stale restart handling, payload-safe logs, tests, and isolated CONU_HOME process smoke. Next: Phase 5 local IPC and agent registration.
 2026-05-10 - Phase 5 completed. File-backed local IPC gateway added with metadata-only agent registration, presence heartbeat, persisted local agent registry, conUD processing, CLI listing, tests, docs, and isolated CONU_HOME smoke validation. Next: Phase 6 opaque envelope messaging.
+2026-05-10 - Phase 6 completed. Local opaque envelope messaging added with stdin submission, registered sender/receiver validation, recipient inboxes, metadata-only receipts/logs, conUD processing, tests, docs, and isolated CONU_HOME smoke validation. Next: Phase 7 pairing and trust.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- Adds Phase 6 local opaque message routing through conUD.
- Adds `runtime/ipc/messages/`, recipient inboxes under `messages/inbox/<agent-id>/`, and metadata-only delivery receipts.
- Adds `conu messages send <from> <to> --stdin`, `conu messages inbox`, and `conu messages receipts`.
- Updates docs, plan, and future-agent guardrails for the local message path.

## Privacy / Security
- Message payloads are read from stdin rather than command-line text.
- CLI output, receipts, processed markers, rejected markers, and logs show metadata only.
- Sender and recipient must both be registered local agents before delivery.
- Rejected message requests delete payload-bearing requests and write only safe reasons.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu test --workspace`
- `cargo +stable-x86_64-pc-windows-gnu build -p conud -p conu-cli`
- Live isolated smoke: init, start, register sender/receiver, send stdin payload, inbox JSON, receipts JSON, stop, process-check
- Smoke log check confirmed `logs/messages.log` only contains metadata with `payload=not_observed`

Closes #11


___

## **CodeAnt-AI Description**
**Add local opaque message delivery between registered agents**

### What Changed
- Added `conu messages send` to submit message bytes from stdin and keep the payload out of the command line and CLI output
- Added `conu messages inbox` and `conu messages receipts` so users can check delivery status and recipient inbox metadata
- conUD now processes local message requests, delivers them to the recipient inbox, and records metadata-only receipts and logs
- Message requests are rejected unless both sender and recipient are registered local agents

### Impact
`✅ Safer local message sending`
`✅ Clearer delivery status for local agents`
`✅ Fewer payload leaks in logs and command output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=bDNwvTynFeg60jkbrhi-TTcEba5itEguvjBWyAOthmg&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
