### PR TITLE
Phase 7: Pairing and trust

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 6.
+The repository has completed Phase 7.
 
 Implemented so far:
 
@@ -25,6 +25,9 @@ Implemented so far:
 - local recipient inbox listing through `conu messages inbox`
 - metadata-only delivery receipts through `conu messages receipts`
 - conUD processing for local message delivery
+- local pairing invitation creation through `conu pair`
+- local pairing join/trust creation through `conu join <code>`
+- trusted peer listing and revocation through `conu peers`
 - payload-safe status and agent registry reporting
 - payload-safe runtime and agent metadata logs
 - payload-safe message delivery metadata logs

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -100,6 +100,25 @@ send_message
 
 Phase 6 intentionally does not expose remote relay delivery, discovery, streams, rooms, or pub/sub. Those start in later phases.
 
+The Phase 7 trust surface is local pairing groundwork:
+
+```txt
+pairing/invites       pending local pairing invitations
+pairing/used          consumed local pairing invitations
+trust.toml            trusted and revoked peer records
+```
+
+Supported commands:
+
+```txt
+conu pair [--json]
+conu join <code> [--json]
+conu peers [--json]
+conu peers revoke <peer-node-id> [--json]
+```
+
+Phase 7 creates trust records but does not discover remote agents or open network sessions. Raw used pairing codes must not appear in peer list output or trust records.
+
 ## Safety
 
 "Full access" means full communication access inside trust boundaries. It does not mean raw filesystem, shell, network, or secret access.

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -65,6 +65,15 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Message logs must use metadata-only lines such as envelope id, from, to, byte count, and `payload=not_observed`.
 - Do not add remote message routing, relay forwarding, discovery, streams, or rooms while completing Phase 6.
 
+## Pairing And Trust Rules
+
+- Phase 7 pairing is local trust-store groundwork only; relay-backed cross-machine rendezvous starts in Phase 8.
+- `conu pair` may display a fresh short code once, but peers listing and trust records must not expose the raw used pairing code.
+- Store `pairing_code_hash` in `trust.toml`, not `pairing_code`.
+- Trusted peer ids and display names should be derived from a hash suffix, not from the raw six-digit code.
+- `conu join <code>` should create a trusted peer only when the local invitation exists, is pending, and is not expired.
+- Revocation must preserve the peer record with `status = "revoked"` so future agents can reason about trust history.
+
 ## Privacy Rules
 
 - Never log plaintext payloads.

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -23,7 +23,7 @@ crates/conud
   daemon process, local gateway/message processing, session manager, runtime lifecycle
 
 crates/conu-core
-  local state, runtime lifecycle, agent registry, local message routing, future trust/policy logic
+  local state, runtime lifecycle, agent registry, local message routing, trust store, future policy logic
 
 crates/conu-protocol
   envelopes, agent cards, control-plane messages, data-plane messages

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 6 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, local agents can register metadata and presence, and registered local agents can exchange opaque message envelopes through conUD.
+Phase 7 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, local agents can register metadata and presence, registered local agents can exchange opaque message envelopes, and local pairing/trust records can be created and revoked.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -48,6 +48,8 @@ runtime/ipc/rejected/  rejected gateway requests and safe reasons
 runtime/ipc/messages/  opaque local message request queue
 messages/inbox/        delivered local opaque envelopes by recipient agent
 messages/receipts/     metadata-only local delivery receipts
+pairing/invites/       pending local pairing invitations
+pairing/used/          consumed local pairing invitations
 sessions/              future runtime sessions
 mailbox/               future encrypted mailbox storage
 logs/conud.log         runtime metadata log
@@ -87,6 +89,20 @@ conu messages receipts
 
 `conu messages send` reads bytes from stdin so payloads are not placed directly in the command line. When `conUD` is running, delivery is processed automatically. If the runtime is offline, message requests remain queued under `runtime/ipc/messages/inbox/` and can be processed with `conud --process-ipc`.
 
