### PR TITLE
Add Phase 13 direct route manager

### DIFF
--- a/.agents/Pr/SKILL.MD
+++ b/.agents/Pr/SKILL.MD
@@ -56,20 +56,21 @@ Handles:
 
 Build in resumable phases:
 
-1. project memory and architecture
-2. Rust workspace scaffold
-3. CLI identity and dashboard
-4. local identity and persistent state
-5. conUD daemon skeleton
-6. local IPC and agent registration
-7. opaque envelope send/receive
-8. pairing and trust store
-9. WebSocket relay
-10. remote discovery and sessions
-11. streams and watch animation
-12. encryption hardening
-13. SDK/MCP adapter
-14. QUIC/direct transport
+0. project memory and architecture
+1. Rust workspace scaffold
+2. CLI identity and dashboard
+3. local identity and persistent state
+4. conUD daemon skeleton
+5. local IPC and agent registration
+6. opaque envelope send/receive
+7. pairing and trust store
+8. WebSocket relay
+9. remote discovery and sessions
+10. streams and watch animation
+11. encryption hardening
+12. SDK/MCP adapter
+13. direct transport and NAT route manager
+14. rooms, pub/sub, and multi-agent sessions
 15. packaging and production readiness
 
 Always check `plan.md` for the active phase before changing code.

--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 12.
+The repository has completed Phase 13.
 
 Implemented so far:
 
@@ -48,11 +48,16 @@ Implemented so far:
 - stream open/write/close commands with stdin-only opaque writes
 - payload-safe watch event bus under `streams/events.toml`
 - `conu watch` private transport animation
+- conUD-owned direct/relay route manager through `conu routes`
+- metadata-only route registry under `routes/registry.toml`
+- metadata-only route probes under `routes/probes.toml`
+- route sync integration with remote sessions, streams, Rust SDK, Python wrapper SDK, and MCP
 - payload-safe status and agent registry reporting
 - payload-safe runtime and agent metadata logs
 - payload-safe message delivery metadata logs
 - payload-safe remote session metadata logs
 - payload-safe stream metadata logs
+- payload-safe route metadata logs
 - payload-safe protocol scaffold
 - daemon runtime skeleton and relay service binary
 
@@ -60,6 +65,7 @@ Current important files:
 
 - `architecture.md`: production architecture and protocol direction.
 - `plan.md`: phase-by-phase execution plan.
+- `docs/direct-transport-and-routes.md`: Phase 13 route manager, config, and privacy boundary.
 - `.agents/AGENTS.md`: future-agent onboarding.
 - `.agents/about/`: original product vision.
 - `.agents/Rules/SKILL.MD`: hard project rules.

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -173,6 +173,24 @@ conud --process-ipc
 
 `conu sessions sync` reads trusted peers and mirrors route/session metadata so `conu agents` can show visible remote agents. It does not transfer private payloads and does not yet create an interactive live stream. Revoked peers must disappear from the active remote-agent mirror after sync.
 
+The Phase 13 route surface lets agents and users inspect conUD-owned route selection:
+
+```txt
+routes/registry.toml   direct/relay candidate and selected route metadata
+routes/probes.toml     metadata-only route probe history
+logs/routes.log        payload-safe route summaries
+```
+
+Supported commands:
+
+```txt
+conu routes [--json]
+conu routes sync [--json]
+conu routes probes [--json]
+```
+
+`conu routes sync` scores configured direct QUIC candidates against relay WebSocket fallback. It may show route ids, peer ids, transport labels, endpoints, scores, latency estimates, NAT profile labels, and fallback state. It must never show message text, prompt text, reasoning, file contents, private keys, shared secrets, tokens, or payload bytes.
+
 The Phase 10 stream/watch surface is metadata-only stream lifecycle:
 
 ```txt
@@ -226,6 +244,9 @@ ConuClient::register_agent()
 ConuClient::set_presence()
 ConuClient::list_agents()
 ConuClient::list_peers()
+ConuClient::sync_routes()
+ConuClient::list_routes()
+ConuClient::list_route_probes()
 ConuClient::send_message_bytes()
 ConuClient::inbox_metadata()
 ConuClient::receive_message_bytes()
@@ -243,6 +264,8 @@ conu_security_audit
 conu_register_agent
 conu_set_presence
 conu_process_queued
+conu_sync_routes
+conu_list_routes
 conu_list_agents
 conu_list_peers
 conu_send_message

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -94,6 +94,17 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Revoked peers must not remain visible as active remote agents after session sync.
 - Route metadata may include relay endpoint, peer id, state, and reconnect counts; it must not include message contents, tokens, or private payload bytes.
 
+## Direct Route Rules
+
+- Phase 13 route selection belongs in `conu_core::routes`; other modules should call that API instead of parsing route files directly.
+- Route state belongs under `routes/registry.toml`; probe history belongs under `routes/probes.toml`; route logs belong under `logs/routes.log`.
+- Route records may include route id, peer id, display name, transport label, endpoint, state, score, estimated latency, NAT profile, fallback flag, and failure reason.
+- Route records must not include plaintext payloads, prompt text, reasoning, file contents, auth tokens, private keys, shared secrets, or decrypted bytes.
+- Revoked peers must not remain routeable after route sync.
+- `conu sessions sync`, conUD processing, SDK, and MCP may refresh or list route metadata, but they must keep outputs payload-safe.
+- A configured `direct-quic` route is a candidate and route label until real QUIC sockets and NAT traversal are implemented; do not claim live direct byte transport before it exists.
+- Relay fallback must remain available when direct endpoint config is missing, invalid, or disabled by `nat_profile = "relay-only"`.
+
 ## Stream And Watch Rules
 
 - Phase 10 streams are metadata-first in `conu_core::streams`.

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -23,7 +23,7 @@ crates/conud
   daemon process, local gateway/message/session processing, session manager, runtime lifecycle
 
 crates/conu-core
-  local state, security keys/encryption/signatures/replay, runtime lifecycle, agent registry, local message routing, stream metadata, trust store, relay frame contract, remote session mirror, future policy logic
+  local state, security keys/encryption/signatures/replay, runtime lifecycle, agent registry, local message routing, stream metadata, route selection, trust store, relay frame contract, remote session mirror, future policy logic
 
 crates/conu-protocol
   envelopes, agent cards, control-plane messages, data-plane messages
@@ -32,7 +32,7 @@ crates/conu-relay
   std-only WebSocket relay service, session auth, metadata-only forwarding, relay/bootstrap groundwork
 
 crates/conu-sdk
-  Rust agent-facing SDK over registration, presence, peers, messages, receive, streams, and security audit
+  Rust agent-facing SDK over registration, presence, peers, routes, messages, receive, streams, and security audit
 
 crates/conu-mcp
   MCP stdio adapter exposing conU tools over newline-delimited JSON-RPC

--- a/.agents/skills/conu-security-guardian/references/privacy-security-checklist.md
+++ b/.agents/skills/conu-security-guardian/references/privacy-security-checklist.md
@@ -7,6 +7,7 @@
 - SDK and MCP list/send/status/stream outputs do not print payload text.
 - Logs do not include payload text.
 - Metrics do not include payload text.
+- Route registry, probe history, and route logs include only metadata.
 - Tests do not normalize leaking payload contents as expected behavior.
 
 ## Identity And Trust
@@ -45,6 +46,13 @@
 - Local agent cards are signed and signature verification fails on tampering.
 - Replay cache rejects duplicate message request and envelope ids before duplicate delivery.
 - Revoked peers must not remain visible or routeable.
+
+## Routes
+
+- Direct routes are selected only for trusted peers.
+- Relay fallback does not weaken trust checks.
+- Direct endpoint config must not contain tokens, private keys, or payload material.
+- Route failure reasons stay generic and must not echo arbitrary payload-bearing input.
 
 ## CLI Watch
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 12 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state and security keys, `conu start` launches the local `conUD` runtime skeleton, local agents can register signed metadata and presence, registered local agents can exchange encrypted-at-rest opaque message envelopes, local pairing/trust records can be created and revoked, `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding, conUD can sync remote session/discovery metadata for trusted peers, streams produce payload-safe watch events, `conu security audit` reports hardened controls without showing secrets, and agents can now use conU through the Rust SDK, Python wrapper SDK, and MCP stdio adapter.
+Phase 13 is complete. The CLI identity/dashboard shell exists, `conu init` creates real local state and security keys, `conu start` launches the local `conUD` runtime skeleton, local agents can register signed metadata and presence, registered local agents can exchange encrypted-at-rest opaque message envelopes, local pairing/trust records can be created and revoked, `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding, conUD can sync remote session/discovery metadata for trusted peers, streams produce payload-safe watch events, `conu security audit` reports hardened controls without showing secrets, agents can use conU through the Rust SDK, Python wrapper SDK, and MCP stdio adapter, and conUD now owns metadata-only direct/relay route selection.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -54,6 +54,8 @@ messages/inbox/        delivered local opaque envelopes by recipient agent
 messages/receipts/     metadata-only local delivery receipts
 streams/registry.toml  stream lifecycle metadata
 streams/events.toml    payload-safe watch event bus
+routes/registry.toml   direct/relay route candidates and selected paths
+routes/probes.toml     metadata-only route probe history
 pairing/invites/       pending local pairing invitations
 pairing/used/          consumed local pairing invitations
 sessions/registry.toml remote runtime session metadata
@@ -63,6 +65,7 @@ logs/agents.log        local agent metadata log
 logs/messages.log      local message delivery metadata log
 logs/sessions.log      remote session sync metadata log
 logs/streams.log       stream lifecycle metadata log
+logs/routes.log        direct/relay route sync metadata log
 ```
 
 Runtime, agent, and message logs contain metadata only, such as event name, pid, node id, agent id, envelope id, byte count, and `payload=not_observed`. New local message request and recipient-inbox envelope files store conU-owned payload bytes with XChaCha20Poly1305 encrypted-at-rest fields. CLI output, receipts, processed markers, rejected markers, and logs do not display message contents.
@@ -160,6 +163,21 @@ conu agents --json
 
 This phase is still metadata/discovery groundwork: remote agent cards are derived from trusted peer metadata until the full relay-backed session exchange lands. Payloads remain opaque and are never displayed by session or agent listing commands.
 
+## Direct Routes And Relay Fallback
+
+Phase 13 adds a route manager owned by conUD:
+
+```bash
+conu routes sync
+conu routes
+conu routes --json
+conu routes probes
+```
+
+`conu routes sync` reads trusted peers and `config.toml`, scores direct QUIC candidates against relay WebSocket fallback, writes `routes/registry.toml`, appends metadata-only probes to `routes/probes.toml`, and records payload-safe summaries in `logs/routes.log`. Direct endpoints can be configured with `direct_quic_endpoint = "quic://host:port"` or a peer-specific sanitized key like `direct_quic_peer_abcd1234 = "quic://host:port"`.
+
+This is route selection groundwork, not a full QUIC data plane yet. conU can now prefer a configured direct route and fall back to relay metadata, while live QUIC sockets, ICE-style hole punching, and relay-backed encrypted byte delivery remain future transport hardening.
+
 ## Streams And Watch
 
 Phase 10 adds stream lifecycle metadata and a private watch view:
@@ -189,7 +207,7 @@ Rust agents can use `conu_sdk::ConuClient` to register, update presence, list ag
 
 MCP-capable agents can launch `conu-mcp` as a stdio server. It exposes tools such as `conu_register_agent`, `conu_list_agents`, `conu_send_message`, `conu_receive_message`, `conu_open_stream`, and `conu_security_audit`. The adapter follows the current MCP stdio transport shape: newline-delimited JSON-RPC 2.0 messages on stdin/stdout. Tool list/send/status outputs remain metadata-only. Set `CONU_AGENT_ID` when launching one MCP server for one agent; then the adapter rejects attempts to act as another local agent. `conu_receive_message` returns payload bytes as `payloadHex` only when the addressed local agent explicitly passes `includePayload: true`.
 
-See `docs/sdk-and-mcp.md` for SDK examples, MCP tool contracts, and privacy rules.
+See `docs/sdk-and-mcp.md` for SDK examples, MCP tool contracts, route tools, and privacy rules. See `docs/direct-transport-and-routes.md` for the Phase 13 route manager.
 
 ## Development
 
@@ -226,6 +244,9 @@ cargo run -p conu-cli -- streams close stream_example
 cargo run -p conu-cli -- watch
 cargo run -p conu-cli -- sessions sync
 cargo run -p conu-cli -- sessions --json
+cargo run -p conu-cli -- routes sync
+cargo run -p conu-cli -- routes --json
+cargo run -p conu-cli -- routes probes
 cargo run -p conu-cli -- security audit
 cargo run -p conu-cli -- security audit --json
 cargo run -p conu-cli -- pair

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -1,8 +1,8 @@
 //! CLI rendering and command dispatch for conU.
 //!
