### PR TITLE
Add relay-backed encrypted message delivery

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 15 as a directed skip-ahead. Phase 14 rooms/pub-sub remain not started.
+The repository has completed Phase 15 as a directed skip-ahead, and now includes a relay-backed one-shot message MVP. Phase 14 rooms/pub-sub remain not started.
 
 Implemented so far:
 
@@ -27,6 +27,9 @@ Implemented so far:
 - conUD processing for local message delivery
 - encrypted-at-rest local message request and inbox payload storage
 - local X25519 peer key agreement helpers
+- manual public peer-card export/import through `conu identity export` and `conu peers trust`
+- relay-backed peer-encrypted remote message queueing through `conu messages send --peer`
+- explicit relay send/receive sync through `conu relay sync`
 - replay protection for local message request and envelope ids
 - `conu security audit` for payload-safe hardening status
 - Rust SDK crate `conu-sdk` for agent-facing registration, messaging, receive, peer, security, and stream calls
@@ -39,7 +42,7 @@ Implemented so far:
 - shared relay frame contract in `conu-core`
 - std-only `conu-relay` WebSocket service
 - relay session authentication with a shared token
-- connected-runtime metadata forwarding with `WELCOME`, `ENVELOPE`, `SENT`, and `UNDELIVERED` frames
+- connected-runtime blind forwarding with `WELCOME`, `ENVELOPE`, `SENT`, and `UNDELIVERED` frames
 - conUD-owned remote session sync through `conu sessions sync`
 - remote runtime session metadata under `sessions/registry.toml`
 - trusted remote agent mirror under `agents/remote.toml`
@@ -71,6 +74,7 @@ Current important files:
 - `architecture.md`: production architecture and protocol direction.
 - `plan.md`: phase-by-phase execution plan.
 - `docs/direct-transport-and-routes.md`: Phase 13 route manager, config, and privacy boundary.
+- `docs/internet-relay-test.md`: current relay-backed remote message smoke test.
 - `docs/release-checklist.md`: Phase 15 release gate.
 - `docs/observability.md`: payload-safe observability policy.
 - `packaging/README.md`: install and service templates.

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -138,6 +138,7 @@ Supported runtime-to-relay frames:
 ```txt
 HELLO node=<node-id> token=<token> payload=not_observed
 FORWARD to=<node-id> envelope=<envelope-id> bytes=<count> payload=opaque
+FORWARD to=<node-id> envelope=<envelope-id> from_agent=<agent-id> to_agent=<agent-id> bytes=<count> cipher=<cipher> key=<key-id> sender_key=<public-key> nonce=<nonce> body=<ciphertext> payload=peer_encrypted
 PING payload=not_observed
 ```
 
@@ -146,13 +147,14 @@ Supported relay-to-runtime frames:
 ```txt
 WELCOME session=<session-id> payload=not_observed
 ENVELOPE from=<node-id> to=<node-id> envelope=<envelope-id> bytes=<count> payload=opaque
+ENVELOPE from=<node-id> to=<node-id> envelope=<envelope-id> from_agent=<agent-id> to_agent=<agent-id> bytes=<count> cipher=<cipher> key=<key-id> sender_key=<public-key> nonce=<nonce> body=<ciphertext> payload=peer_encrypted
 SENT to=<node-id> envelope=<envelope-id> bytes=<count> payload=not_observed
 UNDELIVERED to=<node-id> envelope=<envelope-id> reason=<safe-reason> payload=not_observed
 PONG payload=not_observed
 ERROR reason=<safe-reason> payload=not_observed
 ```
 
-Phase 8 does not yet expose this relay through the local agent gateway. conUD remote session and discovery mirrors begin in Phase 9, while live relay-backed messaging/streaming lands later.
+The current relay data-plane MVP exposes peer-encrypted one-shot messages through `conu messages send --peer` and `conu relay sync`. Live stream byte routing, reconnect loops, hosted relay auth hardening, and offline mailbox delivery land later.
 
 The Phase 9 remote session surface is conUD-owned metadata sync:
 

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -78,11 +78,11 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 
 - Phase 8 relay is a std-only WebSocket MVP in `crates/conu-relay` with its frame contract in `conu_core::relay`.
 - Runtime clients must authenticate with `HELLO node=<id> token=<token> payload=not_observed` before forwarding.
-- `FORWARD` frames may include target node id, envelope id, byte count, and `payload=opaque`; they must not include plaintext payload fields.
+- `FORWARD` frames may include target node id, agent ids, envelope id, byte count, and peer-encrypted body fields; they must not include plaintext payload fields.
 - Relay server output, errors, tests, and logs must not echo auth tokens or private payload contents.
 - The relay may return `UNDELIVERED reason=peer_offline` when the target runtime is not connected; do not add mailbox storage until the encrypted mailbox phase.
 - On Windows, accepted streams from a nonblocking listener must be set back to blocking mode before frame reads.
-- `conu-relay` alone is not a live remote-agent connection; conUD session/discovery mirrors begin in Phase 9 and live stream routing remains later work.
+- `conu-relay` plus `conu relay sync` can move peer-encrypted one-shot messages for trusted peers. Long-running reconnect loops, stream byte routing, hosted auth hardening, and offline mailbox delivery remain later work.
 
 ## Remote Session And Discovery Rules
 
@@ -90,7 +90,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - conUD owns session sync; CLI commands may request sync or display the mirror but must not inspect payloads.
 - Remote session state belongs under `sessions/registry.toml`; mirrored remote agent cards belong under `agents/remote.toml`.
 - Session logs must use metadata-only lines with counts, route state, and `payload=not_observed`.
-- `conu agents` may show trusted remote agent cards from the mirror, but it must not claim live messaging/streaming before later phases wire the relay client into conUD.
+- `conu agents` may show trusted remote agent cards from the mirror. One-shot relay messages are available through explicit peer-card trust and relay sync; live stream routing remains future work.
 - Revoked peers must not remain visible as active remote agents after session sync.
 - Route metadata may include relay endpoint, peer id, state, and reconnect counts; it must not include message contents, tokens, or private payload bytes.
 
@@ -127,7 +127,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - New message request and inbox files must use `payload_ciphertext_hex`, not `payload_hex`.
 - Agent registry records should include signature metadata for new/updated local agents.
 - CLI security output may show readiness booleans and key ids, but must never show private keys, shared secrets, plaintext payloads, or decrypted payloads.
-- Peer key agreement helpers are available for later live relay-backed encrypted delivery, but current remote sessions are still metadata mirrors.
+- Peer key agreement helpers now back the relay message MVP. The relay must carry ciphertext only, and inbound envelopes must verify the sender exchange public key against the trusted peer card before delivery.
 
 ## SDK And MCP Rules
 
@@ -141,6 +141,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - `conu_receive_message` returns metadata by default and may return `payloadHex` only when `includePayload` is true.
 - `CONU_AGENT_ID` may bind one `conu-mcp` server to one local agent; bound servers must not act as another agent.
 - Python SDK wrappers should pass payload bytes through stdin and avoid printing/logging payloads.
+- SDK/MCP remote send helpers must queue peer-encrypted bytes and return metadata only. Relay sync helpers report counters only.
 - TypeScript SDK is intentionally later; do not mark it complete until implemented and validated.
 
 ## Packaging And Release Rules
@@ -149,7 +150,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Release artifacts must not include local conU state, `CONU_HOME`, `.conu`, private keys, logs, inboxes, route registries, message stores, or test payload output.
 - `conu doctor` may report binary paths, readiness booleans, runtime health, and payload-safe log scan counts; it must not print log contents, private keys, payload text, or secrets.
 - Windows service, Linux systemd, and macOS launchd files are templates until a signed installer configures platform-specific users and paths.
-- A local release may be marked ready only with documented limits. Do not claim public hosted internet readiness until live encrypted remote data-plane delivery, capability policy, signed remote cards, and OS-backed key storage are implemented.
+- A local release may be marked ready only with documented limits. Do not claim public hosted internet readiness until hosted relay auth/TLS, reconnect loops, stream byte routing, capability policy, signed remote cards, and OS-backed key storage are implemented.
 - CI/release workflows must run metadata-only checks and must not upload conU state directories or logs as artifacts.
 
 ## Privacy Rules

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -23,16 +23,16 @@ crates/conud
   daemon process, local gateway/message/session processing, session manager, runtime lifecycle
 
 crates/conu-core
-  local state, security keys/encryption/signatures/replay, runtime lifecycle, agent registry, local message routing, stream metadata, route selection, trust store, relay frame contract, remote session mirror, future policy logic
+  local state, security keys/encryption/signatures/replay, runtime lifecycle, agent registry, local message routing, relay-backed remote message delivery, stream metadata, route selection, trust store, relay frame contract, remote session mirror, future policy logic
 
 crates/conu-protocol
   envelopes, agent cards, control-plane messages, data-plane messages
 
 crates/conu-relay
-  std-only WebSocket relay service, session auth, metadata-only forwarding, relay/bootstrap groundwork
+  std-only WebSocket relay service, session auth, blind ciphertext forwarding, relay/bootstrap groundwork
 
 crates/conu-sdk
-  Rust agent-facing SDK over registration, presence, peers, routes, messages, receive, streams, and security audit
+  Rust agent-facing SDK over registration, presence, peers, peer cards, routes, local/remote messages, relay sync, receive, streams, and security audit
 
 crates/conu-mcp
   MCP stdio adapter exposing conU tools over newline-delimited JSON-RPC

--- a/.agents/skills/conu-security-guardian/references/privacy-security-checklist.md
+++ b/.agents/skills/conu-security-guardian/references/privacy-security-checklist.md
@@ -15,6 +15,7 @@
 - Node identity is generated locally.
 - Agent identity is bound to a trusted node.
 - Pairing is explicit.
+- Manual peer-card trust must import only public node id, display name, public exchange key, and relay endpoint.
 - Trust is revocable.
 - Discovery is scoped by trust and policy.
 
@@ -31,12 +32,15 @@
 - Relay logs metadata only.
 - Relay cannot impersonate a peer.
 - Relay fallback does not weaken trust checks.
+- Relay message delivery must decrypt only after the sender exchange public key matches the trusted peer card.
+- Relay frames may carry ciphertext bodies, never plaintext payload fields.
 
 ## Storage
 
 - Trust store avoids plaintext secrets when possible.
 - Message request and inbox files use encrypted-at-rest payload fields.
 - Mailbox stores encrypted envelopes when mailbox delivery is implemented.
+- Relay outbox stores peer-encrypted envelope bodies, not plaintext payloads.
 - Logs are payload-safe.
 - Config does not store private keys.
 - Security key files remain local-only and must not appear in CLI output, logs, docs examples, or tests except artificial field-name checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ name = "conu-relay"
 version = "0.1.0"
 dependencies = [
  "conu-core",
+ "conu-protocol",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 15 is complete for the current local-first app. The CLI identity/dashboard shell exists, `conu init` creates real local state and security keys, `conu start` launches the local `conUD` runtime skeleton, local agents can register signed metadata and presence, registered local agents can exchange encrypted-at-rest opaque message envelopes, local pairing/trust records can be created and revoked, `conu-relay` can accept WebSocket runtime sessions for metadata-only relay forwarding, conUD can sync remote session/discovery metadata for trusted peers, streams produce payload-safe watch events, `conu security audit` reports hardened controls without showing secrets, agents can use conU through the Rust SDK, Python wrapper SDK, and MCP stdio adapter, conUD owns metadata-only direct/relay route selection, and release packaging/readiness checks now exist.
+Phase 15 is complete for the current local-first app, and this branch adds the first live relay-backed internet data-plane slice. The CLI identity/dashboard shell exists, `conu init` creates real local state and security keys, `conu start` launches the local `conUD` runtime skeleton, local agents can register signed metadata and presence, registered local agents can exchange encrypted-at-rest opaque message envelopes, users can exchange public peer cards, trusted peers can send peer-encrypted messages through `conu-relay`, streams produce payload-safe watch events, `conu security audit` reports hardened controls without showing secrets, agents can use conU through the Rust SDK, Python wrapper SDK, and MCP stdio adapter, conUD owns metadata-only direct/relay route selection, and release packaging/readiness checks now exist.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -60,12 +60,16 @@ pairing/invites/       pending local pairing invitations
 pairing/used/          consumed local pairing invitations
 sessions/registry.toml remote runtime session metadata
 mailbox/               future encrypted mailbox storage
+mailbox/relay/outbox/  peer-encrypted outbound relay envelopes
+mailbox/relay/sent/    metadata markers for relay-sent envelopes
+mailbox/relay/rejected/ rejected relay outbox markers
 logs/conud.log         runtime metadata log
 logs/agents.log        local agent metadata log
 logs/messages.log      local message delivery metadata log
 logs/sessions.log      remote session sync metadata log
 logs/streams.log       stream lifecycle metadata log
 logs/routes.log        direct/relay route sync metadata log
+logs/relay-delivery.log relay delivery metadata log
 ```
 
 Runtime, agent, and message logs contain metadata only, such as event name, pid, node id, agent id, envelope id, byte count, and `payload=not_observed`. New local message request and recipient-inbox envelope files store conU-owned payload bytes with XChaCha20Poly1305 encrypted-at-rest fields. CLI output, receipts, processed markers, rejected markers, and logs do not display message contents.
@@ -99,6 +103,19 @@ conu messages receipts
 ```
 
 `conu messages send` reads bytes from stdin so payloads are not placed directly in the command line. When `conUD` is running, delivery is processed automatically. If the runtime is offline, encrypted message requests remain queued under `runtime/ipc/messages/inbox/` and can be processed with `conud --process-ipc`.
+
+## Relay-Backed Remote Messages
+
+conU can now move peer-encrypted message envelopes between two trusted nodes through the WebSocket relay:
+
+```bash
+conu identity export --json
+conu peers trust <peer-node-id> <display-name> --exchange-key <hex> --relay ws://relay-host:8787
+conu messages send agent.sender agent.remote --peer <peer-node-id> --stdin
+conu relay sync --wait-ms 3000
+```
+
+Run `conu relay sync --wait-ms 10000` on the receiving node while the sender syncs. The relay sees node ids, agent ids, envelope id, byte count, public exchange key material, and ciphertext only. It does not receive plaintext message contents. See `docs/internet-relay-test.md` for a local two-node smoke and an internet test checklist.
 
 ## Security Hardening
 
@@ -150,7 +167,7 @@ The release artifact includes `conu`, `conud`, `conu-relay`, `conu-mcp`, docs, p
 
 ## Pairing And Trust
 
-Phase 7 adds local trust-store mechanics before the hosted relay exists:
+Phase 7 adds local trust-store mechanics, and the relay data-plane adds manual public peer-card exchange:
 
 ```bash
 conu pair
@@ -158,9 +175,11 @@ conu join 123456
 conu peers
 conu peers --json
 conu peers revoke peer_example
+conu identity export
+conu peers trust node_example "Peer Node" --exchange-key <hex> --relay ws://127.0.0.1:8787
 ```
 
-`conu pair` creates a short local invitation code with an expiration. `conu join <code>` consumes a local invitation and writes a trusted peer record to `trust.toml`. Peer ids and display names are derived from a hash suffix, and the trust store records `pairing_code_hash` instead of the raw used code. Cross-machine pairing remains local-trust groundwork until remote sessions and discovery are wired into conUD.
+`conu pair` creates a short local invitation code with an expiration. `conu join <code>` consumes a local invitation and writes a trusted peer record to `trust.toml`. For cross-machine testing today, exchange `conu identity export --json` output with the other user and import their public card using `conu peers trust`. Trust records store public exchange keys and relay endpoints when available; private keys are never exported.
 
 ## WebSocket Relay
 
@@ -171,9 +190,9 @@ set CONU_RELAY_TOKEN=local-dev-token
 cargo run -p conu-relay -- --serve 127.0.0.1:8787
 ```
 
-Connected runtimes send `HELLO`, `FORWARD`, and `PING` frames. The relay answers with `WELCOME`, `ENVELOPE`, `SENT`, `UNDELIVERED`, `PONG`, or `ERROR` frames. Forwarding is metadata-only: the relay sees target node id, envelope id, and byte count, while payload fields are rejected and logs/output use `payload=not_observed` or `payload=opaque`.
+Connected runtimes send `HELLO`, `FORWARD`, and `PING` frames. The relay answers with `WELCOME`, `ENVELOPE`, `SENT`, `UNDELIVERED`, `PONG`, or `ERROR` frames. Relay `FORWARD` can carry a peer-encrypted opaque body for message delivery, but plaintext payload fields are rejected and logs/output use `payload=not_observed`, `payload=opaque`, or `payload=peer_encrypted`.
 
-The relay is available now as a standalone service. Full relay-backed live session exchange, reconnect networking, and encrypted payload hardening land in later phases.
+The relay is available now as a standalone service for encrypted message sync. Full live stream byte routing, hosted relay auth hardening, offline relay mailbox storage, reconnect networking, and direct QUIC still land in later transport phases.
 
 ## Remote Sessions And Discovery
 
@@ -203,7 +222,7 @@ conu routes probes
 
 `conu routes sync` reads trusted peers and `config.toml`, scores direct QUIC candidates against relay WebSocket fallback, writes `routes/registry.toml`, appends metadata-only probes to `routes/probes.toml`, and records payload-safe summaries in `logs/routes.log`. Direct endpoints can be configured with `direct_quic_endpoint = "quic://host:port"` or a peer-specific sanitized key like `direct_quic_peer_abcd1234 = "quic://host:port"`.
 
-This is route selection groundwork, not a full QUIC data plane yet. conU can now prefer a configured direct route and fall back to relay metadata, while live QUIC sockets, ICE-style hole punching, and relay-backed encrypted byte delivery remain future transport hardening.
+This is route selection groundwork, not a full QUIC data plane yet. conU can now prefer a configured direct route and fall back to relay metadata, while live QUIC sockets and ICE-style hole punching remain future transport hardening. Relay-backed one-shot message delivery exists for trusted peers.
 
 ## Streams And Watch
 
@@ -230,9 +249,9 @@ cargo run -p conu-sdk --example local_agents
 cargo run -p conu-mcp
 ```
 
-Rust agents can use `conu_sdk::ConuClient` to register, update presence, list agents/peers, send opaque bytes, receive local payload bytes for the addressed agent, and open/write/close streams. Python agents can use the stdlib wrapper under `sdk/python`.
+Rust agents can use `conu_sdk::ConuClient` to register, update presence, list agents/peers, exchange peer cards, send local opaque bytes, queue remote relay messages, run relay sync, receive payload bytes for the addressed local agent, and open/write/close streams. Python agents can use the stdlib wrapper under `sdk/python`.
 
-MCP-capable agents can launch `conu-mcp` as a stdio server. It exposes tools such as `conu_register_agent`, `conu_list_agents`, `conu_send_message`, `conu_receive_message`, `conu_open_stream`, and `conu_security_audit`. The adapter follows the current MCP stdio transport shape: newline-delimited JSON-RPC 2.0 messages on stdin/stdout. Tool list/send/status outputs remain metadata-only. Set `CONU_AGENT_ID` when launching one MCP server for one agent; then the adapter rejects attempts to act as another local agent. `conu_receive_message` returns payload bytes as `payloadHex` only when the addressed local agent explicitly passes `includePayload: true`.
+MCP-capable agents can launch `conu-mcp` as a stdio server. It exposes tools such as `conu_register_agent`, `conu_export_identity`, `conu_trust_peer`, `conu_send_message`, `conu_send_remote_message`, `conu_relay_sync`, `conu_receive_message`, `conu_open_stream`, and `conu_security_audit`. The adapter follows the current MCP stdio transport shape: newline-delimited JSON-RPC 2.0 messages on stdin/stdout. Tool list/send/status outputs remain metadata-only. Set `CONU_AGENT_ID` when launching one MCP server for one agent; then the adapter rejects attempts to act as another local agent. `conu_receive_message` returns payload bytes as `payloadHex` only when the addressed local agent explicitly passes `includePayload: true`.
 
 See `docs/sdk-and-mcp.md` for SDK examples, MCP tool contracts, route tools, and privacy rules. See `docs/direct-transport-and-routes.md` for the Phase 13 route manager.
 
@@ -265,8 +284,11 @@ cargo run -p conu-cli -- agents --json
 cargo run -p conu-cli -- agents register agent.codex "Codex Desktop" --kind coding-agent
 cargo run -p conu-cli -- agents heartbeat agent.codex --presence busy
 cargo run -p conu-cli -- messages send agent.sender agent.receiver --stdin
+cargo run -p conu-cli -- messages send agent.sender agent.remote --peer node_peer --stdin
 cargo run -p conu-cli -- messages inbox agent.receiver --json
 cargo run -p conu-cli -- messages receipts --json
+cargo run -p conu-cli -- identity export --json
+cargo run -p conu-cli -- relay sync --wait-ms 3000
 cargo run -p conu-cli -- streams open agent.sender agent.receiver
 cargo run -p conu-cli -- streams write stream_example --stdin
 cargo run -p conu-cli -- streams close stream_example
@@ -283,6 +305,7 @@ cargo run -p conu-cli -- doctor --json
 cargo run -p conu-cli -- pair
 cargo run -p conu-cli -- join 123456
 cargo run -p conu-cli -- peers --json
+cargo run -p conu-cli -- peers trust node_peer "Peer Node" --exchange-key <hex> --relay ws://127.0.0.1:8787
 cargo run -p conu-cli -- peers revoke peer_example
 cargo run -p conu-cli -- connect
 cargo run -p conu-cli -- watch

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -16,13 +16,14 @@ use conu_core::agents::{
     self, AgentPresence, AgentRegistration, LocalAgentRecord, PresenceHeartbeat,
 };
 use conu_core::messages::{self, DeliveryReceipt, InboxEntry, LocalMessage};
+use conu_core::relay_delivery::{self, RemoteMessage};
 use conu_core::routes::{self, RouteProbe, RouteRecord, RouteSyncReport, RouteTransport};
 use conu_core::runtime::{self, RuntimeState, RuntimeStatus, StopReport};
 use conu_core::security::{self, SecurityAudit, SecurityReport};
 use conu_core::sessions::{self, RemoteAgentRecord, RemoteSession, SessionSyncReport};
 use conu_core::state::{self, InitReport, StateSnapshot};
 use conu_core::streams::{self, StreamEvent, StreamRecord};
-use conu_core::trust::{self, TrustStatus, TrustedPeer};
+use conu_core::trust::{self, PeerCard, TrustStatus, TrustedPeer};
 use conu_protocol::OpaquePayload;
 
 /// A rendered CLI command result.
@@ -102,10 +103,12 @@ where
         "agents" => render_agents(&args[1..], home_override),
         "peers" => render_peers(&args[1..], home_override),
         "messages" => render_messages(&args[1..], home_override, stdin_payload),
+        "relay" => render_relay(&args[1..], home_override),
         "streams" => render_streams(&args[1..], home_override, stdin_payload),
         "sessions" => render_sessions(&args[1..], home_override),
         "routes" => render_routes(&args[1..], home_override),
         "security" => render_security(&args[1..], home_override),
+        "identity" => render_identity(&args[1..], home_override),
         "pair" => render_pair(&args[1..], home_override),
         "join" => render_join(&args[1..], home_override),
         "connect" => render_connect(&args[1..], home_override),
@@ -181,6 +184,9 @@ quick commands
   conu agents
   conu agents register <agent-id> <display-name>
   conu messages send <from-agent> <to-agent> --stdin
+  conu messages send <from-agent> <to-agent> --peer <peer-node-id> --stdin
+  conu relay sync --wait-ms 3000
+  conu identity export
   conu streams open <from-agent> <to-agent>
   conu routes sync
   conu security audit
@@ -776,6 +782,10 @@ fn render_message_send(
         return CliOutput::failure(2, "stdin payload is empty");
     }
 
+    if let Some(peer_node_id) = parsed.peer_node_id.clone() {
+        return render_remote_message_send(parsed, &peer_node_id, home_override, stdin_payload);
+    }
+
     let before = inbox_ids(home_override.clone(), &parsed.to_agent_id);
     let payload_bytes = stdin_payload.len();
     let message = match LocalMessage::new(
@@ -848,6 +858,79 @@ bytes: {}
 privacy
   payload view  contents are not displayed by conU",
         parsed.from_agent_id, parsed.to_agent_id, submission.request_id, payload_bytes
+    ))
+}
+
+fn render_remote_message_send(
+    parsed: MessageSendArgs,
+    peer_node_id: &str,
+    home_override: Option<PathBuf>,
+    stdin_payload: Vec<u8>,
+) -> CliOutput {
+    let payload_bytes = stdin_payload.len();
+    let message = match RemoteMessage::new(
+        &parsed.from_agent_id,
+        &parsed.to_agent_id,
+        peer_node_id,
+        OpaquePayload::from_bytes(stdin_payload),
+    ) {
+        Ok(message) => message,
+        Err(error) => {
+            return CliOutput::failure(2, format!("conU messages send failed\n\n{error}"));
+        }
+    };
+    let submission = match relay_delivery::submit_remote_message(home_override, message) {
+        Ok(submission) => submission,
+        Err(error) => {
+            return CliOutput::failure(1, format!("conU messages send failed\n\n{error}"));
+        }
+    };
+
+    if parsed.json {
+        return CliOutput::success(format!(
+            r#"{{
+  "status": "queued_remote",
+  "fromAgentId": "{}",
+  "toAgentId": "{}",
+  "peerNodeId": "{}",
+  "requestId": "{}",
+  "envelopeId": "{}",
+  "payloadBytes": {},
+  "route": "relay-websocket",
+  "contentsDisplayed": false
+}}"#,
+            json_escape(&parsed.from_agent_id),
+            json_escape(&parsed.to_agent_id),
+            json_escape(&submission.peer_node_id),
+            json_escape(&submission.request_id),
+            json_escape(&submission.envelope_id),
+            payload_bytes
+        ));
+    }
+
+    CliOutput::success(format!(
+        r"conU messages send
+
+status: queued for relay
+from: {}
+to: {}
+peer: {}
+request: {}
+envelope: {}
+bytes: {}
+route: relay-websocket
+
+next
+  conu relay sync --wait-ms 3000
+
+privacy
+  payload view  contents are not displayed by conU",
+        parsed.from_agent_id,
+        parsed.to_agent_id,
+        submission.peer_node_id,
+        submission.request_id,
+        submission.envelope_id,
+        payload_bytes
     ))
 }
 
