### PR TITLE
Implement phase 10 streams and watch

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 9.
+The repository has completed Phase 10.
 
 Implemented so far:
 
@@ -36,10 +36,15 @@ Implemented so far:
 - remote runtime session metadata under `sessions/registry.toml`
 - trusted remote agent mirror under `agents/remote.toml`
 - remote agents visible through `conu agents`
+- stream lifecycle metadata through `conu streams`
+- stream open/write/close commands with stdin-only opaque writes
+- payload-safe watch event bus under `streams/events.toml`
+- `conu watch` private transport animation
 - payload-safe status and agent registry reporting
 - payload-safe runtime and agent metadata logs
 - payload-safe message delivery metadata logs
 - payload-safe remote session metadata logs
+- payload-safe stream metadata logs
 - payload-safe protocol scaffold
 - daemon runtime skeleton and relay service binary
 

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -173,6 +173,26 @@ conud --process-ipc
 
 `conu sessions sync` reads trusted peers and mirrors route/session metadata so `conu agents` can show visible remote agents. It does not transfer private payloads and does not yet create an interactive live stream. Revoked peers must disappear from the active remote-agent mirror after sync.
 
+The Phase 10 stream/watch surface is metadata-only stream lifecycle:
+
+```txt
+streams/registry.toml   stream lifecycle metadata
+streams/events.toml     private watch event bus
+logs/streams.log        metadata-only stream events
+```
+
+Supported commands:
+
+```txt
+conu streams [--json]
+conu streams open <from-agent> <to-agent> [--kind <kind>] [--json]
+conu streams write <stream-id> --stdin [--json]
+conu streams close <stream-id> [--json]
+conu watch
+```
+
+`conu streams write` accepts opaque bytes from stdin and records only byte counts. `conu watch` renders transport flow, route, stream id, packet count, and bytes without rendering message or chunk contents.
+
 ## Safety
 
 "Full access" means full communication access inside trust boundaries. It does not mean raw filesystem, shell, network, or secret access.

--- a/.agents/skills/conu-builder/references/cli-experience.md
+++ b/.agents/skills/conu-builder/references/cli-experience.md
@@ -28,12 +28,18 @@ The conU CLI should feel like a live network control room for agents.
 ```txt
 conU watch
 
-codex-desktop  >>> encrypted stream >>>  claude-laptop
-payload: private
-route: relay-us-east
-latency: 31ms
-streams: 3
-packets: 814
+transport view
+  codex-desktop  == encrypted stream ==>  claude-laptop
+  route         metadata-relay
+  stream        stream_abc
+  event         chunk
+  open streams  1
+  packets       3
+  bytes         814
+  contents      not displayed
+
+animation
+  [agent] >>> private packets >>> [agent]
 ```
 
 ## Design Rule

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -94,6 +94,17 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Revoked peers must not remain visible as active remote agents after session sync.
 - Route metadata may include relay endpoint, peer id, state, and reconnect counts; it must not include message contents, tokens, or private payload bytes.
 
+## Stream And Watch Rules
+
+- Phase 10 streams are metadata-first in `conu_core::streams`.
+- Stream lifecycle state belongs under `streams/registry.toml`; watch events belong under `streams/events.toml`.
+- `conu streams write` must read opaque chunk bytes from stdin and record byte counts only.
+- Stream logs must use metadata-only lines with stream id, route, byte count, chunk count, state, and `payload=not_observed`.
+- `conu watch` may animate agents, stream ids, routes, packet counts, byte counts, and private-packet movement.
+- `conu watch` must never show message text, chunk bytes, prompt text, reasoning, file contents, or tool output.
+- Backpressure checks should reject oversized chunks before writing stream metadata.
+- Do not claim live relay-backed byte streaming until the transport/encryption phases actually move encrypted chunks over the relay.
+
 ## Privacy Rules
 
 - Never log plaintext payloads.

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -17,13 +17,13 @@ plan.md
 
 ```txt
 crates/conu-cli
-  CLI commands, ASCII dashboard, watch animation, user control flow
+  CLI commands, ASCII dashboard, stream/watch animation, user control flow
 
 crates/conud
   daemon process, local gateway/message/session processing, session manager, runtime lifecycle
 
 crates/conu-core
-  local state, runtime lifecycle, agent registry, local message routing, trust store, relay frame contract, remote session mirror, future policy logic
+  local state, runtime lifecycle, agent registry, local message routing, stream metadata, trust store, relay frame contract, remote session mirror, future policy logic
 
 crates/conu-protocol
   envelopes, agent cards, control-plane messages, data-plane messages

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 9 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, local agents can register metadata and presence, registered local agents can exchange opaque message envelopes, local pairing/trust records can be created and revoked, `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding, and conUD can sync remote session/discovery metadata for trusted peers.
+Phase 10 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state, `conu start` launches the local `conUD` runtime skeleton, local agents can register metadata and presence, registered local agents can exchange opaque message envelopes, local pairing/trust records can be created and revoked, `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding, conUD can sync remote session/discovery metadata for trusted peers, and streams now produce payload-safe watch events.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -49,6 +49,8 @@ runtime/ipc/rejected/  rejected gateway requests and safe reasons
 runtime/ipc/messages/  opaque local message request queue
 messages/inbox/        delivered local opaque envelopes by recipient agent
 messages/receipts/     metadata-only local delivery receipts
+streams/registry.toml  stream lifecycle metadata
+streams/events.toml    payload-safe watch event bus
 pairing/invites/       pending local pairing invitations
 pairing/used/          consumed local pairing invitations
 sessions/registry.toml remote runtime session metadata
@@ -57,6 +59,7 @@ logs/conud.log         runtime metadata log
 logs/agents.log        local agent metadata log
 logs/messages.log      local message delivery metadata log
 logs/sessions.log      remote session sync metadata log
+logs/streams.log       stream lifecycle metadata log
 ```
 
 Runtime, agent, and message logs contain metadata only, such as event name, pid, node id, agent id, envelope id, byte count, and `payload=not_observed`. Phase 6 local message payload bytes are stored only as opaque recipient-inbox envelope data; CLI output, receipts, processed markers, rejected markers, and logs do not display message contents. Until encryption hardening lands in Phase 11, agents should prefer already-encrypted payload bytes for sensitive local messages.
@@ -133,6 +136,22 @@ conu agents --json
 
 This phase is still metadata/discovery groundwork: remote agent cards are derived from trusted peer metadata until the full relay-backed session exchange lands. Payloads remain opaque and are never displayed by session or agent listing commands.
 
