### PR TITLE
Docs: user install and agent integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Implemented controls:
 
 The audit reports readiness and key ids only. It never prints private keys, shared secrets, plaintext payloads, or decrypted payloads. See `docs/security-hardening.md` and `docs/production-readiness.md` for the hardening model and release blockers.
 
+For practical user setup, installation, and current agent integration guidance, see `docs/user-install-and-agent-guide.md`.
+
 ## Pairing And Trust
 
 Phase 7 adds local trust-store mechanics before the hosted relay exists:

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -2,6 +2,8 @@
 
 This document tracks what is ready, what is intentionally local-only, and what must be finished before a real public release.
 
+For hands-on install and agent usage instructions, see `docs/user-install-and-agent-guide.md`.
+
 ## Ready In The Current Repo
 
 - Rust workspace for CLI, runtime daemon, core, protocol, and relay.

--- a/docs/user-install-and-agent-guide.md
+++ b/docs/user-install-and-agent-guide.md
@@ -1,0 +1,254 @@
+# conU User Install And Agent Guide
+
+This guide explains how a user can install the current conU app, start it on their PC, and let local agents use it.
+
+Current version status: Phase 11 is complete. conU is usable for local agent registration, local encrypted-at-rest message submission, stream metadata, trust metadata, and private CLI watch output. It is not yet a packaged consumer release, and it does not yet include the Phase 12 SDK/MCP adapter.
+
+## What Works Today
+
+- Install from source with Rust.
+- Initialize local conU state and security keys.
+- Start and stop the local `conUD` runtime.
+- Register local agents by id.
+- Send local opaque payload bytes from one registered local agent to another.
+- Store new conU-owned local payload files encrypted at rest.
+- List inbox, receipt, stream, peer, session, and security metadata.
+- Run a standalone `conu-relay` MVP for metadata-only relay frame tests.
+
+## What Does Not Work Yet
+
+- No one-click installer or signed release package.
+- No stable SDK for Python, TypeScript, or Rust agent apps yet.
+- No MCP adapter yet.
+- No CLI command that reveals message contents. This is intentional, but it also means a clean external receive API is still Phase 12 work.
+- No live internet data-plane routing between two real conUD nodes yet.
+- Pairing and remote sessions are local metadata groundwork, not full cross-machine rendezvous.
+- `conu-relay` exists, but conUD does not yet own a live relay client for encrypted message/stream byte delivery.
+- conUD is not installed as a Windows/macOS/Linux service yet.
+- Local private keys are file-backed today; OS keychain/DPAPI/HSM support is still a release blocker.
+
+## Install From Source
+
+### Requirements
+
+- Git.
+- Rust from `rustup`.
+- On Windows without Visual Studio C++ Build Tools, install the GNU Rust toolchain:
+
+```powershell
+rustup toolchain install stable-x86_64-pc-windows-gnu
+```
+
+### Clone The Repo
+
+```powershell
+git clone https://github.com/imthegoodboy/conU.git
+cd conU
+```
+
+### Install The Binaries
+
+Windows PowerShell:
+
+```powershell
+cargo +stable-x86_64-pc-windows-gnu install --path crates/conu-cli --locked --force
+cargo +stable-x86_64-pc-windows-gnu install --path crates/conud --locked --force
+cargo +stable-x86_64-pc-windows-gnu install --path crates/conu-relay --locked --force
+```
+
+macOS/Linux shell, assuming the default toolchain links successfully:
+
+```bash
+cargo install --path crates/conu-cli --locked --force
+cargo install --path crates/conud --locked --force
+cargo install --path crates/conu-relay --locked --force
+```
+
+Make sure Cargo's bin directory is on `PATH`.
+
+Windows normally uses:
+
+```txt
+%USERPROFILE%\.cargo\bin
+```
+
+macOS/Linux normally uses:
+
+```txt
+$HOME/.cargo/bin
+```
+
+Check the install:
+
+```powershell
+conu --version
+conud --check
+conu-relay --check
+```
+
+## First Run
+
+Initialize local state and local security keys:
+
+```powershell
+conu init
+conu security audit
+conu status
+```
+
+Start conUD:
+
+```powershell
+conu start
+conu status
+```
+
+Stop conUD:
+
+```powershell
+conu stop
+```
+
+If `conu start` cannot find `conud`, set `CONUD_EXE`:
+
+```powershell
+$env:CONUD_EXE = "$env:USERPROFILE\.cargo\bin\conud.exe"
+conu start
+```
+
+For scripts and smoke checks, it is also valid to process queued gateway work without a long-running daemon:
+
+```powershell
+conud --process-ipc
+```
+
+## Register Local Agents
+
+Choose stable ids for each local agent:
+
+```powershell
+conu agents register agent.codex "Codex Desktop" --kind coding-agent
+conu agents register agent.helper "Helper Agent" --kind coding-agent
+conu agents
+```
+
+If conUD is not running, process the queued registration requests:
+
+```powershell
+conud --process-ipc
+conu agents --json
+```
+
+Agents can update presence:
+
+```powershell
+conu agents heartbeat agent.codex --presence busy
+conud --process-ipc
+```
+
+## Send A Local Message
+
+Send payload bytes through stdin. Do not put private payload text directly in command arguments.
+
+PowerShell:
+
+```powershell
+"opaque bytes from agent.codex" | conu messages send agent.codex agent.helper --stdin
+conud --process-ipc
+conu messages inbox agent.helper --json
+conu messages receipts --json
+```
+
+The inbox command shows metadata only: envelope id, sender, receiver, receipt id, byte count, and delivery time. It does not print the payload.
+
+## Give conU To An Agent Today
+
+Until Phase 12 SDK/MCP exists, the safest current integration is to let the agent call the CLI.
+
+Give the agent this operating contract:
+
+```txt
+You may use conU as a local communication transport.
+
+Rules:
+- Register once at startup:
+  conu agents register <agent-id> <display-name> --kind <kind>
+- Refresh presence when your state changes:
+  conu agents heartbeat <agent-id> --presence <ready|busy|idle|offline>
+- Send payload bytes through stdin only:
+  <payload bytes> | conu messages send <your-agent-id> <target-agent-id> --stdin
+- Use JSON commands for machine-readable metadata:
+  conu status --json
+  conu agents --json
+  conu messages inbox <agent-id> --json
+  conu messages receipts --json
+  conu security audit --json
+- Never expect conU CLI output to show message contents.
+- Treat conU as the road, not the conversation.
+```
+
+For local testing, a wrapper script can call:
+
+```powershell
+conu agents register agent.mybot "My Bot" --kind local-agent
+conu agents register agent.other "Other Agent" --kind local-agent
+conud --process-ipc
+"hello as opaque bytes" | conu messages send agent.mybot agent.other --stdin
+conud --process-ipc
+conu messages inbox agent.other --json
+```
+
+## Current App Issues To Know
+
+These are not hidden bugs; they are the honest state of the current app:
+
+| Area | Current issue | User impact | Workaround today |
+| --- | --- | --- | --- |
+| Installer | No packaged installer yet | Users must build from source | Use `cargo install --path` |
+| Windows linker | Default MSVC toolchain may fail without `link.exe` | `cargo check/test/install` can fail | Use `stable-x86_64-pc-windows-gnu` or install Visual Studio C++ Build Tools |
+| Runtime discovery | `conu start` needs `conud` beside `conu` or on PATH | Start can fail after manual binary moves | Install both with Cargo or set `CONUD_EXE` |
+| Agent API | No SDK/MCP adapter yet | Agents need CLI calls or internal Rust integration | Use CLI/stdin and JSON metadata |
+| Receiving payloads | No stable external receive API yet | CLI lists inbox metadata only | Phase 12 should add SDK/MCP receive |
+| Internet messaging | Relay is not wired into conUD data plane yet | Local messages work; real remote payload delivery does not | Use local testing only |
+| Pairing | Pair/join are local trust groundwork | Not real cross-machine pairing yet | Use for metadata/trust testing |
+| Service install | conUD is not an OS service yet | User must start/stop manually | Use `conu start` / `conu stop` |
+| Key storage | Keys are local files | Not ready for high-security public release | Keep user profile protected; future OS keychain work required |
+| IPC | File-backed queues | Good for development, not final hot path | Use current gateway until named pipe/socket IPC lands |
+
+## Recommended User Flow Today
+
+For a developer testing conU locally:
+
+```powershell
+conu init
+conu security audit
+conu start
+conu agents register agent.a "Agent A" --kind test-agent
+conu agents register agent.b "Agent B" --kind test-agent
+"test opaque payload" | conu messages send agent.a agent.b --stdin
+conu messages inbox agent.b --json
+conu watch
+conu stop
+```
+
+For automation where a background daemon is awkward:
+
+```powershell
+conu init
+conu agents register agent.a "Agent A" --kind test-agent
+conu agents register agent.b "Agent B" --kind test-agent
+conud --process-ipc
+"test opaque payload" | conu messages send agent.a agent.b --stdin
+conud --process-ipc
+conu messages inbox agent.b --json
+```
+
+## Best Next Product Work
+
+To make conU genuinely easy for users and agents, the next phase should build:
+
+- Rust SDK receive/send/register APIs.
+- Python SDK wrapper for local agents.
+- MCP adapter exposing conU tools to LLM agents.
+- A stable receive API that returns payload bytes only to the addressed local agent.
+- Packaged installer and service setup after SDK behavior is stable.