@@ -1031,6 +1114,7 @@ privacy
 struct MessageSendArgs {
     from_agent_id: String,
     to_agent_id: String,
+    peer_node_id: Option<String>,
     stdin: bool,
     json: bool,
 }
@@ -1043,17 +1127,27 @@ struct MessageInboxArgs {
 fn parse_message_send_args(args: &[String]) -> Result<MessageSendArgs, CliOutput> {
     let mut json = false;
     let mut stdin = false;
+    let mut peer_node_id = None;
     let mut positional = Vec::new();
+    let mut index = 0;
 
-    for arg in args {
-        match arg.as_str() {
+    while index < args.len() {
+        match args[index].as_str() {
             "--json" => json = true,
             "--stdin" => stdin = true,
+            "--peer" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(CliOutput::failure(2, render_messages_usage()));
+                };
+                peer_node_id = Some(value.clone());
+                index += 1;
+            }
             value if value.starts_with("--") => {
                 return Err(CliOutput::failure(2, format!("unknown option: {value}")));
             }
             value => positional.push(value.to_string()),
         }
+        index += 1;
     }
 
     if positional.len() != 2 {
@@ -1063,6 +1157,7 @@ fn parse_message_send_args(args: &[String]) -> Result<MessageSendArgs, CliOutput
     Ok(MessageSendArgs {
         from_agent_id: positional.remove(0),
         to_agent_id: positional.remove(0),
+        peer_node_id,
         stdin,
         json,
     })
@@ -1097,6 +1192,7 @@ fn parse_message_inbox_args(args: &[String]) -> Result<MessageInboxArgs, CliOutp
 fn render_messages_usage() -> String {
     r"usage:
   conu messages send <from-agent> <to-agent> --stdin [--json]
+  conu messages send <from-agent> <to-agent> --peer <peer-node-id> --stdin [--json]
   conu messages inbox <agent-id> [--json]
   conu messages receipts [--json]"
         .to_string()
@@ -1973,6 +2069,115 @@ fn render_routes_usage() -> String {
         .to_string()
 }
 
+fn render_relay(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    match args.first().map(String::as_str) {
+        Some("sync") => render_relay_sync(&args[1..], home_override),
+        _ => CliOutput::failure(2, render_relay_usage()),
+    }
+}
+
+fn render_relay_sync(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let parsed = match parse_relay_sync_args(args) {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    let report =
+        match relay_delivery::sync_relay_once(home_override, Duration::from_millis(parsed.wait_ms))
+        {
+            Ok(report) => report,
+            Err(error) => {
+                return CliOutput::failure(1, format!("conU relay sync failed\n\n{error}"));
+            }
+        };
+
+    if parsed.json {
+        return CliOutput::success(format!(
+            r#"{{
+  "status": "synced",
+  "endpoint": "{}",
+  "connected": {},
+  "queued": {},
+  "sent": {},
+  "received": {},
+  "undelivered": {},
+  "rejected": {},
+  "contentsDisplayed": false
+}}"#,
+            json_escape(&report.endpoint),
+            report.connected,
+            report.queued,
+            report.sent,
+            report.received,
+            report.undelivered,
+            report.rejected
+        ));
+    }
+
+    CliOutput::success(format!(
+        r"conU relay sync
+
+endpoint: {}
+connected: {}
+queued: {}
+sent: {}
+received: {}
+undelivered: {}
+rejected: {}
+
+flow
+  [agent] -> {{conUD}} == peer-encrypted ws ==> {{relay}} ==> {{remote conUD}} -> [agent]
+
+privacy
+  payload view  contents are not displayed by conU
+  relay view    encrypted body plus route metadata only",
+        report.endpoint,
+        yes_no(report.connected),
+        report.queued,
+        report.sent,
+        report.received,
+        report.undelivered,
+        report.rejected
+    ))
+}
+
+struct RelaySyncArgs {
+    wait_ms: u64,
+    json: bool,
+}
+
+fn parse_relay_sync_args(args: &[String]) -> Result<RelaySyncArgs, CliOutput> {
+    let mut wait_ms = 1000;
+    let mut json = false;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => json = true,
+            "--wait-ms" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(CliOutput::failure(2, render_relay_usage()));
+                };
+                wait_ms = match value.parse::<u64>() {
+                    Ok(value) if value <= 60_000 => value,
+                    _ => return Err(CliOutput::failure(2, render_relay_usage())),
+                };
+                index += 1;
+            }
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            _ => return Err(CliOutput::failure(2, render_relay_usage())),
+        }
+        index += 1;
+    }
+
+    Ok(RelaySyncArgs { wait_ms, json })
+}
+
+fn render_relay_usage() -> String {
+    "usage: conu relay sync [--wait-ms <milliseconds>] [--json]".to_string()
+}
+
 fn render_security(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     let remaining = match args.first().map(String::as_str) {
         None => args,
@@ -2094,6 +2299,67 @@ fn render_security_usage() -> String {
     "usage: conu security audit [--json]".to_string()
 }
 
+fn render_identity(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    match args.first().map(String::as_str) {
+        Some("export") => render_identity_export(&args[1..], home_override),
+        _ => CliOutput::failure(2, render_identity_usage()),
+    }
+}
+
+fn render_identity_export(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let json = match json_flag(args) {
+        Ok(json) => json,
+        Err(error) => return error,
+    };
+    let card = match trust::export_peer_card(home_override) {
+        Ok(card) => card,
+        Err(error) => {
+            return CliOutput::failure(1, format!("conU identity export failed\n\n{error}"));
+        }
+    };
+
+    if json {
+        return CliOutput::success(format!(
+            r#"{{
+  "nodeId": "{}",
+  "displayName": "{}",
+  "exchangePublicKeyHex": "{}",
+  "relayEndpoint": "{}",
+  "contentsDisplayed": false
+}}"#,
+            json_escape(&card.node_id),
+            json_escape(&card.display_name),
+            json_escape(&card.exchange_public_key_hex),
+            json_escape(&card.relay_endpoint)
+        ));
+    }
+
+    CliOutput::success(format!(
+        r"conU identity export
+
+node: {}
+name: {}
+exchange public key: {}
+relay: {}
+
+share this public card with a peer, then import their card with:
+  conu peers trust <peer-node-id> <display-name> --exchange-key <hex> --relay {}
+
+privacy
+  key view      public exchange key only
+  payload view  contents are not displayed by conU",
+        card.node_id,
+        card.display_name,
+        card.exchange_public_key_hex,
+        card.relay_endpoint,
+        card.relay_endpoint
+    ))
+}
+
+fn render_identity_usage() -> String {
+    "usage: conu identity export [--json]".to_string()
+}
+
 fn inbox_ids(home_override: Option<PathBuf>, agent_id: &str) -> HashSet<String> {
     messages::list_agent_inbox(home_override, agent_id)
         .map(|entries| {
@@ -2132,6 +2398,7 @@ fn wait_for_message_delivery(
 fn render_peers(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     match args.first().map(String::as_str) {
         Some("revoke") => render_peer_revoke(&args[1..], home_override),
+        Some("trust") => render_peer_trust(&args[1..], home_override),
         _ => render_peer_list(args, home_override),
     }
 }
@@ -2147,6 +2414,61 @@ fn render_peer_list(args: &[String], home_override: Option<PathBuf>) -> CliOutpu
         Ok(false) => CliOutput::success(render_peers_text(&peers)),
         Err(error) => error,
     }
+}
+
+fn render_peer_trust(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
+    let parsed = match parse_peer_trust_args(args) {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+    let card = PeerCard {
+        node_id: parsed.peer_node_id,
+        display_name: parsed.display_name,
+        exchange_public_key_hex: parsed.exchange_key,
+        relay_endpoint: parsed.relay_endpoint,
+    };
+    let peer = match trust::trust_peer_card(home_override, card) {
+        Ok(peer) => peer,
+        Err(error) => return CliOutput::failure(1, format!("conU peers trust failed\n\n{error}")),
+    };
+
+    if parsed.json {
+        return CliOutput::success(format!(
+            r#"{{
+  "status": "{}",
+  "peerNodeId": "{}",
+  "displayName": "{}",
+  "exchangeKeyTrusted": {},
+  "relayEndpoint": "{}",
+  "contentsDisplayed": false
+}}"#,
+            peer.status.as_str(),
+            json_escape(&peer.peer_node_id),
+            json_escape(&peer.display_name),
+            peer.exchange_public_key_hex.is_some(),
+            json_escape(peer.relay_endpoint.as_deref().unwrap_or(""))
+        ));
+    }
+
+    CliOutput::success(format!(
+        r"conU peers trust
+
+status: {}
+peer: {}
+name: {}
+exchange key: trusted
+relay: {}
+
+next
+  conu relay sync --wait-ms 3000
+
+privacy
+  payload view  contents are not displayed by conU",
+        peer.status.as_str(),
+        peer.peer_node_id,
+        peer.display_name,
+        peer.relay_endpoint.as_deref().unwrap_or("not configured")
+    ))
 }
 
 fn render_peer_revoke(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
@@ -2199,12 +2521,16 @@ fn render_peers_json(peers: &[TrustedPeer]) -> String {
       "displayName": "{}",
       "status": "{}",
       "source": "{}",
+      "exchangeKeyTrusted": {},
+      "relayEndpoint": "{}",
       "updatedAtUnix": {}
     }}"#,
                 json_escape(&peer.peer_node_id),
                 json_escape(&peer.display_name),
                 peer.status.as_str(),
                 json_escape(&peer.source),
+                peer.exchange_public_key_hex.is_some(),
+                json_escape(peer.relay_endpoint.as_deref().unwrap_or("")),
                 peer.updated_at_unix
             )
         })
@@ -2234,10 +2560,16 @@ fn render_peers_text(peers: &[TrustedPeer]) -> String {
             .iter()
             .map(|peer| {
                 format!(
-                    "  {}  {}  {}",
+                    "  {}  {}  {}  key {}  relay {}",
                     peer.peer_node_id,
                     peer.status.as_str(),
-                    peer.display_name
+                    peer.display_name,
+                    if peer.exchange_public_key_hex.is_some() {
+                        "yes"
+                    } else {
+                        "no"
+                    },
+                    peer.relay_endpoint.as_deref().unwrap_or("-")
                 )
             })
             .collect::<Vec<_>>()
@@ -2253,8 +2585,70 @@ trusted peers
 next
   conu pair
   conu join <code>
+  conu identity export
+  conu peers trust <peer-node-id> <display-name> --exchange-key <hex> [--relay <ws://host:port>]
   conu peers revoke <peer-node-id>"
     )
+}
+
+struct PeerTrustArgs {
+    peer_node_id: String,
+    display_name: String,
+    exchange_key: String,
+    relay_endpoint: String,
+    json: bool,
+}
+
+fn parse_peer_trust_args(args: &[String]) -> Result<PeerTrustArgs, CliOutput> {
+    let mut json = false;
+    let mut exchange_key = None;
+    let mut relay_endpoint = "ws://127.0.0.1:8787".to_string();
+    let mut positional = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => json = true,
+            "--exchange-key" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(CliOutput::failure(2, render_peer_trust_usage()));
+                };
+                exchange_key = Some(value.clone());
+                index += 1;
+            }
+            "--relay" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(CliOutput::failure(2, render_peer_trust_usage()));
+                };
+                relay_endpoint = value.clone();
+                index += 1;
+            }
+            value if value.starts_with("--") => {
+                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+            }
+            value => positional.push(value.to_string()),
+        }
+        index += 1;
+    }
+
+    let Some(exchange_key) = exchange_key else {
+        return Err(CliOutput::failure(2, render_peer_trust_usage()));
+    };
+    if positional.len() != 2 {
+        return Err(CliOutput::failure(2, render_peer_trust_usage()));
+    }
+
+    Ok(PeerTrustArgs {
+        peer_node_id: positional.remove(0),
+        display_name: positional.remove(0),
+        exchange_key,
+        relay_endpoint,
+        json,
+    })
+}
+
+fn render_peer_trust_usage() -> String {
+    "usage: conu peers trust <peer-node-id> <display-name> --exchange-key <hex> [--relay <ws://host:port>] [--json]".to_string()
 }
 
 fn parse_peer_revoke_args(args: &[String]) -> Result<(String, bool), CliOutput> {
@@ -2428,7 +2822,8 @@ fn render_watch(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     }
 
     let stream_records = streams::list_streams(home_override.clone()).unwrap_or_default();
-    let events = streams::list_events(home_override).unwrap_or_default();
+    let events = streams::list_events(home_override.clone()).unwrap_or_default();
+    let relay_queue = relay_delivery::relay_queue_summary(home_override).ok();
     let open_streams = stream_records
         .iter()
         .filter(|stream| stream.state.as_str() == "open")
@@ -2459,24 +2854,40 @@ fn render_watch(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     let latest_event = latest
         .map(|event| event.event_type.as_str())
         .unwrap_or("idle");
+    let relay_queued = relay_queue.as_ref().map(|queue| queue.queued).unwrap_or(0);
+    let relay_sent = relay_queue.as_ref().map(|queue| queue.sent).unwrap_or(0);
+    let relay_rejected = relay_queue
+        .as_ref()
+        .map(|queue| queue.rejected)
+        .unwrap_or(0);
 
     CliOutput::success(format!(
         r"conU watch
 
-transport view
+private transport view
   {flow}
+
+  .-----------.      .--------.      .------------.      .---------.
+  |  agent A  | ---> | conUD  | ===> | blind relay | ===> | agent B |
+  '-----------'      '--------'      '------------'      '---------'
+                         peer-encrypted envelopes
+
+live counters
   route         {route}
   stream        {stream_id}
   event         {latest_event}
   open streams  {open_streams}
   packets       {total_packets}
   bytes         {total_bytes}
+  relay queued  {relay_queued}
+  relay sent    {relay_sent}
+  relay reject  {relay_rejected}
   contents      not displayed
 
 animation
-  [agent] >>> private packets >>> [agent]
+  [agent] >>> private packets >>> [conUD] >>> encrypted relay >>> [agent]
 
-status: stream metadata only",
+status: metadata animation only",
     ))
 }
 
@@ -3173,8 +3584,10 @@ Usage:
   conu agents register <agent-id> <display-name> [--kind <kind>] [--json]
   conu agents heartbeat <agent-id> [--presence <ready|busy|idle|offline>] [--json]
   conu messages send <from-agent> <to-agent> --stdin [--json]
+  conu messages send <from-agent> <to-agent> --peer <peer-node-id> --stdin [--json]
   conu messages inbox <agent-id> [--json]
   conu messages receipts [--json]
+  conu relay sync [--wait-ms <milliseconds>] [--json]
   conu streams [--json]
   conu streams open <from-agent> <to-agent> [--kind <kind>] [--json]
   conu streams write <stream-id> --stdin [--json]
@@ -3185,7 +3598,9 @@ Usage:
   conu routes sync [--json]
   conu routes probes [--json]
   conu security audit [--json]
+  conu identity export [--json]
   conu peers [--json]
+  conu peers trust <peer-node-id> <display-name> --exchange-key <hex> [--relay <ws://host:port>] [--json]
   conu peers revoke <peer-node-id> [--json]
   conu pair [--json]
   conu join <code> [--json]
@@ -3198,7 +3613,7 @@ Usage:
   conu --help
   conu --version
 
-Phase 15 adds release readiness checks, packaging paths, and service templates while payload contents remain hidden."
+conU carries local and relay-backed peer-encrypted messages while payload contents remain hidden."
         .to_string()
 }
 
@@ -3824,6 +4239,56 @@ mod tests {
         assert!(request_text.contains("payload_privacy = \"encrypted_at_rest\""));
         assert!(request_text.contains("payload_ciphertext_hex"));
         assert!(!request_text.contains("payload_hex"));
+        assert!(!request_text.contains("private message contents"));
+    }
+
+    #[test]
+    fn messages_send_peer_queues_encrypted_relay_payload() {
+        let alice_home = temp_home("remote-message-alice");
+        let bob_home = temp_home("remote-message-bob");
+        let bob_card = trust::export_peer_card(Some(bob_home)).expect("bob card exports");
+        register_test_agent(&alice_home, "agent.sender");
+
+        let trusted = run_with_home(
+            [
+                "peers",
+                "trust",
+                &bob_card.node_id,
+                &bob_card.display_name,
+                "--exchange-key",
+                &bob_card.exchange_public_key_hex,
+                "--relay",
+                &bob_card.relay_endpoint,
+                "--json",
+            ],
+            Some(alice_home.clone()),
+        );
+        let sent = run_with_home_and_stdin(
+            [
+                "messages",
+                "send",
+                "agent.sender",
+                "agent.remote",
+                "--peer",
+                &bob_card.node_id,
+                "--stdin",
+                "--json",
+            ],
+            Some(alice_home.clone()),
+            b"private message contents".to_vec(),
+        );
+        let request = std::fs::read_dir(state::StatePaths::from_home(alice_home).relay_outbox_dir)
+            .expect("relay outbox reads")
+            .next()
+            .expect("relay request exists")
+            .expect("relay request entry");
+        let request_text = std::fs::read_to_string(request.path()).expect("request reads");
+
+        assert_eq!(trusted.code, 0, "{}", trusted.stderr);
+        assert_eq!(sent.code, 0, "{}", sent.stderr);
+        assert!(sent.stdout.contains("\"status\": \"queued_remote\""));
+        assert!(request_text.contains("payload_privacy = \"peer_encrypted\""));
+        assert!(request_text.contains("payload_ciphertext_hex"));
         assert!(!request_text.contains("private message contents"));
     }
 

--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod agents;
 pub mod messages;
 pub mod relay;
+pub mod relay_delivery;
 pub mod routes;
 pub mod runtime;
 pub mod security;
@@ -49,7 +50,7 @@ pub const COMPONENTS: &[Component] = &[
     },
     Component {
         name: "conu-relay",
-        responsibility: "WebSocket relay service for metadata-only internet connectivity",
+        responsibility: "WebSocket relay service for blind peer-encrypted internet delivery",
     },
 ];
 