+## Streams And Watch
+
+Phase 10 adds stream lifecycle metadata and a private watch view:
+
+```bash
+conu streams
+conu streams open agent.sender agent.receiver
+conu streams write stream_example --stdin
+conu streams close stream_example
+conu watch
+```
+
+`conu streams write` reads chunk bytes from stdin, records byte counts, updates backpressure metadata, and appends watch events without storing or printing the chunk contents. `conu watch` shows route, stream id, packet count, byte count, and an ASCII private-packet flow only.
+
+The stream layer is still metadata-first. Full live relay-backed byte streaming and encrypted stream transport are future hardening/transport work.
+
 ## Development
 
 ```bash
@@ -162,6 +181,10 @@ cargo run -p conu-cli -- agents heartbeat agent.codex --presence busy
 cargo run -p conu-cli -- messages send agent.sender agent.receiver --stdin
 cargo run -p conu-cli -- messages inbox agent.receiver --json
 cargo run -p conu-cli -- messages receipts --json
+cargo run -p conu-cli -- streams open agent.sender agent.receiver
+cargo run -p conu-cli -- streams write stream_example --stdin
+cargo run -p conu-cli -- streams close stream_example
+cargo run -p conu-cli -- watch
 cargo run -p conu-cli -- sessions sync
 cargo run -p conu-cli -- sessions --json
 cargo run -p conu-cli -- pair

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -17,6 +17,7 @@ use conu_core::messages::{self, DeliveryReceipt, InboxEntry, LocalMessage};
 use conu_core::runtime::{self, RuntimeState, RuntimeStatus, StopReport};
 use conu_core::sessions::{self, RemoteAgentRecord, RemoteSession, SessionSyncReport};
 use conu_core::state::{self, InitReport, StateSnapshot};
+use conu_core::streams::{self, StreamEvent, StreamRecord};
 use conu_core::trust::{self, TrustStatus, TrustedPeer};
 use conu_protocol::OpaquePayload;
 
@@ -97,11 +98,12 @@ where
         "agents" => render_agents(&args[1..], home_override),
         "peers" => render_peers(&args[1..], home_override),
         "messages" => render_messages(&args[1..], home_override, stdin_payload),
+        "streams" => render_streams(&args[1..], home_override, stdin_payload),
         "sessions" => render_sessions(&args[1..], home_override),
         "pair" => render_pair(&args[1..], home_override),
         "join" => render_join(&args[1..], home_override),
         "connect" => render_connect(&args[1..], home_override),
-        "watch" => render_watch(&args[1..]),
+        "watch" => render_watch(&args[1..], home_override),
         "components" => render_components(&args[1..]),
         "start" => render_start(&args[1..], home_override),
         "stop" => render_stop(&args[1..], home_override),
@@ -170,6 +172,7 @@ quick commands
   conu agents
   conu agents register <agent-id> <display-name>
   conu messages send <from-agent> <to-agent> --stdin
+  conu streams open <from-agent> <to-agent>
   conu pair
   conu peers
   conu join <code>
@@ -211,8 +214,12 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
         Ok(sessions) => sessions,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
-    let remote_agents = match sessions::list_remote_agents(home_override) {
+    let remote_agents = match sessions::list_remote_agents(home_override.clone()) {
         Ok(agents) => agents,
+        Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
+    };
+    let stream_records = match streams::list_streams(home_override.clone()) {
+        Ok(streams) => streams,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
 
@@ -223,6 +230,7 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
             &local_agents,
             &remote_agents,
             &sessions,
+            &stream_records,
             &peers,
         )),
         Ok(false) => CliOutput::success(render_status_text(
@@ -231,6 +239,7 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
             &local_agents,
             &remote_agents,
             &sessions,
+            &stream_records,
             &peers,
         )),
         Err(error) => error,
@@ -1075,6 +1084,377 @@ fn render_messages_usage() -> String {
         .to_string()
 }
 
+fn render_streams(
+    args: &[String],
+    home_override: Option<PathBuf>,
+    stdin_payload: Vec<u8>,
+) -> CliOutput {
+    match args.first().map(String::as_str) {
+        Some("open") => render_stream_open(&args[1..], home_override),
+        Some("write") => render_stream_write(&args[1..], home_override, stdin_payload),
+        Some("close") => render_stream_close(&args[1..], home_override),
+        _ => render_streams_list(args, home_override),
+    }
+}
+
+fn render_stream_open(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let parsed = match parse_stream_open_args(args) {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    match streams::open_stream(
+        home_override,
+        &parsed.from_agent_id,
+        &parsed.to_agent_id,
+        &parsed.kind,
+    ) {
+        Ok(report) => {
+            if parsed.json {
+                CliOutput::success(render_stream_json(&report.stream, "opened"))
+            } else {
+                CliOutput::success(render_stream_open_text(&report.stream))
+            }
+        }
+        Err(error) => CliOutput::failure(1, format!("conU streams open failed\n\n{error}")),
+    }
+}
+
+fn render_stream_write(
+    args: &[String],
+    home_override: Option<PathBuf>,
+    stdin_payload: Vec<u8>,
+) -> CliOutput {
+    let parsed = match parse_stream_io_args(args, "write") {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    if !parsed.stdin {
+        return CliOutput::failure(2, "usage: conu streams write <stream-id> --stdin [--json]");
+    }
+    if stdin_payload.is_empty() {
+        return CliOutput::failure(2, "stdin payload is empty");
+    }
+
+    match streams::write_stream(
+        home_override,
+        &parsed.stream_id,
+        OpaquePayload::from_bytes(stdin_payload),
+    ) {
+        Ok(report) => {
+            if parsed.json {
+                CliOutput::success(render_stream_event_json(&report.stream, &report.event))
+            } else {
+                CliOutput::success(render_stream_write_text(&report.stream, &report.event))
+            }
+        }
+        Err(error) => CliOutput::failure(1, format!("conU streams write failed\n\n{error}")),
+    }
+}
+
+fn render_stream_close(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let parsed = match parse_stream_io_args(args, "close") {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    match streams::close_stream(home_override, &parsed.stream_id) {
+        Ok(report) => {
+            if parsed.json {
+                CliOutput::success(render_stream_event_json(&report.stream, &report.event))
+            } else {
+                CliOutput::success(render_stream_close_text(&report.stream))
+            }
+        }
+        Err(error) => CliOutput::failure(1, format!("conU streams close failed\n\n{error}")),
+    }
+}
+
+fn render_streams_list(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let streams = match streams::list_streams(home_override) {
+        Ok(streams) => streams,
+        Err(error) => return CliOutput::failure(1, format!("conU streams failed\n\n{error}")),
+    };
+
+    match json_flag(args) {
+        Ok(true) => CliOutput::success(render_streams_json(&streams)),
+        Ok(false) => CliOutput::success(render_streams_text(&streams)),
+        Err(error) => error,
+    }
+}
+
+fn render_streams_json(streams: &[StreamRecord]) -> String {
+    let items = streams
+        .iter()
+        .map(|stream| {
+            format!(
+                r#"    {{
+      "streamId": "{}",
+      "fromAgentId": "{}",
+      "toAgentId": "{}",
+      "kind": "{}",
+      "state": "{}",
+      "route": "{}",
+      "chunksWritten": {},
+      "bytesWritten": {},
+      "backpressureWindow": {}
+    }}"#,
+                json_escape(&stream.stream_id),
+                json_escape(&stream.from_agent_id),
+                json_escape(&stream.to_agent_id),
+                json_escape(&stream.kind),
+                stream.state.as_str(),
+                json_escape(&stream.route),
+                stream.chunks_written,
+                stream.bytes_written,
+                stream.backpressure_window
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let streams_json = if items.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{items}\n  ]")
+    };
+
+    format!(
+        r#"{{
+  "streams": {},
+  "contentsDisplayed": false
+}}"#,
+        streams_json
+    )
+}
+
+fn render_streams_text(streams: &[StreamRecord]) -> String {
+    let lines = if streams.is_empty() {
+        "  none opened yet".to_string()
+    } else {
+        streams
+            .iter()
+            .map(|stream| {
+                format!(
+                    "  {}  {} -> {}  {}  chunks {}  bytes {}",
+                    stream.stream_id,
+                    stream.from_agent_id,
+                    stream.to_agent_id,
+                    stream.state.as_str(),
+                    stream.chunks_written,
+                    stream.bytes_written
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        r"conU streams
+
+streams
+{lines}
+
+privacy
+  payload view  contents are not displayed by conU
+
+next
+  conu streams open <from-agent> <to-agent>"
+    )
+}
+
+fn render_stream_open_text(stream: &StreamRecord) -> String {
+    format!(
+        r"conU streams open
+
+status: opened
+stream: {}
+from: {}
+to: {}
+kind: {}
+route: {}
+backpressure window: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        stream.stream_id,
+        stream.from_agent_id,
+        stream.to_agent_id,
+        stream.kind,
+        stream.route,
+        stream.backpressure_window
+    )
+}
+
+fn render_stream_write_text(stream: &StreamRecord, event: &StreamEvent) -> String {
+    format!(
+        r"conU streams write
+
+status: chunk recorded
+stream: {}
+bytes: {}
+chunks: {}
+total bytes: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        stream.stream_id, event.payload_bytes, stream.chunks_written, stream.bytes_written
+    )
+}
+
+fn render_stream_close_text(stream: &StreamRecord) -> String {
+    format!(
+        r"conU streams close
+
+status: closed
+stream: {}
+chunks: {}
+bytes: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        stream.stream_id, stream.chunks_written, stream.bytes_written
+    )
+}
+
+fn render_stream_json(stream: &StreamRecord, status: &str) -> String {
+    format!(
+        r#"{{
+  "status": "{}",
+  "streamId": "{}",
+  "fromAgentId": "{}",
+  "toAgentId": "{}",
+  "kind": "{}",
+  "state": "{}",
+  "route": "{}",
+  "chunksWritten": {},
+  "bytesWritten": {},
+  "backpressureWindow": {},
+  "contentsDisplayed": false
+}}"#,
+        status,
+        json_escape(&stream.stream_id),
+        json_escape(&stream.from_agent_id),
+        json_escape(&stream.to_agent_id),
+        json_escape(&stream.kind),
+        stream.state.as_str(),
+        json_escape(&stream.route),
+        stream.chunks_written,
+        stream.bytes_written,
+        stream.backpressure_window
+    )
+}
+
+fn render_stream_event_json(stream: &StreamRecord, event: &StreamEvent) -> String {
+    format!(
+        r#"{{
+  "status": "{}",
+  "streamId": "{}",
+  "eventId": "{}",
+  "payloadBytes": {},
+  "chunksWritten": {},
+  "bytesWritten": {},
+  "contentsDisplayed": false
+}}"#,
+        json_escape(&event.event_type),
+        json_escape(&stream.stream_id),
+        json_escape(&event.event_id),
+        event.payload_bytes,
+        stream.chunks_written,
+        stream.bytes_written
+    )
+}
+
+struct StreamOpenArgs {
+    from_agent_id: String,
+    to_agent_id: String,
+    kind: String,
+    json: bool,
+}
+
+struct StreamIoArgs {
+    stream_id: String,
+    stdin: bool,
+    json: bool,
+}
+
+fn parse_stream_open_args(args: &[String]) -> Result<StreamOpenArgs, CliOutput> {
+    let mut json = false;
+    let mut kind = "message".to_string();
+    let mut positional = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => json = true,
+            "--kind" => {
+                index += 1;
+                let Some(value) = args.get(index) else {
+                    return Err(CliOutput::failure(2, render_streams_usage()));
+                };
+                kind = value.clone();
+            }
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            value => positional.push(value.to_string()),
+        }
+        index += 1;
+    }
+
+    if positional.len() != 2 {
+        return Err(CliOutput::failure(2, render_streams_usage()));
+    }
+
+    Ok(StreamOpenArgs {
+        from_agent_id: positional[0].clone(),
+        to_agent_id: positional[1].clone(),
+        kind,
+        json,
+    })
+}
+
+fn parse_stream_io_args(args: &[String], command: &'static str) -> Result<StreamIoArgs, CliOutput> {
+    let mut json = false;
+    let mut stdin = false;
+    let mut stream_id = None;
+
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            "--stdin" => stdin = true,
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            value => {
+                if stream_id.is_some() {
+                    return Err(CliOutput::failure(2, render_streams_usage()));
+                }
+                stream_id = Some(value.to_string());
+            }
+        }
+    }
+
+    let Some(stream_id) = stream_id else {
+        return Err(CliOutput::failure(
+            2,
+            format!("usage: conu streams {command} <stream-id> [--stdin] [--json]"),
+        ));
+    };
+
+    Ok(StreamIoArgs {
+        stream_id,
+        stdin,
+        json,
+    })
+}
+
+fn render_streams_usage() -> String {
+    r"usage:
+  conu streams [--json]
+  conu streams open <from-agent> <to-agent> [--kind <kind>] [--json]
+  conu streams write <stream-id> --stdin [--json]
+  conu streams close <stream-id> [--json]"
+        .to_string()
+}
+
 fn render_sessions(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     match args.first().map(String::as_str) {
         Some("sync") => render_sessions_sync(&args[1..], home_override),
@@ -1560,28 +1940,66 @@ selector
   target remote agent  {remote}
   mode                 message | stream | room | observe
 
-status: remote discovery mirror ready; interactive sessions arrive in Phase 10+",
+status: stream sessions use `conu streams open`; interactive selector remains future work",
     ))
 }
 
-fn render_watch(args: &[String]) -> CliOutput {
+fn render_watch(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     if let Some(error) = reject_args(args) {
         return error;
     }
 
-    CliOutput::success(
+    let stream_records = streams::list_streams(home_override.clone()).unwrap_or_default();
+    let events = streams::list_events(home_override).unwrap_or_default();
+    let open_streams = stream_records
+        .iter()
+        .filter(|stream| stream.state.as_str() == "open")
+        .count();
+    let total_packets: u64 = stream_records
+        .iter()
+        .map(|stream| stream.chunks_written)
+        .sum();
+    let total_bytes: usize = stream_records
+        .iter()
+        .map(|stream| stream.bytes_written)
+        .sum();
+    let latest = events.last();
+    let flow = latest
+        .map(|event| {
+            format!(
+                "{}  == encrypted stream ==>  {}",
+                event.from_agent_id, event.to_agent_id
+            )
+        })
+        .unwrap_or_else(|| "local-agent   -> conUD -> encrypted route -> remote-agent".to_string());
+    let route = latest
+        .map(|event| event.route.as_str())
+        .unwrap_or("inactive");
+    let stream_id = latest
+        .map(|event| event.stream_id.as_str())
+        .unwrap_or("none");
+    let latest_event = latest
+        .map(|event| event.event_type.as_str())
+        .unwrap_or("idle");
+
+    CliOutput::success(format!(
         r"conU watch
 
 transport view
-  local-agent   -> conUD -> encrypted route -> remote conUD -> remote-agent
-  route         inactive
-  latency       n/a
-  streams       0
-  packets       0
+  {flow}
+  route         {route}
+  stream        {stream_id}
+  event         {latest_event}
+  open streams  {open_streams}
+  packets       {total_packets}
+  bytes         {total_bytes}
   contents      not displayed
 
-status: live stream animation arrives in Phase 10",
-    )
+animation
+  [agent] >>> private packets >>> [agent]
+
+status: stream metadata only",
+    ))
 }
 
 fn render_components(args: &[String]) -> CliOutput {
@@ -1734,6 +2152,7 @@ fn render_status_text(
     local_agents: &[LocalAgentRecord],
     remote_agents: &[RemoteAgentRecord],
     sessions: &[RemoteSession],
+    stream_records: &[StreamRecord],
     peers: &[TrustedPeer],
 ) -> String {
     let node = snapshot
@@ -1771,6 +2190,7 @@ agents
   registry      {}
   trusted peers {}
   sessions      {}
+  streams       {}
 
 privacy
   payload view  contents are not displayed by conU",
@@ -1787,7 +2207,8 @@ privacy
         remote_agents.len(),
         ready_label(snapshot.agent_registry_exists),
         trusted_peer_count(peers),
-        sessions.len()
+        sessions.len(),
+        stream_records.len()
     )
 }
 
@@ -1797,6 +2218,7 @@ fn render_status_json(
     local_agents: &[LocalAgentRecord],
     remote_agents: &[RemoteAgentRecord],
     sessions: &[RemoteSession],
+    stream_records: &[StreamRecord],
     peers: &[TrustedPeer],
 ) -> String {
     let node = snapshot
@@ -1833,7 +2255,8 @@ fn render_status_json(
     "remote": {},
     "registry": "{}",
     "trustedPeers": {},
-    "sessions": {}
+    "sessions": {},
+    "streams": {}
   }},
   "privacy": {{
     "contentsDisplayed": false
@@ -1853,7 +2276,8 @@ fn render_status_json(
         remote_agents.len(),
         ready_label(snapshot.agent_registry_exists),
         trusted_peer_count(peers),
-        sessions.len()
+        sessions.len(),
+        stream_records.len()
     )
 }
 
@@ -1870,6 +2294,10 @@ Usage:
   conu messages send <from-agent> <to-agent> --stdin [--json]
   conu messages inbox <agent-id> [--json]
   conu messages receipts [--json]
+  conu streams [--json]
+  conu streams open <from-agent> <to-agent> [--kind <kind>] [--json]
+  conu streams write <stream-id> --stdin [--json]
+  conu streams close <stream-id> [--json]
   conu sessions [--json]
   conu sessions sync [--json]
   conu peers [--json]
@@ -1884,7 +2312,7 @@ Usage:
   conu --help
   conu --version
 
-Phase 9 adds conUD-owned remote session and discovery mirrors. Streaming arrives in later phases."
+Phase 10 adds stream lifecycle metadata and private watch flow. Payload contents remain hidden."
         .to_string()
 }
 
@@ -2124,11 +2552,12 @@ mod tests {
     }
 
     #[test]
-    fn phase_nine_commands_are_registered() {
+    fn phase_ten_commands_are_registered() {
         let home = temp_home("commands");
 
         for command in [
-            "init", "status", "agents", "sessions", "pair", "peers", "connect", "watch", "stop",
+            "init", "status", "agents", "streams", "sessions", "pair", "peers", "connect", "watch",
+            "stop",
         ] {
             let output = run_with_home([command], Some(home.clone()));
             assert_eq!(output.code, 0, "{command} failed: {}", output.stderr);
@@ -2195,6 +2624,38 @@ mod tests {
         assert!(status.stdout.contains("\"remote\": 1"));
         assert!(status.stdout.contains("\"sessions\": 1"));
         assert!(!agents.stdout.contains("private message contents"));
+    }
+
+    #[test]
+    fn streams_flow_and_watch_are_metadata_only() {
+        let home = temp_home("streams-flow");
+        register_test_agent(&home, "agent.sender");
+        register_test_agent(&home, "agent.receiver");
+
+        let opened = run_with_home(
+            ["streams", "open", "agent.sender", "agent.receiver"],
+            Some(home.clone()),
+        );
+        let stream_id = stream_id_from_output(&opened.stdout);
+        let written = run_with_home_and_stdin(
+            ["streams", "write", &stream_id, "--stdin"],
+            Some(home.clone()),
+            b"private message contents".to_vec(),
+        );
+        let watch = run_with_home(["watch"], Some(home.clone()));
+        let closed = run_with_home(["streams", "close", &stream_id], Some(home.clone()));
+        let listed = run_with_home(["streams", "--json"], Some(home));
+
+        assert_eq!(opened.code, 0, "{}", opened.stderr);
+        assert_eq!(written.code, 0, "{}", written.stderr);
+        assert_eq!(closed.code, 0, "{}", closed.stderr);
+        assert!(written.stdout.contains("bytes: 24"));
+        assert!(watch.stdout.contains("private packets"));
+        assert!(watch.stdout.contains("contents      not displayed"));
+        assert!(listed.stdout.contains("\"streams\": ["));
+        assert!(listed.stdout.contains("\"state\": \"closed\""));
+        assert!(!watch.stdout.contains("private message contents"));
+        assert!(!listed.stdout.contains("private message contents"));
     }
 
     #[test]
@@ -2446,6 +2907,7 @@ mod tests {
         assert!(output.stdout.contains("\"remote\": 0"));
         assert!(output.stdout.contains("\"trustedPeers\": 0"));
         assert!(output.stdout.contains("\"sessions\": 0"));
+        assert!(output.stdout.contains("\"streams\": 0"));
         assert!(output.stdout.contains("\"contentsDisplayed\": false"));
     }
 
@@ -2490,6 +2952,14 @@ mod tests {
             .lines()
             .find_map(|line| line.trim().strip_prefix("code: "))
             .expect("pairing code line")
+            .to_string()
+    }
+
+    fn stream_id_from_output(output: &str) -> String {
+        output
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("stream: "))
+            .expect("stream id line")
             .to_string()
     }
 

--- a/crates/conu-cli/src/main.rs
+++ b/crates/conu-cli/src/main.rs
@@ -30,8 +30,36 @@ fn needs_stdin_payload(args: &[String]) -> bool {
     matches!(
         args,
         [command, subcommand, ..]
-            if command == "messages"
-                && subcommand == "send"
+            if ((command == "messages" && subcommand == "send")
+                || (command == "streams" && subcommand == "write"))
                 && args.iter().any(|arg| arg == "--stdin")
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stdin_payload_is_read_for_message_and_stream_writes() {
+        assert!(needs_stdin_payload(&[
+            "messages".to_string(),
+            "send".to_string(),
+            "agent.a".to_string(),
+            "agent.b".to_string(),
+            "--stdin".to_string(),
+        ]));
+        assert!(needs_stdin_payload(&[
+            "streams".to_string(),
+            "write".to_string(),
+            "stream_1".to_string(),
+            "--stdin".to_string(),
+        ]));
+        assert!(!needs_stdin_payload(&[
+            "streams".to_string(),
+            "open".to_string(),
+            "agent.a".to_string(),
+            "agent.b".to_string(),
+        ]));
+    }
 }

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod relay;
 pub mod runtime;
 pub mod sessions;
 pub mod state;
+pub mod streams;
 pub mod trust;
 
 /// The product invariant every crate should preserve.

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -32,6 +32,9 @@ const IPC_REJECTED_DIR: &str = "rejected";
 const MESSAGES_DIR: &str = "messages";
 const MESSAGE_INBOX_DIR: &str = "inbox";
 const MESSAGE_RECEIPTS_DIR: &str = "receipts";
+const STREAMS_DIR: &str = "streams";
+const STREAM_REGISTRY_FILE: &str = "registry.toml";
+const STREAM_EVENTS_FILE: &str = "events.toml";
 const PAIRING_DIR: &str = "pairing";
 const PAIRING_INVITES_DIR: &str = "invites";
 const PAIRING_USED_DIR: &str = "used";
@@ -65,6 +68,9 @@ pub struct StatePaths {
     pub messages_dir: PathBuf,
     pub message_inbox_dir: PathBuf,
     pub message_receipts_dir: PathBuf,
+    pub streams_dir: PathBuf,
+    pub stream_registry: PathBuf,
+    pub stream_events: PathBuf,
     pub pairing_dir: PathBuf,
     pub pairing_invites_dir: PathBuf,
     pub pairing_used_dir: PathBuf,
@@ -92,6 +98,7 @@ impl StatePaths {
         let ipc_dir = runtime_dir.join(IPC_DIR);
         let message_ipc_dir = ipc_dir.join(MESSAGES_DIR);
         let messages_dir = home.join(MESSAGES_DIR);
+        let streams_dir = home.join(STREAMS_DIR);
         let pairing_dir = home.join(PAIRING_DIR);
 
         Self {
@@ -116,6 +123,9 @@ impl StatePaths {
             message_inbox_dir: messages_dir.join(MESSAGE_INBOX_DIR),
             message_receipts_dir: messages_dir.join(MESSAGE_RECEIPTS_DIR),
             messages_dir,
+            stream_registry: streams_dir.join(STREAM_REGISTRY_FILE),
+            stream_events: streams_dir.join(STREAM_EVENTS_FILE),
+            streams_dir,
             pairing_invites_dir: pairing_dir.join(PAIRING_INVITES_DIR),
             pairing_used_dir: pairing_dir.join(PAIRING_USED_DIR),
             pairing_dir,
@@ -294,6 +304,7 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
         &paths.messages_dir,
         &paths.message_inbox_dir,
         &paths.message_receipts_dir,
+        &paths.streams_dir,
         &paths.pairing_dir,
         &paths.pairing_invites_dir,
         &paths.pairing_used_dir,

--- a/crates/conu-core/src/streams.rs
+++ b/crates/conu-core/src/streams.rs
@@ -1,0 +1,728 @@
+//! Stream lifecycle and payload-safe watch events.
+//!
+//! Phase 10 records stream metadata, chunk byte counts, and transport events.
+//! Stream contents stay opaque and are not written to logs, event files, or CLI
+//! watch output.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use conu_protocol::OpaquePayload;
+
+use crate::agents;
+use crate::sessions;
+use crate::state::{self, StateError, StatePaths};
+
+const STREAM_VERSION: &str = "1";
+const DEFAULT_BACKPRESSURE_WINDOW: usize = 64 * 1024;
+
+/// Lifecycle state for a stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamState {
+    Open,
+    Closed,
+}
+
+impl StreamState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+        }
+    }
+
+    fn from_str(value: &str) -> Self {
+        match value {
+            "open" => Self::Open,
+            _ => Self::Closed,
+        }
+    }
+}
+
+/// Metadata for one active or closed stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamRecord {
+    pub stream_id: String,
+    pub from_agent_id: String,
+    pub to_agent_id: String,
+    pub kind: String,
+    pub state: StreamState,
+    pub route: String,
+    pub chunks_written: u64,
+    pub bytes_written: usize,
+    pub backpressure_window: usize,
+    pub opened_at_unix: u64,
+    pub updated_at_unix: u64,
+}
+
+/// Metadata event consumed by `conu watch`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamEvent {
+    pub event_id: String,
+    pub stream_id: String,
+    pub event_type: String,
+    pub from_agent_id: String,
+    pub to_agent_id: String,
+    pub route: String,
+    pub payload_bytes: usize,
+    pub created_at_unix: u64,
+}
+
+/// Result of opening a stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamOpenReport {
+    pub stream: StreamRecord,
+}
+
+/// Result of writing one opaque chunk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamWriteReport {
+    pub stream: StreamRecord,
+    pub event: StreamEvent,
+}
+
+/// Result of closing a stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamCloseReport {
+    pub stream: StreamRecord,
+    pub event: StreamEvent,
+}
+
+/// Errors produced by stream operations.
+#[derive(Debug)]
+pub enum StreamError {
+    State(StateError),
+    Agent(agents::AgentError),
+    Session(sessions::SessionError),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidRequest {
+        reason: String,
+    },
+}
+
+impl StreamError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for StreamError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Agent(error) => write!(formatter, "{error}"),
+            Self::Session(error) => write!(formatter, "{error}"),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidRequest { reason } => {
+                write!(formatter, "invalid stream request: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StreamError {}
+
+impl From<StateError> for StreamError {
+    fn from(error: StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+impl From<agents::AgentError> for StreamError {
+    fn from(error: agents::AgentError) -> Self {
+        Self::Agent(error)
+    }
+}
+
+impl From<sessions::SessionError> for StreamError {
+    fn from(error: sessions::SessionError) -> Self {
+        Self::Session(error)
+    }
+}
+
+/// Open a stream between a local agent and a visible local or remote agent.
+pub fn open_stream(
+    home_override: Option<PathBuf>,
+    from_agent_id: &str,
+    to_agent_id: &str,
+    kind: &str,
+) -> Result<StreamOpenReport, StreamError> {
+    let init = state::init_state(home_override.clone())?;
+    let from_agent_id = validate_identifier(from_agent_id.to_string(), "from agent id")?;
+    let to_agent_id = validate_identifier(to_agent_id.to_string(), "to agent id")?;
+    let kind = validate_identifier(kind.to_string(), "stream kind")?;
+
+    validate_stream_agents(home_override, &from_agent_id, &to_agent_id)?;
+
+    let now = current_unix_seconds();
+    let stream = StreamRecord {
+        stream_id: stream_id(&from_agent_id, &to_agent_id, now),
+        from_agent_id,
+        to_agent_id,
+        kind,
+        state: StreamState::Open,
+        route: "metadata-relay".to_string(),
+        chunks_written: 0,
+        bytes_written: 0,
+        backpressure_window: DEFAULT_BACKPRESSURE_WINDOW,
+        opened_at_unix: now,
+        updated_at_unix: now,
+    };
+
+    let mut streams = read_streams(&init.paths)?;
+    streams.push(stream.clone());
+    write_streams(&init.paths, &streams)?;
+    append_event(&init.paths, event_for(&stream, "opened", 0, now))?;
+    append_stream_log(&init.paths, "stream_opened", &stream, 0)?;
+
+    Ok(StreamOpenReport { stream })
+}
+
+/// Record an opaque stream chunk by byte count only.
+pub fn write_stream(
+    home_override: Option<PathBuf>,
+    stream_id: &str,
+    payload: OpaquePayload,
+) -> Result<StreamWriteReport, StreamError> {
+    let init = state::init_state(home_override)?;
+    let stream_id = validate_identifier(stream_id.to_string(), "stream id")?;
+    let payload_bytes = payload.len();
+    let mut streams = read_streams(&init.paths)?;
+    let now = current_unix_seconds();
+    let Some(index) = streams
+        .iter()
+        .position(|stream| stream.stream_id == stream_id)
+    else {
+        return Err(StreamError::InvalidRequest {
+            reason: "stream is not known".to_string(),
+        });
+    };
+
+    if streams[index].state != StreamState::Open {
+        return Err(StreamError::InvalidRequest {
+            reason: "stream is closed".to_string(),
+        });
+    }
+    if payload_bytes > streams[index].backpressure_window {
+        return Err(StreamError::InvalidRequest {
+            reason: "chunk exceeds stream backpressure window".to_string(),
+        });
+    }
+
+    streams[index].chunks_written = streams[index].chunks_written.saturating_add(1);
+    streams[index].bytes_written = streams[index].bytes_written.saturating_add(payload_bytes);
+    streams[index].updated_at_unix = now;
+    let stream = streams[index].clone();
+    let event = event_for(&stream, "chunk", payload_bytes, now);
+
+    write_streams(&init.paths, &streams)?;
+    append_event(&init.paths, event.clone())?;
+    append_stream_log(&init.paths, "stream_chunk", &stream, payload_bytes)?;
+
+    Ok(StreamWriteReport { stream, event })
+}
+
+/// Close an open stream.
+pub fn close_stream(
+    home_override: Option<PathBuf>,
+    stream_id: &str,
+) -> Result<StreamCloseReport, StreamError> {
+    let init = state::init_state(home_override)?;
+    let stream_id = validate_identifier(stream_id.to_string(), "stream id")?;
+    let mut streams = read_streams(&init.paths)?;
+    let now = current_unix_seconds();
+    let Some(index) = streams
+        .iter()
+        .position(|stream| stream.stream_id == stream_id)
+    else {
+        return Err(StreamError::InvalidRequest {
+            reason: "stream is not known".to_string(),
+        });
+    };
+
+    streams[index].state = StreamState::Closed;
+    streams[index].updated_at_unix = now;
+    let stream = streams[index].clone();
+    let event = event_for(&stream, "closed", 0, now);
+
+    write_streams(&init.paths, &streams)?;
+    append_event(&init.paths, event.clone())?;
+    append_stream_log(&init.paths, "stream_closed", &stream, 0)?;
+
+    Ok(StreamCloseReport { stream, event })
+}
+
+/// List stream metadata.
+pub fn list_streams(home_override: Option<PathBuf>) -> Result<Vec<StreamRecord>, StreamError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_streams(&paths)
+}
+
+/// List watch events in chronological order.
+pub fn list_events(home_override: Option<PathBuf>) -> Result<Vec<StreamEvent>, StreamError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_events(&paths)
+}
+
+fn validate_stream_agents(
+    home_override: Option<PathBuf>,
+    from_agent_id: &str,
+    to_agent_id: &str,
+) -> Result<(), StreamError> {
+    if !agents::agent_exists(home_override.clone(), from_agent_id)? {
+        return Err(StreamError::InvalidRequest {
+            reason: "source agent is not registered locally".to_string(),
+        });
+    }
+
+    let local_target = agents::agent_exists(home_override.clone(), to_agent_id)?;
+    let remote_target = sessions::list_remote_agents(home_override)?
+        .into_iter()
+        .any(|agent| agent.agent_id == to_agent_id);
+
+    if !local_target && !remote_target {
+        return Err(StreamError::InvalidRequest {
+            reason: "target agent is not visible locally or through trusted remote discovery"
+                .to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn read_streams(paths: &StatePaths) -> Result<Vec<StreamRecord>, StreamError> {
+    if !paths.stream_registry.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(&paths.stream_registry)
+        .map_err(|error| StreamError::io("read stream registry", &paths.stream_registry, error))?;
+    parse_streams(&contents)
+}
+
+fn write_streams(paths: &StatePaths, streams: &[StreamRecord]) -> Result<(), StreamError> {
+    fs::create_dir_all(&paths.streams_dir)
+        .map_err(|error| StreamError::io("create streams directory", &paths.streams_dir, error))?;
+    let mut sorted = streams.to_vec();
+    sorted.sort_by(|left, right| left.stream_id.cmp(&right.stream_id));
+    let mut contents = format!("# conU stream registry\nversion = \"{}\"\n", STREAM_VERSION);
+
+    for stream in sorted {
+        contents.push_str("\n[[stream]]\n");
+        contents.push_str(&format!(
+            "stream_id = \"{}\"\n",
+            escape_file_value(&stream.stream_id)
+        ));
+        contents.push_str(&format!(
+            "from_agent_id = \"{}\"\n",
+            escape_file_value(&stream.from_agent_id)
+        ));
+        contents.push_str(&format!(
+            "to_agent_id = \"{}\"\n",
+            escape_file_value(&stream.to_agent_id)
+        ));
+        contents.push_str(&format!("kind = \"{}\"\n", escape_file_value(&stream.kind)));
+        contents.push_str(&format!("state = \"{}\"\n", stream.state.as_str()));
+        contents.push_str(&format!(
+            "route = \"{}\"\n",
+            escape_file_value(&stream.route)
+        ));
+        contents.push_str(&format!("chunks_written = {}\n", stream.chunks_written));
+        contents.push_str(&format!("bytes_written = {}\n", stream.bytes_written));
+        contents.push_str(&format!(
+            "backpressure_window = {}\n",
+            stream.backpressure_window
+        ));
+        contents.push_str(&format!("opened_at_unix = {}\n", stream.opened_at_unix));
+        contents.push_str(&format!("updated_at_unix = {}\n", stream.updated_at_unix));
+        contents.push_str("payload_displayed = false\n");
+    }
+
+    fs::write(&paths.stream_registry, contents)
+        .map_err(|error| StreamError::io("write stream registry", &paths.stream_registry, error))
+}
+
+fn append_event(paths: &StatePaths, event: StreamEvent) -> Result<(), StreamError> {
+    fs::create_dir_all(&paths.streams_dir)
+        .map_err(|error| StreamError::io("create streams directory", &paths.streams_dir, error))?;
+    let mut events = read_events(paths)?;
+    events.push(event);
+    write_events(paths, &events)
+}
+
+fn read_events(paths: &StatePaths) -> Result<Vec<StreamEvent>, StreamError> {
+    if !paths.stream_events.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(&paths.stream_events)
+        .map_err(|error| StreamError::io("read stream events", &paths.stream_events, error))?;
+    parse_events(&contents)
+}
+
+fn write_events(paths: &StatePaths, events: &[StreamEvent]) -> Result<(), StreamError> {
+    let mut contents = format!(
+        "# conU stream event bus\nversion = \"{}\"\n",
+        STREAM_VERSION
+    );
+
+    for event in events {
+        contents.push_str("\n[[event]]\n");
+        contents.push_str(&format!(
+            "event_id = \"{}\"\n",
+            escape_file_value(&event.event_id)
+        ));
+        contents.push_str(&format!(
+            "stream_id = \"{}\"\n",
+            escape_file_value(&event.stream_id)
+        ));
+        contents.push_str(&format!(
+            "event_type = \"{}\"\n",
+            escape_file_value(&event.event_type)
+        ));
+        contents.push_str(&format!(
+            "from_agent_id = \"{}\"\n",
+            escape_file_value(&event.from_agent_id)
+        ));
+        contents.push_str(&format!(
+            "to_agent_id = \"{}\"\n",
+            escape_file_value(&event.to_agent_id)
+        ));
+        contents.push_str(&format!(
+            "route = \"{}\"\n",
+            escape_file_value(&event.route)
+        ));
+        contents.push_str(&format!("payload_bytes = {}\n", event.payload_bytes));
+        contents.push_str(&format!("created_at_unix = {}\n", event.created_at_unix));
+        contents.push_str("payload_displayed = false\n");
+    }
+
+    fs::write(&paths.stream_events, contents)
+        .map_err(|error| StreamError::io("write stream events", &paths.stream_events, error))
+}
+
+fn parse_streams(contents: &str) -> Result<Vec<StreamRecord>, StreamError> {
+    let mut streams = Vec::new();
+    let mut current = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') || line == "version = \"1\"" {
+            continue;
+        }
+        if line == "[[stream]]" {
+            if !current.is_empty() {
+                streams.push(stream_from_values(&current)?);
+                current.clear();
+            }
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        current.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    if !current.is_empty() {
+        streams.push(stream_from_values(&current)?);
+    }
+
+    Ok(streams)
+}
+
+fn parse_events(contents: &str) -> Result<Vec<StreamEvent>, StreamError> {
+    let mut events = Vec::new();
+    let mut current = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') || line == "version = \"1\"" {
+            continue;
+        }
+        if line == "[[event]]" {
+            if !current.is_empty() {
+                events.push(event_from_values(&current)?);
+                current.clear();
+            }
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        current.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    if !current.is_empty() {
+        events.push(event_from_values(&current)?);
+    }
+
+    Ok(events)
+}
+
+fn stream_from_values(values: &HashMap<String, String>) -> Result<StreamRecord, StreamError> {
+    Ok(StreamRecord {
+        stream_id: validate_identifier(required(values, "stream_id")?, "stream id")?,
+        from_agent_id: validate_identifier(required(values, "from_agent_id")?, "from agent id")?,
+        to_agent_id: validate_identifier(required(values, "to_agent_id")?, "to agent id")?,
+        kind: validate_identifier(required(values, "kind")?, "stream kind")?,
+        state: StreamState::from_str(&required(values, "state")?),
+        route: validate_identifier(required(values, "route")?, "route")?,
+        chunks_written: parse_u64(&required(values, "chunks_written")?)?,
+        bytes_written: parse_usize(&required(values, "bytes_written")?)?,
+        backpressure_window: parse_usize(&required(values, "backpressure_window")?)?,
+        opened_at_unix: parse_u64(&required(values, "opened_at_unix")?)?,
+        updated_at_unix: parse_u64(&required(values, "updated_at_unix")?)?,
+    })
+}
+
+fn event_from_values(values: &HashMap<String, String>) -> Result<StreamEvent, StreamError> {
+    Ok(StreamEvent {
+        event_id: validate_identifier(required(values, "event_id")?, "event id")?,
+        stream_id: validate_identifier(required(values, "stream_id")?, "stream id")?,
+        event_type: validate_identifier(required(values, "event_type")?, "event type")?,
+        from_agent_id: validate_identifier(required(values, "from_agent_id")?, "from agent id")?,
+        to_agent_id: validate_identifier(required(values, "to_agent_id")?, "to agent id")?,
+        route: validate_identifier(required(values, "route")?, "route")?,
+        payload_bytes: parse_usize(&required(values, "payload_bytes")?)?,
+        created_at_unix: parse_u64(&required(values, "created_at_unix")?)?,
+    })
+}
+
+fn event_for(
+    stream: &StreamRecord,
+    event_type: &'static str,
+    payload_bytes: usize,
+    now: u64,
+) -> StreamEvent {
+    StreamEvent {
+        event_id: event_id(&stream.stream_id, event_type, now),
+        stream_id: stream.stream_id.clone(),
+        event_type: event_type.to_string(),
+        from_agent_id: stream.from_agent_id.clone(),
+        to_agent_id: stream.to_agent_id.clone(),
+        route: stream.route.clone(),
+        payload_bytes,
+        created_at_unix: now,
+    }
+}
+
+fn append_stream_log(
+    paths: &StatePaths,
+    event: &'static str,
+    stream: &StreamRecord,
+    payload_bytes: usize,
+) -> Result<(), StreamError> {
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| StreamError::io("create logs directory", &paths.logs_dir, error))?;
+    let path = paths.logs_dir.join("streams.log");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|error| StreamError::io("open stream log", &path, error))?;
+
+    writeln!(
+        file,
+        "event={} stream={} from={} to={} route={} bytes={} chunks={} state={} payload=not_observed",
+        event,
+        stream.stream_id,
+        stream.from_agent_id,
+        stream.to_agent_id,
+        stream.route,
+        payload_bytes,
+        stream.chunks_written,
+        stream.state.as_str()
+    )
+    .map_err(|error| StreamError::io("write stream log", &path, error))
+}
+
+fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, StreamError> {
+    values
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| StreamError::InvalidRequest {
+            reason: format!("missing {key}"),
+        })
+}
+
+fn validate_identifier(value: String, field: &'static str) -> Result<String, StreamError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(StreamError::InvalidRequest {
+            reason: format!("{field} cannot be empty"),
+        });
+    }
+    if value.len() > 140 {
+        return Err(StreamError::InvalidRequest {
+            reason: format!("{field} is too long"),
+        });
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Err(StreamError::InvalidRequest {
+            reason: format!("{field} must use ASCII letters, numbers, dash, underscore, or dot"),
+        });
+    }
+    Ok(value)
+}
+
+fn parse_u64(value: &str) -> Result<u64, StreamError> {
+    value
+        .parse::<u64>()
+        .map_err(|_| StreamError::InvalidRequest {
+            reason: "expected unsigned integer".to_string(),
+        })
+}
+
+fn parse_usize(value: &str) -> Result<usize, StreamError> {
+    value
+        .parse::<usize>()
+        .map_err(|_| StreamError::InvalidRequest {
+            reason: "expected unsigned count".to_string(),
+        })
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn stream_id(from_agent_id: &str, to_agent_id: &str, now: u64) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    from_agent_id.hash(&mut hasher);
+    to_agent_id.hash(&mut hasher);
+    now.hash(&mut hasher);
+    current_unix_nanos().hash(&mut hasher);
+    format!("stream_{:016x}", hasher.finish())
+}
+
+fn event_id(stream_id: &str, event_type: &str, now: u64) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    stream_id.hash(&mut hasher);
+    event_type.hash(&mut hasher);
+    now.hash(&mut hasher);
+    current_unix_nanos().hash(&mut hasher);
+    format!("event_{:016x}", hasher.finish())
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::{AgentRegistration, process_gateway_requests, submit_registration};
+    use std::env;
+    use std::process;
+
+    #[test]
+    fn stream_lifecycle_records_metadata_only() {
+        let home = test_home("stream-lifecycle");
+        register_agent(&home, "agent.a");
+        register_agent(&home, "agent.b");
+
+        let opened =
+            open_stream(Some(home.clone()), "agent.a", "agent.b", "message").expect("stream opens");
+        let written = write_stream(
+            Some(home.clone()),
+            &opened.stream.stream_id,
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("stream writes");
+        let closed =
+            close_stream(Some(home.clone()), &opened.stream.stream_id).expect("stream closes");
+        let events = list_events(Some(home.clone())).expect("events read");
+        let log = fs::read_to_string(home.join("logs").join("streams.log")).expect("log reads");
+
+        assert_eq!(written.stream.bytes_written, 24);
+        assert_eq!(written.stream.chunks_written, 1);
+        assert_eq!(closed.stream.state, StreamState::Closed);
+        assert_eq!(events.len(), 3);
+        assert!(log.contains("payload=not_observed"));
+        assert!(!log.contains("private message contents"));
+        assert!(!log.contains("Review this code"));
+    }
+
+    #[test]
+    fn stream_write_enforces_backpressure_window() {
+        let home = test_home("stream-backpressure");
+        register_agent(&home, "agent.a");
+        register_agent(&home, "agent.b");
+        let opened =
+            open_stream(Some(home.clone()), "agent.a", "agent.b", "message").expect("opens");
+        let error = write_stream(
+            Some(home),
+            &opened.stream.stream_id,
+            OpaquePayload::from_bytes(vec![7; DEFAULT_BACKPRESSURE_WINDOW + 1]),
+        )
+        .expect_err("oversized chunk fails");
+
+        assert!(error.to_string().contains("backpressure"));
+    }
+
+    #[test]
+    fn stream_requires_visible_target_agent() {
+        let home = test_home("stream-target");
+        register_agent(&home, "agent.a");
+
+        let error = open_stream(Some(home), "agent.a", "agent.missing", "message")
+            .expect_err("unknown target fails");
+
+        assert!(error.to_string().contains("target agent"));
+    }
+
+    fn register_agent(home: &Path, agent_id: &str) {
+        let registration =
+            AgentRegistration::new(agent_id, agent_id, "test-agent").expect("valid agent");
+        submit_registration(Some(home.to_path_buf()), registration).expect("submits");
+        process_gateway_requests(Some(home.to_path_buf())).expect("processes");
+    }
+
+    fn test_home(name: &str) -> PathBuf {
+        let mut path = env::temp_dir();
+        path.push(format!(
+            "conu-streams-test-{}-{}-{name}",
+            process::id(),
+            current_unix_seconds()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        path
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 10 - Streams And Watch Animation
+Current phase: Phase 11 - Encryption Hardening
 Status: not_started
 Last updated: 2026-05-10
 ```