+## Pairing And Trust
+
+Phase 7 adds local trust-store mechanics before the hosted relay exists:
+
+```bash
+conu pair
+conu join 123456
+conu peers
+conu peers --json
+conu peers revoke peer_example
+```
+
+`conu pair` creates a short local invitation code with an expiration. `conu join <code>` consumes a local invitation and writes a trusted peer record to `trust.toml`. Peer ids and display names are derived from a hash suffix, and the trust store records `pairing_code_hash` instead of the raw used code. Relay-backed cross-machine pairing starts in Phase 8.
+
 ## Development
 
 ```bash
@@ -117,7 +133,9 @@ cargo run -p conu-cli -- messages send agent.sender agent.receiver --stdin
 cargo run -p conu-cli -- messages inbox agent.receiver --json
 cargo run -p conu-cli -- messages receipts --json
 cargo run -p conu-cli -- pair
-cargo run -p conu-cli -- join 482913
+cargo run -p conu-cli -- join 123456
+cargo run -p conu-cli -- peers --json
+cargo run -p conu-cli -- peers revoke peer_example
 cargo run -p conu-cli -- connect
 cargo run -p conu-cli -- watch
 cargo run -p conu-cli -- start

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -16,6 +16,7 @@ use conu_core::agents::{
 use conu_core::messages::{self, DeliveryReceipt, InboxEntry, LocalMessage};
 use conu_core::runtime::{self, RuntimeState, RuntimeStatus, StopReport};
 use conu_core::state::{self, InitReport, StateSnapshot};
+use conu_core::trust::{self, TrustStatus, TrustedPeer};
 use conu_protocol::OpaquePayload;
 
 /// A rendered CLI command result.
@@ -92,10 +93,11 @@ where
     match command {
         "init" => render_init(&args[1..], home_override),
         "status" => render_status(&args[1..], home_override),
-        "agents" | "peers" => render_agents(&args[1..], home_override),
+        "agents" => render_agents(&args[1..], home_override),
+        "peers" => render_peers(&args[1..], home_override),
         "messages" => render_messages(&args[1..], home_override, stdin_payload),
-        "pair" => render_pair(&args[1..]),
-        "join" => render_join(&args[1..]),
+        "pair" => render_pair(&args[1..], home_override),
+        "join" => render_join(&args[1..], home_override),
         "connect" => render_connect(&args[1..], home_override),
         "watch" => render_watch(&args[1..]),
         "components" => render_components(&args[1..]),
@@ -113,8 +115,16 @@ where
 fn render_dashboard(home_override: Option<PathBuf>) -> String {
     let snapshot = state::read_state(home_override.clone()).ok();
     let runtime_status = runtime::read_runtime(home_override.clone()).ok();
-    let local_agents = agents::list_local_agents(home_override)
+    let local_agents = agents::list_local_agents(home_override.clone())
         .map(|agents| agents.len())
+        .unwrap_or(0);
+    let trusted_peers = trust::list_peers(home_override)
+        .map(|peers| {
+            peers
+                .iter()
+                .filter(|peer| peer.status == TrustStatus::Trusted)
+                .count()
+        })
         .unwrap_or(0);
     let node = snapshot
         .as_ref()
@@ -145,7 +155,7 @@ control room
   node          {node}
   state         {state}
   local agents  {local_agents}
-  remote peers  none           pairing arrives in Phase 7
+  remote peers  {trusted_peers} trusted
   network       offline        relay arrives in Phase 8
 
 quick commands
@@ -155,6 +165,7 @@ quick commands
   conu agents register <agent-id> <display-name>
   conu messages send <from-agent> <to-agent> --stdin
   conu pair
+  conu peers
   conu join <code>
   conu connect
   conu watch",
@@ -182,8 +193,12 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
         Ok(status) => status,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
-    let local_agents = match agents::list_local_agents(home_override) {
+    let local_agents = match agents::list_local_agents(home_override.clone()) {
         Ok(agents) => agents,
+        Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
+    };
+    let peers = match trust::list_peers(home_override) {
+        Ok(peers) => peers,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
 
@@ -192,11 +207,13 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
             &snapshot,
             &runtime_status,
             &local_agents,
+            &peers,
         )),
         Ok(false) => CliOutput::success(render_status_text(
             &snapshot,
             &runtime_status,
             &local_agents,
+            &peers,
         )),
         Err(error) => error,
     }
@@ -1002,48 +1019,240 @@ fn wait_for_message_delivery(
     None
 }
 
-fn render_pair(args: &[String]) -> CliOutput {
-    match json_flag(args) {
-        Ok(true) => CliOutput::success(
-            r#"{
-  "status": "reserved",
-  "phase": "Phase 7",
-  "message": "pairing code generation is not active in Phase 6"
-}"#,
-        ),
-        Ok(false) => CliOutput::success(
-            r"conU pair
+fn render_peers(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    match args.first().map(String::as_str) {
+        Some("revoke") => render_peer_revoke(&args[1..], home_override),
+        _ => render_peer_list(args, home_override),
+    }
+}
 
-status: reserved for Phase 7
-code: not generated in Phase 6
-purpose: create trust between two conUD runtimes",
-        ),
+fn render_peer_list(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let peers = match trust::list_peers(home_override) {
+        Ok(peers) => peers,
+        Err(error) => return CliOutput::failure(1, format!("conU peers failed\n\n{error}")),
+    };
+
+    match json_flag(args) {
+        Ok(true) => CliOutput::success(render_peers_json(&peers)),
+        Ok(false) => CliOutput::success(render_peers_text(&peers)),
         Err(error) => error,
     }
 }
 
-fn render_join(args: &[String]) -> CliOutput {
-    if args.iter().any(|arg| arg == "--json") {
-        return match join_code(args) {
-            Ok(_) => CliOutput::success(
-                r#"{
-  "status": "reserved",
-  "phase": "Phase 7",
-  "message": "join validation is not active in Phase 6"
-}"#,
-            ),
-            Err(error) => error,
-        };
+fn render_peer_revoke(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let (peer_node_id, json) = match parse_peer_revoke_args(args) {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    let report = match trust::revoke_peer(home_override, &peer_node_id) {
+        Ok(report) => report,
+        Err(error) => return CliOutput::failure(1, format!("conU peers revoke failed\n\n{error}")),
+    };
+
+    if json {
+        return CliOutput::success(format!(
+            r#"{{
+  "status": "{}",
+  "peerNodeId": "{}",
+  "changed": {},
+  "contentsDisplayed": false
+}}"#,
+            report.peer.status.as_str(),
+            json_escape(&report.peer.peer_node_id),
+            report.changed
+        ));
     }
 
-    match join_code(args) {
-        Ok(_) => CliOutput::success(
-            r"conU join
+    CliOutput::success(format!(
+        r"conU peers revoke
 
-status: reserved for Phase 7
-code: accepted for command shape only
-action: no trust entry created in Phase 6",
-        ),
+status: {}
+peer: {}
+changed: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        report.peer.status.as_str(),
+        report.peer.peer_node_id,
+        report.changed
+    ))
+}
+
+fn render_peers_json(peers: &[TrustedPeer]) -> String {
+    let trusted = trusted_peer_count(peers);
+    let peer_items = peers
+        .iter()
+        .map(|peer| {
+            format!(
+                r#"    {{
+      "peerNodeId": "{}",
+      "displayName": "{}",
+      "status": "{}",
+      "source": "{}",
+      "updatedAtUnix": {}
+    }}"#,
+                json_escape(&peer.peer_node_id),
+                json_escape(&peer.display_name),
+                peer.status.as_str(),
+                json_escape(&peer.source),
+                peer.updated_at_unix
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let peers = if peer_items.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{peer_items}\n  ]")
+    };
+
+    format!(
+        r#"{{
+  "peers": {},
+  "trusted": {},
+  "contentsDisplayed": false
+}}"#,
+        peers, trusted
+    )
+}
+
+fn render_peers_text(peers: &[TrustedPeer]) -> String {
+    let rows = if peers.is_empty() {
+        "  none trusted yet".to_string()
+    } else {
+        peers
+            .iter()
+            .map(|peer| {
+                format!(
+                    "  {}  {}  {}",
+                    peer.peer_node_id,
+                    peer.status.as_str(),
+                    peer.display_name
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        r"conU peers
+
+trusted peers
+{rows}
+
+next
+  conu pair
+  conu join <code>
+  conu peers revoke <peer-node-id>"
+    )
+}
+
+fn parse_peer_revoke_args(args: &[String]) -> Result<(String, bool), CliOutput> {
+    let mut json = false;
+    let mut peer = None;
+
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            value => {
+                if peer.is_some() {
+                    return Err(CliOutput::failure(
+                        2,
+                        "usage: conu peers revoke <peer-node-id> [--json]",
+                    ));
+                }
+                peer = Some(value.to_string());
+            }
+        }
+    }
+
+    let Some(peer) = peer else {
+        return Err(CliOutput::failure(
+            2,
+            "usage: conu peers revoke <peer-node-id> [--json]",
+        ));
+    };
+
+    Ok((peer, json))
+}
+
+fn render_pair(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    match json_flag(args) {
+        Ok(json) => match trust::create_pairing_invite(home_override) {
+            Ok(invite) => {
+                if json {
+                    CliOutput::success(format!(
+                        r#"{{
+  "status": "pairing_code_created",
+  "code": "{}",
+  "peerNodeId": "{}",
+  "expiresAtUnix": {},
+  "relay": "phase_8",
+  "contentsDisplayed": false
+}}"#,
+                        invite.code,
+                        json_escape(&invite.peer_node_id),
+                        invite.expires_at_unix
+                    ))
+                } else {
+                    CliOutput::success(format!(
+                        r"conU pair
+
+status: pairing code created
+code: {}
+peer: {}
+expires at unix: {}
+relay: arrives in Phase 8
+
+next
+  conu join {}",
+                        invite.code, invite.peer_node_id, invite.expires_at_unix, invite.code
+                    ))
+                }
+            }
+            Err(error) => CliOutput::failure(1, format!("conU pair failed\n\n{error}")),
+        },
+        Err(error) => error,
+    }
+}
+
+fn render_join(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let json = args.iter().any(|arg| arg == "--json");
+
+    match join_code(args) {
+        Ok(code) => match trust::join_pairing_code(home_override, code) {
+            Ok(report) => {
+                if json {
+                    CliOutput::success(format!(
+                        r#"{{
+  "status": "trusted",
+  "peerNodeId": "{}",
+  "displayName": "{}",
+  "contentsDisplayed": false
+}}"#,
+                        json_escape(&report.peer.peer_node_id),
+                        json_escape(&report.peer.display_name)
+                    ))
+                } else {
+                    CliOutput::success(format!(
+                        r"conU join
+
+status: trusted
+peer: {}
+name: {}
+source: local pairing code
+
+next
+  conu peers",
+                        report.peer.peer_node_id, report.peer.display_name
+                    ))
+                }
+            }
+            Err(error) => CliOutput::failure(1, format!("conU join failed\n\n{error}")),
+        },
         Err(error) => error,
     }
 }
@@ -1250,6 +1459,7 @@ fn render_status_text(
     snapshot: &StateSnapshot,
     runtime_status: &RuntimeStatus,
     local_agents: &[LocalAgentRecord],
+    peers: &[TrustedPeer],
 ) -> String {
     let node = snapshot
         .node
@@ -1283,7 +1493,7 @@ identity
 agents
   local         {} registered
   registry      {}
-  remote        0 visible
+  trusted peers {}
 
 privacy
   payload view  contents are not displayed by conU",
@@ -1297,7 +1507,8 @@ privacy
         ready_label(snapshot.config_exists),
         ready_label(snapshot.trust_store_exists),
         local_agents.len(),
-        ready_label(snapshot.agent_registry_exists)
+        ready_label(snapshot.agent_registry_exists),
+        trusted_peer_count(peers)
     )
 }
 
@@ -1305,6 +1516,7 @@ fn render_status_json(
     snapshot: &StateSnapshot,
     runtime_status: &RuntimeStatus,
     local_agents: &[LocalAgentRecord],
+    peers: &[TrustedPeer],
 ) -> String {
     let node = snapshot
         .node
@@ -1338,7 +1550,7 @@ fn render_status_json(
   "agents": {{
     "local": {},
     "registry": "{}",
-    "remote": 0
+    "trustedPeers": {}
   }},
   "privacy": {{
     "contentsDisplayed": false
@@ -1355,7 +1567,8 @@ fn render_status_json(
         ready_label(snapshot.config_exists),
         ready_label(snapshot.trust_store_exists),
         local_agents.len(),
-        ready_label(snapshot.agent_registry_exists)
+        ready_label(snapshot.agent_registry_exists),
+        trusted_peer_count(peers)
     )
 }
 
@@ -1373,6 +1586,7 @@ Usage:
   conu messages inbox <agent-id> [--json]
   conu messages receipts [--json]
   conu peers [--json]
+  conu peers revoke <peer-node-id> [--json]
   conu pair [--json]
   conu join <code> [--json]
   conu connect
@@ -1383,7 +1597,7 @@ Usage:
   conu --help
   conu --version
 
-Phase 6 adds local opaque envelope delivery through conUD. Pairing, relay, remote discovery, and streaming arrive in later phases."
+Phase 7 adds local pairing invitations and trusted peer records. Relay, remote discovery, and streaming arrive in later phases."
         .to_string()
 }
 
@@ -1505,6 +1719,13 @@ fn runtime_pid_label(status: &RuntimeStatus) -> String {
         .unwrap_or_else(|| "n/a".to_string())
 }
 
+fn trusted_peer_count(peers: &[TrustedPeer]) -> usize {
+    peers
+        .iter()
+        .filter(|peer| peer.status == TrustStatus::Trusted)
+        .count()
+}
+
 fn json_u32(value: Option<u32>) -> String {
     value
         .map(|value| value.to_string())
@@ -1616,20 +1837,63 @@ mod tests {
     }
 
     #[test]
-    fn phase_six_commands_are_registered() {
+    fn phase_seven_commands_are_registered() {
         let home = temp_home("commands");
 
         for command in [
-            "init", "status", "agents", "pair", "connect", "watch", "stop",
+            "init", "status", "agents", "pair", "peers", "connect", "watch", "stop",
         ] {
             let output = run_with_home([command], Some(home.clone()));
             assert_eq!(output.code, 0, "{command} failed: {}", output.stderr);
         }
 
-        let join = run(["join", "123456"]);
-        assert_eq!(join.code, 0);
         let receipts = run_with_home(["messages", "receipts"], Some(home));
         assert_eq!(receipts.code, 0);
+    }
+
+    #[test]
+    fn pair_and_join_create_trusted_peer() {
+        let home = temp_home("pair-join");
+        let pair = run_with_home(["pair"], Some(home.clone()));
+        let code = pairing_code_from_output(&pair.stdout);
+
+        let join = run_with_home(["join", &code], Some(home.clone()));
+        let peers = run_with_home(["peers"], Some(home));
+
+        assert_eq!(pair.code, 0, "{}", pair.stderr);
+        assert_eq!(join.code, 0, "{}", join.stderr);
+        assert!(join.stdout.contains("status: trusted"));
+        assert!(peers.stdout.contains("peer_"));
+        assert!(peers.stdout.contains("trusted"));
+    }
+
+    #[test]
+    fn peers_json_and_revoke_are_metadata_only() {
+        let home = temp_home("peers-revoke");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let joined = trust::join_pairing_code(Some(home.clone()), &invite.code).expect("join");
+
+        let peers = run_with_home(["peers", "--json"], Some(home.clone()));
+        let revoke = run_with_home(
+            ["peers", "revoke", &joined.peer.peer_node_id, "--json"],
+            Some(home.clone()),
+        );
+        let revoked = run_with_home(["peers"], Some(home));
+
+        assert_eq!(peers.code, 0, "{}", peers.stderr);
+        assert!(peers.stdout.contains("\"status\": \"trusted\""));
+        assert!(peers.stdout.contains("\"contentsDisplayed\": false"));
+        assert_eq!(revoke.code, 0, "{}", revoke.stderr);
+        assert!(revoke.stdout.contains("\"status\": \"revoked\""));
+        assert!(revoked.stdout.contains("revoked"));
+    }
+
+    #[test]
+    fn join_rejects_unknown_local_pairing_code() {
+        let output = run_with_home(["join", "123456"], Some(temp_home("join-missing")));
+
+        assert_eq!(output.code, 1);
+        assert!(output.stderr.contains("not available locally"));
     }
 
     #[test]
@@ -1870,6 +2134,7 @@ mod tests {
         assert!(output.stdout.contains("\"localIpc\": \"file_gateway\""));
         assert!(output.stdout.contains("\"state\": \"initialized\""));
         assert!(output.stdout.contains("\"node\": \"node_"));
+        assert!(output.stdout.contains("\"trustedPeers\": 0"));
         assert!(output.stdout.contains("\"contentsDisplayed\": false"));
     }
 
@@ -1907,6 +2172,14 @@ mod tests {
             .as_nanos();
 
         std::env::temp_dir().join(format!("conu-cli-test-{label}-{}-{nonce}", process::id()))
+    }
+
+    fn pairing_code_from_output(output: &str) -> String {
+        output
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("code: "))
+            .expect("pairing code line")
+            .to_string()
     }
 
     fn register_test_agent(home: &PathBuf, agent_id: &str) {

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod agents;
 pub mod messages;
 pub mod runtime;
 pub mod state;
+pub mod trust;
 
 /// The product invariant every crate should preserve.
 pub const PRODUCT_LAW: &str = "Agents own the conversation. conU owns the connection.";

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -1,9 +1,9 @@
 //! Local persistent state for conU.
 //!
 //! Phase 6 keeps this intentionally small and std-only: a locally generated
-//! node id, config, trust store skeleton, agent registry, runtime metadata,
-//! local gateway inboxes, and local opaque message inboxes. Secret keys and
-//! encrypted remote mailbox storage belong to later phases.
+//! node id, config, trust store, pairing invitations, agent registry, runtime
+//! metadata, local gateway inboxes, and local opaque message inboxes. Secret
+//! keys and encrypted remote mailbox storage belong to later phases.
 
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -31,6 +31,9 @@ const IPC_REJECTED_DIR: &str = "rejected";
 const MESSAGES_DIR: &str = "messages";
 const MESSAGE_INBOX_DIR: &str = "inbox";
 const MESSAGE_RECEIPTS_DIR: &str = "receipts";
+const PAIRING_DIR: &str = "pairing";
+const PAIRING_INVITES_DIR: &str = "invites";
+const PAIRING_USED_DIR: &str = "used";
 const SESSIONS_DIR: &str = "sessions";
 const MAILBOX_DIR: &str = "mailbox";
 const LOGS_DIR: &str = "logs";
@@ -59,6 +62,9 @@ pub struct StatePaths {
     pub messages_dir: PathBuf,
     pub message_inbox_dir: PathBuf,
     pub message_receipts_dir: PathBuf,
+    pub pairing_dir: PathBuf,
+    pub pairing_invites_dir: PathBuf,
+    pub pairing_used_dir: PathBuf,
     pub sessions_dir: PathBuf,
     pub mailbox_dir: PathBuf,
     pub logs_dir: PathBuf,
@@ -82,6 +88,7 @@ impl StatePaths {
         let ipc_dir = runtime_dir.join(IPC_DIR);
         let message_ipc_dir = ipc_dir.join(MESSAGES_DIR);
         let messages_dir = home.join(MESSAGES_DIR);
+        let pairing_dir = home.join(PAIRING_DIR);
 
         Self {
             node_identity: home.join(NODE_FILE),
@@ -104,6 +111,9 @@ impl StatePaths {
             message_inbox_dir: messages_dir.join(MESSAGE_INBOX_DIR),
             message_receipts_dir: messages_dir.join(MESSAGE_RECEIPTS_DIR),
             messages_dir,
+            pairing_invites_dir: pairing_dir.join(PAIRING_INVITES_DIR),
+            pairing_used_dir: pairing_dir.join(PAIRING_USED_DIR),
+            pairing_dir,
             sessions_dir: home.join(SESSIONS_DIR),
             mailbox_dir: home.join(MAILBOX_DIR),
             logs_dir: home.join(LOGS_DIR),
@@ -278,6 +288,9 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
         &paths.messages_dir,
         &paths.message_inbox_dir,
         &paths.message_receipts_dir,
+        &paths.pairing_dir,
+        &paths.pairing_invites_dir,
+        &paths.pairing_used_dir,
         &paths.sessions_dir,
         &paths.mailbox_dir,
         &paths.logs_dir,
@@ -513,6 +526,7 @@ mod tests {
                 .exists()
         );
         assert!(home.join(MESSAGES_DIR).join(MESSAGE_INBOX_DIR).exists());
+        assert!(home.join(PAIRING_DIR).join(PAIRING_INVITES_DIR).exists());
         assert!(
             home.join(RUNTIME_DIR)
                 .join(IPC_DIR)

--- a/crates/conu-core/src/trust.rs
+++ b/crates/conu-core/src/trust.rs
@@ -1,0 +1,664 @@
+//! Local pairing invitations and trust store records.
+//!
+//! Phase 7 creates the trust-store mechanics before relay rendezvous exists.
+//! Pairing codes are local invitations; joining one creates a local trusted peer
+//! record without exposing payload contents.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::fmt;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::state::{self, StateError, StatePaths};
+
+const TRUST_VERSION: &str = "1";
+const PAIRING_VERSION: &str = "1";
+const PAIRING_TTL_SECS: u64 = 10 * 60;
+
+/// Lifecycle state for a local pairing invitation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairingStatus {
+    Pending,
+    Used,
+    Expired,
+}
+
+impl PairingStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Used => "used",
+            Self::Expired => "expired",
+        }
+    }
+
+    fn from_str(value: &str) -> Self {
+        match value {
+            "pending" => Self::Pending,
+            "used" => Self::Used,
+            "expired" => Self::Expired,
+            _ => Self::Expired,
+        }
+    }
+}
+
+/// Trust state for a known peer runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustStatus {
+    Trusted,
+    Revoked,
+}
+
+impl TrustStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::Revoked => "revoked",
+        }
+    }
+
+    fn from_str(value: &str) -> Self {
+        match value {
+            "trusted" => Self::Trusted,
+            "revoked" => Self::Revoked,
+            _ => Self::Revoked,
+        }
+    }
+}
+
+/// Local pairing invitation created by `conu pair`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairingInvite {
+    pub code: String,
+    pub local_node_id: String,
+    pub peer_node_id: String,
+    pub display_name: String,
+    pub created_at_unix: u64,
+    pub expires_at_unix: u64,
+    pub status: PairingStatus,
+}
+
+/// Trusted or revoked peer record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedPeer {
+    pub peer_node_id: String,
+    pub display_name: String,
+    pub status: TrustStatus,
+    pub source: String,
+    pub pairing_code_hash: String,
+    pub created_at_unix: u64,
+    pub updated_at_unix: u64,
+}
+
+/// Result of joining a local pairing invitation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JoinReport {
+    pub peer: TrustedPeer,
+    pub invite: PairingInvite,
+}
+
+/// Result of revoking a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RevokeReport {
+    pub peer: TrustedPeer,
+    pub changed: bool,
+}
+
+/// Errors produced by pairing and trust operations.
+#[derive(Debug)]
+pub enum TrustError {
+    State(StateError),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidRequest {
+        reason: String,
+    },
+}
+
+impl TrustError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for TrustError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidRequest { reason } => write!(formatter, "invalid trust request: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for TrustError {}
+
+impl From<StateError> for TrustError {
+    fn from(error: StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+/// Create a local pairing invitation.
+pub fn create_pairing_invite(home_override: Option<PathBuf>) -> Result<PairingInvite, TrustError> {
+    let init = state::init_state(home_override)?;
+    let now = current_unix_seconds();
+    let code = unique_pairing_code(&init.paths, &init.node.node_id, now)?;
+    let peer_suffix = pairing_code_suffix(&code);
+    let invite = PairingInvite {
+        peer_node_id: format!("peer_{peer_suffix}"),
+        display_name: format!("paired-peer-{peer_suffix}"),
+        code,
+        local_node_id: init.node.node_id,
+        created_at_unix: now,
+        expires_at_unix: now + PAIRING_TTL_SECS,
+        status: PairingStatus::Pending,
+    };
+    write_pairing_invite(&init.paths, &invite)?;
+
+    Ok(invite)
+}
+
+/// Join a local pairing invitation and create a trusted peer record.
+pub fn join_pairing_code(
+    home_override: Option<PathBuf>,
+    code: &str,
+) -> Result<JoinReport, TrustError> {
+    let code = validate_pairing_code(code)?;
+    let init = state::init_state(home_override)?;
+    let mut invite = read_pairing_invite(&init.paths, &code)?;
+    let now = current_unix_seconds();
+
+    if invite.expires_at_unix < now {
+        invite.status = PairingStatus::Expired;
+        write_pairing_invite(&init.paths, &invite)?;
+        return Err(TrustError::InvalidRequest {
+            reason: "pairing code expired".to_string(),
+        });
+    }
+    if invite.status != PairingStatus::Pending {
+        return Err(TrustError::InvalidRequest {
+            reason: "pairing code has already been used".to_string(),
+        });
+    }
+
+    let peer = upsert_trusted_peer(&init.paths, &invite, now)?;
+    invite.status = PairingStatus::Used;
+    write_pairing_invite(&init.paths, &invite)?;
+    move_used_invite(&init.paths, &invite)?;
+
+    Ok(JoinReport { peer, invite })
+}
+
+/// List trusted and revoked peers from the local trust store.
+pub fn list_peers(home_override: Option<PathBuf>) -> Result<Vec<TrustedPeer>, TrustError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_trust_store(&paths)
+}
+
+/// Revoke a peer by node id.
+pub fn revoke_peer(
+    home_override: Option<PathBuf>,
+    peer_node_id: &str,
+) -> Result<RevokeReport, TrustError> {
+    let peer_node_id = validate_identifier(peer_node_id.to_string(), "peer node id")?;
+    let init = state::init_state(home_override)?;
+    let mut peers = read_trust_store(&init.paths)?;
+    let now = current_unix_seconds();
+
+    for peer in &mut peers {
+        if peer.peer_node_id == peer_node_id {
+            let changed = peer.status != TrustStatus::Revoked;
+            peer.status = TrustStatus::Revoked;
+            peer.updated_at_unix = now;
+            let result = peer.clone();
+            write_trust_store(&init.paths, &peers)?;
+            return Ok(RevokeReport {
+                peer: result,
+                changed,
+            });
+        }
+    }
+
+    Err(TrustError::InvalidRequest {
+        reason: "peer is not trusted locally".to_string(),
+    })
+}
+
+fn upsert_trusted_peer(
+    paths: &StatePaths,
+    invite: &PairingInvite,
+    now: u64,
+) -> Result<TrustedPeer, TrustError> {
+    let mut peers = read_trust_store(paths)?;
+    let mut result = None;
+
+    for peer in &mut peers {
+        if peer.peer_node_id == invite.peer_node_id {
+            peer.display_name = invite.display_name.clone();
+            peer.status = TrustStatus::Trusted;
+            peer.source = "local_pair_code".to_string();
+            peer.pairing_code_hash = pairing_code_hash(&invite.code);
+            peer.updated_at_unix = now;
+            result = Some(peer.clone());
+            break;
+        }
+    }
+
+    let peer = result.unwrap_or_else(|| TrustedPeer {
+        peer_node_id: invite.peer_node_id.clone(),
+        display_name: invite.display_name.clone(),
+        status: TrustStatus::Trusted,
+        source: "local_pair_code".to_string(),
+        pairing_code_hash: pairing_code_hash(&invite.code),
+        created_at_unix: now,
+        updated_at_unix: now,
+    });
+
+    if !peers
+        .iter()
+        .any(|entry| entry.peer_node_id == peer.peer_node_id)
+    {
+        peers.push(peer.clone());
+    }
+
+    write_trust_store(paths, &peers)?;
+    Ok(peer)
+}
+
+fn read_pairing_invite(paths: &StatePaths, code: &str) -> Result<PairingInvite, TrustError> {
+    let path = paths.pairing_invites_dir.join(format!("{code}.pair"));
+    if !path.exists() {
+        return Err(TrustError::InvalidRequest {
+            reason: "pairing code is not available locally until relay pairing arrives".to_string(),
+        });
+    }
+
+    let contents = fs::read_to_string(&path)
+        .map_err(|error| TrustError::io("read pairing invitation", &path, error))?;
+    let values = parse_key_values(&contents);
+
+    Ok(PairingInvite {
+        code: validate_pairing_code(&required(&values, "code")?)?,
+        local_node_id: validate_identifier(required(&values, "local_node_id")?, "local node id")?,
+        peer_node_id: validate_identifier(required(&values, "peer_node_id")?, "peer node id")?,
+        display_name: validate_display_name(required(&values, "display_name")?)?,
+        created_at_unix: parse_u64(&required(&values, "created_at_unix")?)?,
+        expires_at_unix: parse_u64(&required(&values, "expires_at_unix")?)?,
+        status: PairingStatus::from_str(&required(&values, "status")?),
+    })
+}
+
+fn write_pairing_invite(paths: &StatePaths, invite: &PairingInvite) -> Result<(), TrustError> {
+    fs::create_dir_all(&paths.pairing_invites_dir).map_err(|error| {
+        TrustError::io(
+            "create pairing invitation directory",
+            &paths.pairing_invites_dir,
+            error,
+        )
+    })?;
+    let path = paths
+        .pairing_invites_dir
+        .join(format!("{}.pair", invite.code));
+    let contents = format!(
+        "version = \"{}\"\ncode = \"{}\"\nlocal_node_id = \"{}\"\npeer_node_id = \"{}\"\ndisplay_name = \"{}\"\ncreated_at_unix = {}\nexpires_at_unix = {}\nstatus = \"{}\"\npayload_displayed = false\n",
+        PAIRING_VERSION,
+        escape_file_value(&invite.code),
+        escape_file_value(&invite.local_node_id),
+        escape_file_value(&invite.peer_node_id),
+        escape_file_value(&invite.display_name),
+        invite.created_at_unix,
+        invite.expires_at_unix,
+        invite.status.as_str()
+    );
+
+    fs::write(&path, contents)
+        .map_err(|error| TrustError::io("write pairing invitation", &path, error))
+}
+
+fn move_used_invite(paths: &StatePaths, invite: &PairingInvite) -> Result<(), TrustError> {
+    fs::create_dir_all(&paths.pairing_used_dir).map_err(|error| {
+        TrustError::io(
+            "create used pairing invitation directory",
+            &paths.pairing_used_dir,
+            error,
+        )
+    })?;
+    let source = paths
+        .pairing_invites_dir
+        .join(format!("{}.pair", invite.code));
+    let target = paths.pairing_used_dir.join(format!("{}.pair", invite.code));
+    fs::rename(&source, &target)
+        .map_err(|error| TrustError::io("move used pairing invitation", &source, error))
+}
+
+fn read_trust_store(paths: &StatePaths) -> Result<Vec<TrustedPeer>, TrustError> {
+    if !paths.trust_store.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(&paths.trust_store)
+        .map_err(|error| TrustError::io("read trust store", &paths.trust_store, error))?;
+    parse_trust_store(&contents)
+}
+
+fn write_trust_store(paths: &StatePaths, peers: &[TrustedPeer]) -> Result<(), TrustError> {
+    let mut sorted = peers.to_vec();
+    sorted.sort_by(|left, right| left.peer_node_id.cmp(&right.peer_node_id));
+    let mut contents = format!("# conU trust store\nversion = \"{}\"\n", TRUST_VERSION);
+
+    for peer in sorted {
+        contents.push_str("\n[[peer]]\n");
+        contents.push_str(&format!(
+            "peer_node_id = \"{}\"\n",
+            escape_file_value(&peer.peer_node_id)
+        ));
+        contents.push_str(&format!(
+            "display_name = \"{}\"\n",
+            escape_file_value(&peer.display_name)
+        ));
+        contents.push_str(&format!("status = \"{}\"\n", peer.status.as_str()));
+        contents.push_str(&format!(
+            "source = \"{}\"\n",
+            escape_file_value(&peer.source)
+        ));
+        contents.push_str(&format!(
+            "pairing_code_hash = \"{}\"\n",
+            escape_file_value(&peer.pairing_code_hash)
+        ));
+        contents.push_str(&format!("created_at_unix = {}\n", peer.created_at_unix));
+        contents.push_str(&format!("updated_at_unix = {}\n", peer.updated_at_unix));
+        contents.push_str("payload_displayed = false\n");
+    }
+
+    fs::write(&paths.trust_store, contents)
+        .map_err(|error| TrustError::io("write trust store", &paths.trust_store, error))
+}
+
+fn parse_trust_store(contents: &str) -> Result<Vec<TrustedPeer>, TrustError> {
+    let mut peers = Vec::new();
+    let mut current = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty()
+            || line.starts_with('#')
+            || line == "trusted_peers = []"
+            || line == "revoked_peers = []"
+            || line == "version = \"1\""
+        {
+            continue;
+        }
+
+        if line == "[[peer]]" {
+            if !current.is_empty() {
+                peers.push(peer_from_values(&current)?);
+                current.clear();
+            }
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        current.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    if !current.is_empty() {
+        peers.push(peer_from_values(&current)?);
+    }
+
+    Ok(peers)
+}
+
+fn peer_from_values(values: &HashMap<String, String>) -> Result<TrustedPeer, TrustError> {
+    Ok(TrustedPeer {
+        peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
+        display_name: validate_display_name(required(values, "display_name")?)?,
+        status: TrustStatus::from_str(&required(values, "status")?),
+        source: validate_identifier(required(values, "source")?, "source")?,
+        pairing_code_hash: validate_identifier(
+            required(values, "pairing_code_hash")?,
+            "pairing code hash",
+        )?,
+        created_at_unix: parse_u64(&required(values, "created_at_unix")?)?,
+        updated_at_unix: parse_u64(&required(values, "updated_at_unix")?)?,
+    })
+}
+
+fn unique_pairing_code(paths: &StatePaths, node_id: &str, now: u64) -> Result<String, TrustError> {
+    for attempt in 0..10_u64 {
+        let code = generate_pairing_code(node_id, now, attempt);
+        let path = paths.pairing_invites_dir.join(format!("{code}.pair"));
+        if !path.exists() {
+            return Ok(code);
+        }
+    }
+
+    Err(TrustError::InvalidRequest {
+        reason: "could not allocate a unique pairing code".to_string(),
+    })
+}
+
+fn generate_pairing_code(node_id: &str, now: u64, attempt: u64) -> String {
+    let mut hasher = DefaultHasher::new();
+    node_id.hash(&mut hasher);
+    now.hash(&mut hasher);
+    attempt.hash(&mut hasher);
+    process::id().hash(&mut hasher);
+    current_unix_nanos().hash(&mut hasher);
+
+    format!("{:06}", hasher.finish() % 1_000_000)
+}
+
+fn pairing_code_hash(code: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    code.hash(&mut hasher);
+    format!("pair_{:016x}", hasher.finish())
+}
+
+fn pairing_code_suffix(code: &str) -> String {
+    pairing_code_hash(code)
+        .trim_start_matches("pair_")
+        .chars()
+        .take(12)
+        .collect()
+}
+
+fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, TrustError> {
+    values
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| TrustError::InvalidRequest {
+            reason: format!("missing {key}"),
+        })
+}
+
+fn validate_pairing_code(code: &str) -> Result<String, TrustError> {
+    let code = code.trim().to_string();
+    if code.len() != 6 || !code.chars().all(|character| character.is_ascii_digit()) {
+        return Err(TrustError::InvalidRequest {
+            reason: "pairing code must be six digits".to_string(),
+        });
+    }
+    Ok(code)
+}
+
+fn validate_identifier(value: String, field: &'static str) -> Result<String, TrustError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(TrustError::InvalidRequest {
+            reason: format!("{field} cannot be empty"),
+        });
+    }
+    if value.len() > 100 {
+        return Err(TrustError::InvalidRequest {
+            reason: format!("{field} is too long"),
+        });
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Err(TrustError::InvalidRequest {
+            reason: format!("{field} must use ASCII letters, numbers, dash, underscore, or dot"),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_display_name(value: String) -> Result<String, TrustError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(TrustError::InvalidRequest {
+            reason: "display name cannot be empty".to_string(),
+        });
+    }
+    if value.chars().any(|character| character.is_control()) {
+        return Err(TrustError::InvalidRequest {
+            reason: "display name cannot contain control characters".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn parse_key_values(contents: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        values.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    values
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn parse_u64(value: &str) -> Result<u64, TrustError> {
+    value
+        .parse::<u64>()
+        .map_err(|_| TrustError::InvalidRequest {
+            reason: "expected unsigned integer".to_string(),
+        })
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pairing_invite_persists_without_payload() {
+        let home = test_home("invite");
+
+        let invite = create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let invite_file = fs::read_to_string(
+            StatePaths::from_home(home)
+                .pairing_invites_dir
+                .join(format!("{}.pair", invite.code)),
+        )
+        .expect("invite reads");
+
+        assert_eq!(invite.status, PairingStatus::Pending);
+        assert_eq!(invite.code.len(), 6);
+        assert!(invite_file.contains("payload_displayed = false"));
+        assert!(!invite_file.contains("private message contents"));
+    }
+
+    #[test]
+    fn join_pairing_code_creates_trusted_peer() {
+        let home = test_home("join");
+        let invite = create_pairing_invite(Some(home.clone())).expect("invite creates");
+
+        let report = join_pairing_code(Some(home.clone()), &invite.code).expect("join succeeds");
+        let peers = list_peers(Some(home)).expect("peers read");
+
+        assert_eq!(report.peer.status, TrustStatus::Trusted);
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].peer_node_id, invite.peer_node_id);
+        assert_ne!(peers[0].pairing_code_hash, invite.code);
+        assert!(peers[0].pairing_code_hash.starts_with("pair_"));
+    }
+
+    #[test]
+    fn used_pairing_code_cannot_be_joined_twice() {
+        let home = test_home("used");
+        let invite = create_pairing_invite(Some(home.clone())).expect("invite creates");
+        join_pairing_code(Some(home.clone()), &invite.code).expect("first join succeeds");
+
+        let error = join_pairing_code(Some(home), &invite.code).expect_err("second join fails");
+
+        assert!(error.to_string().contains("not available locally"));
+    }
+
+    #[test]
+    fn revoke_peer_marks_record_revoked() {
+        let home = test_home("revoke");
+        let invite = create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let joined = join_pairing_code(Some(home.clone()), &invite.code).expect("join succeeds");
+
+        let report =
+            revoke_peer(Some(home.clone()), &joined.peer.peer_node_id).expect("revoke succeeds");
+        let peers = list_peers(Some(home)).expect("peers read");
+
+        assert!(report.changed);
+        assert_eq!(report.peer.status, TrustStatus::Revoked);
+        assert_eq!(peers[0].status, TrustStatus::Revoked);
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "conu-trust-test-{label}-{}-{}",
+            process::id(),
+            current_unix_nanos()
+        ))
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 7 - Pairing And Trust
+Current phase: Phase 8 - WebSocket Relay MVP
 Status: not_started
 Last updated: 2026-05-10
 ```