--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -285,6 +285,32 @@ pub fn read_message_payload(
     Ok(OpaquePayload::from_bytes(payload))
 }
 
+/// Deliver a peer-decrypted remote envelope to a local addressed agent inbox.
+pub fn deliver_remote_envelope_from_paths(
+    paths: &StatePaths,
+    envelope_id: &str,
+    from_agent_id: &str,
+    to_agent_id: &str,
+    payload: OpaquePayload,
+) -> Result<InboxEntry, MessageError> {
+    let envelope_id = validate_identifier(envelope_id.to_string(), "envelope id")?;
+    let from_agent_id = validate_identifier(from_agent_id.to_string(), "from agent id")?;
+    let to_agent_id = validate_identifier(to_agent_id.to_string(), "to agent id")?;
+    validate_payload_size(payload.len())?;
+    validate_local_recipient_can_receive(paths, &to_agent_id)?;
+
+    let envelope = Envelope::new(
+        &envelope_id,
+        AgentId::new(from_agent_id)?,
+        AgentId::new(to_agent_id)?,
+        EnvelopeKind::Message,
+        payload,
+    )?;
+
+    security::record_replay_id_from_paths(paths, &envelope_id, "relay_envelope")?;
+    deliver_envelope_with_status(paths, envelope, "delivered_relay")
+}
+
 /// List metadata-only local delivery receipts.
 pub fn list_receipts(home_override: Option<PathBuf>) -> Result<Vec<DeliveryReceipt>, MessageError> {
     let paths = StatePaths::resolve(home_override)?;
@@ -359,7 +385,7 @@ fn process_one_message_request(
     )?;
 
     security::record_replay_id_from_paths(paths, &envelope_id, "message_envelope")?;
-    deliver_envelope(paths, envelope)
+    deliver_envelope_with_status(paths, envelope, "delivered_local")
 }
 
 fn validate_agents_can_message(
@@ -395,7 +421,32 @@ fn validate_agents_can_message(
     Ok(())
 }
 
-fn deliver_envelope(paths: &StatePaths, envelope: Envelope) -> Result<InboxEntry, MessageError> {
+fn validate_local_recipient_can_receive(
+    paths: &StatePaths,
+    to_agent_id: &str,
+) -> Result<(), MessageError> {
+    let registered = agents::list_local_agents(Some(paths.home.clone()))?;
+    let recipient = registered
+        .iter()
+        .find(|agent| agent.agent_id == to_agent_id)
+        .ok_or_else(|| MessageError::InvalidRequest {
+            reason: "recipient is not a registered local agent".to_string(),
+        })?;
+
+    if !recipient.capabilities.messages {
+        return Err(MessageError::InvalidRequest {
+            reason: "recipient is not allowed to receive messages".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn deliver_envelope_with_status(
+    paths: &StatePaths,
+    envelope: Envelope,
+    status: &str,
+) -> Result<InboxEntry, MessageError> {
     let now = current_unix_seconds();
     let receipt_id = request_id("rcpt");
     let inbox_dir = paths.message_inbox_dir.join(envelope.to.as_str());
@@ -430,7 +481,7 @@ fn deliver_envelope(paths: &StatePaths, envelope: Envelope) -> Result<InboxEntry
         envelope_id: entry.envelope_id.clone(),
         from_agent_id: entry.from_agent_id.clone(),
         to_agent_id: entry.to_agent_id.clone(),
-        status: "delivered_local".to_string(),
+        status: status.to_string(),
         delivered_at_unix: now,
         payload_bytes: entry.payload_bytes,
     };
@@ -438,7 +489,7 @@ fn deliver_envelope(paths: &StatePaths, envelope: Envelope) -> Result<InboxEntry
         .message_receipts_dir
         .join(format!("{}.receipt", receipt.receipt_id));
     write_new_file(&receipt_path, &render_receipt(&receipt))?;
-    append_message_log(paths, &entry)?;
+    append_message_log(paths, &entry, status)?;
 
     Ok(entry)
 }
@@ -661,7 +712,11 @@ fn render_receipt(receipt: &DeliveryReceipt) -> String {
     )
 }
 
-fn append_message_log(paths: &StatePaths, entry: &InboxEntry) -> Result<(), MessageError> {
+fn append_message_log(
+    paths: &StatePaths,
+    entry: &InboxEntry,
+    status: &str,
+) -> Result<(), MessageError> {
     fs::create_dir_all(&paths.logs_dir)
         .map_err(|error| MessageError::io("create log directory", &paths.logs_dir, error))?;
     let log_path = paths.logs_dir.join("messages.log");
@@ -673,8 +728,9 @@ fn append_message_log(paths: &StatePaths, entry: &InboxEntry) -> Result<(), Mess
 
     writeln!(
         file,
-        "time={} event=message_delivered envelope={} from={} to={} bytes={} payload=not_observed",
+        "time={} event=message_delivered status={} envelope={} from={} to={} bytes={} payload=not_observed",
         current_unix_seconds(),
+        sanitize_log_value(status),
         sanitize_log_value(&entry.envelope_id),
         sanitize_log_value(&entry.from_agent_id),
         sanitize_log_value(&entry.to_agent_id),

--- a/crates/conu-core/src/relay.rs
+++ b/crates/conu-core/src/relay.rs
@@ -1,11 +1,20 @@
 //! Relay frame contract shared by runtimes and the relay service.
 //!
-//! Phase 8 keeps relay traffic metadata-only at this layer. Payload bytes are
-//! represented by byte counts and envelope ids; the relay never receives a
-//! plaintext payload field.
+//! The relay can carry peer-encrypted envelope bodies, but it must never expose
+//! plaintext payload fields. Frame rendering keeps ciphertext in a dedicated
+//! opaque body field and all user-facing surfaces should summarize only
+//! metadata.
 
 use std::collections::HashMap;
 use std::fmt;
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::process;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const WEBSOCKET_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const MAX_HTTP_HEADER_BYTES: usize = 8192;
+const MAX_FRAME_BYTES: usize = 256 * 1024;
 
 /// Error produced while parsing or rendering relay frames.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,6 +27,10 @@ impl RelayFrameError {
         Self {
             reason: reason.into(),
         }
+    }
+
+    fn io(action: &'static str, source: io::Error) -> Self {
+        Self::new(format!("{action}: {source}"))
     }
 }
 
@@ -59,11 +72,14 @@ impl fmt::Debug for RelayHello {
 }
 
 /// Runtime-to-relay opaque forwarding request.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RelayForward {
     pub to_node_id: String,
     pub envelope_id: String,
     pub payload_bytes: usize,
+    pub from_agent_id: Option<String>,
+    pub to_agent_id: Option<String>,
+    pub body: Option<RelayOpaqueBody>,
 }
 
 impl RelayForward {
@@ -76,7 +92,87 @@ impl RelayForward {
             to_node_id: validate_identifier(to_node_id.into(), "to node id")?,
             envelope_id: validate_identifier(envelope_id.into(), "envelope id")?,
             payload_bytes,
+            from_agent_id: None,
+            to_agent_id: None,
+            body: None,
         })
+    }
+
+    pub fn with_body(
+        to_node_id: impl Into<String>,
+        envelope_id: impl Into<String>,
+        from_agent_id: impl Into<String>,
+        to_agent_id: impl Into<String>,
+        payload_bytes: usize,
+        body: RelayOpaqueBody,
+    ) -> Result<Self, RelayFrameError> {
+        Ok(Self {
+            to_node_id: validate_identifier(to_node_id.into(), "to node id")?,
+            envelope_id: validate_identifier(envelope_id.into(), "envelope id")?,
+            from_agent_id: Some(validate_identifier(from_agent_id.into(), "from agent id")?),
+            to_agent_id: Some(validate_identifier(to_agent_id.into(), "to agent id")?),
+            payload_bytes,
+            body: Some(body),
+        })
+    }
+}
+
+impl fmt::Debug for RelayForward {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RelayForward")
+            .field("to_node_id", &self.to_node_id)
+            .field("envelope_id", &self.envelope_id)
+            .field("payload_bytes", &self.payload_bytes)
+            .field("from_agent_id", &self.from_agent_id)
+            .field("to_agent_id", &self.to_agent_id)
+            .field("body", &self.body)
+            .finish()
+    }
+}
+
+/// Peer-encrypted body material carried by the blind relay.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RelayOpaqueBody {
+    pub algorithm: String,
+    pub key_id: String,
+    pub sender_exchange_public_key_hex: String,
+    pub nonce_hex: String,
+    pub ciphertext_hex: String,
+}
+
+impl RelayOpaqueBody {
+    pub fn new(
+        algorithm: impl Into<String>,
+        key_id: impl Into<String>,
+        sender_exchange_public_key_hex: impl Into<String>,
+        nonce_hex: impl Into<String>,
+        ciphertext_hex: impl Into<String>,
+    ) -> Result<Self, RelayFrameError> {
+        Ok(Self {
+            algorithm: validate_algorithm(algorithm.into())?,
+            key_id: validate_identifier(key_id.into(), "key id")?,
+            sender_exchange_public_key_hex: validate_hex(
+                sender_exchange_public_key_hex.into(),
+                "sender exchange public key",
+            )?,
+            nonce_hex: validate_hex(nonce_hex.into(), "nonce")?,
+            ciphertext_hex: validate_hex(ciphertext_hex.into(), "body")?,
+        })
+    }
+}
+
+impl fmt::Debug for RelayOpaqueBody {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RelayOpaqueBody")
+            .field("algorithm", &self.algorithm)
+            .field("key_id", &self.key_id)
+            .field("sender_exchange_public_key_hex", &"<public-key>")
+            .field("nonce_hex", &"<nonce>")
+            .field("ciphertext_len", &self.ciphertext_hex.len())
+            .field("ciphertext", &"<encrypted>")
+            .finish()
     }
 }
 
@@ -99,6 +195,9 @@ pub enum RelayServerFrame {
         to_node_id: String,
         envelope_id: String,
         payload_bytes: usize,
+        from_agent_id: Option<String>,
+        to_agent_id: Option<String>,
+        body: Option<RelayOpaqueBody>,
     },
     Sent {
         to_node_id: String,
@@ -123,10 +222,7 @@ pub fn render_client_frame(frame: &RelayClientFrame) -> String {
             "HELLO node={} token={} payload=not_observed",
             hello.node_id, hello.auth_token
         ),
-        RelayClientFrame::Forward(forward) => format!(
-            "FORWARD to={} envelope={} bytes={} payload=opaque",
-            forward.to_node_id, forward.envelope_id, forward.payload_bytes
-        ),
+        RelayClientFrame::Forward(forward) => render_forward_line("FORWARD", None, forward),
         RelayClientFrame::Ping => "PING payload=not_observed".to_string(),
     }
 }
@@ -145,11 +241,14 @@ pub fn parse_client_frame(line: &str) -> Result<RelayClientFrame, RelayFrameErro
             required(&values, "node")?,
             required(&values, "token")?,
         )?)),
-        "FORWARD" => Ok(RelayClientFrame::Forward(RelayForward::new(
-            required(&values, "to")?,
-            required(&values, "envelope")?,
-            parse_usize(&required(&values, "bytes")?)?,
-        )?)),
+        "FORWARD" => Ok(RelayClientFrame::Forward(
+            RelayForward::new(
+                required(&values, "to")?,
+                required(&values, "envelope")?,
+                parse_usize(&required(&values, "bytes")?)?,
+            )?
+            .with_optional_body(&values)?,
+        )),
         "PING" => Ok(RelayClientFrame::Ping),
         _ => Err(RelayFrameError::new("unsupported client frame type")),
     }
@@ -166,9 +265,17 @@ pub fn render_server_frame(frame: &RelayServerFrame) -> String {
             to_node_id,
             envelope_id,
             payload_bytes,
-        } => format!(
-            "ENVELOPE from={} to={} envelope={} bytes={} payload=opaque",
-            from_node_id, to_node_id, envelope_id, payload_bytes
+            from_agent_id,
+            to_agent_id,
+            body,
+        } => render_forwarded_line(
+            from_node_id,
+            to_node_id,
+            envelope_id,
+            *payload_bytes,
+            from_agent_id.as_deref(),
+            to_agent_id.as_deref(),
+            body.as_ref(),
         ),
         RelayServerFrame::Sent {
             to_node_id,
@@ -196,6 +303,189 @@ pub fn render_server_frame(frame: &RelayServerFrame) -> String {
             )
         }
     }