@@ -751,7 +751,7 @@ Next:
 
 ## Phase 10 - Streams And Watch Animation
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -759,17 +759,64 @@ Add stream support and the private CLI animation showing agent traffic flow.
 
 Deliverables:
 
-- stream ids
-- stream open/write/close
-- backpressure windows
-- watch event bus
-- CLI animation
+- [x] stream ids
+- [x] stream open/write/close
+- [x] backpressure windows
+- [x] watch event bus
+- [x] CLI animation
 
 Exit criteria:
 
-- Agents can open streams.
-- `conu watch` shows traffic metadata only.
-- No payload text appears in watch output.
+- [x] Agents can open streams.
+- [x] `conu watch` shows traffic metadata only.
+- [x] No payload text appears in watch output.
+
+Completed work:
+
+- Created GitHub issue #19 for Phase 10.
+- Created and pushed branch `codex/phase-10-streams-watch`.
+- Added `conu_core::streams` for stream lifecycle metadata, opaque chunk byte counts, backpressure validation, watch events, and payload-safe stream logs.
+- Added `streams/registry.toml`, `streams/events.toml`, and `logs/streams.log` state surfaces.
+- Added `conu streams`, `conu streams --json`, `conu streams open`, `conu streams write --stdin`, and `conu streams close`.
+- Updated the CLI binary so `streams write --stdin` reads stdin like message send.
+- Updated `conu watch` to render private stream flow, route, stream id, event type, open stream count, packet count, and byte count without payload contents.
+- Updated `conu status`, `conu connect`, help text, README, repo overview, builder guardrails, repo map, CLI experience reference, and agent gateway contract.
+- Added tests for stream lifecycle, backpressure rejection, target visibility, binary stdin routing, CLI stream flow, and watch privacy.
+
+Files changed:
+
+- `README.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-builder/references/cli-experience.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `plan.md`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-cli/src/main.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conu-core/src/streams.rs`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `git diff --check` passed.
+- Isolated `CONU_HOME` smoke passed: `conu init`, two `conu agents register` calls, two `conud --process-ipc` calls, `conu streams open`, `conu streams write <stream-id> --stdin`, `conu watch`, `conu streams close`, and `conu streams --json`.
+- Privacy scan reviewed payload/token terms; matches were limited to negative tests, placeholder frame documentation, original product examples, and existing opaque local storage internals.
+
+Known gaps:
+
+- Phase 10 streams record metadata and byte counts only; they do not yet move encrypted chunk bytes over a live relay transport.
+- Stream chunks are accepted from stdin and counted, but conU-owned stream storage intentionally does not persist chunk contents.
+- Watch animation is static CLI rendering over the event bus, not a continuously refreshing TUI yet.
+- End-to-end stream encryption, signed stream peers, and replay protection begin in Phase 11.
+
+Next:
+
+- Start Phase 11: encryption hardening, signed cards, replay protection, encrypted storage, and key rotation planning.
 
 ## Phase 11 - Encryption Hardening
 
