### PR TITLE
Phase 12: SDK and MCP adapter

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 11.
+The repository has completed Phase 12.
 
 Implemented so far:
 
@@ -29,6 +29,10 @@ Implemented so far:
 - local X25519 peer key agreement helpers
 - replay protection for local message request and envelope ids
 - `conu security audit` for payload-safe hardening status
+- Rust SDK crate `conu-sdk` for agent-facing registration, messaging, receive, peer, security, and stream calls
+- MCP stdio adapter crate `conu-mcp` exposing conU tools over newline-delimited JSON-RPC
+- Python stdlib wrapper SDK under `sdk/python`
+- local examples for Rust and Python agents
 - local pairing invitation creation through `conu pair`
 - local pairing join/trust creation through `conu join <code>`
 - trusted peer listing and revocation through `conu peers`
@@ -75,7 +79,8 @@ crates/
 |- conu-core/      shared runtime logic
 |- conu-protocol/  protocol types and envelopes
 |- conu-relay/     hosted WebSocket relay/bootstrap service
-`- conu-sdk/       agent-facing client libraries later
+|- conu-sdk/       Rust agent-facing client API
+`- conu-mcp/       MCP stdio adapter for agent tool use
 ```
 
 Current Rust crates:
@@ -85,6 +90,8 @@ Current Rust crates:
 - `crates/conu-core`
 - `crates/conu-protocol`
 - `crates/conu-relay`
+- `crates/conu-sdk`
+- `crates/conu-mcp`
 
 ## Non-Negotiable Product Rule
 

--- a/.agents/skills/conu-builder/SKILL.md
+++ b/.agents/skills/conu-builder/SKILL.md
@@ -56,6 +56,9 @@ conUD
 Agent Gateway
   local entrance for agents
 
+SDK/MCP
+  agent-facing API and tool adapter
+
 Protocol
   control plane + data plane
 

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -211,6 +211,51 @@ conu security audit [--json]
 
 New local message request and inbox files store encrypted-at-rest payload fields instead of `payload_hex`. New or updated local agent cards are signed in `agents/registry.toml`. `conu security audit` may report readiness and key ids, but it must not display private keys, shared secrets, plaintext payloads, or decrypted payloads.
 
+The Phase 12 SDK/MCP surface is the preferred agent integration path:
+
+```txt
+crates/conu-sdk          Rust SDK for typed local conU calls
+crates/conu-mcp          MCP stdio adapter for agent tool use
+sdk/python/conu_sdk      Python wrapper around conu/conud binaries
+```
+
+Rust SDK calls:
+
+```txt
+ConuClient::register_agent()
+ConuClient::set_presence()
+ConuClient::list_agents()
+ConuClient::list_peers()
+ConuClient::send_message_bytes()
+ConuClient::inbox_metadata()
+ConuClient::receive_message_bytes()
+ConuClient::open_stream()
+ConuClient::write_stream_bytes()
+ConuClient::close_stream()
+ConuClient::security_audit()
+```
+
+MCP tools:
+
+```txt
+conu_status
+conu_security_audit
+conu_register_agent
+conu_set_presence
+conu_process_queued
+conu_list_agents
+conu_list_peers
+conu_send_message
+conu_receive_message
+conu_open_stream
+conu_write_stream
+conu_close_stream
+```
+
+SDK/MCP receive is explicit. Normal list, send, receipt, status, and stream outputs remain metadata-only. Payload bytes may be returned only through `ConuClient::receive_message_bytes()` or `conu_receive_message` with `includePayload: true`, and only for an envelope present in the addressed local agent inbox.
+
+When launching `conu-mcp` for one agent, set `CONU_AGENT_ID`. A bound MCP server must reject register, presence, send, receive, stream-open, stream-write, and stream-close attempts for a different local agent.
+
 ## Safety
 
 "Full access" means full communication access inside trust boundaries. It does not mean raw filesystem, shell, network, or secret access.

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -118,6 +118,20 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - CLI security output may show readiness booleans and key ids, but must never show private keys, shared secrets, plaintext payloads, or decrypted payloads.
 - Peer key agreement helpers are available for later live relay-backed encrypted delivery, but current remote sessions are still metadata mirrors.
 
+## SDK And MCP Rules
+
+- Phase 12 agent-facing APIs live in `crates/conu-sdk`, `crates/conu-mcp`, and `sdk/python/conu_sdk`.
+- The Rust SDK should wrap `conu-core` surfaces instead of duplicating file-format logic.
+- SDK send/list/status/receipt/stream methods must return metadata only unless the method is an explicit receive call.
+- `receive_message_bytes(agent_id, envelope_id)` must verify the envelope is present in that addressed local agent inbox before returning bytes.
+- `conu-mcp` uses MCP stdio: newline-delimited JSON-RPC on stdin/stdout.
+- `conu-mcp` stdout must contain only valid MCP messages. Use stderr only for infrastructure errors, never payloads.
+- MCP tools should return text content containing JSON-shaped results for compatibility, but send/list/status/stream results must not echo payload text.
+- `conu_receive_message` returns metadata by default and may return `payloadHex` only when `includePayload` is true.
+- `CONU_AGENT_ID` may bind one `conu-mcp` server to one local agent; bound servers must not act as another agent.
+- Python SDK wrappers should pass payload bytes through stdin and avoid printing/logging payloads.
+- TypeScript SDK is intentionally later; do not mark it complete until implemented and validated.
+
 ## Privacy Rules
 
 - Never log plaintext payloads.

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -32,7 +32,16 @@ crates/conu-relay
   std-only WebSocket relay service, session auth, metadata-only forwarding, relay/bootstrap groundwork
 
 crates/conu-sdk
-  agent gateway clients later
+  Rust agent-facing SDK over registration, presence, peers, messages, receive, streams, and security audit
+
+crates/conu-mcp
+  MCP stdio adapter exposing conU tools over newline-delimited JSON-RPC
+
+sdk/python/conu_sdk
+  stdlib Python wrapper around installed conu and conud binaries
+
+examples/python
+  Python local-agent integration examples
 ```
 
 ## Placement Rule

--- a/.agents/skills/conu-security-guardian/references/privacy-security-checklist.md
+++ b/.agents/skills/conu-security-guardian/references/privacy-security-checklist.md
@@ -4,6 +4,7 @@
 
 - Payload content is opaque to conU runtime surfaces unless the local agent intentionally handles it.
 - CLI does not print payload text.
+- SDK and MCP list/send/status/stream outputs do not print payload text.
 - Logs do not include payload text.
 - Metrics do not include payload text.
 - Tests do not normalize leaking payload contents as expected behavior.
@@ -21,6 +22,7 @@
 - Agent actions require grants where appropriate.
 - Sending, streaming, subscribing, room joining, file transfer, and mailbox use are separately controllable.
 - "Full access" means full communication within trust boundaries, not raw system access.
+- SDK/MCP receive APIs return payload bytes only to the addressed local agent and only after an explicit receive request.
 
 ## Relay
 
@@ -48,3 +50,11 @@
 
 - Shows route, latency, bytes, packet count, stream count, presence.
 - Never shows message text, prompt text, reasoning, file contents, or tool output.