+}
+
+/// Parse a relay server frame line received by a runtime.
+pub fn parse_server_frame(line: &str) -> Result<RelayServerFrame, RelayFrameError> {
+    let (kind, values) = parse_frame_values(line)?;
+    if values.contains_key("payload_hex") || values.contains_key("payload_text") {
+        return Err(RelayFrameError::new(
+            "relay frame must not include plaintext payload fields",
+        ));
+    }
+
+    match kind {
+        "WELCOME" => Ok(RelayServerFrame::Welcome {
+            session_id: required(&values, "session")?,
+        }),
+        "ENVELOPE" => {
+            let body = optional_body(&values)?;
+            Ok(RelayServerFrame::Forwarded {
+                from_node_id: validate_identifier(required(&values, "from")?, "from node id")?,
+                to_node_id: validate_identifier(required(&values, "to")?, "to node id")?,
+                envelope_id: validate_identifier(required(&values, "envelope")?, "envelope id")?,
+                payload_bytes: parse_usize(&required(&values, "bytes")?)?,
+                from_agent_id: optional_identifier(&values, "from_agent", "from agent id")?,
+                to_agent_id: optional_identifier(&values, "to_agent", "to agent id")?,
+                body,
+            })
+        }
+        "SENT" => Ok(RelayServerFrame::Sent {
+            to_node_id: validate_identifier(required(&values, "to")?, "to node id")?,
+            envelope_id: validate_identifier(required(&values, "envelope")?, "envelope id")?,
+            payload_bytes: parse_usize(&required(&values, "bytes")?)?,
+        }),
+        "UNDELIVERED" => Ok(RelayServerFrame::Undelivered {
+            to_node_id: validate_identifier(required(&values, "to")?, "to node id")?,
+            envelope_id: validate_identifier(required(&values, "envelope")?, "envelope id")?,
+            reason: required(&values, "reason")?,
+        }),
+        "PONG" => Ok(RelayServerFrame::Pong),
+        "ERROR" => Ok(RelayServerFrame::Error {
+            reason: required(&values, "reason")?,
+        }),
+        _ => Err(RelayFrameError::new("unsupported server frame type")),
+    }
+}
+
+/// Minimal std-only WebSocket client for runtime-to-relay sync.
+pub struct RelayWebSocketClient {
+    stream: TcpStream,
+}
+
+impl RelayWebSocketClient {
+    pub fn connect(endpoint: &str, timeout: Duration) -> Result<Self, RelayFrameError> {
+        let parsed = ParsedEndpoint::parse(endpoint)?;
+        let mut stream = TcpStream::connect((&parsed.host[..], parsed.port))
+            .map_err(|error| RelayFrameError::io("connect relay endpoint", error))?;
+        stream
+            .set_read_timeout(Some(timeout))
+            .map_err(|error| RelayFrameError::io("configure relay read timeout", error))?;
+        stream
+            .set_write_timeout(Some(timeout))
+            .map_err(|error| RelayFrameError::io("configure relay write timeout", error))?;
+        perform_client_handshake(&mut stream, &parsed)?;
+
+        Ok(Self { stream })
+    }
+
+    pub fn send(&mut self, frame: &RelayClientFrame) -> Result<(), RelayFrameError> {
+        write_client_text_frame(&mut self.stream, &render_client_frame(frame))
+    }
+
+    pub fn read(&mut self) -> Result<Option<RelayServerFrame>, RelayFrameError> {
+        let Some(text) = read_server_text_frame(&mut self.stream)? else {
+            return Ok(None);
+        };
+        parse_server_frame(&text).map(Some)
+    }
+}
+
+impl RelayForward {
+    fn with_optional_body(
+        mut self,
+        values: &HashMap<String, String>,
+    ) -> Result<Self, RelayFrameError> {
+        self.body = optional_body(values)?;
+        if self.body.is_some() {
+            self.from_agent_id = Some(validate_identifier(
+                required(values, "from_agent")?,
+                "from agent id",
+            )?);
+            self.to_agent_id = Some(validate_identifier(
+                required(values, "to_agent")?,
+                "to agent id",
+            )?);
+        }
+        Ok(self)
+    }
+}
+
+fn render_forward_line(kind: &str, from_node: Option<&str>, forward: &RelayForward) -> String {
+    let mut line = match from_node {
+        Some(from_node) => format!(
+            "{kind} from={} to={} envelope={} bytes={}",
+            from_node, forward.to_node_id, forward.envelope_id, forward.payload_bytes
+        ),
+        None => format!(
+            "{kind} to={} envelope={} bytes={}",
+            forward.to_node_id, forward.envelope_id, forward.payload_bytes
+        ),
+    };
+
+    append_forward_body(
+        &mut line,
+        forward.from_agent_id.as_deref(),
+        forward.to_agent_id.as_deref(),
+        forward.body.as_ref(),
+    );
+    line
+}
+
+fn render_forwarded_line(
+    from_node_id: &str,
+    to_node_id: &str,
+    envelope_id: &str,
+    payload_bytes: usize,
+    from_agent_id: Option<&str>,
+    to_agent_id: Option<&str>,
+    body: Option<&RelayOpaqueBody>,
+) -> String {
+    let mut line = format!(
+        "ENVELOPE from={} to={} envelope={} bytes={}",
+        from_node_id, to_node_id, envelope_id, payload_bytes
+    );
+    append_forward_body(&mut line, from_agent_id, to_agent_id, body);
+    line
+}
+
+fn append_forward_body(
+    line: &mut String,
+    from_agent_id: Option<&str>,
+    to_agent_id: Option<&str>,
+    body: Option<&RelayOpaqueBody>,
+) {
+    if let Some(body) = body {
+        line.push_str(&format!(
+            " from_agent={} to_agent={} cipher={} key={} sender_key={} nonce={} body={} payload=peer_encrypted",
+            from_agent_id.unwrap_or("unknown"),
+            to_agent_id.unwrap_or("unknown"),
+            body.algorithm,
+            body.key_id,
+            body.sender_exchange_public_key_hex,
+            body.nonce_hex,
+            body.ciphertext_hex
+        ));
+    } else {
+        line.push_str(" payload=opaque");
+    }
+}
+
+fn optional_body(
+    values: &HashMap<String, String>,
+) -> Result<Option<RelayOpaqueBody>, RelayFrameError> {
+    if !values.contains_key("body") {
+        return Ok(None);
+    }
+
+    Ok(Some(RelayOpaqueBody::new(
+        required(values, "cipher")?,
+        required(values, "key")?,
+        required(values, "sender_key")?,
+        required(values, "nonce")?,
+        required(values, "body")?,
+    )?))
+}
+
+fn optional_identifier(
+    values: &HashMap<String, String>,
+    key: &'static str,
+    field: &'static str,
+) -> Result<Option<String>, RelayFrameError> {
+    values
+        .get(key)
+        .map(|value| validate_identifier(value.clone(), field))
+        .transpose()
 }
 
 fn parse_frame_values(line: &str) -> Result<(&str, HashMap<String, String>), RelayFrameError> {
@@ -259,6 +549,36 @@ fn validate_token(value: String) -> Result<String, RelayFrameError> {
     Ok(value)
 }
 
+fn validate_algorithm(value: String) -> Result<String, RelayFrameError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(RelayFrameError::new("cipher algorithm cannot be empty"));
+    }
+    if value.len() > 80 {
+        return Err(RelayFrameError::new("cipher algorithm is too long"));
+    }
+    if !value.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '+' | '.')
+    }) {
+        return Err(RelayFrameError::new("cipher algorithm is invalid"));
+    }
+    Ok(value)
+}
+
+fn validate_hex(value: String, field: &'static str) -> Result<String, RelayFrameError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(RelayFrameError::new(format!("{field} cannot be empty")));
+    }
+    if value.len() > MAX_FRAME_BYTES * 2 {
+        return Err(RelayFrameError::new(format!("{field} is too large")));
+    }
+    if value.len() % 2 != 0 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(RelayFrameError::new(format!("{field} must be hex")));
+    }
+    Ok(value)
+}
+
 fn parse_usize(value: &str) -> Result<usize, RelayFrameError> {
     value
         .parse::<usize>()
@@ -276,6 +596,349 @@ fn sanitize_reason(reason: &str) -> String {
     } else {
         sanitized
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedEndpoint {
+    host: String,
+    port: u16,
+    path: String,
+}
+
+impl ParsedEndpoint {
+    fn parse(endpoint: &str) -> Result<Self, RelayFrameError> {
+        if endpoint.starts_with("wss://") {
+            return Err(RelayFrameError::new(
+                "wss relay endpoints need a TLS terminator; this std client supports ws://",
+            ));
+        }
+        let rest = endpoint
+            .strip_prefix("ws://")
+            .ok_or_else(|| RelayFrameError::new("relay endpoint must start with ws://"))?;
+        let (authority, path) = match rest.split_once('/') {
+            Some((authority, path)) => (authority, format!("/{path}")),
+            None => (rest, "/relay".to_string()),
+        };
+        let (host, port) = match authority.rsplit_once(':') {
+            Some((host, port)) => (
+                host.trim().to_string(),
+                port.parse::<u16>()
+                    .map_err(|_| RelayFrameError::new("relay endpoint port is invalid"))?,
+            ),
+            None => (authority.trim().to_string(), 80),
+        };
+
+        if host.is_empty() || host.chars().any(char::is_whitespace) {
+            return Err(RelayFrameError::new("relay endpoint host is invalid"));
+        }
+        if path.is_empty() || path.chars().any(char::is_whitespace) {
+            return Err(RelayFrameError::new("relay endpoint path is invalid"));
+        }
+
+        Ok(Self { host, port, path })
+    }
+
+    fn authority(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+fn perform_client_handshake(
+    stream: &mut TcpStream,
+    endpoint: &ParsedEndpoint,
+) -> Result<(), RelayFrameError> {
+    let key = websocket_key();
+    let request = format!(
+        "GET {} HTTP/1.1\r\nHost: {}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: {}\r\nSec-WebSocket-Version: 13\r\n\r\n",
+        endpoint.path,
+        endpoint.authority(),
+        key
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| RelayFrameError::io("write websocket handshake", error))?;
+    let response = read_http_response(stream)?;
+
+    if !response.starts_with("HTTP/1.1 101") && !response.starts_with("HTTP/1.0 101") {
+        return Err(RelayFrameError::new(
+            "relay websocket upgrade was not accepted",
+        ));
+    }
+    let accept = header_value(&response, "sec-websocket-accept")
+        .ok_or_else(|| RelayFrameError::new("relay handshake missing accept header"))?;
+    if accept != websocket_accept_key(&key) {
+        return Err(RelayFrameError::new("relay websocket accept key mismatch"));
+    }
+
+    Ok(())
+}
+
+fn read_http_response(stream: &mut TcpStream) -> Result<String, RelayFrameError> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0_u8; 1];
+
+    while bytes.len() < MAX_HTTP_HEADER_BYTES {
+        stream
+            .read_exact(&mut buffer)
+            .map_err(|error| RelayFrameError::io("read websocket handshake", error))?;
+        bytes.push(buffer[0]);
+        if bytes.ends_with(b"\r\n\r\n") {
+            return String::from_utf8(bytes)
+                .map_err(|_| RelayFrameError::new("websocket handshake is not UTF-8"));
+        }
+    }
+
+    Err(RelayFrameError::new(
+        "websocket handshake headers are too large",
+    ))
+}
+
+fn header_value(response: &str, header: &str) -> Option<String> {
+    response.lines().find_map(|line| {
+        let (key, value) = line.split_once(':')?;
+        if key.trim().eq_ignore_ascii_case(header) {
+            Some(value.trim().to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn write_client_text_frame(stream: &mut TcpStream, text: &str) -> Result<(), RelayFrameError> {
+    write_client_raw_frame(stream, 0x1, text.as_bytes())
+}
+
+fn write_client_raw_frame(
+    stream: &mut TcpStream,
+    opcode: u8,
+    payload: &[u8],
+) -> Result<(), RelayFrameError> {
+    let mask = websocket_mask();
+    let mut frame = Vec::with_capacity(payload.len() + 14);
+    frame.push(0x80 | opcode);
+
+    if payload.len() <= 125 {
+        frame.push(0x80 | payload.len() as u8);
+    } else if payload.len() <= u16::MAX as usize {
+        frame.push(0x80 | 126);
+        frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+    } else {
+        frame.push(0x80 | 127);
+        frame.extend_from_slice(&(payload.len() as u64).to_be_bytes());
+    }
+
+    frame.extend_from_slice(&mask);
+    for (index, byte) in payload.iter().enumerate() {
+        frame.push(byte ^ mask[index % 4]);
+    }
+
+    stream
+        .write_all(&frame)
+        .map_err(|error| RelayFrameError::io("write websocket frame", error))
+}
+
+fn read_server_text_frame(stream: &mut TcpStream) -> Result<Option<String>, RelayFrameError> {
+    let mut header = [0_u8; 2];
+    match stream.read_exact(&mut header) {
+        Ok(()) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::UnexpectedEof
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::TimedOut
+                    | io::ErrorKind::WouldBlock
+            ) =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(RelayFrameError::io("read websocket frame", error)),
+    }
+
+    let opcode = header[0] & 0x0f;
+    let masked = header[1] & 0x80 != 0;
+    let mut len = u64::from(header[1] & 0x7f);
+
+    if len == 126 {
+        let mut bytes = [0_u8; 2];
+        stream
+            .read_exact(&mut bytes)
+            .map_err(|error| RelayFrameError::io("read websocket frame length", error))?;
+        len = u64::from(u16::from_be_bytes(bytes));
+    } else if len == 127 {
+        let mut bytes = [0_u8; 8];
+        stream
+            .read_exact(&mut bytes)
+            .map_err(|error| RelayFrameError::io("read websocket frame length", error))?;
+        len = u64::from_be_bytes(bytes);
+    }
+
+    if len as usize > MAX_FRAME_BYTES {
+        return Err(RelayFrameError::new("websocket frame is too large"));
+    }
+
+    let mut mask = [0_u8; 4];
+    if masked {
+        stream
+            .read_exact(&mut mask)
+            .map_err(|error| RelayFrameError::io("read websocket frame mask", error))?;
+    }
+
+    let mut payload = vec![0_u8; len as usize];
+    stream
+        .read_exact(&mut payload)
+        .map_err(|error| RelayFrameError::io("read websocket frame body", error))?;
+
+    if masked {
+        for (index, byte) in payload.iter_mut().enumerate() {
+            *byte ^= mask[index % 4];
+        }
+    }
+
+    match opcode {
+        0x1 => String::from_utf8(payload)
+            .map(Some)
+            .map_err(|_| RelayFrameError::new("text frame is not UTF-8")),
+        0x8 => Ok(None),
+        0x9 => {
+            write_client_raw_frame(stream, 0xA, &payload)?;
+            Ok(Some("PONG payload=not_observed".to_string()))
+        }
+        _ => Err(RelayFrameError::new(
+            "unsupported websocket frame opcode from relay",
+        )),
+    }
+}
+
+fn websocket_key() -> String {
+    let mut bytes = [0_u8; 16];
+    bytes[..4].copy_from_slice(&process::id().to_be_bytes());
+    bytes[4..12].copy_from_slice(&(current_unix_nanos() as u64).to_be_bytes());
+    bytes[12..].copy_from_slice(&websocket_mask());
+    base64_encode(&bytes)
+}
+
+fn websocket_mask() -> [u8; 4] {
+    let now = current_unix_nanos();
+    [
+        (now & 0xff) as u8,
+        ((now >> 8) & 0xff) as u8,
+        ((now >> 16) & 0xff) as u8,
+        ((now >> 24) & 0xff) as u8,
+    ]
+}
+
+fn websocket_accept_key(client_key: &str) -> String {
+    let mut input = String::with_capacity(client_key.len() + WEBSOCKET_GUID.len());
+    input.push_str(client_key.trim());
+    input.push_str(WEBSOCKET_GUID);
+    base64_encode(&sha1(input.as_bytes()))
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = *chunk.get(1).unwrap_or(&0);
+        let b2 = *chunk.get(2).unwrap_or(&0);
+        let n = ((b0 as u32) << 16) | ((b1 as u32) << 8) | b2 as u32;
+
+        out.push(TABLE[((n >> 18) & 0x3f) as usize] as char);
+        out.push(TABLE[((n >> 12) & 0x3f) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(TABLE[((n >> 6) & 0x3f) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        if chunk.len() > 2 {
+            out.push(TABLE[(n & 0x3f) as usize] as char);
+        } else {
+            out.push('=');
+        }
+    }
+
+    out
+}
+
+fn sha1(bytes: &[u8]) -> [u8; 20] {
+    let mut h0: u32 = 0x67452301;
+    let mut h1: u32 = 0xefcdab89;
+    let mut h2: u32 = 0x98badcfe;
+    let mut h3: u32 = 0x10325476;
+    let mut h4: u32 = 0xc3d2e1f0;
+    let bit_len = (bytes.len() as u64) * 8;
+    let mut message = bytes.to_vec();
+
+    message.push(0x80);
+    while (message.len() % 64) != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in message.chunks(64) {
+        let mut w = [0_u32; 80];
+        for (i, word) in w.iter_mut().take(16).enumerate() {
+            let offset = i * 4;
+            *word = u32::from_be_bytes([
+                chunk[offset],
+                chunk[offset + 1],
+                chunk[offset + 2],
+                chunk[offset + 3],
+            ]);
+        }
+        for i in 16..80 {
+            w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);
+        }
+
+        let mut a = h0;
+        let mut b = h1;
+        let mut c = h2;
+        let mut d = h3;
+        let mut e = h4;
+
+        for (i, word) in w.iter().enumerate() {
+            let (f, k) = match i {
+                0..=19 => ((b & c) | ((!b) & d), 0x5a827999),
+                20..=39 => (b ^ c ^ d, 0x6ed9eba1),
+                40..=59 => ((b & c) | (b & d) | (c & d), 0x8f1bbcdc),
+                _ => (b ^ c ^ d, 0xca62c1d6),
+            };
+            let temp = a
+                .rotate_left(5)
+                .wrapping_add(f)
+                .wrapping_add(e)
+                .wrapping_add(k)
+                .wrapping_add(*word);
+            e = d;
+            d = c;
+            c = b.rotate_left(30);
+            b = a;
+            a = temp;
+        }
+
+        h0 = h0.wrapping_add(a);
+        h1 = h1.wrapping_add(b);
+        h2 = h2.wrapping_add(c);
+        h3 = h3.wrapping_add(d);
+        h4 = h4.wrapping_add(e);
+    }
+
+    let mut out = [0_u8; 20];
+    out[0..4].copy_from_slice(&h0.to_be_bytes());
+    out[4..8].copy_from_slice(&h1.to_be_bytes());
+    out[8..12].copy_from_slice(&h2.to_be_bytes());
+    out[12..16].copy_from_slice(&h3.to_be_bytes());
+    out[16..20].copy_from_slice(&h4.to_be_bytes());
+    out
+}
+
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
 }
 
 #[cfg(test)]

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -1,0 +1,1010 @@
+//! Relay-backed encrypted message delivery.
+//!
+//! This module is the first live internet data-plane slice. It queues local
+//! agent bytes as peer-encrypted envelopes, syncs them over the blind WebSocket
+//! relay, and delivers decrypted inbound envelopes into the addressed local
+//! agent inbox. Logs and reports remain metadata-only.
+
+use std::collections::HashMap;
+use std::env;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use conu_protocol::OpaquePayload;
+
+use crate::agents::{self, AgentError};
+use crate::messages::{self, InboxEntry, MessageError};
+use crate::relay::{
+    RelayClientFrame, RelayForward, RelayFrameError, RelayHello, RelayOpaqueBody, RelayServerFrame,
+    RelayWebSocketClient,
+};
+use crate::security::{self, PeerEncryptedPayload, SecurityError};
+use crate::state::{self, StateError, StatePaths};
+use crate::trust::{self, TrustStatus, TrustedPeer};
+
+const RELAY_REQUEST_VERSION: &str = "1";
+const DEFAULT_RELAY_ENDPOINT: &str = "ws://127.0.0.1:8787";
+const DEFAULT_RELAY_TOKEN: &str = "local-dev-token";
+const MAX_RELAY_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Opaque remote message submitted by a local agent.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RemoteMessage {
+    pub from_agent_id: String,
+    pub to_agent_id: String,
+    pub peer_node_id: String,
+    pub payload: OpaquePayload,
+}
+
+impl RemoteMessage {
+    pub fn new(
+        from_agent_id: impl Into<String>,
+        to_agent_id: impl Into<String>,
+        peer_node_id: impl Into<String>,
+        payload: OpaquePayload,
+    ) -> Result<Self, RelayDeliveryError> {
+        validate_payload_size(payload.len())?;
+
+        Ok(Self {
+            from_agent_id: validate_identifier(from_agent_id.into(), "from agent id")?,
+            to_agent_id: validate_identifier(to_agent_id.into(), "to agent id")?,
+            peer_node_id: validate_identifier(peer_node_id.into(), "peer node id")?,
+            payload,
+        })
+    }
+}
+
+impl fmt::Debug for RemoteMessage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RemoteMessage")
+            .field("from_agent_id", &self.from_agent_id)
+            .field("to_agent_id", &self.to_agent_id)
+            .field("peer_node_id", &self.peer_node_id)
+            .field("payload_len", &self.payload.len())
+            .field("payload", &"<opaque>")
+            .finish()
+    }
+}
+
+/// Result of queueing a remote relay message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteMessageSubmission {
+    pub request_id: String,
+    pub envelope_id: String,
+    pub request_path: PathBuf,
+    pub peer_node_id: String,
+    pub payload_bytes: usize,
+}
+
+/// One relay sync pass summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelaySyncReport {
+    pub endpoint: String,
+    pub connected: bool,
+    pub queued: usize,
+    pub sent: usize,
+    pub received: usize,
+    pub undelivered: usize,
+    pub rejected: usize,
+    pub inbox_entries: Vec<InboxEntry>,
+}
+
+/// Current relay queue counts for CLI status/watch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelayQueueSummary {
+    pub queued: usize,
+    pub sent: usize,
+    pub rejected: usize,
+}
+
+#[derive(Debug)]
+pub enum RelayDeliveryError {
+    State(StateError),
+    Agent(AgentError),
+    Message(MessageError),
+    Security(SecurityError),
+    Trust(trust::TrustError),
+    Relay(RelayFrameError),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidRequest {
+        reason: String,
+    },
+}
+
+impl RelayDeliveryError {
+    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            action,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for RelayDeliveryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => write!(formatter, "{error}"),
+            Self::Agent(error) => write!(formatter, "{error}"),
+            Self::Message(error) => write!(formatter, "{error}"),
+            Self::Security(error) => write!(formatter, "{error}"),
+            Self::Trust(error) => write!(formatter, "{error}"),
+            Self::Relay(error) => write!(formatter, "{error}"),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidRequest { reason } => write!(formatter, "invalid relay request: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for RelayDeliveryError {}
+
+impl From<StateError> for RelayDeliveryError {
+    fn from(error: StateError) -> Self {
+        Self::State(error)
+    }
+}
+
+impl From<AgentError> for RelayDeliveryError {
+    fn from(error: AgentError) -> Self {
+        Self::Agent(error)
+    }
+}
+
+impl From<MessageError> for RelayDeliveryError {
+    fn from(error: MessageError) -> Self {
+        Self::Message(error)
+    }
+}
+
+impl From<SecurityError> for RelayDeliveryError {
+    fn from(error: SecurityError) -> Self {
+        Self::Security(error)
+    }
+}
+
+impl From<trust::TrustError> for RelayDeliveryError {
+    fn from(error: trust::TrustError) -> Self {
+        Self::Trust(error)
+    }
+}
+
+impl From<RelayFrameError> for RelayDeliveryError {
+    fn from(error: RelayFrameError) -> Self {
+        Self::Relay(error)
+    }
+}
+
+/// Queue a peer-encrypted remote message into the relay outbox.
+pub fn submit_remote_message(
+    home_override: Option<PathBuf>,
+    message: RemoteMessage,
+) -> Result<RemoteMessageSubmission, RelayDeliveryError> {
+    let init = state::init_state(home_override)?;
+    ensure_relay_dirs(&init.paths)?;
+    validate_local_sender_can_message(&init.paths, &message.from_agent_id)?;
+    let peer = trusted_peer_with_key(&init.paths, &message.peer_node_id)?;
+
+    let relay_request_id = request_id("relayreq");
+    let envelope_id = request_id("env");
+    let aad = relay_aad(
+        &envelope_id,
+        &init.node.node_id,
+        &peer.peer_node_id,
+        &message.from_agent_id,
+        &message.to_agent_id,
+    );
+    let encrypted = security::encrypt_for_peer_from_paths(
+        &init.paths,
+        peer.exchange_public_key_hex.as_deref().ok_or_else(|| {
+            RelayDeliveryError::InvalidRequest {
+                reason: "trusted peer does not have an exchange public key".to_string(),
+            }
+        })?,
+        message.payload.as_bytes(),
+        &aad,
+    )?;
+    let request_path = init
+        .paths
+        .relay_outbox_dir
+        .join(format!("{relay_request_id}.relay"));
+    let contents = render_relay_request(
+        &relay_request_id,
+        &envelope_id,
+        &init.node.node_id,
+        &peer.peer_node_id,
+        &message.from_agent_id,
+        &message.to_agent_id,
+        &encrypted,
+    );
+    write_new_file(&request_path, &contents)?;
+
+    Ok(RemoteMessageSubmission {
+        request_id: relay_request_id,
+        envelope_id,
+        request_path,
+        peer_node_id: peer.peer_node_id,
+        payload_bytes: message.payload.len(),
+    })
+}
+
+/// Connect to the configured relay, send pending remote messages, and receive
+/// inbound encrypted envelopes for a bounded wait.
+pub fn sync_relay_once(
+    home_override: Option<PathBuf>,
+    wait: Duration,
+) -> Result<RelaySyncReport, RelayDeliveryError> {
+    let init = state::init_state(home_override)?;
+    ensure_relay_dirs(&init.paths)?;
+
+    let queued_paths = pending_relay_requests(&init.paths)?;
+    let endpoint = relay_endpoint_for_sync(&init.paths, &queued_paths)?;
+    let token = relay_token();
+    let timeout = Duration::from_millis(500);
+    let mut client = RelayWebSocketClient::connect(&endpoint, timeout)?;
+    client.send(&RelayClientFrame::Hello(RelayHello::new(
+        init.node.node_id.clone(),
+        token,
+    )?))?;
+
+    let mut report = RelaySyncReport {
+        endpoint,
+        connected: false,
+        queued: queued_paths.len(),
+        sent: 0,
+        received: 0,
+        undelivered: 0,
+        rejected: 0,
+        inbox_entries: Vec::new(),
+    };
+
+    match client.read()? {
+        Some(RelayServerFrame::Welcome { .. }) => report.connected = true,
+        Some(RelayServerFrame::Error { reason }) => {
+            return Err(RelayDeliveryError::InvalidRequest { reason });
+        }
+        _ => {
+            return Err(RelayDeliveryError::InvalidRequest {
+                reason: "relay did not welcome the runtime session".to_string(),
+            });
+        }
+    }
+
+    for request_path in queued_paths {
+        let request = match read_relay_request(&request_path) {
+            Ok(request) => request,
+            Err(error) => {
+                report.rejected += 1;
+                move_relay_request(&init.paths.relay_rejected_dir, &request_path, "rejected")?;
+                append_relay_log(&init.paths, "outbox_rejected", "", "", 0)?;
+                return Err(error);
+            }
+        };
+        client.send(&RelayClientFrame::Forward(request.to_forward_frame()?))?;
+        drain_relay_frames(
+            &mut client,
+            &init.paths,
+            &mut report,
+            Duration::from_millis(600),
+        )?;
+    }
+
+    drain_relay_frames(&mut client, &init.paths, &mut report, wait)?;
+    Ok(report)
+}
+
+/// Return relay queue counts without connecting to the network.
+pub fn relay_queue_summary(
+    home_override: Option<PathBuf>,
+) -> Result<RelayQueueSummary, RelayDeliveryError> {
+    let paths = StatePaths::resolve(home_override)?;
+    Ok(RelayQueueSummary {
+        queued: count_files_with_extension(&paths.relay_outbox_dir, "relay")?,
+        sent: count_files_with_extension(&paths.relay_sent_dir, "sent")?,
+        rejected: count_files_with_extension(&paths.relay_rejected_dir, "rejected")?,
+    })
+}
+
+fn drain_relay_frames(
+    client: &mut RelayWebSocketClient,
+    paths: &StatePaths,
+    report: &mut RelaySyncReport,
+    wait: Duration,
+) -> Result<(), RelayDeliveryError> {
+    let start = Instant::now();
+
+    while start.elapsed() < wait {
+        match client.read()? {
+            Some(frame) => handle_relay_frame(paths, report, frame)?,
+            None => break,
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_relay_frame(
+    paths: &StatePaths,
+    report: &mut RelaySyncReport,
+    frame: RelayServerFrame,
+) -> Result<(), RelayDeliveryError> {
+    match frame {
+        RelayServerFrame::Forwarded {
+            from_node_id,
+            to_node_id,
+            envelope_id,
+            payload_bytes,
+            from_agent_id,
+            to_agent_id,
+            body,
+        } => {
+            let incoming = IncomingRelayEnvelope {
+                from_node_id,
+                to_node_id,
+                envelope_id,
+                payload_bytes,
+                from_agent_id,
+                to_agent_id,
+                body,
+            };
+            let entry = receive_forwarded_envelope(paths, &incoming)?;
+            report.received += 1;
+            report.inbox_entries.push(entry);
+        }
+        RelayServerFrame::Sent {
+            envelope_id,
+            to_node_id,
+            payload_bytes,
+        } => {
+            report.sent += 1;
+            mark_sent_by_envelope(paths, &envelope_id)?;
+            append_relay_log(
+                paths,
+                "outbox_sent",
+                &envelope_id,
+                &to_node_id,
+                payload_bytes,
+            )?;
+        }
+        RelayServerFrame::Undelivered {
+            to_node_id,
+            envelope_id,
+            reason: _,
+        } => {
+            report.undelivered += 1;
+            append_relay_log(paths, "outbox_undelivered", &envelope_id, &to_node_id, 0)?;
+        }
+        RelayServerFrame::Error { reason: _ } => {
+            report.rejected += 1;
+            append_relay_log(paths, "relay_error", "", "", 0)?;
+        }
+        RelayServerFrame::Welcome { .. } | RelayServerFrame::Pong => {}
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct IncomingRelayEnvelope {
+    from_node_id: String,
+    to_node_id: String,
+    envelope_id: String,
+    payload_bytes: usize,
+    from_agent_id: Option<String>,
+    to_agent_id: Option<String>,
+    body: Option<RelayOpaqueBody>,
+}
+
+fn receive_forwarded_envelope(
+    paths: &StatePaths,
+    incoming: &IncomingRelayEnvelope,
+) -> Result<InboxEntry, RelayDeliveryError> {
+    let local = state::read_state(Some(paths.home.clone()))?
+        .node
+        .ok_or_else(|| RelayDeliveryError::InvalidRequest {
+            reason: "local node identity is missing".to_string(),
+        })?;
+    if incoming.to_node_id != local.node_id {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "relay envelope was not addressed to this node".to_string(),
+        });
+    }
+    let peer = trusted_peer_with_key(paths, &incoming.from_node_id)?;
+    let expected_sender_key = peer.exchange_public_key_hex.as_deref().ok_or_else(|| {
+        RelayDeliveryError::InvalidRequest {
+            reason: "trusted peer does not have an exchange public key".to_string(),
+        }
+    })?;
+    let from_agent_id =
+        incoming
+            .from_agent_id
+            .as_deref()
+            .ok_or_else(|| RelayDeliveryError::InvalidRequest {
+                reason: "relay envelope is missing from_agent metadata".to_string(),
+            })?;
+    let to_agent_id =
+        incoming
+            .to_agent_id
+            .as_deref()
+            .ok_or_else(|| RelayDeliveryError::InvalidRequest {
+                reason: "relay envelope is missing to_agent metadata".to_string(),
+            })?;
+    let body = incoming
+        .body
+        .as_ref()
+        .ok_or_else(|| RelayDeliveryError::InvalidRequest {
+            reason: "relay envelope is missing encrypted body".to_string(),
+        })?;
+    if body.sender_exchange_public_key_hex != expected_sender_key {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "relay sender key does not match trusted peer card".to_string(),
+        });
+    }
+
+    let encrypted = PeerEncryptedPayload {
+        algorithm: body.algorithm.clone(),
+        key_id: body.key_id.clone(),
+        sender_exchange_public_key_hex: body.sender_exchange_public_key_hex.clone(),
+        nonce_hex: body.nonce_hex.clone(),
+        ciphertext_hex: body.ciphertext_hex.clone(),
+        plaintext_len: incoming.payload_bytes,
+    };
+    let aad = relay_aad(
+        &incoming.envelope_id,
+        &incoming.from_node_id,
+        &incoming.to_node_id,
+        from_agent_id,
+        to_agent_id,
+    );
+    let plaintext =
+        security::decrypt_from_peer_from_paths(paths, expected_sender_key, &encrypted, &aad)?;
+    validate_payload_size(plaintext.len())?;
+    let entry = messages::deliver_remote_envelope_from_paths(
+        paths,
+        &incoming.envelope_id,
+        from_agent_id,
+        to_agent_id,
+        OpaquePayload::from_bytes(plaintext),
+    )?;
+    append_relay_log(
+        paths,
+        "inbox_delivered",
+        &incoming.envelope_id,
+        &incoming.from_node_id,
+        incoming.payload_bytes,
+    )?;
+
+    Ok(entry)
+}
+
+#[derive(Debug, Clone)]
+struct RelayRequest {
+    envelope_id: String,
+    to_node_id: String,
+    from_agent_id: String,
+    to_agent_id: String,
+    encrypted: PeerEncryptedPayload,
+}
+
+impl RelayRequest {
+    fn to_forward_frame(&self) -> Result<RelayForward, RelayDeliveryError> {
+        Ok(RelayForward::with_body(
+            &self.to_node_id,
+            &self.envelope_id,
+            &self.from_agent_id,
+            &self.to_agent_id,
+            self.encrypted.plaintext_len,
+            RelayOpaqueBody::new(
+                &self.encrypted.algorithm,
+                &self.encrypted.key_id,
+                &self.encrypted.sender_exchange_public_key_hex,
+                &self.encrypted.nonce_hex,
+                &self.encrypted.ciphertext_hex,
+            )?,
+        )?)
+    }
+}
+
+fn read_relay_request(path: &Path) -> Result<RelayRequest, RelayDeliveryError> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| RelayDeliveryError::io("read relay outbox request", path, error))?;
+    let values = parse_key_values(&contents);
+
+    if value_or_empty(&values, "version") != RELAY_REQUEST_VERSION {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "unsupported relay request version".to_string(),
+        });
+    }
+    if value_or_empty(&values, "type") != "relay_message" {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "unsupported relay request type".to_string(),
+        });
+    }
+
+    let _request_id = validate_identifier(required(&values, "request_id")?, "request id")?;
+    let _from_node_id = validate_identifier(required(&values, "from_node_id")?, "from node id")?;
+    let request = RelayRequest {
+        envelope_id: validate_identifier(required(&values, "envelope_id")?, "envelope id")?,
+        to_node_id: validate_identifier(required(&values, "to_node_id")?, "to node id")?,
+        from_agent_id: validate_identifier(required(&values, "from_agent_id")?, "from agent id")?,
+        to_agent_id: validate_identifier(required(&values, "to_agent_id")?, "to agent id")?,
+        encrypted: PeerEncryptedPayload {
+            algorithm: required(&values, "payload_cipher")?,
+            key_id: required(&values, "payload_key_id")?,
+            sender_exchange_public_key_hex: required(&values, "sender_exchange_public_key_hex")?,
+            nonce_hex: required(&values, "payload_nonce_hex")?,
+            ciphertext_hex: required(&values, "payload_ciphertext_hex")?,
+            plaintext_len: parse_usize(&required(&values, "payload_len")?)?,
+        },
+    };
+    validate_payload_size(request.encrypted.plaintext_len)?;
+    Ok(request)
+}
+
+fn render_relay_request(
+    request_id: &str,
+    envelope_id: &str,
+    from_node_id: &str,
+    to_node_id: &str,
+    from_agent_id: &str,
+    to_agent_id: &str,
+    encrypted: &PeerEncryptedPayload,
+) -> String {
+    format!(
+        "version = \"{}\"\ntype = \"relay_message\"\nrequest_id = \"{}\"\nenvelope_id = \"{}\"\nfrom_node_id = \"{}\"\nto_node_id = \"{}\"\nfrom_agent_id = \"{}\"\nto_agent_id = \"{}\"\npayload_len = {}\npayload_privacy = \"peer_encrypted\"\npayload_cipher = \"{}\"\npayload_key_id = \"{}\"\nsender_exchange_public_key_hex = \"{}\"\npayload_nonce_hex = \"{}\"\npayload_ciphertext_hex = \"{}\"\npayload_displayed = false\n",
+        RELAY_REQUEST_VERSION,
+        escape_file_value(request_id),
+        escape_file_value(envelope_id),
+        escape_file_value(from_node_id),
+        escape_file_value(to_node_id),
+        escape_file_value(from_agent_id),
+        escape_file_value(to_agent_id),
+        encrypted.plaintext_len,
+        escape_file_value(&encrypted.algorithm),
+        escape_file_value(&encrypted.key_id),
+        escape_file_value(&encrypted.sender_exchange_public_key_hex),
+        escape_file_value(&encrypted.nonce_hex),
+        escape_file_value(&encrypted.ciphertext_hex)
+    )
+}
+
+fn ensure_relay_dirs(paths: &StatePaths) -> Result<(), RelayDeliveryError> {
+    for directory in [
+        &paths.mailbox_dir,
+        &paths.relay_dir,
+        &paths.relay_outbox_dir,
+        &paths.relay_sent_dir,
+        &paths.relay_rejected_dir,
+        &paths.logs_dir,
+    ] {
+        fs::create_dir_all(directory)
+            .map_err(|error| RelayDeliveryError::io("create relay directory", directory, error))?;
+    }
+    Ok(())
+}
+
+fn pending_relay_requests(paths: &StatePaths) -> Result<Vec<PathBuf>, RelayDeliveryError> {
+    let mut requests = Vec::new();
+    if !paths.relay_outbox_dir.exists() {
+        return Ok(requests);
+    }
+
+    for entry in fs::read_dir(&paths.relay_outbox_dir).map_err(|error| {
+        RelayDeliveryError::io("read relay outbox", &paths.relay_outbox_dir, error)
+    })? {
+        let entry = entry.map_err(|error| {
+            RelayDeliveryError::io("read relay outbox entry", &paths.relay_outbox_dir, error)
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("relay") {
+            requests.push(path);
+        }
+    }
+
+    requests.sort();
+    Ok(requests)
+}
+
+fn mark_sent_by_envelope(paths: &StatePaths, envelope_id: &str) -> Result<(), RelayDeliveryError> {
+    for request_path in pending_relay_requests(paths)? {
+        let request = read_relay_request(&request_path)?;
+        if request.envelope_id == envelope_id {
+            move_relay_request(&paths.relay_sent_dir, &request_path, "sent")?;
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+fn move_relay_request(
+    target_dir: &Path,
+    request_path: &Path,
+    extension: &str,
+) -> Result<(), RelayDeliveryError> {
+    fs::create_dir_all(target_dir).map_err(|error| {
+        RelayDeliveryError::io("create relay marker directory", target_dir, error)
+    })?;
+    let stem = request_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("relay-request");
+    let target = target_dir.join(format!("{stem}.{extension}"));
+    fs::rename(request_path, &target)
+        .map_err(|error| RelayDeliveryError::io("move relay request marker", request_path, error))
+}
+
+fn relay_endpoint_for_sync(
+    paths: &StatePaths,
+    queued_paths: &[PathBuf],
+) -> Result<String, RelayDeliveryError> {
+    if let Some(first) = queued_paths.first() {
+        let request = read_relay_request(first)?;
+        if let Some(peer) = trusted_peer(paths, &request.to_node_id)? {
+            if let Some(endpoint) = peer.relay_endpoint {
+                return validate_endpoint(endpoint);
+            }
+        }
+    }
+
+    for peer in trust::list_peers(Some(paths.home.clone()))? {
+        if peer.status == TrustStatus::Trusted {
+            if let Some(endpoint) = peer.relay_endpoint {
+                return validate_endpoint(endpoint);
+            }
+        }
+    }
+
+    configured_relay_endpoint(paths)
+}
+
+fn configured_relay_endpoint(paths: &StatePaths) -> Result<String, RelayDeliveryError> {
+    let contents = match fs::read_to_string(&paths.config) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(DEFAULT_RELAY_ENDPOINT.to_string());
+        }
+        Err(error) => {
+            return Err(RelayDeliveryError::io(
+                "read conU config",
+                &paths.config,
+                error,
+            ));
+        }
+    };
+    let values = parse_key_values(&contents);
+    validate_endpoint(
+        values
+            .get("default_relay")
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
+            .unwrap_or_else(|| DEFAULT_RELAY_ENDPOINT.to_string()),
+    )
+}
+
+fn relay_token() -> String {
+    env::var("CONU_RELAY_TOKEN")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_RELAY_TOKEN.to_string())
+}
+
+fn trusted_peer_with_key(
+    paths: &StatePaths,
+    peer_node_id: &str,
+) -> Result<TrustedPeer, RelayDeliveryError> {
+    let peer =
+        trusted_peer(paths, peer_node_id)?.ok_or_else(|| RelayDeliveryError::InvalidRequest {
+            reason: "peer is not trusted locally".to_string(),
+        })?;
+    if peer.status != TrustStatus::Trusted {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "peer is revoked".to_string(),
+        });
+    }
+    if peer.exchange_public_key_hex.is_none() {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "peer is missing exchange public key; import a peer card first".to_string(),
+        });
+    }
+    Ok(peer)
+}
+
+fn trusted_peer(
+    paths: &StatePaths,
+    peer_node_id: &str,
+) -> Result<Option<TrustedPeer>, RelayDeliveryError> {
+    let peer_node_id = validate_identifier(peer_node_id.to_string(), "peer node id")?;
+    Ok(trust::list_peers(Some(paths.home.clone()))?
+        .into_iter()
+        .find(|peer| peer.peer_node_id == peer_node_id))
+}
+
+fn validate_local_sender_can_message(
+    paths: &StatePaths,
+    from_agent_id: &str,
+) -> Result<(), RelayDeliveryError> {
+    let registered = agents::list_local_agents(Some(paths.home.clone()))?;
+    let sender = registered
+        .iter()
+        .find(|agent| agent.agent_id == from_agent_id)
+        .ok_or_else(|| RelayDeliveryError::InvalidRequest {
+            reason: "sender is not a registered local agent".to_string(),
+        })?;
+
+    if !sender.capabilities.messages {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "sender is not allowed to send messages".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn append_relay_log(
+    paths: &StatePaths,
+    event: &str,
+    envelope_id: &str,
+    peer_node_id: &str,
+    payload_bytes: usize,
+) -> Result<(), RelayDeliveryError> {
+    fs::create_dir_all(&paths.logs_dir)
+        .map_err(|error| RelayDeliveryError::io("create log directory", &paths.logs_dir, error))?;
+    let path = paths.logs_dir.join("relay-delivery.log");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|error| RelayDeliveryError::io("open relay delivery log", &path, error))?;
+
+    writeln!(
+        file,
+        "time={} event={} envelope={} peer={} bytes={} payload=not_observed",
+        current_unix_seconds(),
+        sanitize_log_value(event),
+        sanitize_log_value(envelope_id),
+        sanitize_log_value(peer_node_id),
+        payload_bytes
+    )
+    .map_err(|error| RelayDeliveryError::io("write relay delivery log", &path, error))
+}
+
+fn count_files_with_extension(path: &Path, extension: &str) -> Result<usize, RelayDeliveryError> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    let mut count = 0;
+    for entry in fs::read_dir(path)
+        .map_err(|error| RelayDeliveryError::io("read relay queue directory", path, error))?
+    {
+        let entry =
+            entry.map_err(|error| RelayDeliveryError::io("read relay queue entry", path, error))?;
+        if entry.path().extension().and_then(|value| value.to_str()) == Some(extension) {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+fn write_new_file(path: &Path, contents: &str) -> Result<(), RelayDeliveryError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| RelayDeliveryError::io("create relay file", path, error))?;
+    file.write_all(contents.as_bytes())
+        .map_err(|error| RelayDeliveryError::io("write relay file", path, error))
+}
+
+fn relay_aad(
+    envelope_id: &str,
+    from_node_id: &str,
+    to_node_id: &str,
+    from_agent_id: &str,
+    to_agent_id: &str,
+) -> Vec<u8> {
+    format!(
+        "conu:relay-message:v1:{envelope_id}:{from_node_id}:{to_node_id}:{from_agent_id}:{to_agent_id}"
+    )
+    .into_bytes()
+}
+
+fn parse_key_values(contents: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        values.insert(key.trim().to_string(), clean_value(value));
+    }
+
+    values
+}
+
+fn clean_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn required(
+    values: &HashMap<String, String>,
+    key: &'static str,
+) -> Result<String, RelayDeliveryError> {
+    values
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| RelayDeliveryError::InvalidRequest {
+            reason: format!("missing {key}"),
+        })
+}
+
+fn value_or_empty<'a>(values: &'a HashMap<String, String>, key: &str) -> &'a str {
+    values.get(key).map(String::as_str).unwrap_or("")
+}
+
+fn validate_endpoint(value: String) -> Result<String, RelayDeliveryError> {
+    let value = value.trim().to_string();
+    if !value.starts_with("ws://") {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "relay endpoint must start with ws://".to_string(),
+        });
+    }
+    if value.len() > 220 || value.chars().any(char::is_whitespace) {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "relay endpoint is invalid".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_identifier(value: String, field: &'static str) -> Result<String, RelayDeliveryError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: format!("{field} cannot be empty"),
+        });
+    }
+    if value.len() > 140 {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: format!("{field} is too long"),
+        });
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: format!("{field} must use ASCII letters, numbers, dash, underscore, or dot"),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_payload_size(bytes: usize) -> Result<(), RelayDeliveryError> {
+    if bytes > MAX_RELAY_PAYLOAD_BYTES {
+        return Err(RelayDeliveryError::InvalidRequest {
+            reason: "payload is too large for relay message delivery".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn parse_usize(value: &str) -> Result<usize, RelayDeliveryError> {
+    value
+        .parse::<usize>()
+        .map_err(|_| RelayDeliveryError::InvalidRequest {
+            reason: "expected unsigned integer".to_string(),
+        })
+}
+
+fn request_id(prefix: &str) -> String {
+    format!("{}_{}_{}", prefix, process::id(), current_unix_nanos())
+}
+
+fn escape_file_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn sanitize_log_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+        .collect()
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn current_unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::AgentRegistration;
+
+    #[test]
+    fn remote_message_request_hides_literal_payload() {
+        let alice_home = test_home("hide-alice");
+        let bob_home = test_home("hide-bob");
+        trust_each_other(&alice_home, &bob_home);
+        register_agent(&alice_home, "agent.alice");
+
+        let message = RemoteMessage::new(
+            "agent.alice",
+            "agent.bob",
+            node_id(&bob_home),
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("message valid");
+        let submission =
+            submit_remote_message(Some(alice_home), message).expect("remote message submits");
+        let contents = fs::read_to_string(submission.request_path).expect("request reads");
+
+        assert!(contents.contains("payload_privacy = \"peer_encrypted\""));
+        assert!(contents.contains("payload_ciphertext_hex"));
+        assert!(!contents.contains("private message contents"));
+        assert!(!contents.contains("Review this code"));
+    }
+
+    fn trust_each_other(alice_home: &Path, bob_home: &Path) {
+        let alice = trust::export_peer_card(Some(alice_home.to_path_buf())).expect("alice card");
+        let bob = trust::export_peer_card(Some(bob_home.to_path_buf())).expect("bob card");
+        trust::trust_peer_card(Some(alice_home.to_path_buf()), bob).expect("alice trusts bob");
+        trust::trust_peer_card(Some(bob_home.to_path_buf()), alice).expect("bob trusts alice");
+    }
+
+    fn register_agent(home: &Path, agent_id: &str) {
+        let registration =
+            AgentRegistration::new(agent_id, agent_id, "test-agent").expect("valid agent");
+        agents::submit_registration(Some(home.to_path_buf()), registration)
+            .expect("registration submits");
+        agents::process_gateway_requests(Some(home.to_path_buf())).expect("registration processes");
+    }
+
+    fn node_id(home: &Path) -> String {
+        state::read_state(Some(home.to_path_buf()))
+            .expect("state reads")
+            .node
+            .expect("node exists")
+            .node_id
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "conu-relay-delivery-test-{label}-{}-{}",
+            process::id(),
+            current_unix_nanos()
+        ))
+    }
+}

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -43,6 +43,10 @@ const PAIRING_USED_DIR: &str = "used";
 const SESSIONS_DIR: &str = "sessions";
 const SESSION_REGISTRY_FILE: &str = "registry.toml";
 const MAILBOX_DIR: &str = "mailbox";
+const RELAY_DIR: &str = "relay";
+const RELAY_OUTBOX_DIR: &str = "outbox";
+const RELAY_SENT_DIR: &str = "sent";
+const RELAY_REJECTED_DIR: &str = "rejected";
 const LOGS_DIR: &str = "logs";
 const SECURITY_DIR: &str = "security";
 const IDENTITY_SIGNING_KEY_FILE: &str = "identity-signing.key";
@@ -88,6 +92,10 @@ pub struct StatePaths {
     pub sessions_dir: PathBuf,
     pub session_registry: PathBuf,
     pub mailbox_dir: PathBuf,
+    pub relay_dir: PathBuf,
+    pub relay_outbox_dir: PathBuf,
+    pub relay_sent_dir: PathBuf,
+    pub relay_rejected_dir: PathBuf,
     pub logs_dir: PathBuf,
     pub security_dir: PathBuf,
     pub identity_signing_key: PathBuf,
@@ -119,6 +127,8 @@ impl StatePaths {
         let routes_dir = home.join(ROUTES_DIR);
         let pairing_dir = home.join(PAIRING_DIR);
         let security_dir = home.join(SECURITY_DIR);
+        let mailbox_dir = home.join(MAILBOX_DIR);
+        let relay_dir = mailbox_dir.join(RELAY_DIR);
 
         Self {
             node_identity: home.join(NODE_FILE),
@@ -153,7 +163,11 @@ impl StatePaths {
             pairing_dir,
             sessions_dir: home.join(SESSIONS_DIR),
             session_registry: home.join(SESSIONS_DIR).join(SESSION_REGISTRY_FILE),
-            mailbox_dir: home.join(MAILBOX_DIR),
+            relay_outbox_dir: relay_dir.join(RELAY_OUTBOX_DIR),
+            relay_sent_dir: relay_dir.join(RELAY_SENT_DIR),
+            relay_rejected_dir: relay_dir.join(RELAY_REJECTED_DIR),
+            relay_dir,
+            mailbox_dir,
             logs_dir: home.join(LOGS_DIR),
             identity_signing_key: security_dir.join(IDENTITY_SIGNING_KEY_FILE),
             identity_exchange_key: security_dir.join(IDENTITY_EXCHANGE_KEY_FILE),
@@ -339,6 +353,10 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
         &paths.pairing_used_dir,
         &paths.sessions_dir,
         &paths.mailbox_dir,
+        &paths.relay_dir,
+        &paths.relay_outbox_dir,
+        &paths.relay_sent_dir,
+        &paths.relay_rejected_dir,
         &paths.logs_dir,
         &paths.security_dir,
     ] {

--- a/crates/conu-core/src/trust.rs
+++ b/crates/conu-core/src/trust.rs
@@ -14,11 +14,13 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::security;
 use crate::state::{self, StateError, StatePaths};
 
 const TRUST_VERSION: &str = "1";
 const PAIRING_VERSION: &str = "1";
 const PAIRING_TTL_SECS: u64 = 10 * 60;
+const DEFAULT_RELAY_ENDPOINT: &str = "ws://127.0.0.1:8787";
 
 /// Lifecycle state for a local pairing invitation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,8 +93,19 @@ pub struct TrustedPeer {
     pub status: TrustStatus,
     pub source: String,
     pub pairing_code_hash: String,
+    pub exchange_public_key_hex: Option<String>,
+    pub relay_endpoint: Option<String>,
     pub created_at_unix: u64,
     pub updated_at_unix: u64,
+}
+
+/// Public card a user can exchange with another conU node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerCard {
+    pub node_id: String,
+    pub display_name: String,
+    pub exchange_public_key_hex: String,
+    pub relay_endpoint: String,
 }
 
 /// Result of joining a local pairing invitation.
@@ -121,6 +134,7 @@ pub enum TrustError {
     InvalidRequest {
         reason: String,
     },
+    Security(security::SecurityError),
 }
 
 impl TrustError {
@@ -143,6 +157,7 @@ impl fmt::Display for TrustError {
                 source,
             } => write!(formatter, "{action} at {}: {source}", path.display()),
             Self::InvalidRequest { reason } => write!(formatter, "invalid trust request: {reason}"),
+            Self::Security(error) => write!(formatter, "{error}"),
         }
     }
 }
@@ -152,6 +167,12 @@ impl std::error::Error for TrustError {}
 impl From<StateError> for TrustError {
     fn from(error: StateError) -> Self {
         Self::State(error)
+    }
+}
+
+impl From<security::SecurityError> for TrustError {
+    fn from(error: security::SecurityError) -> Self {
+        Self::Security(error)
     }
 }
 
@@ -212,6 +233,43 @@ pub fn list_peers(home_override: Option<PathBuf>) -> Result<Vec<TrustedPeer>, Tr
     read_trust_store(&paths)
 }
 
+/// Export this node's public card for manual cross-machine trust.
+pub fn export_peer_card(home_override: Option<PathBuf>) -> Result<PeerCard, TrustError> {
+    let init = state::init_state(home_override)?;
+    let material = security::local_peer_key_material(&init.paths)?;
+
+    Ok(PeerCard {
+        node_id: init.node.node_id,
+        display_name: init.node.display_name,
+        exchange_public_key_hex: material.local_exchange_public_key_hex,
+        relay_endpoint: configured_relay_endpoint(&init.paths)?,
+    })
+}
+
+/// Trust a peer from an explicitly exchanged public card.
+pub fn trust_peer_card(
+    home_override: Option<PathBuf>,
+    card: PeerCard,
+) -> Result<TrustedPeer, TrustError> {
+    let init = state::init_state(home_override)?;
+    let now = current_unix_seconds();
+    let card = validate_peer_card(card)?;
+
+    if card.node_id == init.node.node_id {
+        return Err(TrustError::InvalidRequest {
+            reason: "cannot trust the local node as a remote peer".to_string(),
+        });
+    }
+
+    security::derive_peer_key_agreement_from_paths(
+        &init.paths,
+        &card.exchange_public_key_hex,
+        b"conu manual peer trust v1",
+    )?;
+
+    upsert_manual_trusted_peer(&init.paths, card, now)
+}
+
 /// Revoke a peer by node id.
 pub fn revoke_peer(
     home_override: Option<PathBuf>,
@@ -267,6 +325,54 @@ fn upsert_trusted_peer(
         status: TrustStatus::Trusted,
         source: "local_pair_code".to_string(),
         pairing_code_hash: pairing_code_hash(&invite.code),
+        exchange_public_key_hex: None,
+        relay_endpoint: None,
+        created_at_unix: now,
+        updated_at_unix: now,
+    });
+
+    if !peers
+        .iter()
+        .any(|entry| entry.peer_node_id == peer.peer_node_id)
+    {
+        peers.push(peer.clone());
+    }
+
+    write_trust_store(paths, &peers)?;
+    Ok(peer)
+}
+
+fn upsert_manual_trusted_peer(
+    paths: &StatePaths,
+    card: PeerCard,
+    now: u64,
+) -> Result<TrustedPeer, TrustError> {
+    let mut peers = read_trust_store(paths)?;
+    let fingerprint = manual_peer_hash(&card.node_id, &card.exchange_public_key_hex);
+    let mut result = None;
+
+    for peer in &mut peers {
+        if peer.peer_node_id == card.node_id {
+            peer.display_name = card.display_name.clone();
+            peer.status = TrustStatus::Trusted;
+            peer.source = "manual_peer_card".to_string();
+            peer.pairing_code_hash = fingerprint.clone();
+            peer.exchange_public_key_hex = Some(card.exchange_public_key_hex.clone());
+            peer.relay_endpoint = Some(card.relay_endpoint.clone());
+            peer.updated_at_unix = now;
+            result = Some(peer.clone());
+            break;
+        }
+    }
+
+    let peer = result.unwrap_or_else(|| TrustedPeer {
+        peer_node_id: card.node_id,
+        display_name: card.display_name,
+        status: TrustStatus::Trusted,
+        source: "manual_peer_card".to_string(),
+        pairing_code_hash: fingerprint,
+        exchange_public_key_hex: Some(card.exchange_public_key_hex),
+        relay_endpoint: Some(card.relay_endpoint),
         created_at_unix: now,
         updated_at_unix: now,
     });
@@ -382,6 +488,14 @@ fn write_trust_store(paths: &StatePaths, peers: &[TrustedPeer]) -> Result<(), Tr
             "pairing_code_hash = \"{}\"\n",
             escape_file_value(&peer.pairing_code_hash)
         ));
