### PR TITLE
Implement phase 9 remote sessions

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 8.
+The repository has completed Phase 9.
 
 Implemented so far:
 
@@ -32,9 +32,14 @@ Implemented so far:
 - std-only `conu-relay` WebSocket service
 - relay session authentication with a shared token
 - connected-runtime metadata forwarding with `WELCOME`, `ENVELOPE`, `SENT`, and `UNDELIVERED` frames
+- conUD-owned remote session sync through `conu sessions sync`
+- remote runtime session metadata under `sessions/registry.toml`
+- trusted remote agent mirror under `agents/remote.toml`
+- remote agents visible through `conu agents`
 - payload-safe status and agent registry reporting
 - payload-safe runtime and agent metadata logs
 - payload-safe message delivery metadata logs
+- payload-safe remote session metadata logs
 - payload-safe protocol scaffold
 - daemon runtime skeleton and relay service binary
 

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -152,7 +152,26 @@ PONG payload=not_observed
 ERROR reason=<safe-reason> payload=not_observed
 ```
 
-Phase 8 does not yet expose this relay through the local agent gateway. conUD remote session management, remote agent discovery, reconnects, and relay-backed local commands begin in later phases.
+Phase 8 does not yet expose this relay through the local agent gateway. conUD remote session and discovery mirrors begin in Phase 9, while live relay-backed messaging/streaming lands later.
+
+The Phase 9 remote session surface is conUD-owned metadata sync:
+
+```txt
+sessions/registry.toml   remote runtime session metadata
+agents/remote.toml       mirrored trusted remote agent cards
+logs/sessions.log        metadata-only sync log
+```
+
+Supported commands:
+
+```txt
+conu sessions [--json]
+conu sessions sync [--json]
+conu agents [--json]
+conud --process-ipc
+```
+
+`conu sessions sync` reads trusted peers and mirrors route/session metadata so `conu agents` can show visible remote agents. It does not transfer private payloads and does not yet create an interactive live stream. Revoked peers must disappear from the active remote-agent mirror after sync.
 
 ## Safety
 

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -82,7 +82,17 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Relay server output, errors, tests, and logs must not echo auth tokens or private payload contents.
 - The relay may return `UNDELIVERED reason=peer_offline` when the target runtime is not connected; do not add mailbox storage until the encrypted mailbox phase.
 - On Windows, accepted streams from a nonblocking listener must be set back to blocking mode before frame reads.
-- conUD remote session management and remote agent discovery are not complete just because `conu-relay` exists; keep those changes in Phase 9.
+- `conu-relay` alone is not a live remote-agent connection; conUD session/discovery mirrors begin in Phase 9 and live stream routing remains later work.
+
+## Remote Session And Discovery Rules
+
+- Phase 9 remote sessions are file-backed metadata mirrors in `conu_core::sessions`.
+- conUD owns session sync; CLI commands may request sync or display the mirror but must not inspect payloads.
+- Remote session state belongs under `sessions/registry.toml`; mirrored remote agent cards belong under `agents/remote.toml`.
+- Session logs must use metadata-only lines with counts, route state, and `payload=not_observed`.
+- `conu agents` may show trusted remote agent cards from the mirror, but it must not claim live messaging/streaming before later phases wire the relay client into conUD.
+- Revoked peers must not remain visible as active remote agents after session sync.
+- Route metadata may include relay endpoint, peer id, state, and reconnect counts; it must not include message contents, tokens, or private payload bytes.
 
 ## Privacy Rules
 

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -20,10 +20,10 @@ crates/conu-cli
   CLI commands, ASCII dashboard, watch animation, user control flow
 
 crates/conud
-  daemon process, local gateway/message processing, session manager, runtime lifecycle
+  daemon process, local gateway/message/session processing, session manager, runtime lifecycle
 
 crates/conu-core
-  local state, runtime lifecycle, agent registry, local message routing, trust store, relay frame contract, future policy logic
+  local state, runtime lifecycle, agent registry, local message routing, trust store, relay frame contract, remote session mirror, future policy logic
 
 crates/conu-protocol
   envelopes, agent cards, control-plane messages, data-plane messages

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 8 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, local agents can register metadata and presence, registered local agents can exchange opaque message envelopes, local pairing/trust records can be created and revoked, and `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding.
+Phase 9 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, local agents can register metadata and presence, registered local agents can exchange opaque message envelopes, local pairing/trust records can be created and revoked, `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding, and conUD can sync remote session/discovery metadata for trusted peers.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -39,6 +39,7 @@ node.toml              local node id only, not a secret or auth credential
 config.toml            local runtime config skeleton
 trust.toml             trusted/revoked peer skeleton
 agents/registry.toml   local agent registry skeleton
+agents/remote.toml     mirrored trusted remote agent cards
 runtime/status.toml    conUD heartbeat/status metadata
 runtime/conud.lock     local runtime process lock
 runtime/stop.request   graceful shutdown request file
@@ -50,11 +51,12 @@ messages/inbox/        delivered local opaque envelopes by recipient agent
 messages/receipts/     metadata-only local delivery receipts
 pairing/invites/       pending local pairing invitations
 pairing/used/          consumed local pairing invitations
-sessions/              future runtime sessions
+sessions/registry.toml remote runtime session metadata
 mailbox/               future encrypted mailbox storage
 logs/conud.log         runtime metadata log
 logs/agents.log        local agent metadata log
 logs/messages.log      local message delivery metadata log
+logs/sessions.log      remote session sync metadata log
 ```
 
 Runtime, agent, and message logs contain metadata only, such as event name, pid, node id, agent id, envelope id, byte count, and `payload=not_observed`. Phase 6 local message payload bytes are stored only as opaque recipient-inbox envelope data; CLI output, receipts, processed markers, rejected markers, and logs do not display message contents. Until encryption hardening lands in Phase 11, agents should prefer already-encrypted payload bytes for sensitive local messages.
@@ -114,7 +116,22 @@ cargo run -p conu-relay -- --serve 127.0.0.1:8787
 
 Connected runtimes send `HELLO`, `FORWARD`, and `PING` frames. The relay answers with `WELCOME`, `ENVELOPE`, `SENT`, `UNDELIVERED`, `PONG`, or `ERROR` frames. Forwarding is metadata-only: the relay sees target node id, envelope id, and byte count, while payload fields are rejected and logs/output use `payload=not_observed` or `payload=opaque`.
 
-The relay is available now as a standalone service. conUD remote session management, remote agent discovery, reconnect loops, and encrypted payload hardening land in later phases.
+The relay is available now as a standalone service. Full relay-backed live session exchange, reconnect networking, and encrypted payload hardening land in later phases.
+
+## Remote Sessions And Discovery
+
+Phase 9 adds a conUD-owned remote session mirror for trusted peers:
+
+```bash
+conu sessions sync
+conu sessions
+conu sessions --json
+conu agents --json
+```
+
+`conu sessions sync` reads trusted peers, writes route/session metadata under `sessions/registry.toml`, mirrors visible remote agent cards into `agents/remote.toml`, and appends only metadata to `logs/sessions.log`. `conUD --process-ipc`, `conUD --once`, and the runtime serve loop also sync remote sessions.
+
+This phase is still metadata/discovery groundwork: remote agent cards are derived from trusted peer metadata until the full relay-backed session exchange lands. Payloads remain opaque and are never displayed by session or agent listing commands.
 
 ## Development
 
@@ -145,6 +162,8 @@ cargo run -p conu-cli -- agents heartbeat agent.codex --presence busy
 cargo run -p conu-cli -- messages send agent.sender agent.receiver --stdin
 cargo run -p conu-cli -- messages inbox agent.receiver --json
 cargo run -p conu-cli -- messages receipts --json