@@ -898,4 +945,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 7 completed. Local pairing invitations, join-to-trust, peer listing, revocation, pairing code hash storage, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 8 WebSocket relay MVP.
 2026-05-10 - Phase 8 completed. std-only WebSocket relay service, shared relay frame contract, token-authenticated sessions, metadata-only connected-peer forwarding, tests, docs, and relay binary smoke validation added. Next: Phase 9 remote discovery and sessions.
 2026-05-10 - Phase 9 completed. conUD-owned remote session mirror, trusted remote agent cards, `conu sessions`, remote visibility in agents/status/connect, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 10 streams and watch animation.
+2026-05-10 - Phase 10 completed. Stream lifecycle metadata, stdin-only opaque stream writes, backpressure checks, watch event bus, private watch animation, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 11 encryption hardening.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- add `conu_core::streams` for stream lifecycle metadata, backpressure checks, watch events, and payload-safe stream logs
- add `conu streams` open/write/close/list commands and update the CLI binary to read stdin for stream writes
- update `conu watch` with private packet flow, stream id, route, packet count, and byte count without payload contents
- update README, repo memory, guardrails, CLI experience, and `plan.md` for completed Phase 10

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu test --workspace`
- `git diff --check`
- isolated `CONU_HOME` smoke: `conu init`, two `conu agents register` calls, two `conud --process-ipc` calls, `conu streams open`, `conu streams write <stream-id> --stdin`, `conu watch`, `conu streams close`, `conu streams --json`

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `conu streams` command group with subcommands to open, write, close, and list streams.
  * Added `conu watch` command to monitor stream and transport metadata while keeping payload contents private.
  * Stream operations now provide metadata-only reporting with packet and byte counts.
  * Status output now includes stream record counts.

* **Documentation**
  * Updated guides to document Phase 10 stream lifecycle support and watch event capabilities.
  * Added examples of streams and watch commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add stream lifecycle commands and a private watch view**

### What Changed
- Added `conu streams` so users can open, write, close, and list streams from the CLI
- `streams write --stdin` now accepts input from standard input and records only byte counts, not payload contents
- `conu watch` now shows stream route, stream id, event type, open stream count, packet count, and byte count while keeping payloads hidden
- `conu status` now includes stream counts, and the help text and docs reflect the new stream workflow

### Impact
`✅ Open and manage streams from the CLI`
`✅ Private stream activity shown without payload leakage`
`✅ Clearer status for active streams`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=-GxhJppq1BcZ27IHMmzr_-PVo20YPlCSH7Qng1F0fD8&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