@@ -538,7 +538,7 @@ Next:
 
 ## Phase 7 - Pairing And Trust
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -546,16 +546,64 @@ Create the trust-forming flow between runtimes.
 
 Deliverables:
 
-- `conu pair`
-- `conu join <code>`
-- pairing code lifecycle
-- trust entry
-- peer revocation command if needed
+- [x] `conu pair`
+- [x] `conu join <code>`
+- [x] pairing code lifecycle
+- [x] trust entry
+- [x] peer revocation command if needed
 
 Exit criteria:
 
-- Pairing creates trusted peer records.
-- Trust can be listed and revoked.
+- [x] Pairing creates trusted peer records.
+- [x] Trust can be listed and revoked.
+
+Completed work:
+
+- Created GitHub issue #13 for Phase 7.
+- Created and pushed branch `codex/phase-7-pairing-trust`.
+- Added std-only `conu_core::trust` local pairing and trust store module.
+- Added local pairing invitation persistence under `pairing/invites/` and consumed invitations under `pairing/used/`.
+- Added `conu pair` to create a six-digit local pairing invitation with expiration.
+- Added `conu join <code>` to consume a local invitation and write a trusted peer record.
+- Added `conu peers` and `conu peers --json` for trust listing.
+- Added `conu peers revoke <peer-node-id>` for revocation.
+- Updated status/dashboard output to count trusted peers.
+- Stored `pairing_code_hash` in `trust.toml` instead of raw used pairing codes.
+- Derived peer ids and display names from a hash suffix instead of the raw pairing code.
+- Updated README, repo overview, builder guardrails, repo map, and agent gateway contract.
+
+Files changed:
+
+- `README.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `plan.md`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conu-core/src/trust.rs`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu build -p conu-cli` passed.
+- Isolated `CONU_HOME` smoke passed: `conu init`, `conu pair`, `conu join <code>`, `conu peers --json`, and `conu peers revoke <peer-node-id> --json`.
+- Smoke confirmed peer output does not expose the raw used pairing code and `trust.toml` stores `pairing_code_hash`.
+
+Known gaps:
+
+- Phase 7 pairing is local-only trust groundwork; cross-machine rendezvous requires the Phase 8 relay.
+- Pairing invitations are file-backed and not cryptographically signed yet.
+- Trust records are persistent metadata, but full permission grants, key exchange, and signed peer verification arrive in later security phases.
+- Remote agent discovery over trusted peers starts in Phase 9.
+
+Next:
+
+- Start Phase 8: WebSocket relay MVP for hosted rendezvous and opaque forwarding groundwork.
 
 ## Phase 8 - WebSocket Relay MVP
 
@@ -747,4 +795,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 4 completed. conUD daemon skeleton added with start/stop, runtime heartbeat status, stale restart handling, payload-safe logs, tests, and isolated CONU_HOME process smoke. Next: Phase 5 local IPC and agent registration.
 2026-05-10 - Phase 5 completed. File-backed local IPC gateway added with metadata-only agent registration, presence heartbeat, persisted local agent registry, conUD processing, CLI listing, tests, docs, and isolated CONU_HOME smoke validation. Next: Phase 6 opaque envelope messaging.
 2026-05-10 - Phase 6 completed. Local opaque envelope messaging added with stdin submission, registered sender/receiver validation, recipient inboxes, metadata-only receipts/logs, conUD processing, tests, docs, and isolated CONU_HOME smoke validation. Next: Phase 7 pairing and trust.
+2026-05-10 - Phase 7 completed. Local pairing invitations, join-to-trust, peer listing, revocation, pairing code hash storage, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 8 WebSocket relay MVP.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- Adds Phase 7 local pairing invitation and trust-store mechanics.
- Implements `conu pair`, `conu join <code>`, `conu peers`, and `conu peers revoke`.
- Persists local pairing invitations under `pairing/` and trusted/revoked peers in `trust.toml`.
- Updates dashboard/status peer counts, docs, plan, and future-agent guardrails.

## Privacy / Security
- Raw used pairing codes are not shown in `conu peers` output.
- Trust records store `pairing_code_hash`, not the raw used code.
- Peer ids/display names are hash-derived, not raw-code-derived.
- No payload routing, relay, or remote discovery is added in this phase.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu test --workspace`
- `cargo +stable-x86_64-pc-windows-gnu build -p conu-cli`
- Isolated smoke: init, pair, join, peers JSON, revoke JSON
- Smoke confirmed peers output did not expose the raw used code and `trust.toml` stores `pairing_code_hash`

Closes #13


___

## **CodeAnt-AI Description**
**Add local pairing, trusted peers, and revocation**

### What Changed
- `conu pair` now creates a local pairing code with an expiry and stores the invitation on disk.
- `conu join <code>` now turns a valid local invitation into a trusted peer record, and rejects missing, expired, or reused codes.
- `conu peers` now lists trusted and revoked peers, and `conu peers revoke <peer-node-id>` marks a peer as revoked without deleting its history.
- Status and dashboard output now show the trusted peer count, and trust records store a code hash instead of the raw pairing code.

### Impact
`✅ Local trust setup from the CLI`
`✅ Fewer reused pairing code mistakes`
`✅ Peer revocation history stays visible`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=-IfCmvY_OcvYWVEY_BohinV1vejlhY7q71xz7JRIvpM&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