-//! Phase 11 adds conUD runtime detection, metadata-only local/remote agent
+//! Phase 13 adds conUD runtime detection, metadata-only local/remote agent
 //! visibility, encrypted-at-rest local opaque envelopes, remote session
-//! mirrors, stream/watch metadata, and security audit output.
+//! mirrors, stream/watch metadata, route selection, and security audit output.
 
 use std::collections::HashSet;
 use std::env;
@@ -15,6 +15,7 @@ use conu_core::agents::{
     self, AgentPresence, AgentRegistration, LocalAgentRecord, PresenceHeartbeat,
 };
 use conu_core::messages::{self, DeliveryReceipt, InboxEntry, LocalMessage};
+use conu_core::routes::{self, RouteProbe, RouteRecord, RouteSyncReport, RouteTransport};
 use conu_core::runtime::{self, RuntimeState, RuntimeStatus, StopReport};
 use conu_core::security::{self, SecurityAudit, SecurityReport};
 use conu_core::sessions::{self, RemoteAgentRecord, RemoteSession, SessionSyncReport};
@@ -102,6 +103,7 @@ where
         "messages" => render_messages(&args[1..], home_override, stdin_payload),
         "streams" => render_streams(&args[1..], home_override, stdin_payload),
         "sessions" => render_sessions(&args[1..], home_override),
+        "routes" => render_routes(&args[1..], home_override),
         "security" => render_security(&args[1..], home_override),
         "pair" => render_pair(&args[1..], home_override),
         "join" => render_join(&args[1..], home_override),
@@ -133,6 +135,7 @@ fn render_dashboard(home_override: Option<PathBuf>) -> String {
                 .count()
         })
         .unwrap_or(0);
+    let route_records = routes::list_routes(home_override.clone()).unwrap_or_default();
     let remote_agents = sessions::list_remote_agents(home_override)
         .map(|agents| agents.len())
         .unwrap_or(0);
@@ -167,7 +170,8 @@ control room
   local agents  {local_agents}
   remote agents {remote_agents}
   remote peers  {trusted_peers} trusted
-  network       relay service  available via conu-relay
+  routes        direct {} relay {}
+  network       direct when available, relay fallback
 
 quick commands
   conu init
@@ -176,13 +180,16 @@ quick commands
   conu agents register <agent-id> <display-name>
   conu messages send <from-agent> <to-agent> --stdin
   conu streams open <from-agent> <to-agent>
+  conu routes sync
   conu security audit
   conu pair
   conu peers
   conu join <code>
   conu connect
   conu watch",
-        conu_core::PRODUCT_LAW
+        conu_core::PRODUCT_LAW,
+        selected_direct_route_count(&route_records),
+        selected_relay_route_count(&route_records)
     )
 }
 
@@ -229,6 +236,10 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
         Ok(streams) => streams,
         Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
     };
+    let route_records = match routes::list_routes(home_override.clone()) {
+        Ok(routes) => routes,
+        Err(error) => return CliOutput::failure(1, format!("conU status failed\n\n{error}")),
+    };
     let security_audit =
         security::security_audit(home_override).unwrap_or_else(|_| empty_security_audit());
 
@@ -240,6 +251,7 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
             &remote_agents,
             &sessions,
             &stream_records,
+            &route_records,
             &peers,
             &security_audit,
         )),
@@ -250,6 +262,7 @@ fn render_status(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
             &remote_agents,
             &sessions,
             &stream_records,
+            &route_records,
             &peers,
             &security_audit,
         )),
@@ -1631,6 +1644,341 @@ privacy
     )
 }
 
+fn render_routes(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    match args.first().map(String::as_str) {
+        Some("sync") => render_routes_sync(&args[1..], home_override),
+        Some("probes") => render_route_probes(&args[1..], home_override),
+        None | Some("--json") => render_routes_list(args, home_override),
+        Some(_) => CliOutput::failure(2, render_routes_usage()),
+    }
+}
+
+fn render_routes_sync(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let json = match json_flag(args) {
+        Ok(json) => json,
+        Err(error) => return error,
+    };
+
+    match routes::sync_routes(home_override) {
+        Ok(report) => {
+            if json {
+                CliOutput::success(render_routes_report_json(&report))
+            } else {
+                CliOutput::success(render_routes_report_text(&report))
+            }
+        }
+        Err(error) => CliOutput::failure(1, format!("conU routes sync failed\n\n{error}")),
+    }
+}
+
+fn render_routes_list(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let json = match json_flag(args) {
+        Ok(json) => json,
+        Err(error) => return error,
+    };
+    let route_records = match routes::list_routes(home_override) {
+        Ok(routes) => routes,
+        Err(error) => return CliOutput::failure(1, format!("conU routes failed\n\n{error}")),
+    };
+
+    if json {
+        CliOutput::success(render_routes_json(&route_records))
+    } else {
+        CliOutput::success(render_routes_text(&route_records))
+    }
+}
+
+fn render_route_probes(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let json = match json_flag(args) {
+        Ok(json) => json,
+        Err(error) => return error,
+    };
+    let probes = match routes::list_route_probes(home_override) {
+        Ok(probes) => probes,
+        Err(error) => {
+            return CliOutput::failure(1, format!("conU routes probes failed\n\n{error}"));
+        }
+    };
+
+    if json {
+        CliOutput::success(render_route_probes_json(&probes))
+    } else {
+        CliOutput::success(render_route_probes_text(&probes))
+    }
+}
+
+fn render_routes_json(route_records: &[RouteRecord]) -> String {
+    let route_items = route_records
+        .iter()
+        .map(|route| {
+            format!(
+                r#"    {{
+      "routeId": "{}",
+      "peerNodeId": "{}",
+      "displayName": "{}",
+      "transport": "{}",
+      "endpoint": "{}",
+      "state": "{}",
+      "score": {},
+      "latencyMs": {},
+      "directAttempted": {},
+      "relayFallback": {},
+      "natProfile": "{}",
+      "failureReason": {},
+      "updatedAtUnix": {}
+    }}"#,
+                json_escape(&route.route_id),
+                json_escape(&route.peer_node_id),
+                json_escape(&route.display_name),
+                route.transport.as_str(),
+                json_escape(&route.endpoint),
+                route.state.as_str(),
+                route.score,
+                json_u64(route.latency_ms),
+                route.direct_attempted,
+                route.relay_fallback,
+                route.nat_profile.as_str(),
+                json_optional_string(route.failure_reason.as_deref()),
+                route.updated_at_unix
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let routes_json = if route_items.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{route_items}\n  ]")
+    };
+
+    format!(
+        r#"{{
+  "routes": {},
+  "selectedDirect": {},
+  "selectedRelay": {},
+  "relayFallbacks": {},
+  "contentsDisplayed": false
+}}"#,
+        routes_json,
+        selected_direct_route_count(route_records),
+        selected_relay_route_count(route_records),
+        relay_fallback_route_count(route_records)
+    )
+}
+
+fn render_routes_text(route_records: &[RouteRecord]) -> String {
+    let selected_text = route_records
+        .iter()
+        .filter(|route| route.is_selected())
+        .map(render_route_line)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let selected_text = if selected_text.is_empty() {
+        "  none selected yet".to_string()
+    } else {
+        selected_text
+    };
+
+    let candidates_text = route_records
+        .iter()
+        .filter(|route| !route.is_selected())
+        .map(render_route_line)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let candidates_text = if candidates_text.is_empty() {
+        "  none recorded yet".to_string()
+    } else {
+        candidates_text
+    };
+
+    format!(
+        r"conU routes
+
+selected
+{selected_text}
+
+candidates
+{candidates_text}
+
+summary
+  selected direct  {}
+  selected relay   {}
+  relay fallbacks  {}
+
+privacy
+  payload view     contents are not displayed by conU
+
+next
+  conu routes sync",
+        selected_direct_route_count(route_records),
+        selected_relay_route_count(route_records),
+        relay_fallback_route_count(route_records)
+    )
+}
+
+fn render_route_line(route: &RouteRecord) -> String {
+    let latency = route
+        .latency_ms
+        .map(|latency| format!("{latency}ms"))
+        .unwrap_or_else(|| "n/a".to_string());
+    let state = if route.relay_fallback {
+        "fallback"
+    } else {
+        route.state.as_str()
+    };
+
+    format!(
+        "  {}  {}  {}  score {}  latency {}  endpoint {}",
+        route.peer_node_id,
+        route.transport.as_str(),
+        state,
+        route.score,
+        latency,
+        route.endpoint
+    )
+}
+
+fn render_route_probes_json(probes: &[RouteProbe]) -> String {
+    let probe_items = probes
+        .iter()
+        .map(|probe| {
+            format!(
+                r#"    {{
+      "probeId": "{}",
+      "routeId": "{}",
+      "peerNodeId": "{}",
+      "transport": "{}",
+      "endpoint": "{}",
+      "outcome": "{}",
+      "score": {},
+      "latencyMs": {},
+      "createdAtUnix": {}
+    }}"#,
+                json_escape(&probe.probe_id),
+                json_escape(&probe.route_id),
+                json_escape(&probe.peer_node_id),
+                probe.transport.as_str(),
+                json_escape(&probe.endpoint),
+                json_escape(&probe.outcome),
+                probe.score,
+                json_u64(probe.latency_ms),
+                probe.created_at_unix
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let probes_json = if probe_items.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[\n{probe_items}\n  ]")
+    };
+
+    format!(
+        r#"{{
+  "probes": {},
+  "contentsDisplayed": false
+}}"#,
+        probes_json
+    )
+}
+
+fn render_route_probes_text(probes: &[RouteProbe]) -> String {
+    let mut recent = probes.iter().rev().take(12).collect::<Vec<_>>();
+    recent.reverse();
+    let probes_text = recent
+        .iter()
+        .map(|probe| {
+            let latency = probe
+                .latency_ms
+                .map(|latency| format!("{latency}ms"))
+                .unwrap_or_else(|| "n/a".to_string());
+            format!(
+                "  {}  {}  {}  score {}  latency {}",
+                probe.peer_node_id,
+                probe.transport.as_str(),
+                probe.outcome,
+                probe.score,
+                latency
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let probes_text = if probes_text.is_empty() {
+        "  none recorded yet".to_string()
+    } else {
+        probes_text
+    };
+
+    format!(
+        r"conU route probes
+
+recent probes
+{probes_text}
+
+privacy
+  payload view  contents are not displayed by conU"
+    )
+}
+
+fn render_routes_report_json(report: &RouteSyncReport) -> String {
+    format!(
+        r#"{{
+  "status": "synced",
+  "peers": {},
+  "candidates": {},
+  "directAttempts": {},
+  "directAvailable": {},
+  "selectedDirect": {},
+  "selectedRelay": {},
+  "relayFallbacks": {},
+  "probesRecorded": {},
+  "contentsDisplayed": false
+}}"#,
+        report.peers,
+        report.candidates,
+        report.direct_attempts,
+        report.direct_available,
+        report.selected_direct,
+        report.selected_relay,
+        report.relay_fallbacks,
+        report.probes_recorded
+    )
+}
+
+fn render_routes_report_text(report: &RouteSyncReport) -> String {
+    format!(
+        r"conU routes sync
+
+status: synced
+trusted peers: {}
+candidates: {}
+direct attempts: {}
+direct available: {}
+selected direct: {}
+selected relay: {}
+relay fallbacks: {}
+probes recorded: {}
+
+privacy
+  payload view  contents are not displayed by conU",
+        report.peers,
+        report.candidates,
+        report.direct_attempts,
+        report.direct_available,
+        report.selected_direct,
+        report.selected_relay,
+        report.relay_fallbacks,
+        report.probes_recorded
+    )
+}
+
+fn render_routes_usage() -> String {
+    r"usage:
+  conu routes [--json]
+  conu routes sync [--json]
+  conu routes probes [--json]"
+        .to_string()
+}
+
 fn render_security(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     let remaining = match args.first().map(String::as_str) {
         None => args,
@@ -2030,6 +2378,7 @@ fn render_connect(args: &[String], home_override: Option<PathBuf>) -> CliOutput 
         return error;
     }
     let local_agents = agents::list_local_agents(home_override.clone()).unwrap_or_default();
+    let route_records = routes::list_routes(home_override.clone()).unwrap_or_default();
     let remote_agents = sessions::list_remote_agents(home_override).unwrap_or_default();
     let local = if local_agents.is_empty() {
         "none registered".to_string()
@@ -2070,9 +2419,12 @@ fn render_connect(args: &[String], home_override: Option<PathBuf>) -> CliOutput 
 selector
   source local agent   {local}
   target remote agent  {remote}
+  route plan           direct {} | relay {}
   mode                 message | stream | room | observe
 
 status: stream sessions use `conu streams open`; interactive selector remains future work",
+        selected_direct_route_count(&route_records),
+        selected_relay_route_count(&route_records)
     ))
 }
 