+        contents.push_str(&format!(
+            "exchange_public_key_hex = \"{}\"\n",
+            escape_file_value(peer.exchange_public_key_hex.as_deref().unwrap_or(""))
+        ));
+        contents.push_str(&format!(
+            "relay_endpoint = \"{}\"\n",
+            escape_file_value(peer.relay_endpoint.as_deref().unwrap_or(""))
+        ));
         contents.push_str(&format!("created_at_unix = {}\n", peer.created_at_unix));
         contents.push_str(&format!("updated_at_unix = {}\n", peer.updated_at_unix));
         contents.push_str("payload_displayed = false\n");
@@ -436,6 +550,8 @@ fn peer_from_values(values: &HashMap<String, String>) -> Result<TrustedPeer, Tru
             required(values, "pairing_code_hash")?,
             "pairing code hash",
         )?,
+        exchange_public_key_hex: optional_hex(values.get("exchange_public_key_hex"))?,
+        relay_endpoint: optional_endpoint(values.get("relay_endpoint"))?,
         created_at_unix: parse_u64(&required(values, "created_at_unix")?)?,
         updated_at_unix: parse_u64(&required(values, "updated_at_unix")?)?,
     })
@@ -470,6 +586,13 @@ fn pairing_code_hash(code: &str) -> String {
     let mut hasher = DefaultHasher::new();
     code.hash(&mut hasher);
     format!("pair_{:016x}", hasher.finish())
+}
+
+fn manual_peer_hash(node_id: &str, exchange_public_key_hex: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    node_id.hash(&mut hasher);
+    exchange_public_key_hex.hash(&mut hasher);
+    format!("manual_{:016x}", hasher.finish())
 }
 
 fn pairing_code_suffix(code: &str) -> String {
@@ -536,6 +659,83 @@ fn validate_display_name(value: String) -> Result<String, TrustError> {
         });
     }
     Ok(value)