+
+## MCP Adapter
+
+- stdout contains only valid MCP JSON-RPC messages.
+- Tool schemas do not encourage plaintext payload logging.
+- `conu_receive_message` returns metadata by default.
+- `payloadHex` is returned only for explicit addressed-agent receive calls.
+- When `CONU_AGENT_ID` is set, the MCP server rejects attempts to act as another local agent.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 **/*.rs.bk
 Cargo.lock.orig
 
+# Python/editor noise
+__pycache__/
+*.py[cod]
+
 # Local environment
 .env
 .env.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "conu-mcp"
+version = "0.1.0"
+dependencies = [
+ "conu-sdk",
+ "serde_json",
+]
+
+[[package]]
 name = "conu-protocol"
 version = "0.1.0"
 
@@ -103,6 +111,14 @@ name = "conu-relay"
 version = "0.1.0"
 dependencies = [
  "conu-core",
+]
+
+[[package]]
+name = "conu-sdk"
+version = "0.1.0"
+dependencies = [
+ "conu-core",
+ "conu-protocol",
 ]
 
 [[package]]
@@ -241,10 +257,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "opaque-debug"
@@ -343,6 +371,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -457,3 +498,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,10 @@
 members = [
     "crates/conu-cli",
     "crates/conu-core",
+    "crates/conu-mcp",
     "crates/conu-protocol",
     "crates/conu-relay",
+    "crates/conu-sdk",
     "crates/conud",
 ]
 resolver = "3"
@@ -17,6 +19,7 @@ authors = ["conU contributors"]
 [workspace.dependencies]
 conu-core = { path = "crates/conu-core" }
 conu-protocol = { path = "crates/conu-protocol" }
+conu-sdk = { path = "crates/conu-sdk" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 11 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state and security keys, `conu start` launches the local `conUD` runtime skeleton, local agents can register signed metadata and presence, registered local agents can exchange encrypted-at-rest opaque message envelopes, local pairing/trust records can be created and revoked, `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding, conUD can sync remote session/discovery metadata for trusted peers, streams produce payload-safe watch events, and `conu security audit` reports hardened controls without showing secrets.
+Phase 12 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state and security keys, `conu start` launches the local `conUD` runtime skeleton, local agents can register signed metadata and presence, registered local agents can exchange encrypted-at-rest opaque message envelopes, local pairing/trust records can be created and revoked, `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding, conUD can sync remote session/discovery metadata for trusted peers, streams produce payload-safe watch events, `conu security audit` reports hardened controls without showing secrets, and agents can now use conU through the Rust SDK, Python wrapper SDK, and MCP stdio adapter.
 
 The repository currently contains compile-ready crate boundaries for:
 
 - `conu-cli`: human control room.
+- `conu-sdk`: Rust agent-facing API over conU local gateway surfaces.
+- `conu-mcp`: MCP stdio adapter exposing conU as agent tools.
 - `conud`: local daemon/runtime scaffold.
 - `conu-core`: shared runtime primitives and project invariants.
 - `conu-protocol`: protocol identities, agent cards, and opaque envelopes.
@@ -174,6 +176,21 @@ conu watch
 
 The stream layer is still metadata-first. Full live relay-backed byte streaming and encrypted stream transport are future hardening/transport work.
 
+## SDK And MCP Adapter
+
+Phase 12 adds agent-facing integrations:
+
+```bash
+cargo run -p conu-sdk --example local_agents
+cargo run -p conu-mcp
+```
+
+Rust agents can use `conu_sdk::ConuClient` to register, update presence, list agents/peers, send opaque bytes, receive local payload bytes for the addressed agent, and open/write/close streams. Python agents can use the stdlib wrapper under `sdk/python`.
+
+MCP-capable agents can launch `conu-mcp` as a stdio server. It exposes tools such as `conu_register_agent`, `conu_list_agents`, `conu_send_message`, `conu_receive_message`, `conu_open_stream`, and `conu_security_audit`. The adapter follows the current MCP stdio transport shape: newline-delimited JSON-RPC 2.0 messages on stdin/stdout. Tool list/send/status outputs remain metadata-only. Set `CONU_AGENT_ID` when launching one MCP server for one agent; then the adapter rejects attempts to act as another local agent. `conu_receive_message` returns payload bytes as `payloadHex` only when the addressed local agent explicitly passes `includePayload: true`.
+
+See `docs/sdk-and-mcp.md` for SDK examples, MCP tool contracts, and privacy rules.
+
 ## Development
 
 ```bash
@@ -224,6 +241,8 @@ cargo run -p conud -- --once
 cargo run -p conud -- --process-ipc
 cargo run -p conu-relay -- --check
 cargo run -p conu-relay -- --serve 127.0.0.1:8787
+cargo run -p conu-sdk --example local_agents
+cargo run -p conu-mcp
 ```
 
 When running from a development checkout, build `conud` first or set `CONUD_EXE` to the local daemon binary before using `conu start`.

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -20,11 +20,19 @@ pub struct Component {
     pub responsibility: &'static str,
 }
 
-/// Static manifest for the Phase 1 workspace.
+/// Static manifest for the conU workspace.
 pub const COMPONENTS: &[Component] = &[
     Component {
         name: "conu-cli",
         responsibility: "human control room for runtime state and private transport flow",
+    },
+    Component {
+        name: "conu-sdk",
+        responsibility: "typed agent-facing API over conU-owned connection surfaces",
+    },
+    Component {
+        name: "conu-mcp",
+        responsibility: "MCP stdio adapter exposing conU as payload-safe agent tools",
     },
     Component {
         name: "conud",
@@ -51,7 +59,7 @@ pub fn scaffold_status(component: &str) -> String {
     )
 }
 
-/// Return true when the named component is part of the Phase 1 workspace.
+/// Return true when the named component is part of the conU workspace.
 pub fn has_component(name: &str) -> bool {
     COMPONENTS
         .iter()
@@ -66,6 +74,8 @@ mod tests {
     fn phase_one_manifest_contains_required_components() {
         for name in [
             "conu-cli",
+            "conu-sdk",
+            "conu-mcp",
             "conud",
             "conu-core",
             "conu-protocol",

--- a/crates/conu-mcp/Cargo.toml
+++ b/crates/conu-mcp/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "conu-mcp"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "conu-mcp"
+path = "src/main.rs"
+
+[dependencies]
+conu-sdk.workspace = true
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/conu-mcp/src/lib.rs
+++ b/crates/conu-mcp/src/lib.rs
@@ -1,0 +1,1026 @@
+//! MCP stdio adapter for conU.
+//!
+//! The adapter exposes conU as MCP tools over newline-delimited JSON-RPC on
+//! stdin/stdout. Tool outputs are metadata-only unless an addressed local agent
+//! explicitly calls `conu_receive_message` with `includePayload: true`.
+
+use std::path::PathBuf;
+
+use conu_sdk::{Capabilities, ConuClient, Presence, SdkError, Stream};
+use serde_json::{Map, Value, json};
+
+const JSONRPC_VERSION: &str = "2.0";
+const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Minimal MCP server that dispatches conU tools.
+#[derive(Debug, Clone)]
+pub struct McpServer {
+    client: ConuClient,
+    bound_agent_id: Option<String>,
+}
+
+impl McpServer {
+    /// Use the default conU state home.
+    pub fn new() -> Self {
+        Self {
+            client: ConuClient::new(),
+            bound_agent_id: bound_agent_from_env(),
+        }
+    }
+
+    /// Use a specific conU state home.
+    pub fn with_home(home: impl Into<PathBuf>) -> Self {
+        Self {
+            client: ConuClient::with_home(home),
+            bound_agent_id: None,
+        }
+    }
+
+    /// Use a specific conU state home and bind the server to one local agent id.
+    pub fn with_home_and_agent(home: impl Into<PathBuf>, agent_id: impl Into<String>) -> Self {
+        Self {
+            client: ConuClient::with_home(home),
+            bound_agent_id: Some(agent_id.into()),
+        }
+    }
+
+    /// Handle one newline-delimited JSON-RPC message.
+    pub fn handle_line(&self, line: &str) -> Option<String> {
+        let line = line.trim();
+        if line.is_empty() {
+            return None;
+        }
+
+        let response = match serde_json::from_str::<Value>(line) {
+            Ok(message) => self.handle_message(message),
+            Err(_) => Some(error_response(Value::Null, -32700, "parse error")),
+        }?;
+
+        Some(response.to_string())
+    }
+
+    fn handle_message(&self, message: Value) -> Option<Value> {
+        let Some(object) = message.as_object() else {
+            return Some(error_response(Value::Null, -32600, "invalid request"));
+        };
+        let id = object.get("id").cloned();
+        let Some(method) = object.get("method").and_then(Value::as_str) else {
+            return id.map(|id| error_response(id, -32600, "missing method"));
+        };
+
+        if matches!(id, Some(Value::Null)) {
+            return Some(error_response(
+                Value::Null,
+                -32600,
+                "request id must not be null",
+            ));
+        }
+        if id.is_none() {
+            return None;
+        }
+        let id = id.unwrap_or(Value::Null);
+
+        let result = match method {
+            "initialize" => Ok(self.initialize_result()),
+            "ping" => Ok(json!({})),
+            "tools/list" => Ok(json!({ "tools": self.tools() })),
+            "tools/call" => self.call_tool(object.get("params")),
+            _ => Err(jsonrpc_error(-32601, "method not found")),
+        };
+
+        Some(match result {
+            Ok(result) => json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "id": id,
+                "result": result
+            }),
+            Err(error) => json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "id": id,
+                "error": error
+            }),
+        })
+    }
+
+    fn initialize_result(&self) -> Value {
+        json!({
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": {}
+            },
+            "serverInfo": {
+                "name": "conu-mcp",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        })
+    }
+
+    fn call_tool(&self, params: Option<&Value>) -> Result<Value, Value> {
+        let params = params
+            .and_then(Value::as_object)
+            .ok_or_else(|| jsonrpc_error(-32602, "tools/call requires params"))?;
+        let name = params
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| jsonrpc_error(-32602, "tools/call requires a tool name"))?;
+        let arguments_value = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let arguments = arguments_value
+            .as_object()
+            .ok_or_else(|| jsonrpc_error(-32602, "tool arguments must be an object"))?;
+
+        let result = match self.dispatch_tool(name, arguments) {
+            Ok(value) => tool_success(value),
+            Err(error) => tool_failure(error),
+        };
+
+        Ok(result)
+    }
+
+    fn dispatch_tool(&self, name: &str, args: &Map<String, Value>) -> Result<Value, String> {
+        match name {
+            "conu_status" => self.tool_status(),
+            "conu_security_audit" => self.tool_security_audit(),
+            "conu_register_agent" => self.tool_register_agent(args),
+            "conu_set_presence" => self.tool_set_presence(args),
+            "conu_process_queued" => self.tool_process_queued(),
+            "conu_list_agents" => self.tool_list_agents(args),
+            "conu_list_peers" => self.tool_list_peers(),
+            "conu_send_message" => self.tool_send_message(args),
+            "conu_receive_message" => self.tool_receive_message(args),
+            "conu_open_stream" => self.tool_open_stream(args),
+            "conu_write_stream" => self.tool_write_stream(args),
+            "conu_close_stream" => self.tool_close_stream(args),
+            _ => Err(format!("unknown conU tool: {name}")),
+        }
+    }
+
+    fn tool_status(&self) -> Result<Value, String> {
+        let snapshot = self.client.state_snapshot().map_err(safe_sdk_error)?;
+        let runtime = self.client.runtime_status().map_err(safe_sdk_error)?;
+        let agents = self
+            .client
+            .list_agents()
+            .unwrap_or_else(|_| conu_sdk::AgentDirectory {
+                local: Vec::new(),
+                remote: Vec::new(),
+            });
+
+        Ok(json!({
+            "initialized": snapshot.is_initialized(),
+            "nodeId": snapshot.node.as_ref().map(|node| node.node_id.as_str()),
+            "runtime": runtime.state.as_str(),
+            "localEndpoint": runtime.local_endpoint,
+            "localAgents": agents.local.len(),
+            "remoteAgents": agents.remote.len(),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_security_audit(&self) -> Result<Value, String> {
+        let audit = self.client.security_audit().map_err(safe_sdk_error)?;
+        Ok(json!({
+            "initialized": audit.initialized,
+            "identitySigningKey": audit.identity_signing_key,
+            "identityExchangeKey": audit.identity_exchange_key,
+            "storageKey": audit.storage_key,
+            "replayCache": audit.replay_cache,
+            "keyRotationPlan": audit.key_rotation_plan,
+            "localPayloadEncryption": audit.local_payload_encryption,
+            "signedAgentCards": audit.signed_agent_cards,
+            "peerKeyExchange": audit.peer_key_exchange,
+            "contentsDisplayed": audit.contents_displayed
+        }))
+    }
+
+    fn tool_register_agent(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let agent_id = required_string(args, "agentId")?;
+        self.ensure_agent_allowed(&agent_id)?;
+        let display_name = required_string(args, "displayName")?;
+        let kind = optional_string(args, "kind")?.unwrap_or_else(|| "local-agent".to_string());
+        let capabilities = capabilities_from_args(args)?;
+        let submission = self
+            .client
+            .register_agent_with_capabilities(&agent_id, &display_name, &kind, capabilities)
+            .map_err(safe_sdk_error)?;
+        let process = if optional_bool(args, "process", true)? {
+            Some(self.client.process_queued().map_err(safe_sdk_error)?)
+        } else {
+            None
+        };
+
+        Ok(json!({
+            "status": if process.is_some() { "processed" } else { "queued" },
+            "agentId": agent_id,
+            "requestId": submission.request_id,
+            "processed": process.as_ref().map(|report| report.agents.processed),
+            "rejected": process.as_ref().map(|report| report.agents.rejected),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_set_presence(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let agent_id = required_string(args, "agentId")?;
+        self.ensure_agent_allowed(&agent_id)?;
+        let presence = presence_from_args(args)?;
+        let submission = self
+            .client
+            .set_presence(&agent_id, presence)
+            .map_err(safe_sdk_error)?;
+        let process = if optional_bool(args, "process", true)? {
+            Some(self.client.process_queued().map_err(safe_sdk_error)?)
+        } else {
+            None
+        };
+
+        Ok(json!({
+            "status": if process.is_some() { "processed" } else { "queued" },
+            "agentId": agent_id,
+            "presence": presence.as_str(),
+            "requestId": submission.request_id,
+            "processed": process.as_ref().map(|report| report.agents.processed),
+            "rejected": process.as_ref().map(|report| report.agents.rejected),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_process_queued(&self) -> Result<Value, String> {
+        let report = self.client.process_queued().map_err(safe_sdk_error)?;
+        Ok(json!({
+            "agents": {
+                "processed": report.agents.processed,
+                "rejected": report.agents.rejected,
+                "registeredAgents": report.agents.registered_agents,
+                "heartbeatAgents": report.agents.heartbeat_agents
+            },
+            "messages": {
+                "delivered": report.messages.delivered,
+                "rejected": report.messages.rejected,
+                "envelopeIds": report.messages.envelope_ids
+            },
+            "sessions": {
+                "sessionsSynced": report.sessions.sessions_synced,
+                "remoteAgentsSynced": report.sessions.remote_agents_synced,
+                "connected": report.sessions.connected,
+                "reconnecting": report.sessions.reconnecting,
+                "offline": report.sessions.offline
+            },
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_list_agents(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        if optional_bool(args, "process", false)? {
+            self.client.process_queued().map_err(safe_sdk_error)?;
+        }
+        let directory = self.client.list_agents().map_err(safe_sdk_error)?;
+
+        Ok(json!({
+            "local": directory.local.iter().map(|agent| json!({
+                "agentId": &agent.agent_id,
+                "displayName": &agent.display_name,
+                "kind": &agent.kind,
+                "presence": agent.presence.as_str(),
+                "nodeId": &agent.node_id,
+                "lastSeenUnix": agent.last_seen_unix,
+                "capabilities": capabilities_to_json(&agent.capabilities)
+            })).collect::<Vec<_>>(),
+            "remote": directory.remote.iter().map(|agent| json!({
+                "agentId": &agent.agent_id,
+                "displayName": &agent.display_name,
+                "kind": &agent.kind,
+                "presence": agent.presence.as_str(),
+                "nodeId": &agent.node_id,
+                "peerNodeId": &agent.peer_node_id,
+                "lastSeenUnix": agent.last_seen_unix,
+                "capabilities": capabilities_to_json(&agent.capabilities)
+            })).collect::<Vec<_>>(),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_list_peers(&self) -> Result<Value, String> {
+        let peers = self.client.list_peers().map_err(safe_sdk_error)?;
+        Ok(json!({
+            "peers": peers.iter().map(|peer| json!({
+                "peerNodeId": &peer.peer_node_id,
+                "displayName": &peer.display_name,
+                "status": peer.status.as_str(),
+                "source": &peer.source,
+                "createdAtUnix": peer.created_at_unix,
+                "updatedAtUnix": peer.updated_at_unix
+            })).collect::<Vec<_>>(),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_send_message(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let from_agent_id = required_string(args, "fromAgentId")?;
+        self.ensure_agent_allowed(&from_agent_id)?;
+        let to_agent_id = required_string(args, "toAgentId")?;
+        let payload = payload_from_args(args)?;
+        let submission = self
+            .client
+            .send_message_bytes(&from_agent_id, &to_agent_id, payload)
+            .map_err(safe_sdk_error)?;
+        let process = if optional_bool(args, "process", true)? {
+            Some(self.client.process_queued().map_err(safe_sdk_error)?)
+        } else {
+            None
+        };
+
+        Ok(json!({
+            "status": if process.is_some() { "processed" } else { "queued" },
+            "requestId": submission.request_id,
+            "fromAgentId": from_agent_id,
+            "toAgentId": to_agent_id,
+            "payloadBytes": submission.payload_bytes,
+            "delivered": process.as_ref().map(|report| report.messages.delivered),
+            "rejected": process.as_ref().map(|report| report.messages.rejected),
+            "envelopeIds": process
+                .as_ref()
+                .map(|report| report.messages.envelope_ids.clone())
+                .unwrap_or_default(),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_receive_message(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let agent_id = required_string(args, "agentId")?;
+        self.ensure_agent_allowed(&agent_id)?;
+        let envelope_id = required_string(args, "envelopeId")?;
+        let include_payload = optional_bool(args, "includePayload", false)?;
+        let inbox = self
+            .client
+            .inbox_metadata(&agent_id)
+            .map_err(safe_sdk_error)?;
+        let entry = inbox
+            .iter()
+            .find(|entry| entry.envelope_id == envelope_id)
+            .ok_or_else(|| {
+                "message envelope was not found in the addressed agent inbox".to_string()
+            })?;
+        let mut result = json!({
+            "envelopeId": &entry.envelope_id,
+            "fromAgentId": &entry.from_agent_id,
+            "toAgentId": &entry.to_agent_id,
+            "receiptId": &entry.receipt_id,
+            "deliveredAtUnix": entry.delivered_at_unix,
+            "payloadBytes": entry.payload_bytes,
+            "payloadReturned": false,
+            "contentsDisplayed": false
+        });
+
+        if include_payload {
+            let payload = self
+                .client
+                .receive_message_bytes(&agent_id, &envelope_id)
+                .map_err(safe_sdk_error)?;
+            result["payloadHex"] = Value::String(hex_encode(&payload));
+            result["payloadEncoding"] = Value::String("hex".to_string());
+            result["payloadReturned"] = Value::Bool(true);
+        }
+
+        Ok(result)
+    }
+
+    fn tool_open_stream(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let from_agent_id = required_string(args, "fromAgentId")?;
+        self.ensure_agent_allowed(&from_agent_id)?;
+        let to_agent_id = required_string(args, "toAgentId")?;
+        let kind = optional_string(args, "kind")?.unwrap_or_else(|| "message".to_string());
+        let report = self
+            .client
+            .open_stream(&from_agent_id, &to_agent_id, &kind)
+            .map_err(safe_sdk_error)?;
+
+        Ok(json!({
+            "stream": stream_to_json(&report.stream),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_write_stream(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let stream_id = required_string(args, "streamId")?;
+        self.ensure_stream_owned(&stream_id)?;
+        let payload = payload_from_args(args)?;
+        let report = self
+            .client
+            .write_stream_bytes(&stream_id, payload)
+            .map_err(safe_sdk_error)?;
+
+        Ok(json!({
+            "stream": stream_to_json(&report.stream),
+            "event": {
+                "eventId": report.event.event_id,
+                "eventType": report.event.event_type,
+                "payloadBytes": report.event.payload_bytes,
+                "createdAtUnix": report.event.created_at_unix
+            },
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_close_stream(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let stream_id = required_string(args, "streamId")?;
+        self.ensure_stream_owned(&stream_id)?;
+        let report = self
+            .client
+            .close_stream(&stream_id)
+            .map_err(safe_sdk_error)?;
+
+        Ok(json!({
+            "stream": stream_to_json(&report.stream),
+            "event": {
+                "eventId": report.event.event_id,
+                "eventType": report.event.event_type,
+                "payloadBytes": report.event.payload_bytes,
+                "createdAtUnix": report.event.created_at_unix
+            },
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tools(&self) -> Vec<Value> {
+        vec![
+            tool(
+                "conu_status",
+                "Read conU node, runtime, and agent counts.",
+                schema(json!({}), vec![]),
+            ),
+            tool(
+                "conu_security_audit",
+                "Read conU security-control status without exposing keys or payloads.",
+                schema(json!({}), vec![]),
+            ),
+            tool(
+                "conu_register_agent",
+                "Register the calling agent with conU's local gateway.",
+                schema(
+                    json!({
+                        "agentId": { "type": "string" },
+                        "displayName": { "type": "string" },
+                        "kind": { "type": "string" },
+                        "process": { "type": "boolean" },
+                        "capabilities": capability_schema()
+                    }),
+                    vec!["agentId", "displayName"],
+                ),
+            ),
+            tool(
+                "conu_set_presence",
+                "Publish a local agent presence heartbeat.",
+                schema(
+                    json!({
+                        "agentId": { "type": "string" },
+                        "presence": { "type": "string", "enum": ["ready", "busy", "idle", "offline"] },
+                        "process": { "type": "boolean" }
+                    }),
+                    vec!["agentId", "presence"],
+                ),
+            ),
+            tool(
+                "conu_process_queued",
+                "Process queued conU gateway work once.",
+                schema(json!({}), vec![]),
+            ),
+            tool(
+                "conu_list_agents",
+                "List local and trusted remote agent metadata.",
+                schema(json!({ "process": { "type": "boolean" } }), vec![]),
+            ),
+            tool(
+                "conu_list_peers",
+                "List trusted and revoked peer metadata.",
+                schema(json!({}), vec![]),
+            ),
+            tool(
+                "conu_send_message",
+                "Queue an opaque message. The response reports metadata and byte counts only.",
+                schema(
+                    json!({
+                        "fromAgentId": { "type": "string" },
+                        "toAgentId": { "type": "string" },
+                        "payloadText": { "type": "string" },
+                        "payloadHex": { "type": "string" },
+                        "process": { "type": "boolean" }
+                    }),
+                    vec!["fromAgentId", "toAgentId"],
+                ),
+            ),
+            tool(
+                "conu_receive_message",
+                "Read message metadata, and optionally return payloadHex to the addressed local agent.",
+                schema(
+                    json!({
+                        "agentId": { "type": "string" },
+                        "envelopeId": { "type": "string" },
+                        "includePayload": { "type": "boolean" }
+                    }),
+                    vec!["agentId", "envelopeId"],
+                ),
+            ),
+            tool(
+                "conu_open_stream",
+                "Open a metadata-tracked stream between visible agents.",
+                schema(
+                    json!({
+                        "fromAgentId": { "type": "string" },
+                        "toAgentId": { "type": "string" },
+                        "kind": { "type": "string" }
+                    }),
+                    vec!["fromAgentId", "toAgentId"],
+                ),
+            ),
+            tool(
+                "conu_write_stream",
+                "Record one opaque stream chunk by byte count.",
+                schema(
+                    json!({
+                        "streamId": { "type": "string" },
+                        "payloadText": { "type": "string" },
+                        "payloadHex": { "type": "string" }
+                    }),
+                    vec!["streamId"],
+                ),
+            ),
+            tool(
+                "conu_close_stream",
+                "Close a metadata-tracked stream.",
+                schema(
+                    json!({ "streamId": { "type": "string" } }),
+                    vec!["streamId"],
+                ),
+            ),
+        ]
+    }
+
+    fn ensure_agent_allowed(&self, agent_id: &str) -> Result<(), String> {
+        match self.bound_agent_id.as_deref() {
+            Some(bound) if bound != agent_id => {
+                Err("this conu-mcp server is bound to a different local agent id".to_string())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn ensure_stream_owned(&self, stream_id: &str) -> Result<(), String> {
+        let Some(bound_agent_id) = self.bound_agent_id.as_deref() else {
+            return Ok(());
+        };
+        let stream = self
+            .client
+            .list_streams()
+            .map_err(safe_sdk_error)?
+            .into_iter()
+            .find(|stream| stream.stream_id == stream_id)
+            .ok_or_else(|| "stream is not known".to_string())?;
+
+        if stream.from_agent_id == bound_agent_id {
+            Ok(())
+        } else {
+            Err(
+                "this conu-mcp server cannot write or close a stream owned by another local agent"
+                    .to_string(),
+            )
+        }
+    }
+}
+
+impl Default for McpServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn tool(name: &str, description: &str, input_schema: Value) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "inputSchema": input_schema
+    })
+}
+
+fn schema(properties: Value, required: Vec<&str>) -> Value {
+    json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": false
+    })
+}
+
+fn capability_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "messages": { "type": "boolean" },
+            "streams": { "type": "boolean" },
+            "rooms": { "type": "boolean" },
+            "files": { "type": "boolean" },
+            "presence": { "type": "boolean" }
+        },
+        "additionalProperties": false
+    })
+}
+
+fn tool_success(result: Value) -> Value {
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": serde_json::to_string_pretty(&result).unwrap_or_else(|_| "{}".to_string())
+            }
+        ],
+        "isError": false
+    })
+}
+
+fn tool_failure(message: String) -> Value {
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": message
+            }
+        ],
+        "isError": true
+    })
+}
+
+fn jsonrpc_error(code: i64, message: &str) -> Value {
+    json!({
+        "code": code,
+        "message": message
+    })
+}
+
+fn error_response(id: Value, code: i64, message: &str) -> Value {
+    json!({
+        "jsonrpc": JSONRPC_VERSION,
+        "id": id,
+        "error": jsonrpc_error(code, message)
+    })
+}
+
+fn required_string(args: &Map<String, Value>, key: &'static str) -> Result<String, String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("missing required argument: {key}"))
+}
+
+fn optional_string(args: &Map<String, Value>, key: &'static str) -> Result<Option<String>, String> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if !value.trim().is_empty() => {
+            Ok(Some(value.trim().to_string()))
+        }
+        Some(Value::String(_)) => Ok(None),
+        Some(_) => Err(format!("{key} must be a string")),
+    }
+}
+
+fn optional_bool(
+    args: &Map<String, Value>,
+    key: &'static str,
+    default: bool,
+) -> Result<bool, String> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(default),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(format!("{key} must be a boolean")),
+    }
+}
+
+fn presence_from_args(args: &Map<String, Value>) -> Result<Presence, String> {
+    match required_string(args, "presence")?.as_str() {
+        "ready" => Ok(Presence::Ready),
+        "busy" => Ok(Presence::Busy),
+        "idle" => Ok(Presence::Idle),
+        "offline" => Ok(Presence::Offline),
+        _ => Err("presence must be ready, busy, idle, or offline".to_string()),
+    }
+}
+
+fn capabilities_from_args(args: &Map<String, Value>) -> Result<Capabilities, String> {
+    let mut capabilities = Capabilities::basic();
+    let Some(value) = args.get("capabilities") else {
+        return Ok(capabilities);
+    };
+    let Some(values) = value.as_object() else {
+        return Err("capabilities must be an object".to_string());
+    };
+
+    if let Some(value) = values.get("messages").and_then(Value::as_bool) {
+        capabilities.messages = value;
+    }
+    if let Some(value) = values.get("streams").and_then(Value::as_bool) {
+        capabilities.streams = value;
+    }
+    if let Some(value) = values.get("rooms").and_then(Value::as_bool) {
+        capabilities.rooms = value;
+    }
+    if let Some(value) = values.get("files").and_then(Value::as_bool) {
+        capabilities.files = value;
+    }
+    if let Some(value) = values.get("presence").and_then(Value::as_bool) {
+        capabilities.presence = value;
+    }
+
+    Ok(capabilities)
+}
+
+fn payload_from_args(args: &Map<String, Value>) -> Result<Vec<u8>, String> {
+    let text = optional_string(args, "payloadText")?;
+    let hex = optional_string(args, "payloadHex")?;
+    match (text, hex) {
+        (Some(_), Some(_)) => Err("provide payloadText or payloadHex, not both".to_string()),
+        (Some(value), None) => Ok(value.into_bytes()),
+        (None, Some(value)) => hex_decode(&value),
+        (None, None) => Err("missing payloadText or payloadHex".to_string()),
+    }
+}
+
+fn capabilities_to_json(capabilities: &Capabilities) -> Value {
+    json!({
+        "messages": capabilities.messages,
+        "streams": capabilities.streams,
+        "rooms": capabilities.rooms,
+        "files": capabilities.files,
+        "presence": capabilities.presence
+    })
+}
+
+fn stream_to_json(stream: &Stream) -> Value {
+    json!({
+        "streamId": &stream.stream_id,
+        "fromAgentId": &stream.from_agent_id,
+        "toAgentId": &stream.to_agent_id,
+        "kind": &stream.kind,
+        "state": stream.state.as_str(),
+        "route": &stream.route,
+        "chunksWritten": stream.chunks_written,
+        "bytesWritten": stream.bytes_written,
+        "backpressureWindow": stream.backpressure_window,
+        "openedAtUnix": stream.opened_at_unix,
+        "updatedAtUnix": stream.updated_at_unix
+    })
+}
+
+fn safe_sdk_error(error: SdkError) -> String {
+    error.to_string()
+}
+
+fn bound_agent_from_env() -> Option<String> {
+    std::env::var("CONU_AGENT_ID")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn hex_decode(value: &str) -> Result<Vec<u8>, String> {
+    let value = value.trim();
+    if value.len() % 2 != 0 {
+        return Err("payloadHex must have an even number of characters".to_string());
+    }
+
+    let mut bytes = Vec::with_capacity(value.len() / 2);
+    for pair in value.as_bytes().chunks_exact(2) {
+        let high = hex_nibble(pair[0])?;
+        let low = hex_nibble(pair[1])?;
+        bytes.push((high << 4) | low);
+    }
+    Ok(bytes)
+}
+
+fn hex_nibble(byte: u8) -> Result<u8, String> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err("payloadHex must contain only hex characters".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::process;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn initialize_advertises_tools_capability() {
+        let server = McpServer::with_home(test_home("init"));
+        let response = request(&server, 1, "initialize", json!({}));
+
+        assert_eq!(
+            response["result"]["protocolVersion"],
+            Value::String(MCP_PROTOCOL_VERSION.to_string())
+        );
+        assert!(response["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[test]
+    fn tools_list_includes_agent_message_and_stream_tools() {
+        let server = McpServer::with_home(test_home("tools"));
+        let response = request(&server, 1, "tools/list", json!({}));
+        let body = response.to_string();
+
+        assert!(body.contains("conu_register_agent"));
+        assert!(body.contains("conu_send_message"));
+        assert!(body.contains("conu_receive_message"));
+        assert!(body.contains("conu_open_stream"));
+    }
+
+    #[test]
+    fn message_tool_flow_keeps_send_and_metadata_reads_payload_safe() {
+        let server = McpServer::with_home(test_home("message-flow"));
+        call_tool(
+            &server,
+            1,
+            "conu_register_agent",
+            json!({
+                "agentId": "agent.sender",
+                "displayName": "Sender"
+            }),
+        );
+        call_tool(
+            &server,
+            2,
+            "conu_register_agent",
+            json!({
+                "agentId": "agent.receiver",
+                "displayName": "Receiver"
+            }),
+        );
+        let send = call_tool(
+            &server,
+            3,
+            "conu_send_message",
+            json!({
+                "fromAgentId": "agent.sender",
+                "toAgentId": "agent.receiver",
+                "payloadText": "private message contents"
+            }),
+        );
+        let send_response = send.to_string();
+        assert!(!send_response.contains("private message contents"));
+
+        let send_text = tool_text(&send);
+        let send_payload: Value = serde_json::from_str(&send_text).expect("send tool text json");
+        let envelope_id = send_payload["envelopeIds"][0]
+            .as_str()
+            .expect("envelope id")
+            .to_string();
+        let metadata = call_tool(
+            &server,
+            4,
+            "conu_receive_message",
+            json!({
+                "agentId": "agent.receiver",
+                "envelopeId": envelope_id
+            }),
+        );
+        let metadata_text = tool_text(&metadata);
+
+        assert!(metadata_text.contains("\"payloadReturned\": false"));
+        assert!(!metadata_text.contains("private message contents"));
+    }
+
+    #[test]
+    fn receive_payload_returns_hex_only_when_requested() {
+        let server = McpServer::with_home(test_home("receive-payload"));
+        call_tool(
+            &server,
+            1,
+            "conu_register_agent",
+            json!({ "agentId": "agent.sender", "displayName": "Sender" }),
+        );
+        call_tool(
+            &server,
+            2,
+            "conu_register_agent",
+            json!({ "agentId": "agent.receiver", "displayName": "Receiver" }),
+        );
+        let send = call_tool(
+            &server,
+            3,
+            "conu_send_message",
+            json!({
+                "fromAgentId": "agent.sender",
+                "toAgentId": "agent.receiver",
+                "payloadText": "private message contents"
+            }),
+        );
+        let send_payload: Value =
+            serde_json::from_str(&tool_text(&send)).expect("send text parses");
+        let envelope_id = send_payload["envelopeIds"][0]
+            .as_str()
+            .expect("envelope id");
+        let received = call_tool(
+            &server,
+            4,
+            "conu_receive_message",
+            json!({
+                "agentId": "agent.receiver",
+                "envelopeId": envelope_id,
+                "includePayload": true
+            }),
+        );
+        let text = tool_text(&received);
+
+        assert!(text.contains("\"payloadReturned\": true"));
+        assert!(text.contains("\"payloadEncoding\": \"hex\""));
+        assert!(text.contains("70726976617465206d65737361676520636f6e74656e7473"));
+        assert!(!text.contains("private message contents"));
+    }
+
+    #[test]
+    fn bound_server_cannot_act_as_another_agent() {
+        let home = test_home("bound-agent");
+        let setup = McpServer::with_home(home.clone());
+        call_tool(
+            &setup,
+            1,
+            "conu_register_agent",
+            json!({ "agentId": "agent.sender", "displayName": "Sender" }),
+        );
+        call_tool(
+            &setup,
+            2,
+            "conu_register_agent",
+            json!({ "agentId": "agent.receiver", "displayName": "Receiver" }),
+        );
+        let bound = McpServer::with_home_and_agent(home, "agent.sender");
+        let blocked = call_tool(
+            &bound,
+            3,
+            "conu_send_message",
+            json!({
+                "fromAgentId": "agent.receiver",
+                "toAgentId": "agent.sender",
+                "payloadText": "private message contents"
+            }),
+        );
+
+        assert_eq!(blocked["result"]["isError"], Value::Bool(true));
+        assert!(tool_text(&blocked).contains("bound to a different local agent id"));
+        assert!(!blocked.to_string().contains("private message contents"));
+    }
+
+    fn request(server: &McpServer, id: u64, method: &str, params: Value) -> Value {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        })
+        .to_string();
+        let response = server.handle_line(&line).expect("response");
+        serde_json::from_str(&response).expect("response parses")
+    }
+
+    fn call_tool(server: &McpServer, id: u64, name: &str, arguments: Value) -> Value {
+        request(
+            server,
+            id,
+            "tools/call",
+            json!({
+                "name": name,
+                "arguments": arguments
+            }),
+        )
+    }
+
+    fn tool_text(response: &Value) -> String {
+        response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("tool text")
+            .to_string()
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        env::temp_dir().join(format!("conu-mcp-test-{label}-{}-{nonce}", process::id()))
+    }
+}

--- a/crates/conu-mcp/src/main.rs
+++ b/crates/conu-mcp/src/main.rs
@@ -1,0 +1,27 @@
+use std::io::{self, BufRead, Write};
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let server = conu_mcp::McpServer::default();
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        match line {
+            Ok(line) => {
+                if let Some(response) = server.handle_line(&line) {
+                    if writeln!(stdout, "{response}").is_err() || stdout.flush().is_err() {
+                        eprintln!("conu-mcp failed to write MCP response");
+                        return ExitCode::from(1);
+                    }
+                }
+            }
+            Err(error) => {
+                eprintln!("conu-mcp failed to read MCP input: {error}");
+                return ExitCode::from(1);
+            }
+        }
+    }
+
+    ExitCode::SUCCESS
+}

--- a/crates/conu-sdk/Cargo.toml
+++ b/crates/conu-sdk/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "conu-sdk"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+conu-core.workspace = true
+conu-protocol.workspace = true
+
+[lints]
+workspace = true

--- a/crates/conu-sdk/examples/local_agents.rs
+++ b/crates/conu-sdk/examples/local_agents.rs
@@ -1,0 +1,43 @@
+use std::env;
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use conu_sdk::ConuClient;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = ConuClient::with_home(example_home());
+
+    client.init()?;
+    client.register_agent(
+        "agent.example.alice",
+        "Alice Example Agent",
+        "example-agent",
+    )?;
+    client.register_agent("agent.example.bob", "Bob Example Agent", "example-agent")?;
+    client.process_queued()?;
+
+    let sent = client.send_message_text(
+        "agent.example.alice",
+        "agent.example.bob",
+        "example private payload",
+    )?;
+    let processed = client.process_queued()?;
+    let inbox = client.inbox_metadata("agent.example.bob")?;
+    let received = client.receive_message_bytes("agent.example.bob", &inbox[0].envelope_id)?;
+
+    println!("queued request {}", sent.request_id);
+    println!("delivered envelopes {}", processed.messages.delivered);
+    println!("bob received {} opaque bytes", received.len());
+    println!("payload contents were not displayed by conU");
+
+    Ok(())
+}
+
+fn example_home() -> std::path::PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+
+    env::temp_dir().join(format!("conu-sdk-example-{}-{nonce}", process::id()))
+}

--- a/crates/conu-sdk/src/lib.rs
+++ b/crates/conu-sdk/src/lib.rs
@@ -1,0 +1,499 @@
+//! Agent-facing SDK for conU.
+//!
+//! This crate gives agents a narrow, typed way to use conU as a connection
+//! layer. It intentionally mirrors the core gateway surfaces and keeps list,
+//! send, receipt, and stream operations metadata-only. Payload bytes are only
+//! returned by explicit receive calls for the addressed local agent.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use conu_core::agents::{
+    self, AgentPresence, AgentRegistration, GatewayProcessReport, GatewaySubmission,
+    LocalAgentRecord, PresenceHeartbeat,
+};
+use conu_core::messages::{
+    self, DeliveryReceipt, InboxEntry, LocalMessage, MessageProcessReport, MessageSubmission,
+};
+use conu_core::runtime::{self, RuntimeStatus};
+use conu_core::security::{self, SecurityAudit};
+use conu_core::sessions::{self, RemoteAgentRecord, RemoteSession, SessionSyncReport};
+use conu_core::state::{self, InitReport, StateSnapshot};
+use conu_core::streams::{
+    self, StreamCloseReport, StreamEvent, StreamOpenReport, StreamRecord, StreamWriteReport,
+};
+use conu_core::trust::{self, JoinReport, PairingInvite, RevokeReport, TrustedPeer};
+use conu_protocol::{AgentCapabilities, OpaquePayload};
+
+pub use conu_core::agents::AgentPresence as Presence;
+pub use conu_core::streams::StreamRecord as Stream;
+pub use conu_protocol::AgentCapabilities as Capabilities;
+
+/// High-level SDK client bound to a conU state home.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConuClient {
+    home: Option<PathBuf>,
+}
+
+impl ConuClient {
+    /// Use the default conU state home for this user.
+    pub fn new() -> Self {
+        Self { home: None }
+    }
+
+    /// Use a specific conU state home. This is useful for agent sandboxes and tests.
+    pub fn with_home(home: impl Into<PathBuf>) -> Self {
+        Self {
+            home: Some(home.into()),
+        }
+    }
+
+    /// Return the configured home override, if this client has one.
+    pub fn home(&self) -> Option<&PathBuf> {
+        self.home.as_ref()
+    }
+
+    /// Initialize local conU state and security material.
+    pub fn init(&self) -> Result<InitReport, SdkError> {
+        let report = state::init_state(self.home_override())?;
+        security::ensure_security_state_from_paths(&report.paths)?;
+        Ok(report)
+    }
+
+    /// Read local state without creating missing files.
+    pub fn state_snapshot(&self) -> Result<StateSnapshot, SdkError> {
+        Ok(state::read_state(self.home_override())?)
+    }
+
+    /// Read current conUD runtime metadata.
+    pub fn runtime_status(&self) -> Result<RuntimeStatus, SdkError> {
+        Ok(runtime::read_runtime(self.home_override())?)
+    }
+
+    /// Run the local security audit.
+    pub fn security_audit(&self) -> Result<SecurityAudit, SdkError> {
+        Ok(security::security_audit(self.home_override())?)
+    }
+
+    /// Register an agent with the default message/presence capabilities.
+    pub fn register_agent(
+        &self,
+        agent_id: impl Into<String>,
+        display_name: impl Into<String>,
+        kind: impl Into<String>,
+    ) -> Result<GatewaySubmission, SdkError> {
+        let registration = AgentRegistration::new(agent_id, display_name, kind)?;
+        Ok(agents::submit_registration(
+            self.home_override(),
+            registration,
+        )?)
+    }
+
+    /// Register an agent with an explicit capability set.
+    pub fn register_agent_with_capabilities(
+        &self,
+        agent_id: impl Into<String>,
+        display_name: impl Into<String>,
+        kind: impl Into<String>,
+        capabilities: AgentCapabilities,
+    ) -> Result<GatewaySubmission, SdkError> {
+        let mut registration = AgentRegistration::new(agent_id, display_name, kind)?;
+        registration.capabilities = capabilities;
+        Ok(agents::submit_registration(
+            self.home_override(),
+            registration,
+        )?)
+    }
+
+    /// Submit an agent presence heartbeat.
+    pub fn set_presence(
+        &self,
+        agent_id: impl Into<String>,
+        presence: AgentPresence,
+    ) -> Result<GatewaySubmission, SdkError> {
+        let heartbeat = PresenceHeartbeat::new(agent_id, presence)?;
+        Ok(agents::submit_presence_heartbeat(
+            self.home_override(),
+            heartbeat,
+        )?)
+    }
+
+    /// Process all queued local gateway work once.
+    pub fn process_queued(&self) -> Result<ProcessReport, SdkError> {
+        let agents = agents::process_gateway_requests(self.home_override())?;
+        let messages = messages::process_message_requests(self.home_override())?;
+        let sessions = sessions::sync_remote_sessions(self.home_override())?;
+
+        Ok(ProcessReport {
+            agents,
+            messages,
+            sessions,
+        })
+    }
+
+    /// List local and mirrored remote agents.
+    pub fn list_agents(&self) -> Result<AgentDirectory, SdkError> {
+        Ok(AgentDirectory {
+            local: agents::list_local_agents(self.home_override())?,
+            remote: sessions::list_remote_agents(self.home_override())?,
+        })
+    }
+
+    /// List trusted/revoked peers.
+    pub fn list_peers(&self) -> Result<Vec<TrustedPeer>, SdkError> {
+        Ok(trust::list_peers(self.home_override())?)
+    }
+
+    /// Create a local pairing invitation.
+    pub fn create_pairing_invite(&self) -> Result<PairingInvite, SdkError> {
+        Ok(trust::create_pairing_invite(self.home_override())?)
+    }
+
+    /// Join a local pairing code.
+    pub fn join_pairing_code(&self, code: &str) -> Result<JoinReport, SdkError> {
+        Ok(trust::join_pairing_code(self.home_override(), code)?)
+    }
+
+    /// Revoke a trusted peer.
+    pub fn revoke_peer(&self, peer_node_id: &str) -> Result<RevokeReport, SdkError> {
+        Ok(trust::revoke_peer(self.home_override(), peer_node_id)?)
+    }
+
+    /// List remote runtime sessions.
+    pub fn list_remote_sessions(&self) -> Result<Vec<RemoteSession>, SdkError> {
+        Ok(sessions::list_remote_sessions(self.home_override())?)
+    }
+
+    /// List mirrored remote agent cards.
+    pub fn list_remote_agents(&self) -> Result<Vec<RemoteAgentRecord>, SdkError> {
+        Ok(sessions::list_remote_agents(self.home_override())?)
+    }
+
+    /// Queue an opaque one-shot message.
+    pub fn send_message_bytes(
+        &self,
+        from_agent_id: impl Into<String>,
+        to_agent_id: impl Into<String>,
+        payload: impl Into<Vec<u8>>,
+    ) -> Result<MessageSubmission, SdkError> {
+        let message = LocalMessage::new(
+            from_agent_id,
+            to_agent_id,
+            OpaquePayload::from_bytes(payload.into()),
+        )?;
+        Ok(messages::submit_local_message(
+            self.home_override(),
+            message,
+        )?)
+    }
+
+    /// Queue a UTF-8 message as opaque bytes.
+    pub fn send_message_text(
+        &self,
+        from_agent_id: impl Into<String>,
+        to_agent_id: impl Into<String>,
+        payload: impl Into<String>,
+    ) -> Result<MessageSubmission, SdkError> {
+        self.send_message_bytes(from_agent_id, to_agent_id, payload.into().into_bytes())
+    }
+
+    /// List metadata for messages delivered to a local agent.
+    pub fn inbox_metadata(&self, agent_id: &str) -> Result<Vec<InboxEntry>, SdkError> {
+        Ok(messages::list_agent_inbox(self.home_override(), agent_id)?)
+    }
+
+    /// Read payload bytes for a delivered local message addressed to `agent_id`.
+    pub fn receive_message_bytes(
+        &self,
+        agent_id: &str,
+        envelope_id: &str,
+    ) -> Result<Vec<u8>, SdkError> {
+        let inbox = messages::list_agent_inbox(self.home_override(), agent_id)?;
+        let Some(entry) = inbox.iter().find(|entry| entry.envelope_id == envelope_id) else {
+            return Err(SdkError::EnvelopeNotFound {
+                agent_id: agent_id.to_string(),
+                envelope_id: envelope_id.to_string(),
+            });
+        };
+
+        if entry.to_agent_id != agent_id {
+            return Err(SdkError::UnauthorizedReceive {
+                agent_id: agent_id.to_string(),
+                envelope_id: envelope_id.to_string(),
+            });
+        }
+
+        let payload = messages::read_message_payload(self.home_override(), agent_id, envelope_id)?;
+        Ok(payload.as_bytes().to_vec())
+    }
+
+    /// List metadata-only delivery receipts.
+    pub fn list_receipts(&self) -> Result<Vec<DeliveryReceipt>, SdkError> {
+        Ok(messages::list_receipts(self.home_override())?)
+    }
+
+    /// Open a metadata-tracked stream.
+    pub fn open_stream(
+        &self,
+        from_agent_id: &str,
+        to_agent_id: &str,
+        kind: &str,
+    ) -> Result<StreamOpenReport, SdkError> {
+        Ok(streams::open_stream(
+            self.home_override(),
+            from_agent_id,
+            to_agent_id,
+            kind,
+        )?)
+    }
+
+    /// Record one opaque stream chunk by byte count.
+    pub fn write_stream_bytes(
+        &self,
+        stream_id: &str,
+        payload: impl Into<Vec<u8>>,
+    ) -> Result<StreamWriteReport, SdkError> {
+        Ok(streams::write_stream(
+            self.home_override(),
+            stream_id,
+            OpaquePayload::from_bytes(payload.into()),
+        )?)
+    }
+
+    /// Close an open stream.
+    pub fn close_stream(&self, stream_id: &str) -> Result<StreamCloseReport, SdkError> {
+        Ok(streams::close_stream(self.home_override(), stream_id)?)
+    }
+
+    /// List stream metadata.
+    pub fn list_streams(&self) -> Result<Vec<StreamRecord>, SdkError> {
+        Ok(streams::list_streams(self.home_override())?)
+    }
+
+    /// List payload-safe stream events.
+    pub fn list_stream_events(&self) -> Result<Vec<StreamEvent>, SdkError> {
+        Ok(streams::list_events(self.home_override())?)
+    }
+
+    fn home_override(&self) -> Option<PathBuf> {
+        self.home.clone()
+    }
+}
+
+/// Local + remote agent directory view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentDirectory {
+    pub local: Vec<LocalAgentRecord>,
+    pub remote: Vec<RemoteAgentRecord>,
+}
+
+/// Result of one SDK-driven processing pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessReport {
+    pub agents: GatewayProcessReport,
+    pub messages: MessageProcessReport,
+    pub sessions: SessionSyncReport,
+}
+
+/// Errors returned by the SDK.
+#[derive(Debug)]
+pub enum SdkError {
+    State(state::StateError),
+    Security(security::SecurityError),
+    Agent(agents::AgentError),
+    Message(messages::MessageError),
+    Runtime(runtime::RuntimeError),
+    Session(sessions::SessionError),
+    Stream(streams::StreamError),
+    Trust(trust::TrustError),
+    EnvelopeNotFound {
+        agent_id: String,
+        envelope_id: String,
+    },
+    UnauthorizedReceive {
+        agent_id: String,
+        envelope_id: String,
+    },
+}
+
+impl fmt::Display for SdkError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Security(error) => write!(formatter, "{error}"),
+            Self::Agent(error) => write!(formatter, "{error}"),
+            Self::Message(error) => write!(formatter, "{error}"),
+            Self::Runtime(error) => write!(formatter, "{error}"),
+            Self::Session(error) => write!(formatter, "{error}"),
+            Self::Stream(error) => write!(formatter, "{error}"),
+            Self::Trust(error) => write!(formatter, "{error}"),
+            Self::EnvelopeNotFound {
+                agent_id,
+                envelope_id,
+            } => write!(
+                formatter,
+                "message envelope {envelope_id} was not found in {agent_id}'s inbox"
+            ),
+            Self::UnauthorizedReceive {
+                agent_id,
+                envelope_id,
+            } => write!(
+                formatter,
+                "agent {agent_id} is not authorized to receive envelope {envelope_id}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SdkError {}
+
+impl From<state::StateError> for SdkError {
+    fn from(error: state::StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+impl From<security::SecurityError> for SdkError {
+    fn from(error: security::SecurityError) -> Self {
+        Self::Security(error)
+    }
+}
+
+impl From<agents::AgentError> for SdkError {
+    fn from(error: agents::AgentError) -> Self {
+        Self::Agent(error)
+    }
+}
+
+impl From<messages::MessageError> for SdkError {
+    fn from(error: messages::MessageError) -> Self {
+        Self::Message(error)
+    }
+}
+
+impl From<runtime::RuntimeError> for SdkError {
+    fn from(error: runtime::RuntimeError) -> Self {
+        Self::Runtime(error)
+    }
+}
+
+impl From<sessions::SessionError> for SdkError {
+    fn from(error: sessions::SessionError) -> Self {
+        Self::Session(error)
+    }
+}
+
+impl From<streams::StreamError> for SdkError {
+    fn from(error: streams::StreamError) -> Self {
+        Self::Stream(error)
+    }
+}
+
+impl From<trust::TrustError> for SdkError {
+    fn from(error: trust::TrustError) -> Self {
+        Self::Trust(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::process;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn sdk_sends_and_receives_opaque_payload_for_addressed_agent() {
+        let client = ConuClient::with_home(test_home("send-receive"));
+        client.init().expect("state initializes");
+        client
+            .register_agent("agent.sender", "Sender", "test-agent")
+            .expect("sender registers");
+        client
+            .register_agent("agent.receiver", "Receiver", "test-agent")
+            .expect("receiver registers");
+        let agent_report = client.process_queued().expect("registrations process");
+        let sent = client
+            .send_message_bytes(
+                "agent.sender",
+                "agent.receiver",
+                b"private message contents",
+            )
+            .expect("message queues");
+        let message_report = client.process_queued().expect("message processes");
+        let inbox = client
+            .inbox_metadata("agent.receiver")
+            .expect("inbox metadata reads");
+        let received = client
+            .receive_message_bytes("agent.receiver", &inbox[0].envelope_id)
+            .expect("payload reads");
+
+        assert_eq!(agent_report.agents.processed, 2);
+        assert_eq!(sent.payload_bytes, 24);
+        assert_eq!(message_report.messages.delivered, 1);
+        assert_eq!(inbox[0].payload_bytes, 24);
+        assert_eq!(received, b"private message contents");
+    }
+
+    #[test]
+    fn sdk_receive_is_scoped_to_recipient_inbox() {
+        let client = ConuClient::with_home(test_home("scoped-receive"));
+        client.init().expect("state initializes");
+        client
+            .register_agent("agent.sender", "Sender", "test-agent")
+            .expect("sender registers");
+        client
+            .register_agent("agent.receiver", "Receiver", "test-agent")
+            .expect("receiver registers");
+        client.process_queued().expect("registrations process");
+        client
+            .send_message_bytes(
+                "agent.sender",
+                "agent.receiver",
+                b"private message contents",
+            )
+            .expect("message queues");
+        client.process_queued().expect("message processes");
+        let inbox = client
+            .inbox_metadata("agent.receiver")
+            .expect("inbox metadata reads");
+        let error = client
+            .receive_message_bytes("agent.sender", &inbox[0].envelope_id)
+            .expect_err("wrong local agent cannot receive");
+
+        assert!(matches!(error, SdkError::EnvelopeNotFound { .. }));
+    }
+
+    #[test]
+    fn sdk_debug_metadata_does_not_expose_payload_contents() {
+        let client = ConuClient::with_home(test_home("debug"));
+        client.init().expect("state initializes");
+        client
+            .register_agent("agent.sender", "Sender", "test-agent")
+            .expect("sender registers");
+        client
+            .register_agent("agent.receiver", "Receiver", "test-agent")
+            .expect("receiver registers");
+        let process = client.process_queued().expect("registrations process");
+        let sent = client
+            .send_message_bytes(
+                "agent.sender",
+                "agent.receiver",
+                b"private message contents",
+            )
+            .expect("message queues");
+        let debug = format!("{process:?}\n{sent:?}");
+
+        assert!(!debug.contains("private message contents"));
+        assert!(!debug.contains("Review this code"));
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        env::temp_dir().join(format!("conu-sdk-test-{label}-{}-{nonce}", process::id()))
+    }
+}

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -17,8 +17,11 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 - Remote session and remote agent metadata mirror for trusted peers.
 - Stream lifecycle metadata, backpressure counters, and private watch animation.
 - Replay protection for local message request and envelope ids.
+- Rust SDK for local agent registration, messaging, receive, peer, security, and stream calls.
+- Python stdlib wrapper SDK around installed `conu` and `conud` binaries.
+- MCP stdio adapter exposing conU as JSON-RPC tools for MCP-capable agents.
 - Payload-safe logs, receipts, watch output, and CLI JSON.
-- Phase 11 security audit command.
+- Phase 11 security audit command and Phase 12 SDK/MCP receive path.
 
 ## Still Local Or Groundwork
 
@@ -27,12 +30,15 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 - The relay forwards metadata frames, but conUD does not yet own a live relay client for data-plane delivery.
 - Stream writes count bytes and emit events. They do not persist or relay chunk bytes yet.
 - Pairing is local trust-store groundwork, not full cross-machine rendezvous.
+- MCP is stdio-only. HTTP MCP transport, auth, and remote MCP hosting are intentionally not implemented.
+- TypeScript SDK remains future work.
 
 ## Release Blockers
 
 - Live relay-backed encrypted message and stream routing.
 - Remote signed agent-card exchange and verification.
 - Capability grants and user-visible permission policy.
+- SDK permission policy hardening before public package distribution.
 - OS-backed private key storage.
 - Key rotation migration tooling.
 - Installer/service setup for Windows, macOS, and Linux.
@@ -59,6 +65,8 @@ On Windows machines without Visual Studio C++ Build Tools, the default MSVC tool
 Every release candidate must confirm:
 
 - CLI output does not show message text, prompt text, reasoning, file contents, private keys, or shared secrets.
+- SDK/MCP list, send, status, receipt, and stream outputs stay metadata-only.
+- SDK/MCP receive APIs return payload bytes only to the addressed local agent by explicit request.
 - Logs use `payload=not_observed` or metadata-only equivalents.
 - Relay frames reject plaintext payload fields.
 - Message and mailbox storage use encrypted payload fields.

--- a/docs/sdk-and-mcp.md
+++ b/docs/sdk-and-mcp.md
@@ -1,0 +1,141 @@
+# conU SDK And MCP Adapter
+
+Phase 12 gives agents stable ways to call conU without learning its internal file layout.
+
+The contract stays the same:
+
+```txt
+Agents own the conversation.
+conU owns the connection.
+```
+
+conU list, send, receipt, status, watch, and stream outputs are metadata-only. Payload bytes are returned only through an explicit receive API for the addressed local agent.
+
+## Rust SDK
+
+The Rust SDK lives in `crates/conu-sdk`.
+
+```rust
+use conu_sdk::ConuClient;
+
+let client = ConuClient::new();
+client.init()?;
+client.register_agent("agent.alpha", "Alpha", "local-agent")?;
+client.register_agent("agent.beta", "Beta", "local-agent")?;
+client.process_queued()?;
+
+client.send_message_bytes("agent.alpha", "agent.beta", b"private bytes")?;
+let report = client.process_queued()?;
+let inbox = client.inbox_metadata("agent.beta")?;
+let payload = client.receive_message_bytes("agent.beta", &inbox[0].envelope_id)?;
+```
+
+Useful calls:
+
+```txt
+init()
+state_snapshot()
+runtime_status()
+security_audit()
+register_agent()
+register_agent_with_capabilities()
+set_presence()
+process_queued()
+list_agents()
+list_peers()
+send_message_bytes()
+inbox_metadata()
+receive_message_bytes()
+list_receipts()
+open_stream()
+write_stream_bytes()
+close_stream()
+list_streams()
+list_stream_events()
+```
+
+Run the example:
+
+```bash
+cargo +stable-x86_64-pc-windows-gnu run -p conu-sdk --example local_agents
+```
+
+## Python SDK
+
+The Python wrapper lives in `sdk/python/conu_sdk`. It is stdlib-only and wraps installed `conu` and `conud` binaries.
+
+```powershell
+$env:PYTHONPATH = "$PWD\sdk\python"
+```
+
+```python
+from conu_sdk import ConuClient
+
+client = ConuClient(home=".conu-agent")
+client.init()
+client.register_agent("agent.alpha", "Alpha")
+client.register_agent("agent.beta", "Beta")
+client.process_queued()
+sent = client.send_message("agent.alpha", "agent.beta", b"private bytes")
+print(sent["payloadBytes"])
+```
+
+The wrapper passes send/stream payload bytes through stdin and returns command output to the caller. It does not print or log payloads.
+
+## MCP Adapter
+
+The MCP adapter lives in `crates/conu-mcp` and runs as a stdio server:
+
+```bash
+cargo +stable-x86_64-pc-windows-gnu run -p conu-mcp
+```
+
+Installed usage:
+
+```json
+{
+  "mcpServers": {
+    "conu": {
+      "command": "conu-mcp",
+      "env": {
+        "CONU_HOME": "C:\\Users\\you\\AppData\\Roaming\\conU",
+        "CONU_AGENT_ID": "agent.mybot"
+      }
+    }
+  }
+}
+```
+
+Implemented MCP tools:
+
+```txt
+conu_status
+conu_security_audit
+conu_register_agent
+conu_set_presence
+conu_process_queued
+conu_list_agents
+conu_list_peers
+conu_send_message
+conu_receive_message
+conu_open_stream
+conu_write_stream
+conu_close_stream
+```
+
+`conu_send_message` accepts `payloadText` or `payloadHex`, but the tool response reports only request id, byte count, delivery counts, and envelope ids. `conu_receive_message` returns metadata by default. It returns `payloadHex` only when `includePayload` is `true`.
+
+When `CONU_AGENT_ID` is set, `conu-mcp` is bound to that local agent id. Register, presence, send, receive, stream open, stream write, and stream close actions are rejected if they attempt to act as a different local agent.
+
+## MCP Protocol Notes
+
+The adapter follows MCP stdio as JSON-RPC 2.0 over stdin/stdout, with newline-delimited messages and no non-MCP data on stdout. This matches the latest MCP transport documentation, which defines stdio messages as JSON-RPC messages delimited by newlines.
+
+Reference: [MCP 2025-11-25 Transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
+
+## Current Boundaries
+
+- TypeScript SDK remains future work.
+- Remote relay-backed data-plane delivery is not active yet.
+- MCP uses local stdio only; HTTP MCP transport is not implemented.
+- `conu_receive_message` is intentionally explicit because normal CLI and tool metadata views must not display payload contents.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -71,6 +71,14 @@ conu security audit --json
 
 The audit reports whether local signing, exchange, storage encryption, replay cache, and key rotation plan are ready. It never displays private keys, shared secrets, plaintext payloads, or decrypted payloads.
 
+## SDK And MCP Receive Boundary
+
+Phase 12 adds agent-facing receive APIs without changing CLI privacy:
+
+- `conu_sdk::ConuClient::receive_message_bytes(agent_id, envelope_id)` returns bytes only after the envelope is found in that local agent inbox.
+- `conu-mcp` returns message metadata by default and only returns `payloadHex` when `conu_receive_message` is called with `includePayload: true`.
+- `conu-mcp` stdout is reserved for valid MCP JSON-RPC messages; send/list/status/stream tool responses do not echo payload text.
+
 ## Production Gaps
 
 Phase 11 hardens the current local product surface, but these items still need dedicated future work:
@@ -80,6 +88,7 @@ Phase 11 hardens the current local product surface, but these items still need d
 - Live relay-backed encrypted envelope routing using the peer key agreement helpers.
 - Signed remote agent-card exchange over real sessions instead of derived metadata mirrors.
 - Permission grants that bind trusted peers to specific local agent actions.
+- SDK/MCP permission hardening for multi-tenant or hosted deployments.
 - Encrypted mailbox storage and retention policy.
 - CI on Windows, macOS, and Linux with security/privacy regression scans.
 

--- a/docs/user-install-and-agent-guide.md
+++ b/docs/user-install-and-agent-guide.md
@@ -2,7 +2,7 @@
 
 This guide explains how a user can install the current conU app, start it on their PC, and let local agents use it.
 
-Current version status: Phase 11 is complete. conU is usable for local agent registration, local encrypted-at-rest message submission, stream metadata, trust metadata, and private CLI watch output. It is not yet a packaged consumer release, and it does not yet include the Phase 12 SDK/MCP adapter.
+Current version status: Phase 12 is complete. conU is usable for local agent registration, local encrypted-at-rest message submission, stream metadata, trust metadata, private CLI watch output, Rust SDK calls, a Python wrapper SDK, and an MCP stdio adapter. It is not yet a packaged consumer release.
 
 ## What Works Today
 
@@ -14,13 +14,15 @@ Current version status: Phase 11 is complete. conU is usable for local agent reg
 - Store new conU-owned local payload files encrypted at rest.
 - List inbox, receipt, stream, peer, session, and security metadata.
 - Run a standalone `conu-relay` MVP for metadata-only relay frame tests.
+- Let Rust agents use `conu_sdk::ConuClient`.
+- Let Python agents use `sdk/python/conu_sdk`.
+- Let MCP-capable agents launch `conu-mcp` and call conU tools.
 
 ## What Does Not Work Yet
 
 - No one-click installer or signed release package.
-- No stable SDK for Python, TypeScript, or Rust agent apps yet.
-- No MCP adapter yet.
-- No CLI command that reveals message contents. This is intentional, but it also means a clean external receive API is still Phase 12 work.
+- No TypeScript SDK yet.
+- No CLI command that reveals message contents. This is intentional; use SDK or MCP explicit receive APIs when the addressed local agent needs payload bytes.
 - No live internet data-plane routing between two real conUD nodes yet.
 - Pairing and remote sessions are local metadata groundwork, not full cross-machine rendezvous.
 - `conu-relay` exists, but conUD does not yet own a live relay client for encrypted message/stream byte delivery.
@@ -54,6 +56,7 @@ Windows PowerShell:
 cargo +stable-x86_64-pc-windows-gnu install --path crates/conu-cli --locked --force
 cargo +stable-x86_64-pc-windows-gnu install --path crates/conud --locked --force
 cargo +stable-x86_64-pc-windows-gnu install --path crates/conu-relay --locked --force
+cargo +stable-x86_64-pc-windows-gnu install --path crates/conu-mcp --locked --force
 ```
 
 macOS/Linux shell, assuming the default toolchain links successfully:
@@ -62,6 +65,7 @@ macOS/Linux shell, assuming the default toolchain links successfully:
 cargo install --path crates/conu-cli --locked --force
 cargo install --path crates/conud --locked --force
 cargo install --path crates/conu-relay --locked --force
+cargo install --path crates/conu-mcp --locked --force
 ```
 
 Make sure Cargo's bin directory is on `PATH`.
@@ -85,6 +89,8 @@ conu --version
 conud --check
 conu-relay --check
 ```
+
+`conu-mcp` is a stdio server for MCP clients, so it normally waits for JSON-RPC input instead of printing a standalone check screen.
 
 ## First Run
 
@@ -161,9 +167,83 @@ conu messages receipts --json
 
 The inbox command shows metadata only: envelope id, sender, receiver, receipt id, byte count, and delivery time. It does not print the payload.
 
-## Give conU To An Agent Today
+## Give conU To An Agent
 
-Until Phase 12 SDK/MCP exists, the safest current integration is to let the agent call the CLI.
+Agents can use conU through MCP, Rust, Python, or direct CLI calls.
+
+### MCP Agent Setup
+
+Add `conu-mcp` to the agent's MCP server config:
+
+```json
+{
+  "mcpServers": {
+    "conu": {
+      "command": "conu-mcp",
+      "env": {
+        "CONU_HOME": "C:\\Users\\you\\AppData\\Roaming\\conU",
+        "CONU_AGENT_ID": "agent.mybot"
+      }
+    }
+  }
+}
+```
+
+Tell the MCP agent:
+
+```txt
+Use conU tools for communication.
+
+Rules:
+- Launch one `conu-mcp` server per agent and set `CONU_AGENT_ID`.
+- Register once with conu_register_agent.
+- Use conu_set_presence when your state changes.
+- Discover local and trusted remote metadata with conu_list_agents and conu_list_peers.
+- Send opaque bytes with conu_send_message.
+- Read inbox metadata first; request payloadHex only with conu_receive_message when you are the addressed local agent.
+- Use conu_open_stream, conu_write_stream, and conu_close_stream for stream metadata flows.
+- Treat conU as the road, not the conversation.
+```
+
+### Rust Agent Setup
+
+Inside this workspace, Rust agents can depend on:
+
+```toml
+conu-sdk = { path = "crates/conu-sdk" }
+```
+
+Minimal usage:
+
+```rust
+use conu_sdk::ConuClient;
+
+let client = ConuClient::new();
+client.init()?;
+client.register_agent("agent.mybot", "My Bot", "local-agent")?;
+client.process_queued()?;
+client.send_message_bytes("agent.mybot", "agent.other", b"opaque bytes")?;
+```
+
+### Python Agent Setup
+
+For local development:
+
+```powershell
+$env:PYTHONPATH = "$PWD\sdk\python"
+```
+
+```python
+from conu_sdk import ConuClient
+
+client = ConuClient(home=".conu-agent")
+client.init()
+client.register_agent("agent.mybot", "My Bot")
+client.process_queued()
+client.send_message("agent.mybot", "agent.other", b"opaque bytes")
+```
+
+### CLI Agent Fallback
 
 Give the agent this operating contract:
 
@@ -207,8 +287,8 @@ These are not hidden bugs; they are the honest state of the current app:
 | Installer | No packaged installer yet | Users must build from source | Use `cargo install --path` |
 | Windows linker | Default MSVC toolchain may fail without `link.exe` | `cargo check/test/install` can fail | Use `stable-x86_64-pc-windows-gnu` or install Visual Studio C++ Build Tools |
 | Runtime discovery | `conu start` needs `conud` beside `conu` or on PATH | Start can fail after manual binary moves | Install both with Cargo or set `CONUD_EXE` |
-| Agent API | No SDK/MCP adapter yet | Agents need CLI calls or internal Rust integration | Use CLI/stdin and JSON metadata |
-| Receiving payloads | No stable external receive API yet | CLI lists inbox metadata only | Phase 12 should add SDK/MCP receive |
+| Agent API | Rust SDK, Python wrapper, and MCP adapter exist; TypeScript is later | Most agents can integrate now, TS apps need wrapper work | Use MCP, Rust SDK, Python SDK, or CLI/stdin |
+| Receiving payloads | CLI intentionally lists inbox metadata only | Agents needing bytes must use explicit receive APIs | Use Rust SDK `receive_message_bytes` or MCP `conu_receive_message` with `includePayload` |
 | Internet messaging | Relay is not wired into conUD data plane yet | Local messages work; real remote payload delivery does not | Use local testing only |
 | Pairing | Pair/join are local trust groundwork | Not real cross-machine pairing yet | Use for metadata/trust testing |
 | Service install | conUD is not an OS service yet | User must start/stop manually | Use `conu start` / `conu stop` |
@@ -245,10 +325,9 @@ conu messages inbox agent.b --json
 
 ## Best Next Product Work
 
-To make conU genuinely easy for users and agents, the next phase should build:
+To make conU genuinely useful over the internet, the next phase should build:
 
-- Rust SDK receive/send/register APIs.
-- Python SDK wrapper for local agents.
-- MCP adapter exposing conU tools to LLM agents.
-- A stable receive API that returns payload bytes only to the addressed local agent.
+- Direct/relay route selection owned by conUD.
+- Live encrypted relay-backed message and stream byte delivery.
+- TypeScript SDK after the protocol surface stabilizes.
 - Packaged installer and service setup after SDK behavior is stable.

--- a/examples/python/local_agent_pair.py
+++ b/examples/python/local_agent_pair.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+import tempfile
+
+from conu_sdk import ConuClient
+
+
+def main() -> None:
+    home = os.path.join(tempfile.gettempdir(), "conu-python-example")
+    client = ConuClient(home=home)
+
+    client.init()
+    client.register_agent("agent.python.alice", "Alice Python Agent")
+    client.register_agent("agent.python.bob", "Bob Python Agent")
+    client.process_queued()
+
+    result = client.send_message(
+        "agent.python.alice",
+        "agent.python.bob",
+        b"example private payload",
+    )
+    client.process_queued()
+
+    print(f"queued request {result['requestId']}")
+    print(f"opaque bytes {result['payloadBytes']}")
+    print("payload contents were not displayed by conU")
+
+
+if __name__ == "__main__":
+    main()

--- a/plan.md
+++ b/plan.md
@@ -28,9 +28,9 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 12 - SDK And MCP Adapter
+Current phase: Phase 13 - Direct Transport And NAT Upgrade
 Status: not_started
-Last updated: 2026-05-10
+Last updated: 2026-05-11
 ```
 
 ## Phase 0 - Project Memory
@@ -130,6 +130,7 @@ Files changed:
 - `.gitignore`
 - `Cargo.toml`
 - `Cargo.lock`
+- `.gitignore`
 - `README.md`
 - `crates/conu-cli/Cargo.toml`
 - `crates/conu-cli/src/main.rs`
@@ -900,7 +901,7 @@ Next:
 
 ## Phase 12 - SDK And MCP Adapter
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -916,8 +917,72 @@ Deliverables:
 
 Exit criteria:
 
-- Agent can call register, peers, send, receive, stream.
-- MCP-capable agents can use conU as tools.
+- [x] Agent can call register, peers, send, receive, stream.
+- [x] MCP-capable agents can use conU as tools.
+
+Completed work:
+
+- Created GitHub issue #26 for Phase 12.
+- Created branch `codex/phase-12-sdk-mcp-adapter`.
+- Added `crates/conu-sdk`, a Rust SDK wrapping existing `conu-core` gateway, message, trust, session, stream, runtime, state, and security surfaces.
+- Added explicit addressed-agent receive API through `ConuClient::receive_message_bytes`.
+- Added `crates/conu-mcp`, a newline-delimited JSON-RPC MCP stdio adapter exposing conU as tools.
+- Added MCP tools for status, security audit, register, presence, process queued, list agents, list peers, send message, receive message, open stream, write stream, and close stream.
+- Added payload-safe MCP behavior: list/send/status/stream results are metadata-only, while `conu_receive_message` returns `payloadHex` only when `includePayload` is true.
+- Added optional `CONU_AGENT_ID` binding so one `conu-mcp` stdio server can be scoped to one local agent.
+- Added stdlib Python wrapper SDK under `sdk/python/conu_sdk`.
+- Added Rust and Python local-agent examples.
+- Updated README, user install guide, production/security docs, repo memory, agent gateway contract, implementation guardrails, repo map, and security checklist.
+- Checked current MCP transport docs and aligned the adapter with stdio JSON-RPC messages delimited by newlines.
+
+Files changed:
+
+- `Cargo.toml`
+- `Cargo.lock`
+- `README.md`
+- `docs/sdk-and-mcp.md`
+- `docs/user-install-and-agent-guide.md`
+- `docs/production-readiness.md`
+- `docs/security-hardening.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/SKILL.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `.agents/skills/conu-security-guardian/references/privacy-security-checklist.md`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-sdk/Cargo.toml`
+- `crates/conu-sdk/src/lib.rs`
+- `crates/conu-sdk/examples/local_agents.rs`
+- `crates/conu-mcp/Cargo.toml`
+- `crates/conu-mcp/src/lib.rs`
+- `crates/conu-mcp/src/main.rs`
+- `sdk/python/README.md`
+- `sdk/python/conu_sdk/__init__.py`
+- `examples/python/local_agent_pair.py`
+
+Validation:
+
+- `cargo fmt` passed.
+- `cargo +stable-x86_64-pc-windows-gnu check --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-sdk --example local_agents` passed.
+- `cargo +stable-x86_64-pc-windows-gnu run -p conu-mcp` stdio `tools/list` smoke passed.
+- `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py` passed.
+- Python SDK smoke passed with local `target/debug/conu.exe` and `target/debug/conud.exe`.
+- Default `cargo check --workspace` still fails locally because the active MSVC toolchain cannot find `link.exe`; GNU toolchain validation passed.
+
+Known gaps:
+
+- TypeScript SDK remains future work.
+- MCP adapter is stdio-only; no HTTP MCP transport is implemented.
+- SDK/MCP local receive returns payload bytes only for local addressed inboxes; real remote data-plane delivery remains future work.
+- Capability grants and richer permission policy are not complete yet.
+- Packaging and installer support remain Phase 15.
+
+Next:
+
+- Start Phase 13: direct transport and NAT upgrade, including route selection, relay fallback integration in conUD, and live encrypted data-plane delivery groundwork.
 
 ## Phase 13 - Direct Transport And NAT Upgrade
 
@@ -1005,4 +1070,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 9 completed. conUD-owned remote session mirror, trusted remote agent cards, `conu sessions`, remote visibility in agents/status/connect, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 10 streams and watch animation.
 2026-05-10 - Phase 10 completed. Stream lifecycle metadata, stdin-only opaque stream writes, backpressure checks, watch event bus, private watch animation, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 11 encryption hardening.
 2026-05-10 - Phase 11 completed. Local security module added with Ed25519 signed agent cards, X25519 peer key agreement helpers, XChaCha20Poly1305 encrypted-at-rest message storage, replay protection, `conu security audit`, tests, docs, and GNU-toolchain validation. Next: Phase 12 SDK and MCP adapter.
+2026-05-11 - Phase 12 completed. Rust SDK, MCP stdio adapter, Python wrapper SDK, local agent examples, explicit addressed-agent receive API, tests, docs, and GNU-toolchain validation added. Next: Phase 13 direct transport and NAT upgrade.
 ```

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,20 @@
+# conU Python SDK
+
+This wrapper lets Python-based agents call an installed `conu` and `conud`
+binary without parsing terminal UI by hand.
+
+```python
+from conu_sdk import ConuClient
+
+client = ConuClient(home=".conu-agent")
+client.init()
+client.register_agent("agent.alpha", "Alpha")
+client.register_agent("agent.beta", "Beta")
+client.process_queued()
+
+sent = client.send_message("agent.alpha", "agent.beta", b"private bytes")
+print(sent["payloadBytes"])
+```
+
+The wrapper does not log or print payloads. Message payload bytes are sent to
+`conu messages send --stdin`; metadata commands use `--json`.

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -1,0 +1,193 @@
+"""Small Python SDK wrapper for the conU CLI.
+
+The wrapper never logs or prints payloads. Payload bytes are passed through
+stdin for send/write operations, and command output is returned to the caller.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ConuError(RuntimeError):
+    """Raised when a conU command exits unsuccessfully."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Result of one conU subprocess call."""
+
+    args: tuple[str, ...]
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+class ConuClient:
+    """Agent-facing Python wrapper around `conu` and `conud` binaries."""
+
+    def __init__(
+        self,
+        conu_bin: str | Path = "conu",
+        conud_bin: str | Path = "conud",
+        home: str | Path | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str | Path | None = None,
+    ) -> None:
+        self.conu_bin = str(conu_bin)
+        self.conud_bin = str(conud_bin)
+        self.cwd = None if cwd is None else str(cwd)
+        self.env = os.environ.copy()
+        if env:
+            self.env.update(env)
+        if home is not None:
+            self.env["CONU_HOME"] = str(home)
+
+    def init(self) -> CommandResult:
+        return self._run_conu("init")
+
+    def security_audit(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "security", "audit", "--json")
+
+    def status(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "status", "--json")
+
+    def agents(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "agents", "--json")
+
+    def peers(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "peers", "--json")
+
+    def inbox(self, agent_id: str) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "messages", "inbox", agent_id, "--json")
+
+    def receipts(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "messages", "receipts", "--json")
+
+    def register_agent(
+        self,
+        agent_id: str,
+        display_name: str,
+        kind: str = "local-agent",
+    ) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "agents",
+            "register",
+            agent_id,
+            display_name,
+            "--kind",
+            kind,
+            "--json",
+        )
+
+    def heartbeat(self, agent_id: str, presence: str = "ready") -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "agents",
+            "heartbeat",
+            agent_id,
+            "--presence",
+            presence,
+            "--json",
+        )
+
+    def send_message(
+        self,
+        from_agent_id: str,
+        to_agent_id: str,
+        payload: bytes,
+    ) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "messages",
+            "send",
+            from_agent_id,
+            to_agent_id,
+            "--stdin",
+            "--json",
+            input_bytes=payload,
+        )
+
+    def open_stream(
+        self,
+        from_agent_id: str,
+        to_agent_id: str,
+        kind: str = "message",
+    ) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "streams",
+            "open",
+            from_agent_id,
+            to_agent_id,
+            "--kind",
+            kind,
+            "--json",
+        )
+
+    def write_stream(self, stream_id: str, payload: bytes) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "streams",
+            "write",
+            stream_id,
+            "--stdin",
+            "--json",
+            input_bytes=payload,
+        )
+
+    def close_stream(self, stream_id: str) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "streams",
+            "close",
+            stream_id,
+            "--json",
+        )
+
+    def process_queued(self) -> CommandResult:
+        return self._run(self.conud_bin, "--process-ipc")
+
+    def _run_conu(self, *args: str, input_bytes: bytes | None = None) -> CommandResult:
+        return self._run(self.conu_bin, *args, input_bytes=input_bytes)
+
+    def _run_json(
+        self,
+        binary: str,
+        *args: str,
+        input_bytes: bytes | None = None,
+    ) -> dict[str, Any]:
+        result = self._run(binary, *args, input_bytes=input_bytes)
+        return json.loads(result.stdout)
+
+    def _run(
+        self,
+        binary: str,
+        *args: str,
+        input_bytes: bytes | None = None,
+    ) -> CommandResult:
+        argv = (binary, *args)
+        completed = subprocess.run(
+            argv,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.cwd,
+            env=self.env,
+            check=False,
+        )
+        stdout = completed.stdout.decode("utf-8", errors="replace")
+        stderr = completed.stderr.decode("utf-8", errors="replace")
+        result = CommandResult(argv, stdout, stderr, completed.returncode)
+        if completed.returncode != 0:
+            raise ConuError(f"conU command failed ({completed.returncode}): {' '.join(argv)}")
+        return result
+
+
+__all__ = ["CommandResult", "ConuClient", "ConuError"]


### PR DESCRIPTION
## **User description**
## Summary
- Add `conu-sdk` Rust client for agent registration, presence, peers, messages, explicit addressed-agent receive, receipts, streams, runtime/status, and security audit calls.
- Add `conu-mcp` stdio adapter with MCP tools for status, security, register, presence, process, list, send, receive, stream open/write/close.
- Add Python stdlib wrapper SDK, Rust/Python examples, SDK/MCP docs, and future-agent memory updates.
- Keep payload privacy: send/list/status/stream outputs are metadata-only; MCP receive returns `payloadHex` only with `includePayload`; optional `CONU_AGENT_ID` binds one MCP server to one local agent.

## Validation
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace`
- `cargo +stable-x86_64-pc-windows-gnu test --workspace`
- `cargo +stable-x86_64-pc-windows-gnu run -p conu-sdk --example local_agents`
- `cargo +stable-x86_64-pc-windows-gnu run -q -p conu-mcp` with `tools/list` JSON-RPC smoke
- `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py`
- Python SDK smoke with local `target/debug/conu.exe` and `target/debug/conud.exe`
- `git diff --check`

## Notes
- Default MSVC `cargo check --workspace` still fails locally because `link.exe` is not installed; GNU toolchain validation passed.
- Root `SKILL.md` was pre-existing/unrelated and intentionally left untracked.

Closes #26


___

## **CodeAnt-AI Description**
**Add Rust, Python, and MCP agent access to conU**

### What Changed
- Added a Rust SDK for agents to register, update presence, list agents and peers, send opaque messages, read inbox metadata, receive payload bytes only for the addressed local agent, and open/write/close streams
- Added an MCP stdio adapter with tools for status, security audit, registration, presence, queue processing, agent and peer listing, messaging, receiving, and stream actions
- Kept normal list/send/status/stream outputs metadata-only; payload bytes are returned only through an explicit receive call
- Added a Python wrapper for calling installed `conu` and `conud` binaries, plus Rust and Python local-agent examples and updated docs

### Impact
`✅ Easier local agent integration`
`✅ Explicit payload access only for the addressed agent`
`✅ Clearer MCP tool usage for agents`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=pULlpzh4Ytq7Ry7EINgkhmDt9m9UG7SwL-8DfR659UU&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