@@ -2292,6 +2644,7 @@ fn render_status_text(
     remote_agents: &[RemoteAgentRecord],
     sessions: &[RemoteSession],
     stream_records: &[StreamRecord],
+    route_records: &[RouteRecord],
     peers: &[TrustedPeer],
     security: &SecurityAudit,
 ) -> String {
@@ -2315,6 +2668,7 @@ runtime
   health        {}
   local IPC     file gateway active
   relay         service available via conu-relay
+  routes        direct {} relay {} fallback {}
 
 identity
   state         {}
@@ -2332,6 +2686,7 @@ agents
   trusted peers {}
   sessions      {}
   streams       {}
+  routes        {} selected
 
 privacy
   local storage encrypted at rest: {}
@@ -2341,6 +2696,9 @@ privacy
         runtime_state_label(runtime_status),
         runtime_pid_label(runtime_status),
         runtime_health_label(runtime_status),
+        selected_direct_route_count(route_records),
+        selected_relay_route_count(route_records),
+        relay_fallback_route_count(route_records),
         initialization_label(snapshot),
         node,
         display_name,
@@ -2354,6 +2712,7 @@ privacy
         trusted_peer_count(peers),
         sessions.len(),
         stream_records.len(),
+        selected_route_count(route_records),
         yes_no(security.local_payload_encryption),
         yes_no(security.signed_agent_cards),
         yes_no(security.replay_cache)
@@ -2367,6 +2726,7 @@ fn render_status_json(
     remote_agents: &[RemoteAgentRecord],
     sessions: &[RemoteSession],
     stream_records: &[StreamRecord],
+    route_records: &[RouteRecord],
     peers: &[TrustedPeer],
     security: &SecurityAudit,
 ) -> String {
@@ -2389,7 +2749,10 @@ fn render_status_json(
     "heartbeatAgeSecs": {},
     "localHealth": "{}",
     "localIpc": "file_gateway",
-    "relay": "service_available"
+    "relay": "service_available",
+    "selectedDirectRoutes": {},
+    "selectedRelayRoutes": {},
+    "relayFallbacks": {}
   }},
   "identity": {{
     "state": "{}",
@@ -2405,7 +2768,8 @@ fn render_status_json(
     "registry": "{}",
     "trustedPeers": {},
     "sessions": {},
-    "streams": {}
+    "streams": {},
+    "routes": {}
   }},
   "security": {{
     "initialized": {},
@@ -2423,6 +2787,9 @@ fn render_status_json(
         json_u32(runtime_status.pid),
         json_u64(runtime_status.heartbeat_age_secs()),
         json_escape(runtime_health_label(runtime_status)),
+        selected_direct_route_count(route_records),
+        selected_relay_route_count(route_records),
+        relay_fallback_route_count(route_records),
         initialization_label(snapshot),
         json_escape(node),
         json_escape(display_name),
@@ -2435,6 +2802,7 @@ fn render_status_json(
         trusted_peer_count(peers),
         sessions.len(),
         stream_records.len(),
+        selected_route_count(route_records),
         security.initialized,
         security.local_payload_encryption,
         security.signed_agent_cards,
@@ -2463,6 +2831,9 @@ Usage:
   conu streams close <stream-id> [--json]
   conu sessions [--json]
   conu sessions sync [--json]
+  conu routes [--json]
+  conu routes sync [--json]
+  conu routes probes [--json]
   conu security audit [--json]
   conu peers [--json]
   conu peers revoke <peer-node-id> [--json]
@@ -2476,7 +2847,7 @@ Usage:
   conu --help
   conu --version
 
-Phase 11 adds encrypted local payload storage, signed agent cards, replay protection, and peer key agreement helpers. Payload contents remain hidden."
+Phase 13 adds direct QUIC route candidates, NAT-aware scoring, relay fallback selection, and metadata-only route probes. Payload contents remain hidden."
         .to_string()
 }
 
@@ -2624,6 +2995,34 @@ fn trusted_peer_count(peers: &[TrustedPeer]) -> usize {
         .count()
 }
 
+fn selected_route_count(route_records: &[RouteRecord]) -> usize {
+    route_records
+        .iter()
+        .filter(|route| route.is_selected())
+        .count()
+}
+
+fn selected_direct_route_count(route_records: &[RouteRecord]) -> usize {
+    route_records
+        .iter()
+        .filter(|route| route.is_selected() && route.transport == RouteTransport::DirectQuic)
+        .count()
+}
+
+fn selected_relay_route_count(route_records: &[RouteRecord]) -> usize {
+    route_records
+        .iter()
+        .filter(|route| route.is_selected() && route.transport == RouteTransport::RelayWebSocket)
+        .count()
+}
+
+fn relay_fallback_route_count(route_records: &[RouteRecord]) -> usize {
+    route_records
+        .iter()
+        .filter(|route| route.relay_fallback)
+        .count()
+}
+
 fn json_u32(value: Option<u32>) -> String {
     value
         .map(|value| value.to_string())
@@ -2634,6 +3033,10 @@ fn json_u64(value: Option<u64>) -> String {
     value
         .map(|value| value.to_string())
         .unwrap_or_else(|| "null".to_string())
+}
+
+fn json_optional_string(value: Option<&str>) -> String {
+    value.map(json_string).unwrap_or_else(|| "null".to_string())
 }
 
 fn resolve_conud_executable() -> PathBuf {
@@ -2721,6 +3124,7 @@ fn finish(mut output: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::process;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -2735,12 +3139,12 @@ mod tests {
     }
 
     #[test]
-    fn phase_eleven_commands_are_registered() {
+    fn phase_thirteen_commands_are_registered() {
         let home = temp_home("commands");
 
         for command in [
             "init", "status", "agents", "streams", "sessions", "security", "pair", "peers",
-            "connect", "watch", "stop",
+            "routes", "connect", "watch", "stop",
         ] {
             let output = run_with_home([command], Some(home.clone()));
             assert_eq!(output.code, 0, "{command} failed: {}", output.stderr);
@@ -2807,6 +3211,67 @@ mod tests {
         assert!(status.stdout.contains("\"remote\": 1"));
         assert!(status.stdout.contains("\"sessions\": 1"));
         assert!(!agents.stdout.contains("private message contents"));
+    }
+
+    #[test]
+    fn routes_sync_selects_relay_fallback_without_payloads() {
+        let home = temp_home("routes-relay");
+        let pair = run_with_home(["pair"], Some(home.clone()));
+        let code = pairing_code_from_output(&pair.stdout);
+        let join = run_with_home(["join", &code], Some(home.clone()));
+        let sync = run_with_home(["routes", "sync", "--json"], Some(home.clone()));
+        let routes = run_with_home(["routes", "--json"], Some(home.clone()));
+        let probes = run_with_home(["routes", "probes"], Some(home));
+
+        assert_eq!(join.code, 0, "{}", join.stderr);
+        assert_eq!(sync.code, 0, "{}", sync.stderr);
+        assert!(sync.stdout.contains("\"selectedRelay\": 1"));
+        assert!(sync.stdout.contains("\"relayFallbacks\": 1"));
+        assert!(routes.stdout.contains("\"transport\": \"relay-websocket\""));
+        assert!(routes.stdout.contains("\"contentsDisplayed\": false"));
+        assert!(
+            probes
+                .stdout
+                .contains("payload view  contents are not displayed")
+        );
+        assert!(!routes.stdout.contains("private message contents"));
+        assert!(!probes.stdout.contains("private message contents"));
+    }
+
+    #[test]
+    fn routes_sync_prefers_configured_direct_quic_candidate() {
+        let home = temp_home("routes-direct");
+        let pair = run_with_home(["pair"], Some(home.clone()));
+        let code = pairing_code_from_output(&pair.stdout);
+        let join = run_with_home(["join", &code], Some(home.clone()));
+        let peer_id = join
+            .stdout
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("peer: "))
+            .expect("peer id line")
+            .to_string();
+        let config_key = format!("direct_quic_{}", config_key_suffix_for_test(&peer_id));
+        fs::write(
+            state::StatePaths::from_home(home.clone()).config,
+            format!(
+                "version = \"1\"\ndefault_relay = \"ws://127.0.0.1:8787\"\nnat_profile = \"public\"\n{config_key} = \"quic://127.0.0.1:9443\"\n"
+            ),
+        )
+        .expect("config writes");
+
+        let sync = run_with_home(["routes", "sync", "--json"], Some(home.clone()));
+        let routes = run_with_home(["routes"], Some(home.clone()));
+        let session_sync = run_with_home(["sessions", "sync"], Some(home.clone()));
+        let sessions = run_with_home(["sessions"], Some(home));
+
+        assert_eq!(join.code, 0, "{}", join.stderr);
+        assert_eq!(sync.code, 0, "{}", sync.stderr);
+        assert!(sync.stdout.contains("\"selectedDirect\": 1"));
+        assert!(sync.stdout.contains("\"selectedRelay\": 0"));
+        assert!(routes.stdout.contains("direct-quic"));
+        assert!(session_sync.stdout.contains("sessions: 1"));
+        assert!(sessions.stdout.contains("route direct-quic"));
+        assert!(!routes.stdout.contains("private message contents"));
     }
 
     #[test]
@@ -3162,6 +3627,19 @@ mod tests {
             .find_map(|line| line.trim().strip_prefix("stream: "))
             .expect("stream id line")
             .to_string()
+    }
+
+    fn config_key_suffix_for_test(value: &str) -> String {
+        value
+            .chars()
+            .map(|character| {
+                if character.is_ascii_alphanumeric() {
+                    character.to_ascii_lowercase()
+                } else {
+                    '_'
+                }
+            })
+            .collect()
     }
 
     fn register_test_agent(home: &PathBuf, agent_id: &str) {

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod agents;
 pub mod messages;
 pub mod relay;
+pub mod routes;
 pub mod runtime;
 pub mod security;
 pub mod sessions;

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -1,0 +1,984 @@
+//! Route selection and direct-transport probing metadata.
+//!
+//! Phase 13 introduces a conUD-owned route manager. It records direct QUIC
+//! candidates, relay fallback candidates, route scores, and probe metadata
+//! without moving or observing payload bytes.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::state::{self, StateError, StatePaths};
+use crate::trust::{self, TrustStatus, TrustedPeer};
+
+const ROUTE_VERSION: &str = "1";
+const DEFAULT_RELAY_ENDPOINT: &str = "ws://127.0.0.1:8787";
+const DIRECT_QUIC_LATENCY_MS: u64 = 25;
+const RELAY_WEBSOCKET_LATENCY_MS: u64 = 80;
+
+/// Transport class for a candidate route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteTransport {
+    DirectQuic,
+    RelayWebSocket,
+}
+
+impl RouteTransport {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DirectQuic => "direct-quic",
+            Self::RelayWebSocket => "relay-websocket",
+        }
+    }
+
+    fn from_str(value: &str) -> Self {
+        match value {
+            "direct-quic" => Self::DirectQuic,
+            _ => Self::RelayWebSocket,
+        }
+    }
+}
+
+/// Current route candidate state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteState {
+    Selected,
+    Candidate,
+    Fallback,
+    Unavailable,
+}
+
+impl RouteState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Selected => "selected",
+            Self::Candidate => "candidate",
+            Self::Fallback => "fallback",
+            Self::Unavailable => "unavailable",
+        }
+    }
+
+    fn from_str(value: &str) -> Self {
+        match value {
+            "selected" => Self::Selected,
+            "candidate" => Self::Candidate,
+            "fallback" => Self::Fallback,
+            _ => Self::Unavailable,
+        }
+    }
+}
+
+/// NAT posture inferred from local configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NatProfile {
+    Unknown,
+    Public,
+    Cone,
+    Symmetric,
+    RelayOnly,
+}
+
+impl NatProfile {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Public => "public",
+            Self::Cone => "cone",
+            Self::Symmetric => "symmetric",
+            Self::RelayOnly => "relay-only",
+        }
+    }
+
+    fn from_config(value: Option<&String>) -> Self {
+        match value.map(String::as_str) {
+            Some("public") => Self::Public,
+            Some("cone") => Self::Cone,
+            Some("symmetric") => Self::Symmetric,
+            Some("relay-only") => Self::RelayOnly,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Persisted route candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteRecord {
+    pub route_id: String,
+    pub peer_node_id: String,
+    pub display_name: String,
+    pub transport: RouteTransport,
+    pub endpoint: String,
+    pub state: RouteState,
+    pub score: u16,
+    pub latency_ms: Option<u64>,
+    pub direct_attempted: bool,
+    pub relay_fallback: bool,
+    pub nat_profile: NatProfile,
+    pub failure_reason: Option<String>,
+    pub updated_at_unix: u64,
+}
+
+impl RouteRecord {
+    pub fn is_selected(&self) -> bool {
+        self.state == RouteState::Selected
+    }
+
+    pub fn is_direct(&self) -> bool {
+        self.transport == RouteTransport::DirectQuic
+    }
+}
+
+/// One metadata-only route probe event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteProbe {
+    pub probe_id: String,
+    pub route_id: String,
+    pub peer_node_id: String,
+    pub transport: RouteTransport,
+    pub endpoint: String,
+    pub outcome: String,
+    pub score: u16,
+    pub latency_ms: Option<u64>,
+    pub created_at_unix: u64,
+}
+
+/// Summary of a route sync/probe pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteSyncReport {
+    pub peers: usize,
+    pub candidates: usize,
+    pub direct_attempts: usize,
+    pub direct_available: usize,
+    pub selected_direct: usize,
+    pub selected_relay: usize,
+    pub relay_fallbacks: usize,
+    pub probes_recorded: usize,
+}
+
+/// Errors produced by route management.
+#[derive(Debug)]
+pub enum RouteError {
+    State(StateError),
+    Trust(trust::TrustError),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidRecord {
+        reason: String,
+    },
+}
+
+impl RouteError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for RouteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Trust(error) => write!(formatter, "{error}"),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidRecord { reason } => write!(formatter, "invalid route record: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for RouteError {}
+
+impl From<StateError> for RouteError {
+    fn from(error: StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+impl From<trust::TrustError> for RouteError {
+    fn from(error: trust::TrustError) -> Self {
+        Self::Trust(error)
+    }
+}
+
+/// Probe trusted-peer routes and write the selected route registry.
+pub fn sync_routes(home_override: Option<PathBuf>) -> Result<RouteSyncReport, RouteError> {
+    let init = state::init_state(home_override)?;
+    sync_routes_from_paths(&init.paths)
+}
+
+/// Probe trusted-peer routes using already resolved state paths.
+pub fn sync_routes_from_paths(paths: &StatePaths) -> Result<RouteSyncReport, RouteError> {
+    ensure_route_files(paths)?;
+
+    let peers = trust::list_peers(Some(paths.home.clone()))?;
+    let config = read_config(paths)?;
+    let relay_endpoint = relay_endpoint(&config)?;
+    let nat_profile = NatProfile::from_config(config.get("nat_profile"));
+    let now = current_unix_seconds();
+    let mut routes = Vec::new();
+    let mut probes = Vec::new();
+
+    for peer in peers
+        .iter()
+        .filter(|peer| peer.status == TrustStatus::Trusted)
+    {
+        let direct = direct_route_candidate(peer, &config, nat_profile, now)?;
+        let relay = relay_route_candidate(peer, &relay_endpoint, nat_profile, now)?;
+        let direct_available = direct.state != RouteState::Unavailable;
+        let direct_selected = direct_available && direct.score >= relay.score;
+
+        let selected_direct = RouteRecord {
+            state: if direct_selected {
+                RouteState::Selected
+            } else {
+                direct.state
+            },
+            ..direct
+        };
+        let selected_relay = RouteRecord {
+            state: if direct_selected {
+                RouteState::Candidate
+            } else {
+                RouteState::Selected
+            },
+            relay_fallback: !direct_selected,
+            ..relay
+        };
+
+        probes.push(probe_from_route(&selected_direct, now));
+        probes.push(probe_from_route(&selected_relay, now));
+        routes.push(selected_direct);
+        routes.push(selected_relay);
+    }
+
+    write_routes(paths, &routes)?;
+    append_probes(paths, &probes)?;
+    append_route_log(paths, &routes)?;
+
+    Ok(report_from_routes(&routes, probes.len()))
+}
+
+/// Read route candidate records.
+pub fn list_routes(home_override: Option<PathBuf>) -> Result<Vec<RouteRecord>, RouteError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_routes(&paths)
+}
+
+/// Read metadata-only route probe history.
+pub fn list_route_probes(home_override: Option<PathBuf>) -> Result<Vec<RouteProbe>, RouteError> {
+    let paths = StatePaths::resolve(home_override)?;
+    read_probes(&paths)
+}
+
+/// Return the selected route for a peer, if one exists.
+pub fn selected_route_for_peer(
+    home_override: Option<PathBuf>,
+    peer_node_id: &str,
+) -> Result<Option<RouteRecord>, RouteError> {
+    let paths = StatePaths::resolve(home_override)?;
+    selected_route_for_peer_from_paths(&paths, peer_node_id)
+}
+
+/// Return the selected route for a peer from resolved paths.
+pub fn selected_route_for_peer_from_paths(
+    paths: &StatePaths,
+    peer_node_id: &str,
+) -> Result<Option<RouteRecord>, RouteError> {
+    let peer_node_id = validate_identifier(peer_node_id.to_string(), "peer node id")?;
+    Ok(read_routes(paths)?
+        .into_iter()
+        .find(|route| route.peer_node_id == peer_node_id && route.is_selected()))
+}
+
+fn direct_route_candidate(
+    peer: &TrustedPeer,
+    config: &HashMap<String, String>,
+    nat_profile: NatProfile,
+    now: u64,
+) -> Result<RouteRecord, RouteError> {
+    let endpoint = direct_endpoint(config, &peer.peer_node_id);
+    let route_id = route_id(
+        &peer.peer_node_id,
+        RouteTransport::DirectQuic,
+        endpoint.as_deref(),
+    );
+    let mut state = RouteState::Unavailable;
+    let mut score = 0;
+    let mut latency_ms = None;
+    let mut failure_reason = Some("no_direct_quic_candidate".to_string());
+
+    if nat_profile == NatProfile::RelayOnly {
+        failure_reason = Some("nat_profile_relay_only".to_string());
+    } else if let Some(endpoint) = endpoint.as_deref() {
+        if valid_direct_endpoint(endpoint) {
+            state = RouteState::Candidate;
+            score = direct_score(nat_profile);
+            latency_ms = Some(DIRECT_QUIC_LATENCY_MS);
+            failure_reason = None;
+        } else {
+            failure_reason = Some("invalid_direct_quic_endpoint".to_string());
+        }
+    }
+
+    Ok(RouteRecord {
+        route_id,
+        peer_node_id: peer.peer_node_id.clone(),
+        display_name: peer.display_name.clone(),
+        transport: RouteTransport::DirectQuic,
+        endpoint: endpoint.unwrap_or_else(|| "quic://unconfigured".to_string()),
+        state,
+        score,
+        latency_ms,
+        direct_attempted: true,
+        relay_fallback: false,
+        nat_profile,
+        failure_reason,
+        updated_at_unix: now,
+    })
+}
+
+fn relay_route_candidate(
+    peer: &TrustedPeer,
+    endpoint: &str,
+    nat_profile: NatProfile,
+    now: u64,
+) -> Result<RouteRecord, RouteError> {
+    Ok(RouteRecord {
+        route_id: route_id(
+            &peer.peer_node_id,
+            RouteTransport::RelayWebSocket,
+            Some(endpoint),
+        ),
+        peer_node_id: peer.peer_node_id.clone(),
+        display_name: peer.display_name.clone(),
+        transport: RouteTransport::RelayWebSocket,
+        endpoint: validate_endpoint(endpoint.to_string())?,
+        state: RouteState::Candidate,
+        score: 70,
+        latency_ms: Some(RELAY_WEBSOCKET_LATENCY_MS),
+        direct_attempted: false,
+        relay_fallback: false,
+        nat_profile,
+        failure_reason: None,
+        updated_at_unix: now,
+    })
+}
+
+fn direct_score(nat_profile: NatProfile) -> u16 {
+    match nat_profile {
+        NatProfile::Public => 98,
+        NatProfile::Cone => 92,
+        NatProfile::Unknown => 88,
+        NatProfile::Symmetric => 72,
+        NatProfile::RelayOnly => 0,
+    }
+}
+
+fn probe_from_route(route: &RouteRecord, now: u64) -> RouteProbe {
+    let outcome = match route.state {
+        RouteState::Selected | RouteState::Candidate => "available",
+        RouteState::Fallback => "fallback",
+        RouteState::Unavailable => route.failure_reason.as_deref().unwrap_or("unavailable"),
+    };
+
+    RouteProbe {
+        probe_id: probe_id(&route.route_id, now),
+        route_id: route.route_id.clone(),
+        peer_node_id: route.peer_node_id.clone(),
+        transport: route.transport,
+        endpoint: route.endpoint.clone(),
+        outcome: outcome.to_string(),
+        score: route.score,
+        latency_ms: route.latency_ms,
+        created_at_unix: now,
+    }
+}
+
+fn report_from_routes(routes: &[RouteRecord], probes_recorded: usize) -> RouteSyncReport {
+    let peers = routes
+        .iter()
+        .map(|route| route.peer_node_id.as_str())
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+    RouteSyncReport {
+        peers,
+        candidates: routes.len(),
+        direct_attempts: routes
+            .iter()
+            .filter(|route| route.transport == RouteTransport::DirectQuic)
+            .count(),
+        direct_available: routes
+            .iter()
+            .filter(|route| {
+                route.transport == RouteTransport::DirectQuic
+                    && route.state != RouteState::Unavailable
+            })
+            .count(),
+        selected_direct: routes
+            .iter()
+            .filter(|route| route.is_selected() && route.is_direct())
+            .count(),
+        selected_relay: routes
+            .iter()
+            .filter(|route| {
+                route.is_selected() && route.transport == RouteTransport::RelayWebSocket
+            })
+            .count(),
+        relay_fallbacks: routes.iter().filter(|route| route.relay_fallback).count(),
+        probes_recorded,
+    }
+}
+
+fn ensure_route_files(paths: &StatePaths) -> Result<(), RouteError> {
+    fs::create_dir_all(&paths.routes_dir)
+        .map_err(|error| RouteError::io("create routes directory", &paths.routes_dir, error))?;
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| RouteError::io("create logs directory", &paths.logs_dir, error))
+}
+
+fn read_config(paths: &StatePaths) -> Result<HashMap<String, String>, RouteError> {
+    let contents = match fs::read_to_string(&paths.config) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(HashMap::new()),
+        Err(error) => return Err(RouteError::io("read route config", &paths.config, error)),
+    };
+    Ok(parse_key_values(&contents))
+}
+
+fn relay_endpoint(config: &HashMap<String, String>) -> Result<String, RouteError> {
+    validate_endpoint(
+        config
+            .get("default_relay")
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
+            .unwrap_or_else(|| DEFAULT_RELAY_ENDPOINT.to_string()),
+    )
+}
+
+fn direct_endpoint(config: &HashMap<String, String>, peer_node_id: &str) -> Option<String> {
+    let keyed = format!("direct_quic_{}", config_key_suffix(peer_node_id));
+    config
+        .get(&keyed)
+        .or_else(|| config.get("direct_quic_endpoint"))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn read_routes(paths: &StatePaths) -> Result<Vec<RouteRecord>, RouteError> {
+    if !paths.route_registry.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(&paths.route_registry)
+        .map_err(|error| RouteError::io("read route registry", &paths.route_registry, error))?;
+    parse_routes(&contents)
+}
+
+fn write_routes(paths: &StatePaths, routes: &[RouteRecord]) -> Result<(), RouteError> {
+    fs::create_dir_all(&paths.routes_dir)
+        .map_err(|error| RouteError::io("create routes directory", &paths.routes_dir, error))?;
+    let mut sorted = routes.to_vec();
+    sorted.sort_by(|left, right| {
+        left.peer_node_id
+            .cmp(&right.peer_node_id)
+            .then(left.transport.as_str().cmp(right.transport.as_str()))
+    });
+    let mut contents = format!("# conU route registry\nversion = \"{}\"\n", ROUTE_VERSION);
+
+    for route in sorted {
+        contents.push_str("\n[[route]]\n");
+        contents.push_str(&format!(
+            "route_id = \"{}\"\n",
+            escape_file_value(&route.route_id)
+        ));
+        contents.push_str(&format!(
+            "peer_node_id = \"{}\"\n",
+            escape_file_value(&route.peer_node_id)
+        ));
+        contents.push_str(&format!(
+            "display_name = \"{}\"\n",
+            escape_file_value(&route.display_name)
+        ));
+        contents.push_str(&format!("transport = \"{}\"\n", route.transport.as_str()));
+        contents.push_str(&format!(
+            "endpoint = \"{}\"\n",
+            escape_file_value(&route.endpoint)
+        ));
+        contents.push_str(&format!("state = \"{}\"\n", route.state.as_str()));
+        contents.push_str(&format!("score = {}\n", route.score));
+        contents.push_str(&format!("latency_ms = {}\n", route.latency_ms.unwrap_or(0)));
+        contents.push_str(&format!("direct_attempted = {}\n", route.direct_attempted));
+        contents.push_str(&format!("relay_fallback = {}\n", route.relay_fallback));
+        contents.push_str(&format!(
+            "nat_profile = \"{}\"\n",
+            route.nat_profile.as_str()
+        ));
+        contents.push_str(&format!(
+            "failure_reason = \"{}\"\n",
+            escape_file_value(route.failure_reason.as_deref().unwrap_or(""))
+        ));
+        contents.push_str(&format!("updated_at_unix = {}\n", route.updated_at_unix));
+        contents.push_str("payload_displayed = false\n");
+    }
+
+    fs::write(&paths.route_registry, contents)
+        .map_err(|error| RouteError::io("write route registry", &paths.route_registry, error))
+}
+
+fn append_probes(paths: &StatePaths, probes: &[RouteProbe]) -> Result<(), RouteError> {
+    if probes.is_empty() {
+        return Ok(());
+    }
+
+    fs::create_dir_all(&paths.routes_dir)
+        .map_err(|error| RouteError::io("create routes directory", &paths.routes_dir, error))?;
+    let new_file = !paths.route_probes.exists();
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&paths.route_probes)
+        .map_err(|error| RouteError::io("open route probes", &paths.route_probes, error))?;
+
+    if new_file {
+        writeln!(file, "# conU route probes\nversion = \"{}\"", ROUTE_VERSION)
+            .map_err(|error| RouteError::io("write route probes", &paths.route_probes, error))?;
+    }
+
+    for probe in probes {
+        writeln!(
+            file,
+            "\n[[probe]]\nprobe_id = \"{}\"\nroute_id = \"{}\"\npeer_node_id = \"{}\"\ntransport = \"{}\"\nendpoint = \"{}\"\noutcome = \"{}\"\nscore = {}\nlatency_ms = {}\ncreated_at_unix = {}\npayload_displayed = false",
+            escape_file_value(&probe.probe_id),
+            escape_file_value(&probe.route_id),
+            escape_file_value(&probe.peer_node_id),
+            probe.transport.as_str(),
+            escape_file_value(&probe.endpoint),
+            escape_file_value(&probe.outcome),
+            probe.score,
+            probe.latency_ms.unwrap_or(0),
+            probe.created_at_unix
+        )
+        .map_err(|error| RouteError::io("write route probe", &paths.route_probes, error))?;
+    }
+
+    Ok(())
+}
+
+fn read_probes(paths: &StatePaths) -> Result<Vec<RouteProbe>, RouteError> {
+    if !paths.route_probes.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(&paths.route_probes)
+        .map_err(|error| RouteError::io("read route probes", &paths.route_probes, error))?;
+    parse_probes(&contents)
+}
+
+fn append_route_log(paths: &StatePaths, routes: &[RouteRecord]) -> Result<(), RouteError> {
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| RouteError::io("create logs directory", &paths.logs_dir, error))?;
+    let log_path = paths.logs_dir.join("routes.log");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|error| RouteError::io("open route log", &log_path, error))?;
+    let report = report_from_routes(routes, 0);
+
+    writeln!(
+        file,
+        "event=route_sync peers={} candidates={} selected_direct={} selected_relay={} relay_fallbacks={} payload=not_observed",
+        report.peers,
+        report.candidates,
+        report.selected_direct,
+        report.selected_relay,
+        report.relay_fallbacks
+    )
+    .map_err(|error| RouteError::io("write route log", &log_path, error))
+}
+
+fn parse_routes(contents: &str) -> Result<Vec<RouteRecord>, RouteError> {
+    let mut routes = Vec::new();
+    let mut current = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') || line == "version = \"1\"" {
+            continue;
+        }
+        if line == "[[route]]" {
+            if !current.is_empty() {
+                routes.push(route_from_values(&current)?);
+                current.clear();
+            }
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        current.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    if !current.is_empty() {
+        routes.push(route_from_values(&current)?);
+    }
+
+    Ok(routes)
+}
+
+fn parse_probes(contents: &str) -> Result<Vec<RouteProbe>, RouteError> {
+    let mut probes = Vec::new();
+    let mut current = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') || line == "version = \"1\"" {
+            continue;
+        }
+        if line == "[[probe]]" {
+            if !current.is_empty() {
+                probes.push(probe_from_values(&current)?);
+                current.clear();
+            }
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        current.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    if !current.is_empty() {
+        probes.push(probe_from_values(&current)?);
+    }
+
+    Ok(probes)
+}
+
+fn route_from_values(values: &HashMap<String, String>) -> Result<RouteRecord, RouteError> {
+    let latency_ms = parse_u64(&required(values, "latency_ms")?)?;
+    let failure_reason = optional_clean(values.get("failure_reason"));
+    Ok(RouteRecord {
+        route_id: validate_identifier(required(values, "route_id")?, "route id")?,
+        peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
+        display_name: validate_display_name(required(values, "display_name")?)?,
+        transport: RouteTransport::from_str(&required(values, "transport")?),
+        endpoint: validate_endpoint(required(values, "endpoint")?)?,
+        state: RouteState::from_str(&required(values, "state")?),
+        score: parse_u16(&required(values, "score")?)?,
+        latency_ms: if latency_ms == 0 {
+            None
+        } else {
+            Some(latency_ms)
+        },
+        direct_attempted: parse_bool(values.get("direct_attempted")).unwrap_or(false),
+        relay_fallback: parse_bool(values.get("relay_fallback")).unwrap_or(false),
+        nat_profile: NatProfile::from_config(values.get("nat_profile")),
+        failure_reason,
+        updated_at_unix: parse_u64(&required(values, "updated_at_unix")?)?,
+    })
+}
+
+fn probe_from_values(values: &HashMap<String, String>) -> Result<RouteProbe, RouteError> {
+    let latency_ms = parse_u64(&required(values, "latency_ms")?)?;
+    Ok(RouteProbe {
+        probe_id: validate_identifier(required(values, "probe_id")?, "probe id")?,
+        route_id: validate_identifier(required(values, "route_id")?, "route id")?,
+        peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
+        transport: RouteTransport::from_str(&required(values, "transport")?),
+        endpoint: validate_endpoint(required(values, "endpoint")?)?,
+        outcome: validate_identifier(required(values, "outcome")?, "outcome")?,
+        score: parse_u16(&required(values, "score")?)?,
+        latency_ms: if latency_ms == 0 {
+            None
+        } else {
+            Some(latency_ms)
+        },
+        created_at_unix: parse_u64(&required(values, "created_at_unix")?)?,
+    })
+}
+
+fn parse_key_values(contents: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        values.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    values
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, RouteError> {
+    values
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| RouteError::InvalidRecord {
+            reason: format!("missing {key}"),
+        })
+}
+
+fn optional_clean(value: Option<&String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn validate_identifier(value: String, field: &'static str) -> Result<String, RouteError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(RouteError::InvalidRecord {
+            reason: format!("{field} cannot be empty"),
+        });
+    }
+    if value.len() > 180 {
+        return Err(RouteError::InvalidRecord {
+            reason: format!("{field} is too long"),
+        });
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Err(RouteError::InvalidRecord {
+            reason: format!("{field} must use ASCII letters, numbers, dash, underscore, or dot"),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_display_name(value: String) -> Result<String, RouteError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(RouteError::InvalidRecord {
+            reason: "display name cannot be empty".to_string(),
+        });
+    }
+    if value.len() > 120 || value.contains('\n') || value.contains('\r') {
+        return Err(RouteError::InvalidRecord {
+            reason: "display name is invalid".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_endpoint(value: String) -> Result<String, RouteError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(RouteError::InvalidRecord {
+            reason: "endpoint cannot be empty".to_string(),
+        });
+    }
+    if value.len() > 220 || value.chars().any(char::is_whitespace) {
+        return Err(RouteError::InvalidRecord {
+            reason: "endpoint is invalid".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn valid_direct_endpoint(value: &str) -> bool {
+    let endpoint = value
+        .strip_prefix("quic://")
+        .or_else(|| value.strip_prefix("udp://"))
+        .unwrap_or(value);
+    let Some((host, port)) = endpoint.rsplit_once(':') else {
+        return false;
+    };
+    !host.trim().is_empty()
+        && port.parse::<u16>().is_ok_and(|port| port > 0)
+        && !endpoint.chars().any(char::is_whitespace)
+}
+
+fn parse_bool(value: Option<&String>) -> Option<bool> {
+    match value?.as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn parse_u16(value: &str) -> Result<u16, RouteError> {
+    value.parse::<u16>().map_err(|_| RouteError::InvalidRecord {
+        reason: "expected unsigned score".to_string(),
+    })
+}
+
+fn parse_u64(value: &str) -> Result<u64, RouteError> {
+    value.parse::<u64>().map_err(|_| RouteError::InvalidRecord {
+        reason: "expected unsigned integer".to_string(),
+    })
+}
+
+fn route_id(peer_node_id: &str, transport: RouteTransport, endpoint: Option<&str>) -> String {
+    let mut hasher = DefaultHasher::new();
+    peer_node_id.hash(&mut hasher);
+    transport.as_str().hash(&mut hasher);
+    endpoint.unwrap_or("").hash(&mut hasher);
+    format!("route_{:016x}", hasher.finish())
+}
+
+fn probe_id(route_id: &str, now: u64) -> String {
+    let mut hasher = DefaultHasher::new();
+    route_id.hash(&mut hasher);
+    now.hash(&mut hasher);
+    current_unix_nanos().hash(&mut hasher);
+    format!("probe_{:016x}", hasher.finish())
+}
+
+fn config_key_suffix(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::process;
+
+    #[test]
+    fn sync_prefers_relay_when_no_direct_candidate_exists() {
+        let home = test_home("relay-fallback");
+        let peer = trusted_peer(&home);
+
+        let report = sync_routes(Some(home.clone())).expect("routes sync");
+        let routes = list_routes(Some(home)).expect("routes read");
+        let selected = routes
+            .iter()
+            .find(|route| route.peer_node_id == peer.peer_node_id && route.is_selected())
+            .expect("selected route");
+
+        assert_eq!(report.relay_fallbacks, 1);
+        assert_eq!(selected.transport, RouteTransport::RelayWebSocket);
+        assert!(selected.relay_fallback);
+    }
+
+    #[test]
+    fn sync_prefers_direct_quic_when_candidate_is_configured() {
+        let home = test_home("direct-quic");
+        let peer = trusted_peer(&home);
+        let config_key = format!("direct_quic_{}", config_key_suffix(&peer.peer_node_id));
+        fs::write(
+            StatePaths::from_home(home.clone()).config,
+            format!(
+                "version = \"1\"\ndefault_relay = \"ws://127.0.0.1:8787\"\nnat_profile = \"public\"\n{config_key} = \"quic://127.0.0.1:9443\"\n"
+            ),
+        )
+        .expect("config writes");
+
+        let report = sync_routes(Some(home.clone())).expect("routes sync");
+        let selected =
+            selected_route_for_peer(Some(home), &peer.peer_node_id).expect("route lookup");
+
+        assert_eq!(report.selected_direct, 1);
+        assert_eq!(report.selected_relay, 0);
+        assert_eq!(
+            selected.expect("selected").transport,
+            RouteTransport::DirectQuic
+        );
+    }
+
+    #[test]
+    fn route_logs_and_probes_are_payload_safe() {
+        let home = test_home("payload-safe");
+        trusted_peer(&home);
+
+        sync_routes(Some(home.clone())).expect("routes sync");
+        let paths = StatePaths::from_home(home.clone());
+        let log = fs::read_to_string(paths.logs_dir.join("routes.log")).expect("log reads");
+        let probes = fs::read_to_string(paths.route_probes).expect("probes read");
+
+        assert!(log.contains("payload=not_observed"));
+        assert!(probes.contains("payload_displayed = false"));
+        assert!(!log.contains("private message contents"));
+        assert!(!probes.contains("private message contents"));
+        assert!(!log.contains("Review this code"));
+    }
+
+    #[test]
+    fn revoked_peer_is_not_routeable() {
+        let home = test_home("revoked");
+        let peer = trusted_peer(&home);
+        trust::revoke_peer(Some(home.clone()), &peer.peer_node_id).expect("revokes");
+
+        let report = sync_routes(Some(home.clone())).expect("routes sync");
+        let routes = list_routes(Some(home)).expect("routes read");
+
+        assert_eq!(report.peers, 0);
+        assert!(routes.is_empty());
+    }
+
+    fn trusted_peer(home: &Path) -> TrustedPeer {
+        state::init_state(Some(home.to_path_buf())).expect("state initializes");
+        let invite =
+            trust::create_pairing_invite(Some(home.to_path_buf())).expect("invite creates");
+        trust::join_pairing_code(Some(home.to_path_buf()), &invite.code)
+            .expect("joins")
+            .peer
+    }
+
+    fn test_home(name: &str) -> PathBuf {
+        let mut path = env::temp_dir();
+        path.push(format!(
+            "conu-routes-test-{}-{}-{name}",
+            process::id(),
+            current_unix_nanos()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        path
+    }
+}

--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -14,6 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use conu_protocol::AgentCapabilities;
 
 use crate::agents::AgentPresence;
+use crate::routes::{self, RouteTransport};
 use crate::state::{self, StateError, StatePaths};
 use crate::trust::{self, TrustStatus, TrustedPeer};
 
@@ -88,6 +89,7 @@ pub struct SessionSyncReport {
 pub enum SessionError {
     State(StateError),
     Trust(trust::TrustError),
+    Route(routes::RouteError),
     Io {
         action: &'static str,
         path: PathBuf,
@@ -113,6 +115,7 @@ impl fmt::Display for SessionError {
         match self {
             Self::State(error) => write!(formatter, "{error}"),
             Self::Trust(error) => write!(formatter, "{error}"),
+            Self::Route(error) => write!(formatter, "{error}"),
             Self::Io {
                 action,
                 path,
@@ -137,6 +140,12 @@ impl From<trust::TrustError> for SessionError {
     }
 }
 
+impl From<routes::RouteError> for SessionError {
+    fn from(error: routes::RouteError) -> Self {
+        Self::Route(error)
+    }
+}
+
 /// Sync remote sessions from the local trust store.
 pub fn sync_remote_sessions(
     home_override: Option<PathBuf>,
@@ -152,6 +161,7 @@ pub fn sync_remote_sessions_from_paths(
     ensure_session_files(paths)?;
 
     let peers = trust::list_peers(Some(paths.home.clone()))?;
+    routes::sync_routes_from_paths(paths)?;
     let previous = read_sessions(paths)?
         .into_iter()
         .map(|session| (session.peer_node_id.clone(), session))
@@ -163,7 +173,8 @@ pub fn sync_remote_sessions_from_paths(
 
     for peer in peers {
         let prior = previous.get(&peer.peer_node_id);
-        let session = session_from_peer(&peer, prior, &relay_endpoint, now);
+        let selected_route = routes::selected_route_for_peer_from_paths(paths, &peer.peer_node_id)?;
+        let session = session_from_peer(&peer, prior, &relay_endpoint, selected_route, now);
         if peer.status == TrustStatus::Trusted {
             remote_agents.push(remote_agent_from_peer(&peer, now));
         }
@@ -197,6 +208,7 @@ fn session_from_peer(
     peer: &TrustedPeer,
     prior: Option<&RemoteSession>,
     relay_endpoint: &str,
+    selected_route: Option<routes::RouteRecord>,
     now: u64,
 ) -> RemoteSession {
     let state = if peer.status == TrustStatus::Trusted {
@@ -216,13 +228,23 @@ fn session_from_peer(
         _ => prior.map(|session| session.last_seen_unix).unwrap_or(now),
     };
     let remote_agent_count = usize::from(peer.status == TrustStatus::Trusted);
+    let (route, endpoint) = match selected_route {
+        Some(route) if peer.status == TrustStatus::Trusted => {
+            let route_label = match route.transport {
+                RouteTransport::DirectQuic => "direct-quic",
+                RouteTransport::RelayWebSocket => "relay-websocket",
+            };
+            (route_label.to_string(), route.endpoint)
+        }
+        _ => ("relay-websocket".to_string(), relay_endpoint.to_string()),
+    };
 
     RemoteSession {
         peer_node_id: peer.peer_node_id.clone(),
         display_name: peer.display_name.clone(),
         state,
-        route: "relay".to_string(),
-        relay_endpoint: relay_endpoint.to_string(),
+        route,
+        relay_endpoint: endpoint,
         reconnect_attempts,
         remote_agent_count,
         last_seen_unix,

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -34,6 +34,9 @@ const MESSAGE_RECEIPTS_DIR: &str = "receipts";
 const STREAMS_DIR: &str = "streams";
 const STREAM_REGISTRY_FILE: &str = "registry.toml";
 const STREAM_EVENTS_FILE: &str = "events.toml";
+const ROUTES_DIR: &str = "routes";
+const ROUTE_REGISTRY_FILE: &str = "registry.toml";
+const ROUTE_PROBES_FILE: &str = "probes.toml";
 const PAIRING_DIR: &str = "pairing";
 const PAIRING_INVITES_DIR: &str = "invites";
 const PAIRING_USED_DIR: &str = "used";
@@ -76,6 +79,9 @@ pub struct StatePaths {
     pub streams_dir: PathBuf,
     pub stream_registry: PathBuf,
     pub stream_events: PathBuf,
+    pub routes_dir: PathBuf,
+    pub route_registry: PathBuf,
+    pub route_probes: PathBuf,
     pub pairing_dir: PathBuf,
     pub pairing_invites_dir: PathBuf,
     pub pairing_used_dir: PathBuf,
@@ -110,6 +116,7 @@ impl StatePaths {
         let message_ipc_dir = ipc_dir.join(MESSAGES_DIR);
         let messages_dir = home.join(MESSAGES_DIR);
         let streams_dir = home.join(STREAMS_DIR);
+        let routes_dir = home.join(ROUTES_DIR);
         let pairing_dir = home.join(PAIRING_DIR);
         let security_dir = home.join(SECURITY_DIR);
 
@@ -138,6 +145,9 @@ impl StatePaths {
             stream_registry: streams_dir.join(STREAM_REGISTRY_FILE),
             stream_events: streams_dir.join(STREAM_EVENTS_FILE),
             streams_dir,
+            route_registry: routes_dir.join(ROUTE_REGISTRY_FILE),
+            route_probes: routes_dir.join(ROUTE_PROBES_FILE),
+            routes_dir,
             pairing_invites_dir: pairing_dir.join(PAIRING_INVITES_DIR),
             pairing_used_dir: pairing_dir.join(PAIRING_USED_DIR),
             pairing_dir,
@@ -323,6 +333,7 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
         &paths.message_inbox_dir,
         &paths.message_receipts_dir,
         &paths.streams_dir,
+        &paths.routes_dir,
         &paths.pairing_dir,
         &paths.pairing_invites_dir,
         &paths.pairing_used_dir,

--- a/crates/conu-core/src/streams.rs
+++ b/crates/conu-core/src/streams.rs
@@ -15,6 +15,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use conu_protocol::OpaquePayload;
 
 use crate::agents;
+use crate::routes;
 use crate::sessions;
 use crate::state::{self, StateError, StatePaths};
 
@@ -99,6 +100,7 @@ pub enum StreamError {
     State(StateError),
     Agent(agents::AgentError),
     Session(sessions::SessionError),
+    Route(routes::RouteError),
     Io {
         action: &'static str,
         path: PathBuf,
@@ -125,6 +127,7 @@ impl fmt::Display for StreamError {
             Self::State(error) => write!(formatter, "{error}"),
             Self::Agent(error) => write!(formatter, "{error}"),
             Self::Session(error) => write!(formatter, "{error}"),
+            Self::Route(error) => write!(formatter, "{error}"),
             Self::Io {
                 action,
                 path,
@@ -157,6 +160,12 @@ impl From<sessions::SessionError> for StreamError {
     }
 }
 
+impl From<routes::RouteError> for StreamError {
+    fn from(error: routes::RouteError) -> Self {
+        Self::Route(error)
+    }
+}
+
 /// Open a stream between a local agent and a visible local or remote agent.
 pub fn open_stream(
     home_override: Option<PathBuf>,
@@ -170,6 +179,7 @@ pub fn open_stream(
     let kind = validate_identifier(kind.to_string(), "stream kind")?;
 
     validate_stream_agents(home_override, &from_agent_id, &to_agent_id)?;
+    let route = stream_route_for_target(&init.paths, &to_agent_id)?;
 
     let now = current_unix_seconds();
     let stream = StreamRecord {
@@ -178,7 +188,7 @@ pub fn open_stream(
         to_agent_id,
         kind,
         state: StreamState::Open,
-        route: "metadata-relay".to_string(),
+        route,
         chunks_written: 0,
         bytes_written: 0,
         backpressure_window: DEFAULT_BACKPRESSURE_WINDOW,
@@ -193,6 +203,25 @@ pub fn open_stream(
     append_stream_log(&init.paths, "stream_opened", &stream, 0)?;
 
     Ok(StreamOpenReport { stream })
+}
+
+fn stream_route_for_target(paths: &StatePaths, to_agent_id: &str) -> Result<String, StreamError> {
+    if agents::agent_exists(Some(paths.home.clone()), to_agent_id)? {
+        return Ok("local".to_string());
+    }
+
+    let remote_agents = sessions::list_remote_agents(Some(paths.home.clone()))?;
+    let Some(remote_agent) = remote_agents
+        .into_iter()
+        .find(|agent| agent.agent_id == to_agent_id)
+    else {
+        return Ok("metadata-relay".to_string());
+    };
+
+    let selected = routes::selected_route_for_peer_from_paths(paths, &remote_agent.peer_node_id)?;
+    Ok(selected
+        .map(|route| route.transport.as_str().to_string())
+        .unwrap_or_else(|| "metadata-relay".to_string()))
 }
 
 /// Record an opaque stream chunk by byte count only.

--- a/crates/conu-mcp/src/lib.rs
+++ b/crates/conu-mcp/src/lib.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 
-use conu_sdk::{Capabilities, ConuClient, Presence, SdkError, Stream};
+use conu_sdk::{Capabilities, ConuClient, Presence, Route, SdkError, Stream};
 use serde_json::{Map, Value, json};
 
 const JSONRPC_VERSION: &str = "2.0";
@@ -146,6 +146,8 @@ impl McpServer {
             "conu_register_agent" => self.tool_register_agent(args),
             "conu_set_presence" => self.tool_set_presence(args),
             "conu_process_queued" => self.tool_process_queued(),
+            "conu_sync_routes" => self.tool_sync_routes(),
+            "conu_list_routes" => self.tool_list_routes(args),
             "conu_list_agents" => self.tool_list_agents(args),
             "conu_list_peers" => self.tool_list_peers(),
             "conu_send_message" => self.tool_send_message(args),
@@ -267,6 +269,33 @@ impl McpServer {
                 "reconnecting": report.sessions.reconnecting,
                 "offline": report.sessions.offline
             },
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_sync_routes(&self) -> Result<Value, String> {
+        let report = self.client.sync_routes().map_err(safe_sdk_error)?;
+        Ok(json!({
+            "status": "synced",
+            "peers": report.peers,
+            "candidates": report.candidates,
+            "directAttempts": report.direct_attempts,
+            "directAvailable": report.direct_available,
+            "selectedDirect": report.selected_direct,
+            "selectedRelay": report.selected_relay,
+            "relayFallbacks": report.relay_fallbacks,
+            "probesRecorded": report.probes_recorded,
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_list_routes(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        if optional_bool(args, "sync", false)? {
+            self.client.sync_routes().map_err(safe_sdk_error)?;
+        }
+        let routes = self.client.list_routes().map_err(safe_sdk_error)?;
+        Ok(json!({
+            "routes": routes.iter().map(route_to_json).collect::<Vec<_>>(),
             "contentsDisplayed": false
         }))
     }
@@ -485,6 +514,16 @@ impl McpServer {
                 "conu_process_queued",
                 "Process queued conU gateway work once.",
                 schema(json!({}), vec![]),
+            ),
+            tool(
+                "conu_sync_routes",
+                "Probe and score direct/relay routes for trusted peers.",
+                schema(json!({}), vec![]),
+            ),
+            tool(
+                "conu_list_routes",
+                "List direct QUIC and relay route candidates without payloads.",
+                schema(json!({ "sync": { "type": "boolean" } }), vec![]),
             ),
             tool(
                 "conu_list_agents",
@@ -772,6 +811,25 @@ fn stream_to_json(stream: &Stream) -> Value {
     })
 }
 
+fn route_to_json(route: &Route) -> Value {
+    json!({
+        "routeId": &route.route_id,
+        "peerNodeId": &route.peer_node_id,
+        "displayName": &route.display_name,
+        "transport": route.transport.as_str(),
+        "endpoint": &route.endpoint,
+        "state": route.state.as_str(),
+        "score": route.score,
+        "latencyMs": route.latency_ms,
+        "directAttempted": route.direct_attempted,
+        "relayFallback": route.relay_fallback,
+        "natProfile": route.nat_profile.as_str(),
+        "failureReason": route.failure_reason.as_deref(),
+        "updatedAtUnix": route.updated_at_unix,
+        "contentsDisplayed": false
+    })
+}
+
 fn safe_sdk_error(error: SdkError) -> String {
     error.to_string()
 }
@@ -846,6 +904,30 @@ mod tests {
         assert!(body.contains("conu_send_message"));
         assert!(body.contains("conu_receive_message"));
         assert!(body.contains("conu_open_stream"));
+        assert!(body.contains("conu_sync_routes"));
+        assert!(body.contains("conu_list_routes"));
+    }
+
+    #[test]
+    fn route_tools_return_metadata_only() {
+        let server = McpServer::with_home(test_home("routes"));
+        let sync = call_tool(&server, 1, "conu_sync_routes", json!({}));
+        let routes = call_tool(
+            &server,
+            2,
+            "conu_list_routes",
+            json!({
+                "sync": true
+            }),
+        );
+        let sync_json: Value = serde_json::from_str(&tool_text(&sync)).expect("sync json");
+        let routes_json: Value = serde_json::from_str(&tool_text(&routes)).expect("routes json");
+        let body = format!("{sync_json}\n{routes_json}");
+
+        assert_eq!(sync_json["contentsDisplayed"], Value::Bool(false));
+        assert_eq!(routes_json["contentsDisplayed"], Value::Bool(false));
+        assert_eq!(routes_json["routes"], json!([]));
+        assert!(!body.contains("private message contents"));
     }
 
     #[test]

--- a/crates/conu-sdk/src/lib.rs
+++ b/crates/conu-sdk/src/lib.rs
@@ -15,6 +15,7 @@ use conu_core::agents::{
 use conu_core::messages::{
     self, DeliveryReceipt, InboxEntry, LocalMessage, MessageProcessReport, MessageSubmission,
 };
+use conu_core::routes::{self, RouteProbe, RouteRecord, RouteSyncReport};
 use conu_core::runtime::{self, RuntimeStatus};
 use conu_core::security::{self, SecurityAudit};
 use conu_core::sessions::{self, RemoteAgentRecord, RemoteSession, SessionSyncReport};
@@ -26,6 +27,7 @@ use conu_core::trust::{self, JoinReport, PairingInvite, RevokeReport, TrustedPee
 use conu_protocol::{AgentCapabilities, OpaquePayload};
 
 pub use conu_core::agents::AgentPresence as Presence;
+pub use conu_core::routes::RouteRecord as Route;
 pub use conu_core::streams::StreamRecord as Stream;
 pub use conu_protocol::AgentCapabilities as Capabilities;
 
@@ -142,6 +144,21 @@ impl ConuClient {
     /// List trusted/revoked peers.
     pub fn list_peers(&self) -> Result<Vec<TrustedPeer>, SdkError> {
         Ok(trust::list_peers(self.home_override())?)
+    }
+
+    /// Probe and score direct/relay routes for trusted peers.
+    pub fn sync_routes(&self) -> Result<RouteSyncReport, SdkError> {
+        Ok(routes::sync_routes(self.home_override())?)
+    }
+
+    /// List direct/relay route candidates.
+    pub fn list_routes(&self) -> Result<Vec<RouteRecord>, SdkError> {
+        Ok(routes::list_routes(self.home_override())?)
+    }
+
+    /// List metadata-only route probe history.
+    pub fn list_route_probes(&self) -> Result<Vec<RouteProbe>, SdkError> {
+        Ok(routes::list_route_probes(self.home_override())?)
     }
 
     /// Create a local pairing invitation.
@@ -303,6 +320,7 @@ pub enum SdkError {
     Agent(agents::AgentError),
     Message(messages::MessageError),
     Runtime(runtime::RuntimeError),
+    Route(routes::RouteError),
     Session(sessions::SessionError),
     Stream(streams::StreamError),
     Trust(trust::TrustError),
@@ -324,6 +342,7 @@ impl fmt::Display for SdkError {
             Self::Agent(error) => write!(formatter, "{error}"),
             Self::Message(error) => write!(formatter, "{error}"),
             Self::Runtime(error) => write!(formatter, "{error}"),
+            Self::Route(error) => write!(formatter, "{error}"),
             Self::Session(error) => write!(formatter, "{error}"),
             Self::Stream(error) => write!(formatter, "{error}"),
             Self::Trust(error) => write!(formatter, "{error}"),
@@ -374,6 +393,12 @@ impl From<messages::MessageError> for SdkError {
 impl From<runtime::RuntimeError> for SdkError {
     fn from(error: runtime::RuntimeError) -> Self {
         Self::Runtime(error)
+    }
+}
+
+impl From<routes::RouteError> for SdkError {
+    fn from(error: routes::RouteError) -> Self {
+        Self::Route(error)
     }
 }
 

--- a/crates/conud/src/main.rs
+++ b/crates/conud/src/main.rs
@@ -159,7 +159,7 @@ fn print_status() -> ExitCode {
 
 fn print_check() {
     println!("{}", conu_core::scaffold_status("conud"));
-    println!("runtime: phase 11 security hardening ready; payloads not observed");
+    println!("runtime: phase 13 route manager ready; payloads not observed");
 }
 
 fn print_help() {

--- a/docs/direct-transport-and-routes.md
+++ b/docs/direct-transport-and-routes.md
@@ -1,0 +1,89 @@
+# conU Direct Transport And Routes
+
+Phase 13 adds the conUD-owned route manager. It lets conU choose between a configured direct QUIC candidate and relay WebSocket fallback for each trusted peer, while keeping all payloads opaque.
+
+```txt
+Agents own the conversation.
+conU owns the connection.
+```
+
+## What Exists Now
+
+- `conu routes sync` probes trusted-peer route metadata and writes selected routes.
+- `conu routes` lists selected and candidate routes.
+- `conu routes probes` lists metadata-only route probe history.
+- `conu status` and the dashboard show selected direct, relay, and fallback counts.
+- `conu sessions sync` now refreshes routes before mirroring remote sessions.
+- Streams opened to mirrored remote agents use the selected route label.
+- Rust SDK and MCP expose route sync/list calls.
+
+## State Files
+
+```txt
+routes/registry.toml   selected and candidate route metadata
+routes/probes.toml     metadata-only route probe history
+logs/routes.log        payload-safe route sync summaries
+```
+
+These files may contain peer ids, route ids, transport labels, endpoints, scores, NAT profile labels, latency estimates, and failure reasons. They must not contain message text, prompt text, chunk bytes, tool output, private keys, shared secrets, auth tokens, or plaintext payload fields.
+
+## Route Selection
+
+For each trusted peer, conUD creates:
+
+- one `direct-quic` candidate from config, when available
+- one `relay-websocket` fallback candidate
+
+The direct route is selected when it has a valid endpoint and its score is at least as high as relay. Otherwise relay is selected and marked as the fallback path.
+
+NAT profile scoring:
+
+```txt
+public      direct score 98
+cone        direct score 92
+unknown     direct score 88
+symmetric   direct score 72
+relay-only  direct disabled
+relay       score 70
+```
+
+## Config
+
+`config.toml` supports a global direct endpoint or a peer-specific endpoint:
+
+```toml
+default_relay = "ws://127.0.0.1:8787"
+nat_profile = "public"
+direct_quic_endpoint = "quic://127.0.0.1:9443"
+```
+
+Peer-specific keys use a sanitized peer node id:
+
+```toml
+direct_quic_peer_abcd1234 = "quic://203.0.113.10:9443"
+```
+
+Accepted direct endpoint schemes are `quic://` and `udp://` with a host and port. Invalid or missing direct endpoints keep relay selected.
+
+## Agent Use
+
+Agents should not read or write route files directly. They should use one of the supported surfaces:
+
+```txt
+CLI:      conu routes sync
+Rust SDK: ConuClient::sync_routes()
+Python:   ConuClient.sync_routes()
+MCP:      conu_sync_routes
+```
+
+Agents can inspect route metadata to understand whether conU will prefer direct or relay, but they still own the conversation and payload bytes.
+
+## Current Boundary
+
+Phase 13 is the route selection and NAT posture layer. It does not yet open a real QUIC socket, perform ICE-style candidate exchange, or move encrypted stream chunks over direct UDP. That remains future transport hardening.
+
+Design references:
+
+- QUIC transport: https://www.rfc-editor.org/rfc/rfc9000
+- QUIC DATAGRAM extension: https://www.rfc-editor.org/rfc/rfc9221
+- ICE candidate negotiation: https://www.rfc-editor.org/rfc/rfc8445

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -16,18 +16,20 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 - Metadata-only relay frame contract and standalone WebSocket relay MVP.
 - Remote session and remote agent metadata mirror for trusted peers.
 - Stream lifecycle metadata, backpressure counters, and private watch animation.
+- Direct QUIC candidate scoring, NAT profile labels, route probes, and relay fallback selection.
 - Replay protection for local message request and envelope ids.
 - Rust SDK for local agent registration, messaging, receive, peer, security, and stream calls.
 - Python stdlib wrapper SDK around installed `conu` and `conud` binaries.
 - MCP stdio adapter exposing conU as JSON-RPC tools for MCP-capable agents.
 - Payload-safe logs, receipts, watch output, and CLI JSON.
-- Phase 11 security audit command and Phase 12 SDK/MCP receive path.
+- Phase 11 security audit command, Phase 12 SDK/MCP receive path, and Phase 13 route manager.
 
 ## Still Local Or Groundwork
 
 - File-backed IPC is reliable for development, but not yet a production named-pipe/socket transport.
 - Remote sessions are metadata mirrors. They do not yet move encrypted payload bytes between machines.
 - The relay forwards metadata frames, but conUD does not yet own a live relay client for data-plane delivery.
+- Direct transport is route metadata only. Real QUIC sockets, ICE-style candidate exchange, and NAT hole punching are not active yet.
 - Stream writes count bytes and emit events. They do not persist or relay chunk bytes yet.
 - Pairing is local trust-store groundwork, not full cross-machine rendezvous.
 - MCP is stdio-only. HTTP MCP transport, auth, and remote MCP hosting are intentionally not implemented.
@@ -36,6 +38,7 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 ## Release Blockers
 
 - Live relay-backed encrypted message and stream routing.
+- Real direct QUIC transport with peer authentication and NAT traversal.
 - Remote signed agent-card exchange and verification.
 - Capability grants and user-visible permission policy.
 - SDK permission policy hardening before public package distribution.
@@ -68,6 +71,7 @@ Every release candidate must confirm:
 - SDK/MCP list, send, status, receipt, and stream outputs stay metadata-only.
 - SDK/MCP receive APIs return payload bytes only to the addressed local agent by explicit request.
 - Logs use `payload=not_observed` or metadata-only equivalents.
+- Route registry, route probes, and route logs contain route metadata only.
 - Relay frames reject plaintext payload fields.
 - Message and mailbox storage use encrypted payload fields.
 - Tests use artificial negative strings only to prove they do not leak.

--- a/docs/sdk-and-mcp.md
+++ b/docs/sdk-and-mcp.md
@@ -43,6 +43,9 @@ set_presence()
 process_queued()
 list_agents()
 list_peers()
+sync_routes()
+list_routes()
+list_route_probes()
 send_message_bytes()
 inbox_metadata()
 receive_message_bytes()
@@ -82,6 +85,8 @@ print(sent["payloadBytes"])
 
 The wrapper passes send/stream payload bytes through stdin and returns command output to the caller. It does not print or log payloads.
 
+Route helpers are available as `sync_routes()`, `routes()`, and `route_probes()`. They return route metadata only.
+
 ## MCP Adapter
 
 The MCP adapter lives in `crates/conu-mcp` and runs as a stdio server:
@@ -114,6 +119,8 @@ conu_security_audit
 conu_register_agent
 conu_set_presence
 conu_process_queued
+conu_sync_routes
+conu_list_routes
 conu_list_agents
 conu_list_peers
 conu_send_message
@@ -123,7 +130,7 @@ conu_write_stream
 conu_close_stream
 ```
 
-`conu_send_message` accepts `payloadText` or `payloadHex`, but the tool response reports only request id, byte count, delivery counts, and envelope ids. `conu_receive_message` returns metadata by default. It returns `payloadHex` only when `includePayload` is `true`.
+`conu_sync_routes` and `conu_list_routes` expose route ids, peer ids, transport labels, endpoints, scores, latency estimates, NAT profile labels, fallback flags, and failure reasons. They do not expose payload bytes. `conu_send_message` accepts `payloadText` or `payloadHex`, but the tool response reports only request id, byte count, delivery counts, and envelope ids. `conu_receive_message` returns metadata by default. It returns `payloadHex` only when `includePayload` is `true`.
 
 When `CONU_AGENT_ID` is set, `conu-mcp` is bound to that local agent id. Register, presence, send, receive, stream open, stream write, and stream close actions are rejected if they attempt to act as a different local agent.
 
@@ -137,5 +144,6 @@ Reference: [MCP 2025-11-25 Transports](https://modelcontextprotocol.io/specifica
 
 - TypeScript SDK remains future work.
 - Remote relay-backed data-plane delivery is not active yet.
+- Route sync selects configured direct QUIC candidates and relay fallback metadata; it does not open a real QUIC socket yet.
 - MCP uses local stdio only; HTTP MCP transport is not implemented.
 - `conu_receive_message` is intentionally explicit because normal CLI and tool metadata views must not display payload contents.

--- a/docs/user-install-and-agent-guide.md
+++ b/docs/user-install-and-agent-guide.md
@@ -2,7 +2,7 @@
 
 This guide explains how a user can install the current conU app, start it on their PC, and let local agents use it.
 
-Current version status: Phase 12 is complete. conU is usable for local agent registration, local encrypted-at-rest message submission, stream metadata, trust metadata, private CLI watch output, Rust SDK calls, a Python wrapper SDK, and an MCP stdio adapter. It is not yet a packaged consumer release.
+Current version status: Phase 13 is complete. conU is usable for local agent registration, local encrypted-at-rest message submission, stream metadata, trust metadata, direct/relay route metadata, private CLI watch output, Rust SDK calls, a Python wrapper SDK, and an MCP stdio adapter. It is not yet a packaged consumer release.
 
 ## What Works Today
 
@@ -13,6 +13,7 @@ Current version status: Phase 12 is complete. conU is usable for local agent reg
 - Send local opaque payload bytes from one registered local agent to another.
 - Store new conU-owned local payload files encrypted at rest.
 - List inbox, receipt, stream, peer, session, and security metadata.
+- Sync and inspect direct QUIC route candidates and relay fallback metadata.
 - Run a standalone `conu-relay` MVP for metadata-only relay frame tests.
 - Let Rust agents use `conu_sdk::ConuClient`.
 - Let Python agents use `sdk/python/conu_sdk`.
@@ -24,6 +25,7 @@ Current version status: Phase 12 is complete. conU is usable for local agent reg
 - No TypeScript SDK yet.
 - No CLI command that reveals message contents. This is intentional; use SDK or MCP explicit receive APIs when the addressed local agent needs payload bytes.
 - No live internet data-plane routing between two real conUD nodes yet.
+- No real QUIC socket or NAT hole punching yet; Phase 13 selects configured direct route candidates and relay fallback metadata.
 - Pairing and remote sessions are local metadata groundwork, not full cross-machine rendezvous.
 - `conu-relay` exists, but conUD does not yet own a live relay client for encrypted message/stream byte delivery.
 - conUD is not installed as a Windows/macOS/Linux service yet.
@@ -167,6 +169,35 @@ conu messages receipts --json
 
 The inbox command shows metadata only: envelope id, sender, receiver, receipt id, byte count, and delivery time. It does not print the payload.
 
+## Sync Routes
+
+Phase 13 lets conUD choose route metadata for trusted peers:
+
+```powershell
+conu pair
+conu join <code>
+conu routes sync
+conu routes
+conu routes --json
+conu routes probes
+```
+
+To test a direct route candidate, add a direct endpoint to `config.toml`:
+
+```toml
+default_relay = "ws://127.0.0.1:8787"
+nat_profile = "public"
+direct_quic_endpoint = "quic://127.0.0.1:9443"
+```
+
+Use a peer-specific sanitized key when one peer needs its own endpoint:
+
+```toml
+direct_quic_peer_abcd1234 = "quic://203.0.113.10:9443"
+```
+
+`conu routes sync` writes only route metadata. It does not print, log, or inspect message contents.
+
 ## Give conU To An Agent
 
 Agents can use conU through MCP, Rust, Python, or direct CLI calls.
@@ -199,6 +230,7 @@ Rules:
 - Register once with conu_register_agent.
 - Use conu_set_presence when your state changes.
 - Discover local and trusted remote metadata with conu_list_agents and conu_list_peers.
+- Sync and inspect route metadata with conu_sync_routes and conu_list_routes.
 - Send opaque bytes with conu_send_message.
 - Read inbox metadata first; request payloadHex only with conu_receive_message when you are the addressed local agent.
 - Use conu_open_stream, conu_write_stream, and conu_close_stream for stream metadata flows.
@@ -290,6 +322,7 @@ These are not hidden bugs; they are the honest state of the current app:
 | Agent API | Rust SDK, Python wrapper, and MCP adapter exist; TypeScript is later | Most agents can integrate now, TS apps need wrapper work | Use MCP, Rust SDK, Python SDK, or CLI/stdin |
 | Receiving payloads | CLI intentionally lists inbox metadata only | Agents needing bytes must use explicit receive APIs | Use Rust SDK `receive_message_bytes` or MCP `conu_receive_message` with `includePayload` |
 | Internet messaging | Relay is not wired into conUD data plane yet | Local messages work; real remote payload delivery does not | Use local testing only |
+| Direct transport | Route selection exists, but real QUIC sockets and NAT hole punching do not | Direct routes show as metadata only | Configure direct endpoints for route scoring tests |
 | Pairing | Pair/join are local trust groundwork | Not real cross-machine pairing yet | Use for metadata/trust testing |
 | Service install | conUD is not an OS service yet | User must start/stop manually | Use `conu start` / `conu stop` |
 | Key storage | Keys are local files | Not ready for high-security public release | Keep user profile protected; future OS keychain work required |
@@ -305,6 +338,7 @@ conu security audit
 conu start
 conu agents register agent.a "Agent A" --kind test-agent
 conu agents register agent.b "Agent B" --kind test-agent
+conu routes sync
 "test opaque payload" | conu messages send agent.a agent.b --stdin
 conu messages inbox agent.b --json
 conu watch
@@ -318,6 +352,7 @@ conu init
 conu agents register agent.a "Agent A" --kind test-agent
 conu agents register agent.b "Agent B" --kind test-agent
 conud --process-ipc
+conu routes sync
 "test opaque payload" | conu messages send agent.a agent.b --stdin
 conud --process-ipc
 conu messages inbox agent.b --json
@@ -327,7 +362,8 @@ conu messages inbox agent.b --json
 
 To make conU genuinely useful over the internet, the next phase should build:
 
-- Direct/relay route selection owned by conUD.
+- Rooms, pub/sub, and multi-agent session metadata.
 - Live encrypted relay-backed message and stream byte delivery.
+- Real QUIC socket transport and NAT candidate exchange after the room/session model is stable.
 - TypeScript SDK after the protocol surface stabilizes.
 - Packaged installer and service setup after SDK behavior is stable.

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,7 @@ needs_revision
 ## Current Status
 
 ```txt
-Current phase: Phase 13 - Direct Transport And NAT Upgrade
+Current phase: Phase 14 - Rooms, Pub/Sub, And Multi-Agent Sessions
 Status: not_started
 Last updated: 2026-05-11
 ```
@@ -966,6 +966,11 @@ Validation:
 - `cargo fmt` passed.
 - `cargo +stable-x86_64-pc-windows-gnu check --workspace` passed.
 - `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py` passed.
+- Python wrapper route smoke passed with local `target/debug/conu.exe`.
+- Isolated CLI smoke passed with `CONU_HOME` under `%TEMP%`: `conu init`, `conu pair`, `conu join`, `conu routes sync --json`, `conu routes --json`, and `conu status --json`.
+- `git diff --check` passed.
+- Privacy scan reviewed payload-looking strings; new route files, logs, CLI, SDK, MCP, and docs remain metadata-only.
 - `cargo +stable-x86_64-pc-windows-gnu run -p conu-sdk --example local_agents` passed.
 - `cargo +stable-x86_64-pc-windows-gnu run -p conu-mcp` stdio `tools/list` smoke passed.
 - `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py` passed.
@@ -986,7 +991,7 @@ Next:
 
 ## Phase 13 - Direct Transport And NAT Upgrade
 
-Status: not_started
+Status: completed
 
 Goal:
 
@@ -994,16 +999,70 @@ Move beyond relay-only networking.
 
 Deliverables:
 
-- QUIC transport
-- direct route attempt
-- relay fallback
-- route quality scoring
-- hole-punching research/prototype
+- [x] direct QUIC candidate route records
+- [x] direct route attempt/probe metadata
+- [x] relay fallback
+- [x] route quality scoring
+- [x] NAT profile config and hole-punching research notes
+- [ ] live QUIC socket transport
 
 Exit criteria:
 
-- Direct route is preferred when available.
-- Relay fallback keeps product reliable.
+- [x] Direct route is preferred when a valid direct endpoint is configured.
+- [x] Relay fallback keeps route selection reliable when direct is unavailable.
+
+Completed work:
+
+- Added `conu_core::routes`, a conUD-owned route manager that builds direct QUIC candidates and relay WebSocket fallback candidates for trusted peers only.
+- Added route scoring by NAT profile, deterministic selected-route lookup, relay fallback flags, route probe history, and payload-safe route logs.
+- Added route state layout under `routes/registry.toml`, `routes/probes.toml`, and `logs/routes.log`.
+- Integrated route sync into `conu sessions sync`, conUD runtime processing, stream route labels for remote agents, Rust SDK, Python SDK wrapper, and MCP.
+- Added CLI commands: `conu routes`, `conu routes sync`, and `conu routes probes`, with text and JSON output.
+- Updated `conu status`, dashboard, and `conu connect` to show selected direct/relay/fallback route metadata.
+- Updated docs and future-agent skills to explain Phase 13 route behavior, config, validation, and privacy boundaries.
+
+Files changed:
+
+- `crates/conu-core/src/routes.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conu-core/src/sessions.rs`
+- `crates/conu-core/src/streams.rs`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-sdk/src/lib.rs`
+- `crates/conu-mcp/src/lib.rs`
+- `crates/conud/src/main.rs`
+- `sdk/python/conu_sdk/__init__.py`
+- `README.md`
+- `docs/direct-transport-and-routes.md`
+- `docs/user-install-and-agent-guide.md`
+- `docs/sdk-and-mcp.md`
+- `docs/production-readiness.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/Pr/SKILL.MD`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-security-guardian/references/privacy-security-checklist.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `plan.md`
+
+Validation:
+
+- `cargo fmt` passed.
+- `cargo +stable-x86_64-pc-windows-gnu check --workspace` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+
+Known gaps:
+
+- Real QUIC packet transport is not implemented yet; Phase 13 selects and records `direct-quic` route candidates.
+- NAT traversal is config/profile based; live ICE-style candidate gathering, STUN/TURN, and hole punching remain future transport work.
+- Route probes are metadata/config probes with latency estimates, not real RTT measurements.
+- conUD still does not own live relay-backed encrypted message or stream byte delivery.
+- Direct endpoint config is manual today.
+
+Next:
+
+- Start Phase 14: rooms, pub/sub, and multi-agent session metadata, while keeping live direct QUIC and relay-backed encrypted data-plane delivery as future transport hardening.
 
 ## Phase 14 - Rooms, Pub/Sub, And Multi-Agent Sessions
 
@@ -1071,4 +1130,5 @@ Add entries here when a phase is completed.
 2026-05-10 - Phase 10 completed. Stream lifecycle metadata, stdin-only opaque stream writes, backpressure checks, watch event bus, private watch animation, tests, docs, and isolated CONU_HOME smoke validation added. Next: Phase 11 encryption hardening.
 2026-05-10 - Phase 11 completed. Local security module added with Ed25519 signed agent cards, X25519 peer key agreement helpers, XChaCha20Poly1305 encrypted-at-rest message storage, replay protection, `conu security audit`, tests, docs, and GNU-toolchain validation. Next: Phase 12 SDK and MCP adapter.
 2026-05-11 - Phase 12 completed. Rust SDK, MCP stdio adapter, Python wrapper SDK, local agent examples, explicit addressed-agent receive API, tests, docs, and GNU-toolchain validation added. Next: Phase 13 direct transport and NAT upgrade.
+2026-05-11 - Phase 13 completed. conUD-owned direct/relay route manager, NAT-profile scoring, relay fallback selection, route probes/logs, CLI route commands, SDK/Python/MCP route tools, docs, skills, and GNU-toolchain validation added. Next: Phase 14 rooms, pub/sub, and multi-agent sessions.
 ```

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -63,6 +63,15 @@ class ConuClient:
     def peers(self) -> dict[str, Any]:
         return self._run_json(self.conu_bin, "peers", "--json")
 
+    def sync_routes(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "routes", "sync", "--json")
+
+    def routes(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "routes", "--json")
+
+    def route_probes(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "routes", "probes", "--json")
+
     def inbox(self, agent_id: str) -> dict[str, Any]:
         return self._run_json(self.conu_bin, "messages", "inbox", agent_id, "--json")
 


### PR DESCRIPTION
## **User description**
## Summary
- add conUD-owned direct/relay route manager with NAT-profile scoring, route probes, and payload-safe route logs
- expose route sync/listing through CLI, Rust SDK, Python wrapper, and MCP tools
- integrate selected routes into session sync, remote stream route labels, status/dashboard/connect, docs, plan, and future-agent skills

## Validation
- cargo fmt
- cargo +stable-x86_64-pc-windows-gnu check --workspace
- cargo +stable-x86_64-pc-windows-gnu test --workspace
- python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py
- isolated CLI route smoke with CONU_HOME under %TEMP%
- Python wrapper route smoke with local target/debug/conu.exe
- git diff --check
- payload/privacy scan reviewed route surfaces

Closes #28


___

## **CodeAnt-AI Description**
**Add route selection and fallback metadata for trusted peers**

### What Changed
- conU now tracks and shows direct route candidates, relay fallback routes, and route probe history for trusted peers
- `conu routes` was added to list routes, sync route selection, and view probes in text or JSON
- `conu status`, the dashboard, `conu connect`, sessions sync, streams, SDKs, MCP tools, and docs now surface the selected route path and route counts
- Route files and logs stay metadata-only and do not display message or payload contents

### Impact
`✅ Clearer direct-vs-relay route visibility`
`✅ Fewer manual checks after pairing`
`✅ Safer route inspection without payload exposure`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=S4B5BU1WCEgUCPpux9r2Ma7yws2DLVTqYkX7p4Jtrcs&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