+cargo run -p conu-cli -- sessions sync
+cargo run -p conu-cli -- sessions --json
 cargo run -p conu-cli -- pair
 cargo run -p conu-cli -- join 123456
 cargo run -p conu-cli -- peers --json

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -1,7 +1,7 @@
 //! CLI rendering and command dispatch for conU.
 //!
-//! Phase 6 adds conUD runtime detection, metadata-only local agent
-//! registration, and local opaque envelope delivery.
+//! Phase 9 adds conUD runtime detection, metadata-only local/remote agent
+//! visibility, local opaque envelopes, and remote session mirrors.
 
 use std::collections::HashSet;
 use std::env;
@@ -15,6 +15,7 @@ use conu_core::agents::{
 };
 use conu_core::messages::{self, DeliveryReceipt, InboxEntry, LocalMessage};
 use conu_core::runtime::{self, RuntimeState, RuntimeStatus, StopReport};
+use conu_core::sessions::{self, RemoteAgentRecord, RemoteSession, SessionSyncReport};
 use conu_core::state::{self, InitReport, StateSnapshot};
 use conu_core::trust::{self, TrustStatus, TrustedPeer};
 use conu_protocol::OpaquePayload;
@@ -96,6 +97,7 @@ where
         "agents" => render_agents(&args[1..], home_override),
         "peers" => render_peers(&args[1..], home_override),
         "messages" => render_messages(&args[1..], home_override, stdin_payload),
+        "sessions" => render_sessions(&args[1..], home_override),
         "pair" => render_pair(&args[1..], home_override),
         "join" => render_join(&args[1..], home_override),
         "connect" => render_connect(&args[1..], home_override),
@@ -118,13 +120,16 @@ fn render_dashboard(home_override: Option<PathBuf>) -> String {
     let local_agents = agents::list_local_agents(home_override.clone())
         .map(|agents| agents.len())
         .unwrap_or(0);
-    let trusted_peers = trust::list_peers(home_override)
+    let trusted_peers = trust::list_peers(home_override.clone())
         .map(|peers| {
             peers
                 .iter()
                 .filter(|peer| peer.status == TrustStatus::Trusted)
                 .count()
         })
+        .unwrap_or(0);
+    let remote_agents = sessions::list_remote_agents(home_override)
+        .map(|agents| agents.len())
         .unwrap_or(0);
     let node = snapshot
         .as_ref()
@@ -155,6 +160,7 @@ control room
   node          {node}
   state         {state}
   local agents  {local_agents}
+  remote agents {remote_agents}
   remote peers  {trusted_peers} trusted
   network       relay service  available via conu-relay
 
@@ -197,8 +203,16 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
         Ok(agents) => agents,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
-    let peers = match trust::list_peers(home_override) {
+    let peers = match trust::list_peers(home_override.clone()) {
         Ok(peers) => peers,
+        Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
+    };
+    let sessions = match sessions::list_remote_sessions(home_override.clone()) {
+        Ok(sessions) => sessions,
+        Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
+    };
+    let remote_agents = match sessions::list_remote_agents(home_override) {
+        Ok(agents) => agents,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
 
@@ -207,12 +221,16 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
             &snapshot,
             &runtime_status,
             &local_agents,
+            &remote_agents,
+            &sessions,
             &peers,
         )),
         Ok(false) => CliOutput::success(render_status_text(
             &snapshot,
             &runtime_status,
             &local_agents,
+            &remote_agents,
+            &sessions,
             &peers,
         )),
         Err(error) => error,
@@ -232,7 +250,11 @@ fn render_agents_list(args: &[String], home_override: Option<PathBuf>) -> CliOut
         Ok(snapshot) => snapshot,
         Err(error) => return CliOutput::failure(1, format!("conU agents failed\n\n{error}")),
     };
-    let local_agents = match agents::list_local_agents(home_override) {
+    let local_agents = match agents::list_local_agents(home_override.clone()) {
+        Ok(agents) => agents,
+        Err(error) => return CliOutput::failure(1, format!("conU agents failed\n\n{error}")),
+    };
+    let remote_agents = match sessions::list_remote_agents(home_override.clone()) {
         Ok(agents) => agents,
         Err(error) => return CliOutput::failure(1, format!("conU agents failed\n\n{error}")),
     };
@@ -241,11 +263,13 @@ fn render_agents_list(args: &[String], home_override: Option<PathBuf>) -> CliOut
     match json_flag(args) {
         Ok(true) => CliOutput::success(render_agents_json(
             &local_agents,
+            &remote_agents,
             registry_state,
             &snapshot.paths.agent_registry.display().to_string(),
         )),
         Ok(false) => CliOutput::success(render_agents_text(
             &local_agents,
+            &remote_agents,
             registry_state,
             &snapshot.paths.agent_registry.display().to_string(),
         )),
@@ -366,7 +390,12 @@ privacy
     ))
 }
 
-fn render_agents_json(agents: &[LocalAgentRecord], registry: &str, registry_path: &str) -> String {
+fn render_agents_json(
+    agents: &[LocalAgentRecord],
+    remote_agents: &[RemoteAgentRecord],
+    registry: &str,
+    registry_path: &str,
+) -> String {
     let local_items = agents
         .iter()
         .map(|agent| {
@@ -404,22 +433,67 @@ fn render_agents_json(agents: &[LocalAgentRecord], registry: &str, registry_path
     } else {
         format!("[\n{local_items}\n  ]")
     };
+    let remote_items = remote_agents
+        .iter()
+        .map(|agent| {
+            format!(
+                r#"    {{
+      "agentId": "{}",
+      "displayName": "{}",
+      "kind": "{}",
+      "presence": "{}",
+      "nodeId": "{}",
+      "peerNodeId": "{}",
+      "capabilities": {{
+        "messages": {},
+        "streams": {},
+        "rooms": {},
+        "files": {},
+        "presence": {}
+      }}
+    }}"#,
+                json_escape(&agent.agent_id),
+                json_escape(&agent.display_name),
+                json_escape(&agent.kind),
+                agent.presence.as_str(),
+                json_escape(&agent.node_id),
+                json_escape(&agent.peer_node_id),
+                agent.capabilities.messages,
+                agent.capabilities.streams,
+                agent.capabilities.rooms,
+                agent.capabilities.files,
+                agent.capabilities.presence
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let remote = if remote_items.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{remote_items}\n  ]")
+    };
 
     format!(
         r#"{{
   "local": {},
-  "remote": [],
+  "remote": {},
   "registry": "{}",
   "registryPath": "{}",
-  "status": "local agent registration active"
+  "status": "agent registry active"
 }}"#,
         local,
+        remote,
         registry,
         json_escape(registry_path)
     )
 }
 