### PR DESCRIPTION
## **User description**
## Summary
- add a practical user install and agent integration guide for the current Phase 11 app
- document how users can install conu/conud/conu-relay from source and initialize/start/audit conU
- document current app issues honestly: no installer, no SDK/MCP, local-only data path, no stable receive API yet

## Validation
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu test --workspace
- git diff --check
- temporary cargo install smoke for conu, conud, and conu-relay with init/security/agent registration/relay check

Closes #24


___

## **CodeAnt-AI Description**
**Add a practical guide for installing conU and using it with local agents**

### What Changed
- Added a step-by-step guide for installing conU from source, starting and stopping the local runtime, and checking that the tools are available
- Explained how to register local agents, send opaque payloads between them, and inspect inbox and receipt metadata without exposing message contents
- Documented the current limits of the app, including the lack of a packaged installer, SDK/MCP adapter, stable receive API, service install, and live remote messaging
- Linked the new guide from the README and production-readiness notes so users can find setup instructions more easily

### Impact
`✅ Easier local setup`
`✅ Clearer agent integration steps`
`✅ Fewer surprises about current release limits`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=hkNGTYGemvZOQRXSj8qEKOlrM8rcYS3dIwFzYHXDP5Q&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive user installation guide covering setup from source, initialization, runtime management, local agent registration, core operations, and current product limitations.
  * Updated production readiness and main documentation to reference the new installation guide.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->