+}
+
+fn validate_endpoint(value: String) -> Result<String, TrustError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(TrustError::InvalidRequest {
+            reason: "relay endpoint cannot be empty".to_string(),
+        });
+    }
+    if !value.starts_with("ws://") {
+        return Err(TrustError::InvalidRequest {
+            reason: "relay endpoint must start with ws:// for the current relay client".to_string(),
+        });
+    }
+    if value.len() > 220 || value.chars().any(char::is_whitespace) {
+        return Err(TrustError::InvalidRequest {
+            reason: "relay endpoint is invalid".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_hex(value: String, field: &'static str) -> Result<String, TrustError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(TrustError::InvalidRequest {
+            reason: format!("{field} cannot be empty"),
+        });
+    }
+    if value.len() % 2 != 0 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(TrustError::InvalidRequest {
+            reason: format!("{field} must be hex"),
+        });
+    }
+    Ok(value)
+}
+
+fn validate_peer_card(card: PeerCard) -> Result<PeerCard, TrustError> {
+    Ok(PeerCard {
+        node_id: validate_identifier(card.node_id, "peer node id")?,
+        display_name: validate_display_name(card.display_name)?,
+        exchange_public_key_hex: validate_hex(card.exchange_public_key_hex, "exchange public key")?,
+        relay_endpoint: validate_endpoint(card.relay_endpoint)?,
+    })
+}
+
+fn optional_hex(value: Option<&String>) -> Result<Option<String>, TrustError> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(|value| validate_hex(value, "exchange public key"))
+        .transpose()
+}
+
+fn optional_endpoint(value: Option<&String>) -> Result<Option<String>, TrustError> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(validate_endpoint)
+        .transpose()
+}
+
+fn configured_relay_endpoint(paths: &StatePaths) -> Result<String, TrustError> {
+    let contents = match fs::read_to_string(&paths.config) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(DEFAULT_RELAY_ENDPOINT.to_string());
+        }
+        Err(error) => return Err(TrustError::io("read conU config", &paths.config, error)),
+    };
+    let values = parse_key_values(&contents);
+    let endpoint = values
+        .get("default_relay")
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_RELAY_ENDPOINT.to_string());
+    validate_endpoint(endpoint)
 }
 
 fn parse_key_values(contents: &str) -> HashMap<String, String> {

--- a/crates/conu-mcp/src/lib.rs
+++ b/crates/conu-mcp/src/lib.rs
@@ -5,8 +5,9 @@
 //! explicitly calls `conu_receive_message` with `includePayload: true`.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
-use conu_sdk::{Capabilities, ConuClient, Presence, Route, SdkError, Stream};
+use conu_sdk::{Capabilities, ConuClient, PeerCard, Presence, Route, SdkError, Stream};
 use serde_json::{Map, Value, json};
 
 const JSONRPC_VERSION: &str = "2.0";
@@ -147,7 +148,11 @@ impl McpServer {
             "conu_list_routes" => self.tool_list_routes(args),
             "conu_list_agents" => self.tool_list_agents(args),
             "conu_list_peers" => self.tool_list_peers(),
+            "conu_export_identity" => self.tool_export_identity(),
+            "conu_trust_peer" => self.tool_trust_peer(args),
             "conu_send_message" => self.tool_send_message(args),
+            "conu_send_remote_message" => self.tool_send_remote_message(args),
+            "conu_relay_sync" => self.tool_relay_sync(args),
             "conu_receive_message" => self.tool_receive_message(args),
             "conu_open_stream" => self.tool_open_stream(args),
             "conu_write_stream" => self.tool_write_stream(args),
@@ -335,9 +340,42 @@ impl McpServer {
                 "displayName": &peer.display_name,
                 "status": peer.status.as_str(),
                 "source": &peer.source,
+                "exchangeKeyTrusted": peer.exchange_public_key_hex.is_some(),
+                "relayEndpoint": peer.relay_endpoint.as_deref(),
                 "createdAtUnix": peer.created_at_unix,
                 "updatedAtUnix": peer.updated_at_unix
             })).collect::<Vec<_>>(),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_export_identity(&self) -> Result<Value, String> {
+        let card = self.client.export_peer_card().map_err(safe_sdk_error)?;
+        Ok(json!({
+            "nodeId": card.node_id,
+            "displayName": card.display_name,
+            "exchangePublicKeyHex": card.exchange_public_key_hex,
+            "relayEndpoint": card.relay_endpoint,
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_trust_peer(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let card = PeerCard {
+            node_id: required_string(args, "peerNodeId")?,
+            display_name: required_string(args, "displayName")?,
+            exchange_public_key_hex: required_string(args, "exchangePublicKeyHex")?,
+            relay_endpoint: optional_string(args, "relayEndpoint")?
+                .unwrap_or_else(|| "ws://127.0.0.1:8787".to_string()),
+        };
+        let peer = self.client.trust_peer_card(card).map_err(safe_sdk_error)?;
+
+        Ok(json!({
+            "status": peer.status.as_str(),
+            "peerNodeId": peer.peer_node_id,
+            "displayName": peer.display_name,
+            "exchangeKeyTrusted": peer.exchange_public_key_hex.is_some(),
+            "relayEndpoint": peer.relay_endpoint,
             "contentsDisplayed": false
         }))
     }
@@ -369,6 +407,49 @@ impl McpServer {
                 .as_ref()
                 .map(|report| report.messages.envelope_ids.clone())
                 .unwrap_or_default(),
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_send_remote_message(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let from_agent_id = required_string(args, "fromAgentId")?;
+        self.ensure_agent_allowed(&from_agent_id)?;
+        let to_agent_id = required_string(args, "toAgentId")?;
+        let peer_node_id = required_string(args, "peerNodeId")?;
+        let payload = payload_from_args(args)?;
+        let submission = self
+            .client
+            .send_remote_message_bytes(&from_agent_id, &to_agent_id, &peer_node_id, payload)
+            .map_err(safe_sdk_error)?;
+
+        Ok(json!({
+            "status": "queued_remote",
+            "requestId": submission.request_id,
+            "envelopeId": submission.envelope_id,
+            "fromAgentId": from_agent_id,
+            "toAgentId": to_agent_id,
+            "peerNodeId": submission.peer_node_id,
+            "payloadBytes": submission.payload_bytes,
+            "contentsDisplayed": false
+        }))
+    }
+
+    fn tool_relay_sync(&self, args: &Map<String, Value>) -> Result<Value, String> {
+        let wait_ms = optional_u64(args, "waitMs", 1000)?;
+        let report = self
+            .client
+            .relay_sync(Duration::from_millis(wait_ms.min(60_000)))
+            .map_err(safe_sdk_error)?;
+
+        Ok(json!({
+            "status": "synced",
+            "endpoint": report.endpoint,
+            "connected": report.connected,
+            "queued": report.queued,
+            "sent": report.sent,
+            "received": report.received,
+            "undelivered": report.undelivered,
+            "rejected": report.rejected,
             "contentsDisplayed": false
         }))
     }
@@ -533,6 +614,24 @@ impl McpServer {
                 schema(json!({}), vec![]),
             ),
             tool(
+                "conu_export_identity",
+                "Export this node's public peer card for cross-machine trust.",
+                schema(json!({}), vec![]),
+            ),
+            tool(
+                "conu_trust_peer",
+                "Trust a remote node from its public peer card.",
+                schema(
+                    json!({
+                        "peerNodeId": { "type": "string" },
+                        "displayName": { "type": "string" },
+                        "exchangePublicKeyHex": { "type": "string" },
+                        "relayEndpoint": { "type": "string" }
+                    }),
+                    vec!["peerNodeId", "displayName", "exchangePublicKeyHex"],
+                ),
+            ),
+            tool(
                 "conu_send_message",
                 "Queue an opaque message. The response reports metadata and byte counts only.",
                 schema(
@@ -545,6 +644,25 @@ impl McpServer {
                     }),
                     vec!["fromAgentId", "toAgentId"],
                 ),
+            ),
+            tool(
+                "conu_send_remote_message",
+                "Queue a peer-encrypted remote message for relay delivery.",
+                schema(
+                    json!({
+                        "fromAgentId": { "type": "string" },
+                        "toAgentId": { "type": "string" },
+                        "peerNodeId": { "type": "string" },
+                        "payloadText": { "type": "string" },
+                        "payloadHex": { "type": "string" }
+                    }),
+                    vec!["fromAgentId", "toAgentId", "peerNodeId"],
+                ),
+            ),
+            tool(
+                "conu_relay_sync",
+                "Connect to the relay once, flush outbound remote messages, and receive inbound envelopes.",
+                schema(json!({ "waitMs": { "type": "integer" } }), vec![]),
             ),
             tool(
                 "conu_receive_message",
@@ -730,6 +848,16 @@ fn optional_bool(
         None | Some(Value::Null) => Ok(default),
         Some(Value::Bool(value)) => Ok(*value),
         Some(_) => Err(format!("{key} must be a boolean")),
+    }
+}
+
+fn optional_u64(args: &Map<String, Value>, key: &'static str, default: u64) -> Result<u64, String> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(default),
+        Some(Value::Number(value)) => value
+            .as_u64()
+            .ok_or_else(|| format!("{key} must be an unsigned integer")),
+        Some(_) => Err(format!("{key} must be an unsigned integer")),
     }
 }
 

--- a/crates/conu-relay/Cargo.toml
+++ b/crates/conu-relay/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 conu-core.workspace = true
+conu-protocol.workspace = true
 
 [lints]
 workspace = true

--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -19,7 +19,7 @@ use conu_core::relay::{
 
 const WEBSOCKET_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 const MAX_HTTP_HEADER_BYTES: usize = 8192;
-const MAX_FRAME_BYTES: usize = 64 * 1024;
+const MAX_FRAME_BYTES: usize = 256 * 1024;
 
 /// Configuration for the relay server.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -275,6 +275,9 @@ fn handle_connection(mut stream: TcpStream, hub: Arc<RelayHub>) -> Result<(), Re
                         to_node_id: forward.to_node_id.clone(),
                         envelope_id: forward.envelope_id.clone(),
                         payload_bytes: forward.payload_bytes,
+                        from_agent_id: forward.from_agent_id.clone(),
+                        to_agent_id: forward.to_agent_id.clone(),
+                        body: forward.body.clone(),
                     });
                     let mut target = target.lock().map_err(|_| {
                         RelayError::Protocol("relay target lock failed".to_string())
@@ -590,7 +593,15 @@ fn sha1(bytes: &[u8]) -> [u8; 20] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use conu_core::agents::{self, AgentRegistration};
+    use conu_core::messages;
     use conu_core::relay::{RelayForward, RelayHello, render_client_frame};
+    use conu_core::relay_delivery::{self, RemoteMessage};
+    use conu_core::{state, trust};
+    use conu_protocol::OpaquePayload;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process;
 
     #[test]
     fn websocket_accept_key_matches_rfc_example() {
@@ -657,6 +668,52 @@ mod tests {
         assert!(!response.contains("secret-bad-token"));
     }
 
+    #[test]
+    fn relay_delivers_peer_encrypted_message_between_two_state_homes() {
+        let relay =
+            spawn_relay(RelayConfig::new("127.0.0.1:0", "local-dev-token").expect("valid config"))
+                .expect("relay starts");
+        let endpoint = format!("ws://{}", relay.local_addr());
+        let alice_home = test_home("alice");
+        let bob_home = test_home("bob");
+        prepare_home(&alice_home, &endpoint);
+        prepare_home(&bob_home, &endpoint);
+        trust_each_other(&alice_home, &bob_home);
+        register_agent(&alice_home, "agent.alice");
+        register_agent(&bob_home, "agent.bob");
+        let bob_node = node_id(&bob_home);
+        let remote = RemoteMessage::new(
+            "agent.alice",
+            "agent.bob",
+            bob_node,
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("remote message valid");
+        relay_delivery::submit_remote_message(Some(alice_home.clone()), remote)
+            .expect("remote message queues");
+
+        let bob_home_for_thread = bob_home.clone();
+        let bob_sync = thread::spawn(move || {
+            relay_delivery::sync_relay_once(Some(bob_home_for_thread), Duration::from_millis(2_000))
+                .expect("bob relay sync")
+        });
+        thread::sleep(Duration::from_millis(100));
+        let alice_report =
+            relay_delivery::sync_relay_once(Some(alice_home), Duration::from_millis(1_000))
+                .expect("alice relay sync");
+        let bob_report = bob_sync.join().expect("bob thread joins");
+        let inbox = messages::list_agent_inbox(Some(bob_home.clone()), "agent.bob")
+            .expect("bob inbox reads");
+        let received =
+            messages::read_message_payload(Some(bob_home), "agent.bob", &inbox[0].envelope_id)
+                .expect("bob payload reads");
+
+        assert_eq!(alice_report.sent, 1);
+        assert_eq!(bob_report.received, 1);
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(received.as_bytes(), b"private message contents");
+    }
+
     fn connect_client(addr: SocketAddr) -> TcpStream {
         let mut stream = TcpStream::connect(addr).expect("client connects");
         stream
@@ -699,5 +756,46 @@ mod tests {
         read_text_frame(stream)
             .expect("server frame reads")
             .expect("server frame exists")
+    }
+
+    fn prepare_home(home: &Path, endpoint: &str) {
+        state::init_state(Some(home.to_path_buf())).expect("state initializes");
+        let paths = state::StatePaths::from_home(home.to_path_buf());
+        fs::write(
+            paths.config,
+            format!("version = \"1\"\ndefault_relay = \"{endpoint}\"\n"),
+        )
+        .expect("config writes");
+    }
+
+    fn trust_each_other(alice_home: &Path, bob_home: &Path) {
+        let alice = trust::export_peer_card(Some(alice_home.to_path_buf())).expect("alice card");
+        let bob = trust::export_peer_card(Some(bob_home.to_path_buf())).expect("bob card");
+        trust::trust_peer_card(Some(alice_home.to_path_buf()), bob).expect("alice trusts bob");
+        trust::trust_peer_card(Some(bob_home.to_path_buf()), alice).expect("bob trusts alice");
+    }
+
+    fn register_agent(home: &Path, agent_id: &str) {
+        let registration =
+            AgentRegistration::new(agent_id, agent_id, "test-agent").expect("valid agent");
+        agents::submit_registration(Some(home.to_path_buf()), registration)
+            .expect("registration submits");
+        agents::process_gateway_requests(Some(home.to_path_buf())).expect("registration processes");
+    }
+
+    fn node_id(home: &Path) -> String {
+        state::read_state(Some(home.to_path_buf()))
+            .expect("state reads")
+            .node
+            .expect("node exists")
+            .node_id
+    }
+
+    fn test_home(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "conu-relay-e2e-test-{label}-{}-{}",
+            process::id(),
+            current_unix_nanos()
+        ))
     }
 }

--- a/crates/conu-relay/src/main.rs
+++ b/crates/conu-relay/src/main.rs
@@ -6,7 +6,7 @@ fn main() -> ExitCode {
     match args.next().as_deref() {
         Some("--check") => {
             println!("{}", conu_core::scaffold_status("conu-relay"));
-            println!("relay: phase 8 websocket relay ready; payloads not observed");
+            println!("relay: websocket relay ready; ciphertext bodies only; payloads not observed");
             ExitCode::SUCCESS
         }
         Some("--serve") => {

--- a/crates/conu-sdk/src/lib.rs
+++ b/crates/conu-sdk/src/lib.rs
@@ -15,6 +15,9 @@ use conu_core::agents::{
 use conu_core::messages::{
     self, DeliveryReceipt, InboxEntry, LocalMessage, MessageProcessReport, MessageSubmission,
 };
+use conu_core::relay_delivery::{
+    self, RelayQueueSummary, RelaySyncReport, RemoteMessage, RemoteMessageSubmission,
+};
 use conu_core::routes::{self, RouteProbe, RouteRecord, RouteSyncReport};
 use conu_core::runtime::{self, RuntimeStatus};
 use conu_core::security::{self, SecurityAudit};
@@ -25,10 +28,12 @@ use conu_core::streams::{
 };
 use conu_core::trust::{self, JoinReport, PairingInvite, RevokeReport, TrustedPeer};
 use conu_protocol::{AgentCapabilities, OpaquePayload};
+use std::time::Duration;
 
 pub use conu_core::agents::AgentPresence as Presence;
 pub use conu_core::routes::RouteRecord as Route;
 pub use conu_core::streams::StreamRecord as Stream;
+pub use conu_core::trust::PeerCard;
 pub use conu_protocol::AgentCapabilities as Capabilities;
 
 /// High-level SDK client bound to a conU state home.
@@ -166,6 +171,16 @@ impl ConuClient {
         Ok(trust::create_pairing_invite(self.home_override())?)
     }
 
+    /// Export this node's public peer card for manual cross-machine trust.
+    pub fn export_peer_card(&self) -> Result<PeerCard, SdkError> {
+        Ok(trust::export_peer_card(self.home_override())?)
+    }
+
+    /// Trust a remote node from its public peer card.
+    pub fn trust_peer_card(&self, card: PeerCard) -> Result<TrustedPeer, SdkError> {
+        Ok(trust::trust_peer_card(self.home_override(), card)?)
+    }
+
     /// Join a local pairing code.
     pub fn join_pairing_code(&self, code: &str) -> Result<JoinReport, SdkError> {
         Ok(trust::join_pairing_code(self.home_override(), code)?)
@@ -212,6 +227,36 @@ impl ConuClient {
         payload: impl Into<String>,
     ) -> Result<MessageSubmission, SdkError> {
         self.send_message_bytes(from_agent_id, to_agent_id, payload.into().into_bytes())
+    }
+
+    /// Queue an opaque message for a trusted remote node through the relay.
+    pub fn send_remote_message_bytes(
+        &self,
+        from_agent_id: impl Into<String>,
+        to_agent_id: impl Into<String>,
+        peer_node_id: impl Into<String>,
+        payload: impl Into<Vec<u8>>,
+    ) -> Result<RemoteMessageSubmission, SdkError> {
+        let message = RemoteMessage::new(
+            from_agent_id,
+            to_agent_id,
+            peer_node_id,
+            OpaquePayload::from_bytes(payload.into()),
+        )?;
+        Ok(relay_delivery::submit_remote_message(
+            self.home_override(),
+            message,
+        )?)
+    }
+
+    /// Connect to the relay once, flush outbound remote messages, and receive inbound envelopes.
+    pub fn relay_sync(&self, wait: Duration) -> Result<RelaySyncReport, SdkError> {
+        Ok(relay_delivery::sync_relay_once(self.home_override(), wait)?)
+    }
+
+    /// Inspect relay queue metadata without connecting to the relay.
+    pub fn relay_queue_summary(&self) -> Result<RelayQueueSummary, SdkError> {
+        Ok(relay_delivery::relay_queue_summary(self.home_override())?)
     }
 
     /// List metadata for messages delivered to a local agent.
@@ -321,6 +366,7 @@ pub enum SdkError {
     Message(messages::MessageError),
     Runtime(runtime::RuntimeError),
     Route(routes::RouteError),
+    RelayDelivery(relay_delivery::RelayDeliveryError),
     Session(sessions::SessionError),
     Stream(streams::StreamError),
     Trust(trust::TrustError),
@@ -343,6 +389,7 @@ impl fmt::Display for SdkError {
             Self::Message(error) => write!(formatter, "{error}"),
             Self::Runtime(error) => write!(formatter, "{error}"),
             Self::Route(error) => write!(formatter, "{error}"),
+            Self::RelayDelivery(error) => write!(formatter, "{error}"),
             Self::Session(error) => write!(formatter, "{error}"),
             Self::Stream(error) => write!(formatter, "{error}"),
             Self::Trust(error) => write!(formatter, "{error}"),
@@ -399,6 +446,12 @@ impl From<runtime::RuntimeError> for SdkError {
 impl From<routes::RouteError> for SdkError {
     fn from(error: routes::RouteError) -> Self {
         Self::Route(error)
+    }
+}
+
+impl From<relay_delivery::RelayDeliveryError> for SdkError {
+    fn from(error: relay_delivery::RelayDeliveryError) -> Self {
+        Self::RelayDelivery(error)
     }
 }
 

--- a/docs/internet-relay-test.md
+++ b/docs/internet-relay-test.md
@@ -1,0 +1,117 @@
+# conU Internet Relay Test
+
+This is the practical smoke test for the current relay-backed message MVP. It proves that two conU nodes can exchange public peer cards, trust each other, and move a peer-encrypted message through a WebSocket relay without showing the payload in CLI output or relay logs.
+
+Current limit: the built-in client supports `ws://` endpoints. For a real internet test, expose the relay port directly or use a tunnel/reverse proxy that accepts TLS publicly and forwards plain WebSocket traffic to `conu-relay`.
+
+## 1. Start The Relay
+
+On the relay machine:
+
+```powershell
+$env:CONU_RELAY_TOKEN = "local-dev-token"
+conu-relay --serve 0.0.0.0:8787
+```
+
+For same-machine testing, use `ws://127.0.0.1:8787`. For two machines, use the reachable host or IP, for example `ws://203.0.113.10:8787`.
+
+## 2. Prepare Node A And Node B
+
+On each node:
+
+```powershell
+conu init
+conu security audit
+```
+
+Set `default_relay` in each node's `config.toml`:
+
+```toml
+version = "1"
+default_relay = "ws://<relay-host>:8787"
+```
+
+## 3. Exchange Public Cards
+
+On Node A:
+
+```powershell
+conu identity export --json
+```
+
+On Node B:
+
+```powershell
+conu identity export --json
+```
+
+Give each side the other side's `nodeId`, `displayName`, `exchangePublicKeyHex`, and `relayEndpoint`.
+
+On Node A, trust Node B:
+
+```powershell
+conu peers trust <node-b-id> "<node-b-name>" --exchange-key <node-b-exchange-key> --relay ws://<relay-host>:8787
+```
+
+On Node B, trust Node A:
+
+```powershell
+conu peers trust <node-a-id> "<node-a-name>" --exchange-key <node-a-exchange-key> --relay ws://<relay-host>:8787
+```
+
+## 4. Register Agents
+
+On Node A:
+
+```powershell
+conu agents register agent.a "Agent A" --kind test-agent
+conud --process-ipc
+```
+
+On Node B:
+
+```powershell
+conu agents register agent.b "Agent B" --kind test-agent
+conud --process-ipc
+```
+
+## 5. Send Through The Relay
+
+On Node B, start a receive sync and keep it open:
+
+```powershell
+conu relay sync --wait-ms 10000
+```
+
+On Node A, queue and flush the message:
+
+```powershell
+"hello over encrypted relay" | conu messages send agent.a agent.b --peer <node-b-id> --stdin
+conu relay sync --wait-ms 3000
+```
+
+On Node B, inspect the addressed inbox metadata:
+
+```powershell
+conu messages inbox agent.b --json
+```
+
+The inbox should show an envelope from `agent.a` to `agent.b` with a byte count and `contentsDisplayed: false`.
+
+## Privacy Checks
+
+Good outputs:
+
+```txt
+payload view  contents are not displayed by conU
+relay view    encrypted body plus route metadata only
+```
+
+Files/logs to spot-check:
+
+```powershell
+conu watch
+conu messages receipts --json
+```
+
+The relay and CLI may show node ids, agent ids, envelope ids, byte counts, route labels, and encrypted-body state. They must not show message text, private keys, shared secrets, prompt text, reasoning, files, or tool output.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -14,6 +14,7 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 - Signed local agent cards.
 - Local pairing/trust records with revocation.
 - Metadata-only relay frame contract and standalone WebSocket relay MVP.
+- Peer-card exchange and relay-backed peer-encrypted one-shot message delivery.
 - Remote session and remote agent metadata mirror for trusted peers.
 - Stream lifecycle metadata, backpressure counters, and private watch animation.
 - Direct QUIC candidate scoring, NAT profile labels, route probes, and relay fallback selection.
@@ -33,8 +34,8 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 ## Still Local Or Groundwork
 
 - File-backed IPC is reliable for development, but not yet a production named-pipe/socket transport.
-- Remote sessions are metadata mirrors. They do not yet move encrypted payload bytes between machines.
-- The relay forwards metadata frames, but conUD does not yet own a live relay client for data-plane delivery.
+- Remote sessions are still metadata mirrors; manual peer-card exchange is the current cross-machine trust path.
+- The relay-backed data plane currently supports one-shot peer-encrypted messages through explicit `conu relay sync`; stream byte routing, reconnect loops, and offline mailbox delivery are not active yet.
 - Direct transport is route metadata only. Real QUIC sockets, ICE-style candidate exchange, and NAT hole punching are not active yet.
 - Stream writes count bytes and emit events. They do not persist or relay chunk bytes yet.
 - Pairing is local trust-store groundwork, not full cross-machine rendezvous.
@@ -44,7 +45,7 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 
 ## Release Blockers
 
-- Live relay-backed encrypted message and stream routing.
+- Live relay-backed encrypted stream routing, reconnect loops, and offline mailbox delivery.
 - Real direct QUIC transport with peer authentication and NAT traversal.
 - Remote signed agent-card exchange and verification.
 - Capability grants and user-visible permission policy.
@@ -82,6 +83,7 @@ Every release candidate must confirm:
 - Logs use `payload=not_observed` or metadata-only equivalents.
 - Route registry, route probes, and route logs contain route metadata only.
 - Relay frames reject plaintext payload fields.
+- Relay message frames may carry ciphertext bodies only after local trust verifies the sender public exchange key.
 - Message and mailbox storage use encrypted payload fields.
 - Tests use artificial negative strings only to prove they do not leak.
 
@@ -105,6 +107,6 @@ Each artifact must include only binaries, docs, packaging templates, and `manife
 
 ## Local Release Decision
 
-Current Phase 15 status is `local_release_ready_with_known_limits`.
+Current status is `relay_message_mvp_ready_with_known_limits`.
 
-This means a developer can install, initialize, start, pair locally, connect visible agents, run readiness checks, and inspect payload-safe logs. It does not mean conU is ready as a hosted public internet network.
+This means a developer can install, initialize, start, pair locally, exchange public peer cards, send a peer-encrypted one-shot message through a reachable `ws://` relay, run readiness checks, and inspect payload-safe logs. It does not mean conU is ready as a hosted public internet network with managed auth, TLS, offline mailbox storage, stream byte routing, or direct QUIC.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -7,7 +7,7 @@ Use this checklist before publishing any conU build.
 - Confirm the release version in all Cargo packages.
 - Confirm `plan.md` reflects the completed phase and known gaps.
 - Confirm Phase 14 rooms are not claimed unless implemented.
-- Confirm public internet data-plane delivery is not claimed until live relay/direct byte transport exists.
+- Confirm public internet claims are limited to the current relay message MVP unless hosted relay auth/TLS, reconnect loops, stream byte routing, and direct transport are implemented.
 
 ## Build
 
@@ -48,6 +48,8 @@ conu status
 conu pair
 conu join <code>
 conu routes sync
+conu identity export
+conu relay sync --wait-ms 1000
 conu connect
 conu stop
 ```
@@ -58,6 +60,7 @@ conu stop
 - `conu security audit` reports initialized local controls.
 - CLI output does not show message text, prompt text, reasoning, file contents, private keys, shared secrets, or raw payload bytes.
 - Logs use metadata-only fields such as `payload=not_observed`.
+- Relay frames carry ciphertext bodies only; no plaintext payload fields are accepted or logged.
 - Release archives do not include `CONU_HOME`, `.conu`, `node.toml`, `security/*.key`, `messages/`, `runtime/`, `logs/`, or `routes/` from a developer machine.
 - MCP stdout remains JSON-RPC only.
 - `conu_receive_message` and SDK receive APIs return payload bytes only to the addressed local agent by explicit request.
@@ -88,4 +91,4 @@ needs_fix
 blocked
 ```
 
-Current Phase 15 decision target is `local_release_ready`. Public hosted/internet release remains blocked until live encrypted remote data-plane delivery, OS-backed key storage, capability policy, and remote signed agent-card exchange are finished.
+Current decision target is `relay_message_mvp_ready`. Public hosted/internet release remains blocked until hosted relay auth/TLS, reconnect loops, stream byte routing, direct QUIC, OS-backed key storage, capability policy, and remote signed agent-card exchange are finished.

--- a/docs/sdk-and-mcp.md
+++ b/docs/sdk-and-mcp.md
@@ -43,10 +43,15 @@ set_presence()
 process_queued()
 list_agents()
 list_peers()
+export_peer_card()
+trust_peer_card()
 sync_routes()
 list_routes()
 list_route_probes()
 send_message_bytes()
+send_remote_message_bytes()
+relay_sync()
+relay_queue_summary()
 inbox_metadata()
 receive_message_bytes()
 list_receipts()
@@ -87,6 +92,8 @@ The wrapper passes send/stream payload bytes through stdin and returns command o
 
 Route helpers are available as `sync_routes()`, `routes()`, and `route_probes()`. They return route metadata only.
 
+Remote relay helpers are available as `identity_export()`, `trust_peer()`, `send_remote_message()`, and `relay_sync()`. They exchange public peer-card metadata and queue peer-encrypted message bytes without printing payload contents.
+
 ## MCP Adapter
 
 The MCP adapter lives in `crates/conu-mcp` and runs as a stdio server:
@@ -123,14 +130,18 @@ conu_sync_routes
 conu_list_routes
 conu_list_agents
 conu_list_peers
+conu_export_identity
+conu_trust_peer
 conu_send_message
+conu_send_remote_message
+conu_relay_sync
 conu_receive_message
 conu_open_stream
 conu_write_stream
 conu_close_stream
 ```
 
-`conu_sync_routes` and `conu_list_routes` expose route ids, peer ids, transport labels, endpoints, scores, latency estimates, NAT profile labels, fallback flags, and failure reasons. They do not expose payload bytes. `conu_send_message` accepts `payloadText` or `payloadHex`, but the tool response reports only request id, byte count, delivery counts, and envelope ids. `conu_receive_message` returns metadata by default. It returns `payloadHex` only when `includePayload` is `true`.
+`conu_sync_routes` and `conu_list_routes` expose route ids, peer ids, transport labels, endpoints, scores, latency estimates, NAT profile labels, fallback flags, and failure reasons. They do not expose payload bytes. `conu_export_identity` returns public node id, display name, public exchange key, and relay endpoint only. `conu_trust_peer` imports another node's public card. `conu_send_message` and `conu_send_remote_message` accept `payloadText` or `payloadHex`, but their responses report only request id, envelope id, byte count, and delivery metadata. `conu_relay_sync` reports relay counters only. `conu_receive_message` returns metadata by default. It returns `payloadHex` only when `includePayload` is `true`.
 
 When `CONU_AGENT_ID` is set, `conu-mcp` is bound to that local agent id. Register, presence, send, receive, stream open, stream write, and stream close actions are rejected if they attempt to act as a different local agent.
 
@@ -143,7 +154,7 @@ Reference: [MCP 2025-11-25 Transports](https://modelcontextprotocol.io/specifica
 ## Current Boundaries
 
 - TypeScript SDK remains future work.
-- Remote relay-backed data-plane delivery is not active yet.
+- Remote relay-backed one-shot message delivery is active through explicit relay sync. Stream byte routing, reconnect loops, offline relay mailbox delivery, and hosted relay auth hardening remain future work.
 - Route sync selects configured direct QUIC candidates and relay fallback metadata; it does not open a real QUIC socket yet.
 - MCP uses local stdio only; HTTP MCP transport is not implemented.
 - `conu_receive_message` is intentionally explicit because normal CLI and tool metadata views must not display payload contents.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -58,7 +58,9 @@ Message request ids and delivered envelope ids are recorded in `security/replay.
 
 ### Peer Key Agreement Helpers
 
-The security module exposes X25519 key agreement helpers and peer payload encryption helpers for the next relay-backed delivery phase. They derive a symmetric key from local exchange material, peer public material, ordered public keys, and context bytes. The derived shared secret is not returned or printed.
+The security module exposes X25519 key agreement helpers and peer payload encryption helpers used by the relay message MVP. They derive a symmetric key from local exchange material, peer public material, ordered public keys, and context bytes. The derived shared secret is not returned or printed.
+
+Inbound relay messages are decrypted only after the sender exchange public key matches the locally trusted peer card. The relay sees ciphertext and routing metadata, not plaintext message contents.
 
 ## CLI Audit
 
@@ -85,7 +87,7 @@ Phase 11 hardens the current local product surface, but these items still need d
 
 - OS keychain, DPAPI, Secure Enclave, HSM, or user-managed secret backend for private key protection.
 - Automated key rotation with multi-key read, re-encryption migration, and old-key retirement.
-- Live relay-backed encrypted envelope routing using the peer key agreement helpers.
+- Hosted relay auth/TLS hardening, reconnect loops, stream byte routing, and offline relay mailbox delivery.
 - Signed remote agent-card exchange over real sessions instead of derived metadata mirrors.
 - Permission grants that bind trusted peers to specific local agent actions.
 - SDK/MCP permission hardening for multi-tenant or hosted deployments.

--- a/docs/user-install-and-agent-guide.md
+++ b/docs/user-install-and-agent-guide.md
@@ -2,7 +2,7 @@
 
 This guide explains how a user can install the current conU app, start it on their PC, and let local agents use it.
 
-Current version status: Phase 15 is complete for the current local-first app. conU is usable for local agent registration, local encrypted-at-rest message submission, stream metadata, trust metadata, direct/relay route metadata, private CLI watch output, Rust SDK calls, a Python wrapper SDK, an MCP stdio adapter, repeatable release builds, service templates, and `conu doctor` readiness checks. It is not yet a public hosted internet release.
+Current version status: Phase 15 is complete for the current local-first app, with an added relay-backed message MVP. conU is usable for local agent registration, local encrypted-at-rest message submission, manual public peer-card exchange, peer-encrypted one-shot relay messages between trusted nodes, stream metadata, trust metadata, direct/relay route metadata, private CLI watch output, Rust SDK calls, a Python wrapper SDK, an MCP stdio adapter, repeatable release builds, service templates, and `conu doctor` readiness checks. It is not yet a managed public hosted internet release.
 
 ## What Works Today
 
@@ -14,7 +14,8 @@ Current version status: Phase 15 is complete for the current local-first app. co
 - Store new conU-owned local payload files encrypted at rest.
 - List inbox, receipt, stream, peer, session, and security metadata.
 - Sync and inspect direct QUIC route candidates and relay fallback metadata.
-- Run a standalone `conu-relay` MVP for metadata-only relay frame tests.
+- Run a standalone `conu-relay` MVP and move peer-encrypted one-shot messages through it.
+- Export/import public peer cards for manual cross-machine trust.
 - Let Rust agents use `conu_sdk::ConuClient`.
 - Let Python agents use `sdk/python/conu_sdk`.
 - Let MCP-capable agents launch `conu-mcp` and call conU tools.
@@ -26,10 +27,10 @@ Current version status: Phase 15 is complete for the current local-first app. co
 - No signed one-click installer yet.
 - No TypeScript SDK yet.
 - No CLI command that reveals message contents. This is intentional; use SDK or MCP explicit receive APIs when the addressed local agent needs payload bytes.
-- No live internet data-plane routing between two real conUD nodes yet.
+- No hosted relay service, TLS client, or managed public relay auth yet. The current client supports reachable `ws://` relay endpoints.
 - No real QUIC socket or NAT hole punching yet; Phase 13 selects configured direct route candidates and relay fallback metadata.
 - Pairing and remote sessions are local metadata groundwork, not full cross-machine rendezvous.
-- `conu-relay` exists, but conUD does not yet own a live relay client for encrypted message/stream byte delivery.
+- Relay-backed one-shot message delivery exists through `conu relay sync`; long-running reconnect loops, stream byte routing, and offline mailbox delivery are not implemented yet.
 - Service templates exist, but users still need to install/register them for their platform.
 - Local private keys are file-backed today; OS keychain/DPAPI/HSM support is still a release blocker.
 
@@ -244,6 +245,43 @@ direct_quic_peer_abcd1234 = "quic://203.0.113.10:9443"
 
 `conu routes sync` writes only route metadata. It does not print, log, or inspect message contents.
 
+## Send A Remote Relay Message
+
+Start a reachable relay. For local testing:
+
+```powershell
+$env:CONU_RELAY_TOKEN = "local-dev-token"
+conu-relay --serve 0.0.0.0:8787
+```
+
+On each node, set `default_relay` in `config.toml` or pass the relay endpoint when trusting a peer. Then exchange public cards:
+
+```powershell
+conu identity export --json
+conu peers trust <peer-node-id> "<peer name>" --exchange-key <exchange-public-key-hex> --relay ws://<relay-host>:8787
+```
+
+Register a local agent on each side. On the receiving node, keep a sync open:
+
+```powershell
+conu relay sync --wait-ms 10000
+```
+
+On the sender:
+
+```powershell
+"opaque bytes for the remote agent" | conu messages send agent.sender agent.remote --peer <receiver-node-id> --stdin
+conu relay sync --wait-ms 3000
+```
+
+On the receiver:
+
+```powershell
+conu messages inbox agent.remote --json
+```
+
+The relay sync command shows counts and route metadata only. It does not show message contents. For a full two-terminal walkthrough, see `docs/internet-relay-test.md`.
+
 ## Give conU To An Agent
 
 Agents can use conU through MCP, Rust, Python, or direct CLI calls.
@@ -276,8 +314,10 @@ Rules:
 - Register once with conu_register_agent.
 - Use conu_set_presence when your state changes.
 - Discover local and trusted remote metadata with conu_list_agents and conu_list_peers.
+- Exchange public peer cards with conu_export_identity and conu_trust_peer when setting up remote trust.
 - Sync and inspect route metadata with conu_sync_routes and conu_list_routes.
 - Send opaque bytes with conu_send_message.
+- Send remote peer-encrypted bytes with conu_send_remote_message, then call conu_relay_sync.
 - Read inbox metadata first; request payloadHex only with conu_receive_message when you are the addressed local agent.
 - Use conu_open_stream, conu_write_stream, and conu_close_stream for stream metadata flows.
 - Treat conU as the road, not the conversation.
@@ -301,6 +341,8 @@ client.init()?;
 client.register_agent("agent.mybot", "My Bot", "local-agent")?;
 client.process_queued()?;
 client.send_message_bytes("agent.mybot", "agent.other", b"opaque bytes")?;
+client.send_remote_message_bytes("agent.mybot", "agent.remote", "node_peer", b"opaque bytes")?;
+client.relay_sync(std::time::Duration::from_millis(3000))?;
 ```
 
 ### Python Agent Setup
@@ -319,6 +361,8 @@ client.init()
 client.register_agent("agent.mybot", "My Bot")
 client.process_queued()
 client.send_message("agent.mybot", "agent.other", b"opaque bytes")
+client.send_remote_message("agent.mybot", "agent.remote", "node_peer", b"opaque bytes")
+client.relay_sync(wait_ms=3000)
 ```
 
 ### CLI Agent Fallback
@@ -338,9 +382,16 @@ Rules:
 - Use JSON commands for machine-readable metadata:
   conu status --json
   conu agents --json
+  conu identity export --json
   conu messages inbox <agent-id> --json
   conu messages receipts --json
   conu security audit --json
+- For remote delivery, import a peer card once:
+  conu peers trust <peer-node-id> <display-name> --exchange-key <hex> --relay <ws://host:port>
+- Send remote payload bytes through stdin only:
+  <payload bytes> | conu messages send <your-agent-id> <target-agent-id> --peer <peer-node-id> --stdin
+- Flush/receive relay envelopes:
+  conu relay sync --wait-ms 3000
 - Never expect conU CLI output to show message contents.
 - Treat conU as the road, not the conversation.
 ```
@@ -367,7 +418,7 @@ These are not hidden bugs; they are the honest state of the current app:
 | Runtime discovery | `conu start` needs `conud` beside `conu` or on PATH | Start can fail after manual binary moves | Install both with Cargo or set `CONUD_EXE` |
 | Agent API | Rust SDK, Python wrapper, and MCP adapter exist; TypeScript is later | Most agents can integrate now, TS apps need wrapper work | Use MCP, Rust SDK, Python SDK, or CLI/stdin |
 | Receiving payloads | CLI intentionally lists inbox metadata only | Agents needing bytes must use explicit receive APIs | Use Rust SDK `receive_message_bytes` or MCP `conu_receive_message` with `includePayload` |
-| Internet messaging | Relay is not wired into conUD data plane yet | Local messages work; real remote payload delivery does not | Use local testing only |
+| Internet messaging | One-shot relay messages work through explicit sync, but no hosted relay/TLS client/reconnect loop exists | Users can test over reachable `ws://`; managed public network is not ready | Run `conu-relay` yourself or expose it through a tunnel/reverse proxy that terminates TLS before conU |
 | Direct transport | Route selection exists, but real QUIC sockets and NAT hole punching do not | Direct routes show as metadata only | Configure direct endpoints for route scoring tests |
 | Pairing | Pair/join are local trust groundwork | Not real cross-machine pairing yet | Use for metadata/trust testing |
 | Service install | Service templates exist but need local edits/admin steps | User must choose service path/user | Use `packaging/windows`, `packaging/linux`, or `packaging/macos` templates |
@@ -410,7 +461,7 @@ conu messages inbox agent.b --json
 To make conU genuinely useful over the internet, the next phase should build:
 
 - Rooms, pub/sub, and multi-agent session metadata.
-- Live encrypted relay-backed message and stream byte delivery.
+- Hosted relay auth/TLS hardening, reconnect loops, offline mailbox, and stream byte delivery.
 - Real QUIC socket transport and NAT candidate exchange after the room/session model is stable.
 - TypeScript SDK after the protocol surface stabilizes.
 - Signed installers and OS keychain-backed secret storage after local packaging stabilizes.

--- a/plan.md
+++ b/plan.md
@@ -31,7 +31,7 @@ needs_revision
 Current phase: Phase 14 - Rooms, Pub/Sub, And Multi-Agent Sessions
 Status: not_started
 Last updated: 2026-05-11
-Note: Phase 15 was completed as a user-directed skip-ahead; Phase 14 remains not started.
+Note: Phase 15 was completed as a user-directed skip-ahead; a post-Phase-15 relay message MVP and CLI polish pass is complete; Phase 14 remains not started.
 ```
 
 ## Phase 0 - Project Memory
@@ -1211,6 +1211,82 @@ Known gaps:
 - No Phase 14 rooms/pub-sub implementation was started in this audit.
 - Public hosted internet readiness remains blocked by the known Phase 15 release blockers.
 
+## Post Phase 15 Internet Data-Plane And CLI Polish
+
+Status: completed
+
+Goal:
+
+Make conU testable over a reachable WebSocket relay for one-shot peer-encrypted agent messages, while improving the CLI control-room flow and keeping all payload surfaces private.
+
+Completed work:
+
+- Created GitHub issue #34 and branch `codex/internet-data-plane-cli-polish`.
+- Extended the shared relay frame contract to carry peer-encrypted opaque bodies while still rejecting plaintext payload fields.
+- Added a std-only relay WebSocket client in `conu_core::relay`.
+- Added manual public peer-card export/import with `conu identity export` and `conu peers trust`.
+- Added relay-backed remote message queueing with `conu messages send --peer <peer-node-id> --stdin`.
+- Added `conu relay sync --wait-ms <ms>` for explicit outbound flush and inbound receive over the relay.
+- Delivered inbound relay envelopes to the addressed local agent inbox after verifying the sender exchange public key against local trust.
+- Added relay queue counters and a richer ASCII `conu watch` transport view.
+- Exposed peer-card, remote send, and relay sync helpers through the Rust SDK, Python wrapper, and MCP adapter.
+- Added `docs/internet-relay-test.md` and updated user, SDK/MCP, production, security, release, README, and future-agent docs.
+
+Files changed:
+
+- `Cargo.toml` lock/dependency metadata as needed by existing workspace updates.
+- `README.md`
+- `docs/internet-relay-test.md`
+- `docs/user-install-and-agent-guide.md`
+- `docs/sdk-and-mcp.md`
+- `docs/production-readiness.md`
+- `docs/security-hardening.md`
+- `docs/release-checklist.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `.agents/skills/conu-security-guardian/references/privacy-security-checklist.md`
+- `crates/conu-core/src/relay.rs`
+- `crates/conu-core/src/relay_delivery.rs`
+- `crates/conu-core/src/messages.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conu-core/src/trust.rs`
+- `crates/conu-core/src/lib.rs`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-relay/Cargo.toml`
+- `crates/conu-relay/src/lib.rs`
+- `crates/conu-relay/src/main.rs`
+- `crates/conu-sdk/src/lib.rs`
+- `crates/conu-mcp/src/lib.rs`
+- `sdk/python/conu_sdk/__init__.py`
+- `plan.md`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed, including a two-home relay E2E test that sends and receives a peer-encrypted message through `conu-relay`.
+- `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py` passed.
+- `powershell -ExecutionPolicy Bypass -File scripts/smoke-local.ps1 -Toolchain stable-x86_64-pc-windows-gnu` passed.
+- `powershell -ExecutionPolicy Bypass -File scripts/build-release.ps1 -Profile release -Toolchain stable-x86_64-pc-windows-gnu` passed and created `dist/conu-0.1.0-host.zip`.
+- `git diff --check` passed.
+- Targeted CLI remote queue test passed and confirmed the relay outbox stores encrypted fields without literal payload text.
+- Privacy scan reviewed payload-looking strings; matches are artificial negative tests, docs examples, or encrypted field names, not runtime log/CLI payload leakage.
+
+Known gaps:
+
+- The relay client supports `ws://`; public `wss://` requires a TLS terminator/reverse proxy in front of `conu-relay`.
+- Relay sync is explicit/one-shot today; no long-running reconnect loop or service-owned relay pump is active.
+- Relay-backed stream byte routing, offline mailbox delivery, hosted relay auth/rate limits, direct QUIC sockets, NAT traversal, signed remote agent-card exchange, capability policy, and OS-backed key storage remain future work.
+- Phase 14 rooms/pub-sub remains not started.
+
+Next recommendation:
+
+- For user testing, run `docs/internet-relay-test.md` locally or over a reachable `ws://` relay.
+- For product hardening, add a conUD-owned relay pump with reconnect/backoff, then stream byte routing and hosted relay auth/TLS strategy.
+
 ## Phase Completion Log
 
 Add entries here when a phase is completed.
@@ -1233,4 +1309,5 @@ Add entries here when a phase is completed.
 2026-05-11 - Phase 13 completed. conUD-owned direct/relay route manager, NAT-profile scoring, relay fallback selection, route probes/logs, CLI route commands, SDK/Python/MCP route tools, docs, skills, and GNU-toolchain validation added. Next: Phase 14 rooms, pub/sub, and multi-agent sessions.
 2026-05-11 - Phase 15 completed as a user-directed skip-ahead. Added doctor readiness checks, release/smoke scripts, packaging templates, CI/release workflows, release checklist, observability docs, strict local-install smoke validation, and GNU-toolchain release validation. Phase 14 remains not started.
 2026-05-11 - Post Phase 15 audit completed. Added clippy-clean polish across runtime, CLI, MCP, CI, and docs while preserving payload privacy and leaving Phase 14 not started.
+2026-05-11 - Post Phase 15 internet data-plane and CLI polish completed. Added public peer-card trust, peer-encrypted relay message queueing, explicit relay sync, richer watch animation, SDK/Python/MCP remote helpers, relay E2E tests, and internet relay test docs. Phase 14 remains not started.
 ```

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -63,6 +63,29 @@ class ConuClient:
     def peers(self) -> dict[str, Any]:
         return self._run_json(self.conu_bin, "peers", "--json")
 
+    def identity_export(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "identity", "export", "--json")
+
+    def trust_peer(
+        self,
+        peer_node_id: str,
+        display_name: str,
+        exchange_public_key_hex: str,
+        relay_endpoint: str | None = None,
+    ) -> dict[str, Any]:
+        args = [
+            "peers",
+            "trust",
+            peer_node_id,
+            display_name,
+            "--exchange-key",
+            exchange_public_key_hex,
+            "--json",
+        ]
+        if relay_endpoint is not None:
+            args.extend(["--relay", relay_endpoint])
+        return self._run_json(self.conu_bin, *args)
+
     def sync_routes(self) -> dict[str, Any]:
         return self._run_json(self.conu_bin, "routes", "sync", "--json")
 
@@ -121,6 +144,36 @@ class ConuClient:
             "--stdin",
             "--json",
             input_bytes=payload,
+        )
+
+    def send_remote_message(
+        self,
+        from_agent_id: str,
+        to_agent_id: str,
+        peer_node_id: str,
+        payload: bytes,
+    ) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "messages",
+            "send",
+            from_agent_id,
+            to_agent_id,
+            "--peer",
+            peer_node_id,
+            "--stdin",
+            "--json",
+            input_bytes=payload,
+        )
+
+    def relay_sync(self, wait_ms: int = 1000) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "relay",
+            "sync",
+            "--wait-ms",
+            str(wait_ms),
+            "--json",
         )
 
     def open_stream(


### PR DESCRIPTION
## **User description**
## Summary
- add blind relay ciphertext frames, std-only relay client, and relay-backed remote message delivery
- add public peer-card export/import, CLI relay sync, richer watch animation, and SDK/Python/MCP remote helpers
- document internet relay testing and update production/security/future-agent guidance

## Validation
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu test --workspace
- python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py
- powershell -ExecutionPolicy Bypass -File scripts/smoke-local.ps1 -Toolchain stable-x86_64-pc-windows-gnu
- powershell -ExecutionPolicy Bypass -File scripts/build-release.ps1 -Profile release -Toolchain stable-x86_64-pc-windows-gnu
- git diff --check

Closes #34


___

## **CodeAnt-AI Description**
**Add peer-card trust and relay-backed encrypted message delivery**

### What Changed
- Users can now export a public peer card, trust another node from that card, and include a relay endpoint for cross-machine setup.
- `conu messages send` can queue a peer-encrypted remote message with `--peer`, and `conu relay sync` sends queued messages and receives inbound envelopes through the relay.
- `conu watch` now shows relay queue counts and a relay-focused transport view, while SDK, Python, and MCP helpers expose the same remote messaging flow.
- Relay and message logs, CLI output, and docs now reflect ciphertext-only delivery and keep message contents hidden.

### Impact
`✅ Cross-machine trust setup`
`✅ Peer-encrypted relay messages`
`✅ Clearer relay delivery status`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=GkCPHXJnLaE77bMFaXpmq0E0-jvbbLhj4lU0HpYwXEM&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added peer-encrypted remote message delivery via relay-backed queueing (`conu messages send --peer` and `conu relay sync`)
  * Peer card export and manual cross-machine trust establishment via `conu peers trust`
  * Identity export functionality and relay queue monitoring in watch output
  * Relay sync support in Rust SDK, Python SDK, and MCP adapter

* **Documentation**
  * Added internet relay test guide and production readiness updates
  * Updated SDK/MCP documentation for remote messaging capabilities

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->