-fn render_agents_text(agents: &[LocalAgentRecord], registry: &str, registry_path: &str) -> String {
+fn render_agents_text(
+    agents: &[LocalAgentRecord],
+    remote_agents: &[RemoteAgentRecord],
+    registry: &str,
+    registry_path: &str,
+) -> String {
     let local = if agents.is_empty() {
         "  none registered yet".to_string()
     } else {
@@ -437,6 +511,23 @@ fn render_agents_text(agents: &[LocalAgentRecord], registry: &str, registry_path
             .collect::<Vec<_>>()
             .join("\n")
     };
+    let remote = if remote_agents.is_empty() {
+        "  none visible yet".to_string()
+    } else {
+        remote_agents
+            .iter()
+            .map(|agent| {
+                format!(
+                    "  {}  {}  {}  peer {}",
+                    agent.agent_id,
+                    agent.presence.as_str(),
+                    agent.display_name,
+                    agent.peer_node_id
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
 
     format!(
         r"conU agents
@@ -447,12 +538,12 @@ local agents
   path          {}
 
 remote agents
-  none visible yet
+{remote}
 
 next
   conu agents register <agent-id> <display-name>
   conu agents heartbeat <agent-id>
-  Phase 9: remote discovery and presence",
+  conu sessions sync",
         registry, registry_path
     )
 }
@@ -984,6 +1075,171 @@ fn render_messages_usage() -> String {
         .to_string()
 }
 
+fn render_sessions(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    match args.first().map(String::as_str) {
+        Some("sync") => render_sessions_sync(&args[1..], home_override),
+        _ => render_sessions_list(args, home_override),
+    }
+}
+
+fn render_sessions_sync(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    match json_flag(args) {
+        Ok(json) => match sessions::sync_remote_sessions(home_override) {
+            Ok(report) => {
+                if json {
+                    CliOutput::success(render_sessions_report_json(&report))
+                } else {
+                    CliOutput::success(render_sessions_report_text(&report))
+                }
+            }
+            Err(error) => CliOutput::failure(1, format!("conU sessions sync failed\n\n{error}")),
+        },
+        Err(error) => error,
+    }
+}
+
+fn render_sessions_list(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let remote_sessions = match sessions::list_remote_sessions(home_override.clone()) {
+        Ok(sessions) => sessions,
+        Err(error) => return CliOutput::failure(1, format!("conU sessions failed\n\n{error}")),
+    };
+    let remote_agents = match sessions::list_remote_agents(home_override) {
+        Ok(agents) => agents,
+        Err(error) => return CliOutput::failure(1, format!("conU sessions failed\n\n{error}")),
+    };
+
+    match json_flag(args) {
+        Ok(true) => CliOutput::success(render_sessions_json(&remote_sessions, &remote_agents)),
+        Ok(false) => CliOutput::success(render_sessions_text(&remote_sessions, &remote_agents)),
+        Err(error) => error,
+    }
+}
+
+fn render_sessions_json(
+    remote_sessions: &[RemoteSession],
+    remote_agents: &[RemoteAgentRecord],
+) -> String {
+    let session_items = remote_sessions
+        .iter()
+        .map(|session| {
+            format!(
+                r#"    {{
+      "peerNodeId": "{}",
+      "displayName": "{}",
+      "state": "{}",
+      "route": "{}",
+      "relayEndpoint": "{}",
+      "reconnectAttempts": {},
+      "remoteAgentCount": {}
+    }}"#,
+                json_escape(&session.peer_node_id),
+                json_escape(&session.display_name),
+                session.state.as_str(),
+                json_escape(&session.route),
+                json_escape(&session.relay_endpoint),
+                session.reconnect_attempts,
+                session.remote_agent_count
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let sessions_json = if session_items.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{session_items}\n  ]")
+    };
+
+    format!(
+        r#"{{
+  "sessions": {},
+  "remoteAgents": {},
+  "contentsDisplayed": false
+}}"#,
+        sessions_json,
+        remote_agents.len()
+    )
+}
+
+fn render_sessions_text(
+    remote_sessions: &[RemoteSession],
+    remote_agents: &[RemoteAgentRecord],
+) -> String {
+    let sessions_text = if remote_sessions.is_empty() {
+        "  none synced yet".to_string()
+    } else {
+        remote_sessions
+            .iter()
+            .map(|session| {
+                format!(
+                    "  {}  {}  route {}  agents {}",
+                    session.peer_node_id,
+                    session.state.as_str(),
+                    session.route,
+                    session.remote_agent_count
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        r"conU sessions
+
+remote sessions
+{sessions_text}
+
+remote agents
+  visible       {}
+
+privacy
+  payload view  contents are not displayed by conU
+
+next
+  conu sessions sync",
+        remote_agents.len()
+    )
+}
+
+fn render_sessions_report_json(report: &SessionSyncReport) -> String {
+    format!(
+        r#"{{
+  "status": "synced",
+  "sessionsSynced": {},
+  "remoteAgentsSynced": {},
+  "connected": {},
+  "reconnecting": {},
+  "offline": {},
+  "contentsDisplayed": false
+}}"#,
+        report.sessions_synced,
+        report.remote_agents_synced,
+        report.connected,
+        report.reconnecting,
+        report.offline
+    )
+}
+
+fn render_sessions_report_text(report: &SessionSyncReport) -> String {
+    format!(
+        r"conU sessions sync
+
+status: synced
+sessions: {}
+remote agents: {}
+connected: {}
+reconnecting: {}
+offline: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        report.sessions_synced,
+        report.remote_agents_synced,
+        report.connected,
+        report.reconnecting,
+        report.offline
+    )
+}
+
 fn inbox_ids(home_override: Option<PathBuf>, agent_id: &str) -> HashSet<String> {
     messages::list_agent_inbox(home_override, agent_id)
         .map(|entries| {
@@ -1261,7 +1517,8 @@ fn render_connect(args: &[String], home_override: Option<PathBuf>) -> CliOutput 
     if let Some(error) = reject_args(args) {
         return error;
     }
-    let local_agents = agents::list_local_agents(home_override).unwrap_or_default();
+    let local_agents = agents::list_local_agents(home_override.clone()).unwrap_or_default();
+    let remote_agents = sessions::list_remote_agents(home_override).unwrap_or_default();
     let local = if local_agents.is_empty() {
         "none registered".to_string()
     } else {
@@ -1278,16 +1535,32 @@ fn render_connect(args: &[String], home_override: Option<PathBuf>) -> CliOutput 
             .collect::<Vec<_>>()
             .join(", ")
     };
+    let remote = if remote_agents.is_empty() {
+        "none visible".to_string()
+    } else {
+        remote_agents
+            .iter()
+            .map(|agent| {
+                format!(
+                    "{} ({}, peer {})",
+                    agent.agent_id,
+                    agent.presence.as_str(),
+                    agent.peer_node_id
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
 
     CliOutput::success(format!(
         r"conU connect
 
 selector
   source local agent   {local}
-  target remote agent  none visible
+  target remote agent  {remote}
   mode                 message | stream | room | observe
 
-status: local messages use `conu messages send`; interactive connect waits for Phase 9 remote discovery",
+status: remote discovery mirror ready; interactive sessions arrive in Phase 10+",
     ))
 }
 
@@ -1459,6 +1732,8 @@ fn render_status_text(
     snapshot: &StateSnapshot,
     runtime_status: &RuntimeStatus,
     local_agents: &[LocalAgentRecord],
+    remote_agents: &[RemoteAgentRecord],
+    sessions: &[RemoteSession],
     peers: &[TrustedPeer],
 ) -> String {
     let node = snapshot
@@ -1492,8 +1767,10 @@ identity
 
 agents
   local         {} registered
+  remote        {} visible
   registry      {}
   trusted peers {}
+  sessions      {}
 
 privacy
   payload view  contents are not displayed by conU",
@@ -1507,8 +1784,10 @@ privacy
         ready_label(snapshot.config_exists),
         ready_label(snapshot.trust_store_exists),
         local_agents.len(),
+        remote_agents.len(),
         ready_label(snapshot.agent_registry_exists),
-        trusted_peer_count(peers)
+        trusted_peer_count(peers),
+        sessions.len()
     )
 }
 
@@ -1516,6 +1795,8 @@ fn render_status_json(
     snapshot: &StateSnapshot,
     runtime_status: &RuntimeStatus,
     local_agents: &[LocalAgentRecord],
+    remote_agents: &[RemoteAgentRecord],
+    sessions: &[RemoteSession],
     peers: &[TrustedPeer],
 ) -> String {
     let node = snapshot
@@ -1549,8 +1830,10 @@ fn render_status_json(
   }},
   "agents": {{
     "local": {},
+    "remote": {},
     "registry": "{}",
-    "trustedPeers": {}
+    "trustedPeers": {},
+    "sessions": {}
   }},
   "privacy": {{
     "contentsDisplayed": false
@@ -1567,8 +1850,10 @@ fn render_status_json(
         ready_label(snapshot.config_exists),
         ready_label(snapshot.trust_store_exists),
         local_agents.len(),
+        remote_agents.len(),
         ready_label(snapshot.agent_registry_exists),
-        trusted_peer_count(peers)
+        trusted_peer_count(peers),
+        sessions.len()
     )
 }
 
@@ -1585,6 +1870,8 @@ Usage:
   conu messages send <from-agent> <to-agent> --stdin [--json]
   conu messages inbox <agent-id> [--json]
   conu messages receipts [--json]
+  conu sessions [--json]
+  conu sessions sync [--json]
   conu peers [--json]
   conu peers revoke <peer-node-id> [--json]
   conu pair [--json]
@@ -1597,7 +1884,7 @@ Usage:
   conu --help
   conu --version
 
-Phase 8 adds the conu-relay WebSocket service for metadata-only relay forwarding. Remote discovery and streaming arrive in later phases."
+Phase 9 adds conUD-owned remote session and discovery mirrors. Streaming arrives in later phases."
         .to_string()
 }
 
@@ -1837,11 +2124,11 @@ mod tests {
     }
 
     #[test]
-    fn phase_eight_commands_are_registered() {
+    fn phase_nine_commands_are_registered() {
         let home = temp_home("commands");
 
         for command in [
-            "init", "status", "agents", "pair", "peers", "connect", "watch", "stop",
+            "init", "status", "agents", "sessions", "pair", "peers", "connect", "watch", "stop",
         ] {
             let output = run_with_home([command], Some(home.clone()));
             assert_eq!(output.code, 0, "{command} failed: {}", output.stderr);
@@ -1886,6 +2173,28 @@ mod tests {
         assert_eq!(revoke.code, 0, "{}", revoke.stderr);
         assert!(revoke.stdout.contains("\"status\": \"revoked\""));
         assert!(revoked.stdout.contains("revoked"));
+    }
+
+    #[test]
+    fn sessions_sync_makes_remote_agent_visible() {
+        let home = temp_home("sessions-sync");
+        let pair = run_with_home(["pair"], Some(home.clone()));
+        let code = pairing_code_from_output(&pair.stdout);
+        let join = run_with_home(["join", &code], Some(home.clone()));
+        let sync = run_with_home(["sessions", "sync"], Some(home.clone()));
+        let sessions = run_with_home(["sessions"], Some(home.clone()));
+        let agents = run_with_home(["agents", "--json"], Some(home.clone()));
+        let status = run_with_home(["status", "--json"], Some(home));
+
+        assert_eq!(join.code, 0, "{}", join.stderr);
+        assert_eq!(sync.code, 0, "{}", sync.stderr);
+        assert!(sync.stdout.contains("remote agents: 1"));
+        assert!(sessions.stdout.contains("connected"));
+        assert!(agents.stdout.contains("\"remote\": ["));
+        assert!(agents.stdout.contains("agent.remote."));
+        assert!(status.stdout.contains("\"remote\": 1"));
+        assert!(status.stdout.contains("\"sessions\": 1"));
+        assert!(!agents.stdout.contains("private message contents"));
     }
 
     #[test]
@@ -2134,7 +2443,9 @@ mod tests {
         assert!(output.stdout.contains("\"localIpc\": \"file_gateway\""));
         assert!(output.stdout.contains("\"state\": \"initialized\""));
         assert!(output.stdout.contains("\"node\": \"node_"));
+        assert!(output.stdout.contains("\"remote\": 0"));
         assert!(output.stdout.contains("\"trustedPeers\": 0"));
+        assert!(output.stdout.contains("\"sessions\": 0"));
         assert!(output.stdout.contains("\"contentsDisplayed\": false"));
     }
 

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod agents;
 pub mod messages;
 pub mod relay;
 pub mod runtime;
+pub mod sessions;
 pub mod state;
 pub mod trust;
 

--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -1,8 +1,7 @@
 //! Local conUD runtime state and heartbeat management.
 //!
-//! Phase 6 uses file-backed health and gateway state so the CLI can detect a
-//! local runtime, agents can register, and local opaque message requests can be
-//! delivered between registered agents.
+//! Phase 9 uses file-backed health, gateway state, local messages, and remote
+//! session mirrors so the CLI can detect conUD-owned communication state.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -14,7 +13,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::state::{self, NodeIdentity, StateError, StatePaths};
-use crate::{agents, messages};
+use crate::{agents, messages, sessions};
 
 const STATUS_VERSION: &str = "1";
 const STALE_AFTER_SECS: u64 = 10;
@@ -129,6 +128,8 @@ impl RuntimeLease {
                 .map_err(RuntimeError::Agent)?;
             messages::process_message_requests_from_paths(&self.paths)
                 .map_err(RuntimeError::Message)?;
+            sessions::sync_remote_sessions_from_paths(&self.paths)
+                .map_err(RuntimeError::Session)?;
             thread::sleep(heartbeat_every);
         }
 
@@ -184,6 +185,7 @@ pub enum RuntimeError {
     State(StateError),
     Agent(agents::AgentError),
     Message(messages::MessageError),
+    Session(sessions::SessionError),
     Io {
         action: &'static str,
         path: PathBuf,
@@ -208,6 +210,7 @@ impl fmt::Display for RuntimeError {
             Self::State(error) => write!(formatter, "{error}"),
             Self::Agent(error) => write!(formatter, "{error}"),
             Self::Message(error) => write!(formatter, "{error}"),
+            Self::Session(error) => write!(formatter, "{error}"),
             Self::Io {
                 action,
                 path,
@@ -241,6 +244,12 @@ impl From<agents::AgentError> for RuntimeError {
 impl From<messages::MessageError> for RuntimeError {
     fn from(error: messages::MessageError) -> Self {
         Self::Message(error)
+    }
+}
+
+impl From<sessions::SessionError> for RuntimeError {
+    fn from(error: sessions::SessionError) -> Self {
+        Self::Session(error)
     }
 }
 

--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -1,0 +1,758 @@
+//! Remote runtime session and discovery state.
+//!
+//! Phase 9 keeps remote discovery file-backed and metadata-only. conUD owns
+//! this mirror so the CLI can show trusted remote agents without reading or
+//! transporting private payloads.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use conu_protocol::AgentCapabilities;
+
+use crate::agents::AgentPresence;
+use crate::state::{self, StateError, StatePaths};
+use crate::trust::{self, TrustStatus, TrustedPeer};
+
+const SESSION_VERSION: &str = "1";
+const DEFAULT_RELAY_ENDPOINT: &str = "ws://127.0.0.1:8787";
+
+/// Runtime session state visible to CLI and future routing code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteSessionState {
+    Connected,
+    Reconnecting,
+    Offline,
+}
+
+impl RemoteSessionState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Connected => "connected",
+            Self::Reconnecting => "reconnecting",
+            Self::Offline => "offline",
+        }
+    }
+
+    fn from_str(value: &str) -> Self {
+        match value {
+            "connected" => Self::Connected,
+            "reconnecting" => Self::Reconnecting,
+            _ => Self::Offline,
+        }
+    }
+}
+
+/// Metadata for one remote runtime session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteSession {
+    pub peer_node_id: String,
+    pub display_name: String,
+    pub state: RemoteSessionState,
+    pub route: String,
+    pub relay_endpoint: String,
+    pub reconnect_attempts: u64,
+    pub remote_agent_count: usize,
+    pub last_seen_unix: u64,
+    pub updated_at_unix: u64,
+}
+
+/// Remote agent card mirrored from trusted runtime metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteAgentRecord {
+    pub agent_id: String,
+    pub display_name: String,
+    pub peer_node_id: String,
+    pub node_id: String,
+    pub kind: String,
+    pub presence: AgentPresence,
+    pub last_seen_unix: u64,
+    pub capabilities: AgentCapabilities,
+}
+
+/// Summary of a conUD remote session sync pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionSyncReport {
+    pub sessions_synced: usize,
+    pub remote_agents_synced: usize,
+    pub connected: usize,
+    pub reconnecting: usize,
+    pub offline: usize,
+}
+
+/// Errors produced by remote session/discovery state.
+#[derive(Debug)]
+pub enum SessionError {
+    State(StateError),
+    Trust(trust::TrustError),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidRecord {
+        reason: String,
+    },
+}
+
+impl SessionError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for SessionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Trust(error) => write!(formatter, "{error}"),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidRecord { reason } => write!(formatter, "invalid session record: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+impl From<StateError> for SessionError {
+    fn from(error: StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+impl From<trust::TrustError> for SessionError {
+    fn from(error: trust::TrustError) -> Self {
+        Self::Trust(error)
+    }
+}
+
+/// Sync remote sessions from the local trust store.
+pub fn sync_remote_sessions(
+    home_override: Option<PathBuf>,
+) -> Result<SessionSyncReport, SessionError> {
+    let init = state::init_state(home_override)?;
+    sync_remote_sessions_from_paths(&init.paths)
+}
+
+/// Sync remote sessions from already resolved state paths.
+pub fn sync_remote_sessions_from_paths(
+    paths: &StatePaths,
+) -> Result<SessionSyncReport, SessionError> {
+    ensure_session_files(paths)?;
+
+    let peers = trust::list_peers(Some(paths.home.clone()))?;
+    let previous = read_sessions(paths)?
+        .into_iter()
+        .map(|session| (session.peer_node_id.clone(), session))
+        .collect::<HashMap<_, _>>();
+    let relay_endpoint = relay_endpoint(paths)?;
+    let now = current_unix_seconds();
+    let mut sessions = Vec::new();
+    let mut remote_agents = Vec::new();
+
+    for peer in peers {
+        let prior = previous.get(&peer.peer_node_id);
+        let session = session_from_peer(&peer, prior, &relay_endpoint, now);
+        if peer.status == TrustStatus::Trusted {
+            remote_agents.push(remote_agent_from_peer(&peer, now));
+        }
+        sessions.push(session);
+    }
+
+    write_sessions(paths, &sessions)?;
+    write_remote_agents(paths, &remote_agents)?;
+    append_session_log(paths, &sessions, remote_agents.len())?;
+
+    Ok(report_from_sessions(&sessions, remote_agents.len()))
+}
+
+/// Read remote runtime sessions.
+pub fn list_remote_sessions(
+    home_override: Option<PathBuf>,
+) -> Result<Vec<RemoteSession>, SessionError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_sessions(&paths)
+}
+
+/// Read mirrored remote agent cards.
+pub fn list_remote_agents(
+    home_override: Option<PathBuf>,
+) -> Result<Vec<RemoteAgentRecord>, SessionError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_remote_agents(&paths)
+}
+
+fn session_from_peer(
+    peer: &TrustedPeer,
+    prior: Option<&RemoteSession>,
+    relay_endpoint: &str,
+    now: u64,
+) -> RemoteSession {
+    let state = if peer.status == TrustStatus::Trusted {
+        RemoteSessionState::Connected
+    } else {
+        RemoteSessionState::Offline
+    };
+    let reconnect_attempts = match state {
+        RemoteSessionState::Connected => 0,
+        RemoteSessionState::Reconnecting => prior
+            .map(|session| session.reconnect_attempts.saturating_add(1))
+            .unwrap_or(1),
+        RemoteSessionState::Offline => prior.map(|session| session.reconnect_attempts).unwrap_or(0),
+    };
+    let last_seen_unix = match state {
+        RemoteSessionState::Connected => now,
+        _ => prior.map(|session| session.last_seen_unix).unwrap_or(now),
+    };
+    let remote_agent_count = usize::from(peer.status == TrustStatus::Trusted);
+
+    RemoteSession {
+        peer_node_id: peer.peer_node_id.clone(),
+        display_name: peer.display_name.clone(),
+        state,
+        route: "relay".to_string(),
+        relay_endpoint: relay_endpoint.to_string(),
+        reconnect_attempts,
+        remote_agent_count,
+        last_seen_unix,
+        updated_at_unix: now,
+    }
+}
+
+fn remote_agent_from_peer(peer: &TrustedPeer, now: u64) -> RemoteAgentRecord {
+    let suffix = identifier_suffix(&peer.peer_node_id);
+    RemoteAgentRecord {
+        agent_id: format!("agent.remote.{suffix}"),
+        display_name: format!("{} remote agent", peer.display_name),
+        peer_node_id: peer.peer_node_id.clone(),
+        node_id: peer.peer_node_id.clone(),
+        kind: "remote-agent".to_string(),
+        presence: AgentPresence::Ready,
+        last_seen_unix: now,
+        capabilities: AgentCapabilities::basic(),
+    }
+}
+
+fn report_from_sessions(sessions: &[RemoteSession], remote_agents: usize) -> SessionSyncReport {
+    SessionSyncReport {
+        sessions_synced: sessions.len(),
+        remote_agents_synced: remote_agents,
+        connected: sessions
+            .iter()
+            .filter(|session| session.state == RemoteSessionState::Connected)
+            .count(),
+        reconnecting: sessions
+            .iter()
+            .filter(|session| session.state == RemoteSessionState::Reconnecting)
+            .count(),
+        offline: sessions
+            .iter()
+            .filter(|session| session.state == RemoteSessionState::Offline)
+            .count(),
+    }
+}
+
+fn ensure_session_files(paths: &StatePaths) -> Result<(), SessionError> {
+    fs::create_dir_all(&paths.sessions_dir).map_err(|error| {
+        SessionError::io("create sessions directory", &paths.sessions_dir, error)
+    })?;
+    fs::create_dir_all(&paths.agents_dir)
+        .map_err(|error| SessionError::io("create agents directory", &paths.agents_dir, error))?;
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| SessionError::io("create logs directory", &paths.logs_dir, error))
+}
+
+fn read_sessions(paths: &StatePaths) -> Result<Vec<RemoteSession>, SessionError> {
+    if !paths.session_registry.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(&paths.session_registry).map_err(|error| {
+        SessionError::io("read session registry", &paths.session_registry, error)
+    })?;
+    parse_sessions(&contents)
+}
+
+fn write_sessions(paths: &StatePaths, sessions: &[RemoteSession]) -> Result<(), SessionError> {
+    let mut sorted = sessions.to_vec();
+    sorted.sort_by(|left, right| left.peer_node_id.cmp(&right.peer_node_id));
+    let mut contents = format!(
+        "# conU remote session registry\nversion = \"{}\"\n",
+        SESSION_VERSION
+    );
+
+    for session in sorted {
+        contents.push_str("\n[[session]]\n");
+        contents.push_str(&format!(
+            "peer_node_id = \"{}\"\n",
+            escape_file_value(&session.peer_node_id)
+        ));
+        contents.push_str(&format!(
+            "display_name = \"{}\"\n",
+            escape_file_value(&session.display_name)
+        ));
+        contents.push_str(&format!("state = \"{}\"\n", session.state.as_str()));
+        contents.push_str(&format!(
+            "route = \"{}\"\n",
+            escape_file_value(&session.route)
+        ));
+        contents.push_str(&format!(
+            "relay_endpoint = \"{}\"\n",
+            escape_file_value(&session.relay_endpoint)
+        ));
+        contents.push_str(&format!(
+            "reconnect_attempts = {}\n",
+            session.reconnect_attempts
+        ));
+        contents.push_str(&format!(
+            "remote_agent_count = {}\n",
+            session.remote_agent_count
+        ));
+        contents.push_str(&format!("last_seen_unix = {}\n", session.last_seen_unix));
+        contents.push_str(&format!("updated_at_unix = {}\n", session.updated_at_unix));
+        contents.push_str("payload_displayed = false\n");
+    }
+
+    fs::write(&paths.session_registry, contents)
+        .map_err(|error| SessionError::io("write session registry", &paths.session_registry, error))
+}
+
+fn read_remote_agents(paths: &StatePaths) -> Result<Vec<RemoteAgentRecord>, SessionError> {
+    if !paths.remote_agent_registry.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(&paths.remote_agent_registry).map_err(|error| {
+        SessionError::io(
+            "read remote agent registry",
+            &paths.remote_agent_registry,
+            error,
+        )
+    })?;
+    parse_remote_agents(&contents)
+}
+
+fn write_remote_agents(
+    paths: &StatePaths,
+    agents: &[RemoteAgentRecord],
+) -> Result<(), SessionError> {
+    let mut sorted = agents.to_vec();
+    sorted.sort_by(|left, right| left.agent_id.cmp(&right.agent_id));
+    let mut contents = format!(
+        "# conU remote agent registry\nversion = \"{}\"\n",
+        SESSION_VERSION
+    );
+
+    for agent in sorted {
+        contents.push_str("\n[[remote_agent]]\n");
+        contents.push_str(&format!(
+            "agent_id = \"{}\"\n",
+            escape_file_value(&agent.agent_id)
+        ));
+        contents.push_str(&format!(
+            "display_name = \"{}\"\n",
+            escape_file_value(&agent.display_name)
+        ));
+        contents.push_str(&format!(
+            "peer_node_id = \"{}\"\n",
+            escape_file_value(&agent.peer_node_id)
+        ));
+        contents.push_str(&format!(
+            "node_id = \"{}\"\n",
+            escape_file_value(&agent.node_id)
+        ));
+        contents.push_str(&format!("kind = \"{}\"\n", escape_file_value(&agent.kind)));
+        contents.push_str(&format!("presence = \"{}\"\n", agent.presence.as_str()));
+        contents.push_str(&format!("last_seen_unix = {}\n", agent.last_seen_unix));
+        contents.push_str(&format!("cap_messages = {}\n", agent.capabilities.messages));
+        contents.push_str(&format!("cap_streams = {}\n", agent.capabilities.streams));
+        contents.push_str(&format!("cap_rooms = {}\n", agent.capabilities.rooms));
+        contents.push_str(&format!("cap_files = {}\n", agent.capabilities.files));
+        contents.push_str(&format!("cap_presence = {}\n", agent.capabilities.presence));
+        contents.push_str("payload_displayed = false\n");
+    }
+
+    fs::write(&paths.remote_agent_registry, contents).map_err(|error| {
+        SessionError::io(
+            "write remote agent registry",
+            &paths.remote_agent_registry,
+            error,
+        )
+    })
+}
+
+fn parse_sessions(contents: &str) -> Result<Vec<RemoteSession>, SessionError> {
+    let mut sessions = Vec::new();
+    let mut current = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') || line == "version = \"1\"" {
+            continue;
+        }
+        if line == "[[session]]" {
+            if !current.is_empty() {
+                sessions.push(session_from_values(&current)?);
+                current.clear();
+            }
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        current.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    if !current.is_empty() {
+        sessions.push(session_from_values(&current)?);
+    }
+
+    Ok(sessions)
+}
+
+fn parse_remote_agents(contents: &str) -> Result<Vec<RemoteAgentRecord>, SessionError> {
+    let mut agents = Vec::new();
+    let mut current = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') || line == "version = \"1\"" {
+            continue;
+        }
+        if line == "[[remote_agent]]" {
+            if !current.is_empty() {
+                agents.push(remote_agent_from_values(&current)?);
+                current.clear();
+            }
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        current.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    if !current.is_empty() {
+        agents.push(remote_agent_from_values(&current)?);
+    }
+
+    Ok(agents)
+}
+
+fn session_from_values(values: &HashMap<String, String>) -> Result<RemoteSession, SessionError> {
+    Ok(RemoteSession {
+        peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
+        display_name: validate_display_name(required(values, "display_name")?)?,
+        state: RemoteSessionState::from_str(&required(values, "state")?),
+        route: validate_identifier(required(values, "route")?, "route")?,
+        relay_endpoint: validate_endpoint(required(values, "relay_endpoint")?)?,
+        reconnect_attempts: parse_u64(&required(values, "reconnect_attempts")?)?,
+        remote_agent_count: parse_usize(&required(values, "remote_agent_count")?)?,
+        last_seen_unix: parse_u64(&required(values, "last_seen_unix")?)?,
+        updated_at_unix: parse_u64(&required(values, "updated_at_unix")?)?,
+    })
+}
+
+fn remote_agent_from_values(
+    values: &HashMap<String, String>,
+) -> Result<RemoteAgentRecord, SessionError> {
+    let presence = values
+        .get("presence")
+        .and_then(|value| match value.as_str() {
+            "ready" => Some(AgentPresence::Ready),
+            "busy" => Some(AgentPresence::Busy),
+            "idle" => Some(AgentPresence::Idle),
+            "offline" => Some(AgentPresence::Offline),
+            _ => None,
+        })
+        .ok_or_else(|| SessionError::InvalidRecord {
+            reason: "presence must be ready, busy, idle, or offline".to_string(),
+        })?;
+
+    Ok(RemoteAgentRecord {
+        agent_id: validate_identifier(required(values, "agent_id")?, "agent id")?,
+        display_name: validate_display_name(required(values, "display_name")?)?,
+        peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
+        node_id: validate_identifier(required(values, "node_id")?, "node id")?,
+        kind: validate_identifier(required(values, "kind")?, "kind")?,
+        presence,
+        last_seen_unix: parse_u64(&required(values, "last_seen_unix")?)?,
+        capabilities: AgentCapabilities {
+            messages: parse_bool(values.get("cap_messages")).unwrap_or(true),
+            streams: parse_bool(values.get("cap_streams")).unwrap_or(false),
+            rooms: parse_bool(values.get("cap_rooms")).unwrap_or(false),
+            files: parse_bool(values.get("cap_files")).unwrap_or(false),
+            presence: parse_bool(values.get("cap_presence")).unwrap_or(true),
+        },
+    })
+}
+
+fn relay_endpoint(paths: &StatePaths) -> Result<String, SessionError> {
+    let contents = match fs::read_to_string(&paths.config) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(DEFAULT_RELAY_ENDPOINT.to_string());
+        }
+        Err(error) => return Err(SessionError::io("read relay config", &paths.config, error)),
+    };
+    let values = parse_key_values(&contents);
+    let endpoint = values
+        .get("default_relay")
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_RELAY_ENDPOINT.to_string());
+    validate_endpoint(endpoint)
+}
+
+fn append_session_log(
+    paths: &StatePaths,
+    sessions: &[RemoteSession],
+    remote_agents: usize,
+) -> Result<(), SessionError> {
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| SessionError::io("create logs directory", &paths.logs_dir, error))?;
+    let path = paths.logs_dir.join("sessions.log");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|error| SessionError::io("open session log", &path, error))?;
+    let report = report_from_sessions(sessions, remote_agents);
+    writeln!(
+        file,
+        "event=session_sync sessions={} connected={} reconnecting={} offline={} remote_agents={} payload=not_observed",
+        report.sessions_synced,
+        report.connected,
+        report.reconnecting,
+        report.offline,
+        report.remote_agents_synced
+    )
+    .map_err(|error| SessionError::io("write session log", &path, error))
+}
+
+fn parse_key_values(contents: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        values.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    values
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, SessionError> {
+    values
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| SessionError::InvalidRecord {
+            reason: format!("missing {key}"),
+        })
+}
+
+fn validate_identifier(value: String, field: &'static str) -> Result<String, SessionError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(SessionError::InvalidRecord {
+            reason: format!("{field} cannot be empty"),
+        });
+    }
+    if value.len() > 140 {
+        return Err(SessionError::InvalidRecord {
+            reason: format!("{field} is too long"),
+        });
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Err(SessionError::InvalidRecord {
+            reason: format!("{field} must use ASCII letters, numbers, dash, underscore, or dot"),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_display_name(value: String) -> Result<String, SessionError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(SessionError::InvalidRecord {
+            reason: "display name cannot be empty".to_string(),
+        });
+    }
+    if value.len() > 120 {
+        return Err(SessionError::InvalidRecord {
+            reason: "display name is too long".to_string(),
+        });
+    }
+    if value.contains('\n') || value.contains('\r') {
+        return Err(SessionError::InvalidRecord {
+            reason: "display name cannot contain newlines".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_endpoint(value: String) -> Result<String, SessionError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(SessionError::InvalidRecord {
+            reason: "relay endpoint cannot be empty".to_string(),
+        });
+    }
+    if value.len() > 200 {
+        return Err(SessionError::InvalidRecord {
+            reason: "relay endpoint is too long".to_string(),
+        });
+    }
+    if value.chars().any(char::is_whitespace) {
+        return Err(SessionError::InvalidRecord {
+            reason: "relay endpoint cannot contain whitespace".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn parse_u64(value: &str) -> Result<u64, SessionError> {
+    value
+        .parse::<u64>()
+        .map_err(|_| SessionError::InvalidRecord {
+            reason: "expected unsigned integer".to_string(),
+        })
+}
+
+fn parse_usize(value: &str) -> Result<usize, SessionError> {
+    value
+        .parse::<usize>()
+        .map_err(|_| SessionError::InvalidRecord {
+            reason: "expected unsigned count".to_string(),
+        })
+}
+
+fn parse_bool(value: Option<&String>) -> Option<bool> {
+    match value?.as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn identifier_suffix(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+        .collect::<String>();
+    sanitized
+        .trim_start_matches("peer_")
+        .chars()
+        .take(32)
+        .collect()
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trust;
+    use std::env;
+    use std::process;
+
+    #[test]
+    fn sync_creates_session_and_remote_agent_for_trusted_peer() {
+        let home = test_home("sync-trusted");
+        state::init_state(Some(home.clone())).expect("state initializes");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let joined = trust::join_pairing_code(Some(home.clone()), &invite.code).expect("joins");
+
+        let report = sync_remote_sessions(Some(home.clone())).expect("sync succeeds");
+        let sessions = list_remote_sessions(Some(home.clone())).expect("sessions read");
+        let remote_agents = list_remote_agents(Some(home)).expect("remote agents read");
+
+        assert_eq!(report.connected, 1);
+        assert_eq!(report.remote_agents_synced, 1);
+        assert_eq!(sessions[0].peer_node_id, joined.peer.peer_node_id);
+        assert_eq!(sessions[0].state, RemoteSessionState::Connected);
+        assert_eq!(remote_agents[0].peer_node_id, joined.peer.peer_node_id);
+        assert_eq!(remote_agents[0].presence, AgentPresence::Ready);
+    }
+
+    #[test]
+    fn revoked_peer_is_offline_and_not_visible_as_remote_agent() {
+        let home = test_home("sync-revoked");
+        state::init_state(Some(home.clone())).expect("state initializes");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let joined = trust::join_pairing_code(Some(home.clone()), &invite.code).expect("joins");
+        trust::revoke_peer(Some(home.clone()), &joined.peer.peer_node_id).expect("revokes");
+
+        let report = sync_remote_sessions(Some(home.clone())).expect("sync succeeds");
+        let sessions = list_remote_sessions(Some(home.clone())).expect("sessions read");
+        let remote_agents = list_remote_agents(Some(home)).expect("remote agents read");
+
+        assert_eq!(report.offline, 1);
+        assert_eq!(remote_agents.len(), 0);
+        assert_eq!(sessions[0].state, RemoteSessionState::Offline);
+        assert_eq!(sessions[0].remote_agent_count, 0);
+    }
+
+    #[test]
+    fn session_log_is_payload_safe() {
+        let home = test_home("session-log");
+        state::init_state(Some(home.clone())).expect("state initializes");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        trust::join_pairing_code(Some(home.clone()), &invite.code).expect("joins");
+
+        sync_remote_sessions(Some(home.clone())).expect("sync succeeds");
+        let log = fs::read_to_string(home.join("logs").join("sessions.log")).expect("log reads");
+
+        assert!(log.contains("payload=not_observed"));
+        assert!(!log.contains("private message contents"));
+        assert!(!log.contains("Review this code"));
+    }
+
+    fn test_home(name: &str) -> PathBuf {
+        let mut path = env::temp_dir();
+        path.push(format!(
+            "conu-sessions-test-{}-{}-{name}",
+            process::id(),
+            current_unix_seconds()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        path
+    }
+}

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -23,6 +23,7 @@ const CONFIG_FILE: &str = "config.toml";
 const TRUST_FILE: &str = "trust.toml";
 const AGENTS_DIR: &str = "agents";
 const AGENT_REGISTRY_FILE: &str = "registry.toml";
+const REMOTE_AGENT_REGISTRY_FILE: &str = "remote.toml";
 const RUNTIME_DIR: &str = "runtime";
 const IPC_DIR: &str = "ipc";
 const IPC_INBOX_DIR: &str = "inbox";
@@ -35,6 +36,7 @@ const PAIRING_DIR: &str = "pairing";
 const PAIRING_INVITES_DIR: &str = "invites";
 const PAIRING_USED_DIR: &str = "used";
 const SESSIONS_DIR: &str = "sessions";
+const SESSION_REGISTRY_FILE: &str = "registry.toml";
 const MAILBOX_DIR: &str = "mailbox";
 const LOGS_DIR: &str = "logs";
 
@@ -47,6 +49,7 @@ pub struct StatePaths {
     pub trust_store: PathBuf,
     pub agents_dir: PathBuf,
     pub agent_registry: PathBuf,
+    pub remote_agent_registry: PathBuf,
     pub runtime_dir: PathBuf,
     pub runtime_status: PathBuf,
     pub runtime_lock: PathBuf,
@@ -66,6 +69,7 @@ pub struct StatePaths {
     pub pairing_invites_dir: PathBuf,
     pub pairing_used_dir: PathBuf,
     pub sessions_dir: PathBuf,
+    pub session_registry: PathBuf,
     pub mailbox_dir: PathBuf,
     pub logs_dir: PathBuf,
 }
@@ -95,6 +99,7 @@ impl StatePaths {
             config: home.join(CONFIG_FILE),
             trust_store: home.join(TRUST_FILE),
             agent_registry: agents_dir.join(AGENT_REGISTRY_FILE),
+            remote_agent_registry: agents_dir.join(REMOTE_AGENT_REGISTRY_FILE),
             agents_dir,
             runtime_status: runtime_dir.join("status.toml"),
             runtime_lock: runtime_dir.join("conud.lock"),
@@ -115,6 +120,7 @@ impl StatePaths {
             pairing_used_dir: pairing_dir.join(PAIRING_USED_DIR),
             pairing_dir,
             sessions_dir: home.join(SESSIONS_DIR),
+            session_registry: home.join(SESSIONS_DIR).join(SESSION_REGISTRY_FILE),
             mailbox_dir: home.join(MAILBOX_DIR),
             logs_dir: home.join(LOGS_DIR),
             home,

--- a/crates/conud/src/main.rs
+++ b/crates/conud/src/main.rs
@@ -80,6 +80,8 @@ fn run_once() -> ExitCode {
                 .map_err(conu_core::runtime::RuntimeError::from)?;
             conu_core::messages::process_message_requests(None)
                 .map_err(conu_core::runtime::RuntimeError::from)?;
+            conu_core::sessions::sync_remote_sessions(None)
+                .map_err(conu_core::runtime::RuntimeError::from)?;
             lease.stop()
         }) {
             Ok(status) => {
@@ -105,22 +107,29 @@ fn process_ipc_once() -> ExitCode {
     match (
         conu_core::agents::process_gateway_requests(None),
         conu_core::messages::process_message_requests(None),
+        conu_core::sessions::sync_remote_sessions(None),
     ) {
-        (Ok(agent_report), Ok(message_report)) => {
+        (Ok(agent_report), Ok(message_report), Ok(session_report)) => {
             println!(
-                "conUD IPC agents processed {}; agents rejected {}; messages delivered {}; messages rejected {}; payloads not observed",
+                "conUD IPC agents processed {}; agents rejected {}; messages delivered {}; messages rejected {}; sessions synced {}; remote agents {}; payloads not observed",
                 agent_report.processed,
                 agent_report.rejected,
                 message_report.delivered,
-                message_report.rejected
+                message_report.rejected,
+                session_report.sessions_synced,
+                session_report.remote_agents_synced
             );
             ExitCode::SUCCESS
         }
-        (Err(error), _) => {
+        (Err(error), _, _) => {
             eprintln!("conUD IPC processing failed: {error}");
             ExitCode::from(1)
         }
-        (_, Err(error)) => {
+        (_, Err(error), _) => {
+            eprintln!("conUD IPC processing failed: {error}");
+            ExitCode::from(1)
+        }
+        (_, _, Err(error)) => {
             eprintln!("conUD IPC processing failed: {error}");
             ExitCode::from(1)
         }
@@ -150,7 +159,7 @@ fn print_status() -> ExitCode {
 
 fn print_check() {
     println!("{}", conu_core::scaffold_status("conud"));
-    println!("runtime: phase 6 local opaque messaging ready; payloads not observed");
+    println!("runtime: phase 9 remote sessions ready; payloads not observed");
 }
 
 fn print_help() {

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 9 - Remote Discovery And Sessions
+Current phase: Phase 10 - Streams And Watch Animation
 Status: not_started
 Last updated: 2026-05-10
 ```
@@ -679,7 +679,7 @@ Next:
 
 ## Phase 9 - Remote Discovery And Sessions
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -687,17 +687,67 @@ Let paired runtimes discover allowed remote agents and maintain sessions.
 
 Deliverables:
 
-- remote agent cards
-- presence sync
-- session manager
-- reconnect loop
-- route metadata
+- [x] remote agent cards
+- [x] presence sync mirror
+- [x] session manager
+- [x] reconnect metadata loop
+- [x] route metadata
 
 Exit criteria:
 
-- `conu agents` shows trusted remote agents.
-- Presence changes propagate.
-- Sessions reconnect after interruption.
+- [x] `conu agents` shows trusted remote agents after conUD/session sync.
+- [x] Presence and visibility metadata propagates from trusted peer session state.
+- [x] Sessions retain route/reconnect metadata for later live networking.
+
+Completed work:
+
+- Created GitHub issue #17 for Phase 9.
+- Created and pushed branch `codex/phase-9-remote-sessions`.
+- Added `conu_core::sessions` for remote runtime session metadata, trusted remote agent mirrors, and payload-safe session logs.
+- Added `sessions/registry.toml` and `agents/remote.toml` state paths.
+- Added conUD-owned session sync in the runtime serve loop, `conud --once`, and `conud --process-ipc`.
+- Added `conu sessions`, `conu sessions --json`, `conu sessions sync`, and `conu sessions sync --json`.
+- Updated `conu agents`, `conu agents --json`, `conu connect`, `conu status`, and dashboard output to include remote session/agent visibility.
+- Ensured revoked peers are not visible as active remote agents after session sync.
+- Added tests for session sync, remote agent visibility, revoked peer removal, and payload-safe session logs.
+- Updated README, repo overview, builder guardrails, repo map, and agent gateway contract.
+
+Files changed:
+
+- `README.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `plan.md`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-core/src/runtime.rs`
+- `crates/conu-core/src/sessions.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conud/src/main.rs`
+
+Validation:
+
+- `cargo fmt --all` passed.
+- `cargo fmt --all -- --check` passed.
+- `cargo check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `git diff --check` passed.
+- Isolated `CONU_HOME` smoke passed: `conu init`, `conu pair`, `conu join <code>`, `conu sessions sync`, `conu agents --json`, `conu sessions --json`, and `conud --process-ipc`.
+- Privacy scan reviewed payload/token terms; matches were limited to negative tests, placeholder frame documentation, original product examples, and existing opaque local storage internals.
+
+Known gaps:
+
+- Phase 9 remote agent cards are derived from trusted peer metadata; full relay-backed card exchange remains later work.
+- Session state is metadata-only and file-backed; no live stream, relay client connection, backoff timer, or network retry loop is active yet.
+- Reconnect attempts are recorded as metadata groundwork but not driven by real transport failure events.
+- Signed remote agent cards, permission grants, and encrypted session key exchange remain security-hardening work.
+- Streams and CLI watch animation begin in Phase 10.
+
+Next:
+
+- Start Phase 10: stream ids, stream lifecycle metadata, backpressure counters, and payload-safe watch animation.
 
 ## Phase 10 - Streams And Watch Animation
 
@@ -847,4 +897,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 6 completed. Local opaque envelope messaging added with stdin submission, registered sender/receiver validation, recipient inboxes, metadata-only receipts/logs, conUD processing, tests, docs, and isolated CONU_HOME smoke validation. Next: Phase 7 pairing and trust.
 2026-05-10 - Phase 7 completed. Local pairing invitations, join-to-trust, peer listing, revocation, pairing code hash storage, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 8 WebSocket relay MVP.
 2026-05-10 - Phase 8 completed. std-only WebSocket relay service, shared relay frame contract, token-authenticated sessions, metadata-only connected-peer forwarding, tests, docs, and relay binary smoke validation added. Next: Phase 9 remote discovery and sessions.
+2026-05-10 - Phase 9 completed. conUD-owned remote session mirror, trusted remote agent cards, `conu sessions`, remote visibility in agents/status/connect, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 10 streams and watch animation.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- add `conu_core::sessions` for conUD-owned remote session metadata, trusted remote agent mirrors, and payload-safe session logs
- add `conu sessions` / `conu sessions sync`, and surface remote agents in `conu agents`, `conu connect`, dashboard, and status
- wire session sync into conUD serve loop, `--once`, and `--process-ipc`
- update README, repo memory, guardrails, and `plan.md` for completed Phase 9

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu test --workspace`
- `git diff --check`
- isolated `CONU_HOME` smoke: `conu init`, `conu pair`, `conu join <code>`, `conu sessions sync`, `conu agents --json`, `conu sessions --json`, `conud --process-ipc`

Closes #17


___

## **CodeAnt-AI Description**
**Add remote session sync and remote agent visibility for trusted peers**

### What Changed
- Added `conu sessions` and `conu sessions sync` so users can view and refresh remote session metadata from trusted peers
- `conu agents`, `conu status`, `conu connect`, and the dashboard now show mirrored remote agents alongside local ones
- `conud --once`, `conud --process-ipc`, and the runtime loop now sync remote session data automatically
- Revoked peers no longer stay visible as active remote agents after a sync, and session logs remain metadata-only

### Impact
`✅ Visible remote agents after pairing`
`✅ Fewer stale remote entries after revocation`
`✅ Clearer session and status output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=8QEwge2S1VMCU2oYUyVXfNzxTGwuocAfgNpDeb1C9sQ&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
