### PR TITLE
Add daemon-owned relay delivery pump

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -6,7 +6,7 @@ conU is not an agent framework. It is the runtime, protocol, CLI, and network la
 
 ## Current State
 
-The repository has completed Phase 15 as a directed skip-ahead, and now includes a relay-backed one-shot message MVP. Phase 14 rooms/pub-sub remain not started.
+The repository has completed Phase 15 as a directed skip-ahead, and now includes daemon-pumped relay-backed one-shot message delivery. Phase 14 rooms/pub-sub remain not started.
 
 Implemented so far:
 
@@ -29,7 +29,8 @@ Implemented so far:
 - local X25519 peer key agreement helpers
 - manual public peer-card export/import through `conu identity export` and `conu peers trust`
 - relay-backed peer-encrypted remote message queueing through `conu messages send --peer`
-- explicit relay send/receive sync through `conu relay sync`
+- daemon-owned relay send/receive pump when relay config or trusted relay peer endpoints exist
+- explicit manual relay send/receive sync through `conu relay sync`
 - replay protection for local message request and envelope ids
 - `conu security audit` for payload-safe hardening status
 - Rust SDK crate `conu-sdk` for agent-facing registration, messaging, receive, peer, security, and stream calls
@@ -52,6 +53,7 @@ Implemented so far:
 - payload-safe watch event bus under `streams/events.toml`
 - `conu watch` private transport animation
 - conUD-owned direct/relay route manager through `conu routes`
+- conUD-owned relay pump for peer-encrypted one-shot remote message delivery
 - metadata-only route registry under `routes/registry.toml`
 - metadata-only route probes under `routes/probes.toml`
 - route sync integration with remote sessions, streams, Rust SDK, Python wrapper SDK, and MCP

--- a/.agents/skills/conu-builder/references/agent-gateway-contract.md
+++ b/.agents/skills/conu-builder/references/agent-gateway-contract.md
@@ -154,7 +154,7 @@ PONG payload=not_observed
 ERROR reason=<safe-reason> payload=not_observed
 ```
 
-The current relay data-plane MVP exposes peer-encrypted one-shot messages through `conu messages send --peer` and `conu relay sync`. Live stream byte routing, reconnect loops, hosted relay auth hardening, and offline mailbox delivery land later.
+The current relay data-plane exposes peer-encrypted one-shot messages through `conu messages send --peer`. Running conUD automatically pumps configured relay send/receive windows; `conu relay sync` remains an explicit manual/debug command. Live stream byte routing, persistent relay sessions, hosted relay auth hardening, and offline mailbox delivery land later.
 
 The Phase 9 remote session surface is conUD-owned metadata sync:
 

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -82,7 +82,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Relay server output, errors, tests, and logs must not echo auth tokens or private payload contents.
 - The relay may return `UNDELIVERED reason=peer_offline` when the target runtime is not connected; do not add mailbox storage until the encrypted mailbox phase.
 - On Windows, accepted streams from a nonblocking listener must be set back to blocking mode before frame reads.
-- `conu-relay` plus `conu relay sync` can move peer-encrypted one-shot messages for trusted peers. Long-running reconnect loops, stream byte routing, hosted auth hardening, and offline mailbox delivery remain later work.
+- `conu-relay` plus the conUD relay pump can move peer-encrypted one-shot messages for trusted peers. `conu relay sync` remains a manual/debug command. Persistent relay sessions, stream byte routing, hosted auth hardening, and offline mailbox delivery remain later work.
 
 ## Remote Session And Discovery Rules
 
@@ -90,7 +90,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - conUD owns session sync; CLI commands may request sync or display the mirror but must not inspect payloads.
 - Remote session state belongs under `sessions/registry.toml`; mirrored remote agent cards belong under `agents/remote.toml`.
 - Session logs must use metadata-only lines with counts, route state, and `payload=not_observed`.
-- `conu agents` may show trusted remote agent cards from the mirror. One-shot relay messages are available through explicit peer-card trust and relay sync; live stream routing remains future work.
+- `conu agents` may show trusted remote agent cards from the mirror. One-shot relay messages are available through explicit peer-card trust and the conUD relay pump; live stream routing remains future work.
 - Revoked peers must not remain visible as active remote agents after session sync.
 - Route metadata may include relay endpoint, peer id, state, and reconnect counts; it must not include message contents, tokens, or private payload bytes.
 
@@ -127,7 +127,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - New message request and inbox files must use `payload_ciphertext_hex`, not `payload_hex`.
 - Agent registry records should include signature metadata for new/updated local agents.
 - CLI security output may show readiness booleans and key ids, but must never show private keys, shared secrets, plaintext payloads, or decrypted payloads.
-- Peer key agreement helpers now back the relay message MVP. The relay must carry ciphertext only, and inbound envelopes must verify the sender exchange public key against the trusted peer card before delivery.
+- Peer key agreement helpers now back relay message delivery. The relay must carry ciphertext only, and inbound envelopes must verify the sender exchange public key against the trusted peer card before delivery.
 
 ## SDK And MCP Rules
 
@@ -150,7 +150,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Release artifacts must not include local conU state, `CONU_HOME`, `.conu`, private keys, logs, inboxes, route registries, message stores, or test payload output.
 - `conu doctor` may report binary paths, readiness booleans, runtime health, and payload-safe log scan counts; it must not print log contents, private keys, payload text, or secrets.
 - Windows service, Linux systemd, and macOS launchd files are templates until a signed installer configures platform-specific users and paths.
-- A local release may be marked ready only with documented limits. Do not claim public hosted internet readiness until hosted relay auth/TLS, reconnect loops, stream byte routing, capability policy, signed remote cards, and OS-backed key storage are implemented.
+- A local release may be marked ready only with documented limits. Do not claim public hosted internet readiness until hosted relay auth/TLS, persistent relay sessions, stream byte routing, capability policy, signed remote cards, and OS-backed key storage are implemented.
 - CI/release workflows must run metadata-only checks and must not upload conU state directories or logs as artifacts.
 
 ## Privacy Rules

--- a/.agents/skills/conu-repo-steward/references/repo-map.md
+++ b/.agents/skills/conu-repo-steward/references/repo-map.md
@@ -20,7 +20,7 @@ crates/conu-cli
   CLI commands, ASCII dashboard, stream/watch animation, user control flow
 
 crates/conud
-  daemon process, local gateway/message/session processing, session manager, runtime lifecycle
+  daemon process, local gateway/message/session processing, relay pump, session manager, runtime lifecycle
 
 crates/conu-core
   local state, security keys/encryption/signatures/replay, runtime lifecycle, agent registry, local message routing, relay-backed remote message delivery, stream metadata, route selection, trust store, relay frame contract, remote session mirror, future policy logic
@@ -32,7 +32,7 @@ crates/conu-relay
   std-only WebSocket relay service, session auth, blind ciphertext forwarding, relay/bootstrap groundwork
 
 crates/conu-sdk
-  Rust agent-facing SDK over registration, presence, peers, peer cards, routes, local/remote messages, relay sync, receive, streams, and security audit
+  Rust agent-facing SDK over registration, presence, peers, peer cards, routes, local/remote messages, optional relay sync, receive, streams, and security audit
 
 crates/conu-mcp
   MCP stdio adapter exposing conU tools over newline-delimited JSON-RPC
@@ -44,7 +44,7 @@ examples/python
   Python local-agent integration examples
 
 scripts
-  release build and local smoke scripts
+  release build, local smoke, and relay-daemon smoke scripts
 
 packaging
   Windows install scripts plus Linux systemd and macOS launchd service templates

--- a/.agents/skills/conu-security-guardian/references/privacy-security-checklist.md
+++ b/.agents/skills/conu-security-guardian/references/privacy-security-checklist.md
@@ -34,6 +34,7 @@
 - Relay fallback does not weaken trust checks.
 - Relay message delivery must decrypt only after the sender exchange public key matches the trusted peer card.
 - Relay frames may carry ciphertext bodies, never plaintext payload fields.
+- The conUD relay pump may retry, count, and route envelopes, but runtime logs must stay metadata-only and must not include relay tokens or plaintext payloads.
 
 ## Storage
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conU owns the connection.
 
 ## Current Status
 
-Phase 15 is complete for the current local-first app, and this branch adds the first live relay-backed internet data-plane slice. The CLI identity/dashboard shell exists, `conu init` creates real local state and security keys, `conu start` launches the local `conUD` runtime skeleton, local agents can register signed metadata and presence, registered local agents can exchange encrypted-at-rest opaque message envelopes, users can exchange public peer cards, trusted peers can send peer-encrypted messages through `conu-relay`, streams produce payload-safe watch events, `conu security audit` reports hardened controls without showing secrets, agents can use conU through the Rust SDK, Python wrapper SDK, and MCP stdio adapter, conUD owns metadata-only direct/relay route selection, and release packaging/readiness checks now exist.
+Phase 15 is complete for the current local-first app, with a hardened relay message path beyond the original MVP. The CLI identity/dashboard shell exists, `conu init` creates real local state and security keys, `conu start` launches the local `conUD` runtime, local agents can register signed metadata and presence, registered local agents can exchange encrypted-at-rest opaque message envelopes, users can exchange public peer cards, trusted peers can send peer-encrypted messages through `conu-relay`, conUD can automatically pump configured relay routes, streams produce payload-safe watch events, `conu security audit` reports hardened controls without showing secrets, agents can use conU through the Rust SDK, Python wrapper SDK, and MCP stdio adapter, conUD owns metadata-only direct/relay route selection, and release packaging/readiness checks now exist.
 
 The repository currently contains compile-ready crate boundaries for:
 
@@ -111,11 +111,11 @@ conU can now move peer-encrypted message envelopes between two trusted nodes thr
 ```bash
 conu identity export --json
 conu peers trust <peer-node-id> <display-name> --exchange-key <hex> --relay ws://relay-host:8787
+conu start
 conu messages send agent.sender agent.remote --peer <peer-node-id> --stdin
-conu relay sync --wait-ms 3000
 ```
 
-Run `conu relay sync --wait-ms 10000` on the receiving node while the sender syncs. The relay sees node ids, agent ids, envelope id, byte count, public exchange key material, and ciphertext only. It does not receive plaintext message contents. See `docs/internet-relay-test.md` for a local two-node smoke and an internet test checklist.
+Run `conu start` on both nodes after `default_relay` or trusted peer relay endpoints are configured. conUD will connect in bounded sync windows, retry on failures, flush pending outbound envelopes, and receive inbound peer-encrypted envelopes. `conu relay sync --wait-ms 3000` remains available as an explicit manual flush/debug command. The relay sees node ids, agent ids, envelope id, byte count, public exchange key material, and ciphertext only. It does not receive plaintext message contents. See `docs/internet-relay-test.md` and `scripts/smoke-relay-daemon.ps1` for local two-node smoke coverage and an internet test checklist.
 
 ## Security Hardening
 
@@ -192,7 +192,7 @@ cargo run -p conu-relay -- --serve 127.0.0.1:8787
 
 Connected runtimes send `HELLO`, `FORWARD`, and `PING` frames. The relay answers with `WELCOME`, `ENVELOPE`, `SENT`, `UNDELIVERED`, `PONG`, or `ERROR` frames. Relay `FORWARD` can carry a peer-encrypted opaque body for message delivery, but plaintext payload fields are rejected and logs/output use `payload=not_observed`, `payload=opaque`, or `payload=peer_encrypted`.
 
-The relay is available now as a standalone service for encrypted message sync. Full live stream byte routing, hosted relay auth hardening, offline relay mailbox storage, reconnect networking, and direct QUIC still land in later transport phases.
+The relay is available now as a standalone service for encrypted message sync, and conUD owns the local relay pump when a relay or trusted relay peer is configured. Full live stream byte routing, hosted relay auth hardening, offline relay mailbox storage, persistent relay sessions, and direct QUIC still land in later transport phases.
 
 ## Remote Sessions And Discovery
 
@@ -249,7 +249,7 @@ cargo run -p conu-sdk --example local_agents
 cargo run -p conu-mcp
 ```
 
-Rust agents can use `conu_sdk::ConuClient` to register, update presence, list agents/peers, exchange peer cards, send local opaque bytes, queue remote relay messages, run relay sync, receive payload bytes for the addressed local agent, and open/write/close streams. Python agents can use the stdlib wrapper under `sdk/python`.
+Rust agents can use `conu_sdk::ConuClient` to register, update presence, list agents/peers, exchange peer cards, send local opaque bytes, queue remote relay messages, optionally run relay sync, receive payload bytes for the addressed local agent, and open/write/close streams. Python agents can use the stdlib wrapper under `sdk/python`.
 
 MCP-capable agents can launch `conu-mcp` as a stdio server. It exposes tools such as `conu_register_agent`, `conu_export_identity`, `conu_trust_peer`, `conu_send_message`, `conu_send_remote_message`, `conu_relay_sync`, `conu_receive_message`, `conu_open_stream`, and `conu_security_audit`. The adapter follows the current MCP stdio transport shape: newline-delimited JSON-RPC 2.0 messages on stdin/stdout. Tool list/send/status outputs remain metadata-only. Set `CONU_AGENT_ID` when launching one MCP server for one agent; then the adapter rejects attempts to act as another local agent. `conu_receive_message` returns payload bytes as `payloadHex` only when the addressed local agent explicitly passes `includePayload: true`.
 
@@ -270,6 +270,7 @@ On Windows machines without Visual Studio C++ Build Tools, use the GNU Rust tool
 rustup toolchain install stable-x86_64-pc-windows-gnu
 cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
 cargo +stable-x86_64-pc-windows-gnu test --workspace
+powershell -ExecutionPolicy Bypass -File scripts/smoke-relay-daemon.ps1 -Toolchain stable-x86_64-pc-windows-gnu
 ```
 
 Useful CLI commands:

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -7,8 +7,9 @@
 use std::collections::HashSet;
 use std::env;
 use std::fs;
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
@@ -180,6 +181,7 @@ control room
 
 quick commands
   conu init
+  conu start
   conu status
   conu agents
   conu agents register <agent-id> <display-name>
@@ -921,7 +923,8 @@ bytes: {}
 route: relay-websocket
 
 next
-  conu relay sync --wait-ms 3000
+  conu start
+  optional manual flush: conu relay sync --wait-ms 3000
 
 privacy
   payload view  contents are not displayed by conU",
@@ -2129,7 +2132,10 @@ flow
 
 privacy
   payload view  contents are not displayed by conU
-  relay view    encrypted body plus route metadata only",
+  relay view    encrypted body plus route metadata only
+
+note
+  conUD runs this relay pump automatically when a relay or trusted relay peer is configured",
         report.endpoint,
         yes_no(report.connected),
         report.queued,
@@ -2460,7 +2466,8 @@ exchange key: trusted
 relay: {}
 
 next
-  conu relay sync --wait-ms 3000
+  conu start
+  optional manual sync: conu relay sync --wait-ms 3000
 
 privacy
   payload view  contents are not displayed by conU",
@@ -2871,6 +2878,7 @@ private transport view
   |  agent A  | ---> | conUD  | ===> | blind relay | ===> | agent B |
   '-----------'      '--------'      '------------'      '---------'
                          peer-encrypted envelopes
+                         daemon pump when configured
 
 live counters
   route         {route}
@@ -3066,7 +3074,7 @@ logs
 
 release gates
   local install      {}
-  public internet    not ready; live remote data plane remains future work
+  public internet    not ready; hosted relay auth/TLS and streams remain future work
   known limits       documented
 
 privacy
@@ -3279,17 +3287,7 @@ fn render_start(args: &[String], home_override: Option<PathBuf>) -> CliOutput {
     }
 
     let daemon = resolve_conud_executable();
-    let mut command = Command::new(&daemon);
-    command
-        .arg("--serve")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    if let Some(home) = home_override.as_ref() {
-        command.env("CONU_HOME", home);
-    }
-
-    let child = match command.spawn() {
+    let child = match spawn_conud_daemon(&daemon, home_override.as_ref()) {
         Ok(child) => child,
         Err(error) => {
             return CliOutput::failure(
@@ -3435,7 +3433,7 @@ runtime
   pid           {}
   health        {}
   local IPC     file gateway active
-  relay         service available via conu-relay
+  relay         daemon pump when configured; service via conu-relay
   routes        direct {} relay {} fallback {}
 
 identity
@@ -3510,7 +3508,7 @@ fn render_status_json(view: &StatusView<'_>) -> String {
     "heartbeatAgeSecs": {},
     "localHealth": "{}",
     "localIpc": "file_gateway",
-    "relay": "service_available",
+    "relay": "daemon_pump_when_configured",
     "selectedDirectRoutes": {},
     "selectedRelayRoutes": {},
     "relayFallbacks": {}
@@ -3613,7 +3611,7 @@ Usage:
   conu --help
   conu --version
 
-conU carries local and relay-backed peer-encrypted messages while payload contents remain hidden."
+conU carries local and relay-backed peer-encrypted messages while payload contents remain hidden. conUD pumps configured relay routes automatically."
         .to_string()
 }
 
@@ -3625,6 +3623,7 @@ fn render_start_report(status: &RuntimeStatus, launched: bool, json: bool) -> St
   "launched": {},
   "pid": {},
   "health": "{}",
+  "relayPump": "auto_when_configured",
   "contentsDisplayed": false
 }}"#,
             status.state.as_str(),
@@ -3647,6 +3646,7 @@ status: {action}
 conUD: {}
 pid: {}
 health: {}
+relay pump: auto when configured
 
 privacy
   payload view  contents are not displayed by conU",
@@ -3654,6 +3654,49 @@ privacy
         runtime_pid_label(status),
         runtime_health_label(status)
     )
+}
+
+fn spawn_conud_daemon(daemon: &Path, home_override: Option<&PathBuf>) -> io::Result<Child> {
+    #[cfg(windows)]
+    {
+        let script = format!(
+            "Start-Process -FilePath {} -ArgumentList '--serve' -WindowStyle Hidden",
+            powershell_quote(&daemon.display().to_string())
+        );
+        let mut command = Command::new("powershell");
+        command
+            .arg("-NoProfile")
+            .arg("-ExecutionPolicy")
+            .arg("Bypass")
+            .arg("-Command")
+            .arg(script)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        if let Some(home) = home_override {
+            command.env("CONU_HOME", home);
+        }
+        command.spawn()
+    }
+
+    #[cfg(not(windows))]
+    {
+        let mut command = Command::new(daemon);
+        command
+            .arg("--serve")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        if let Some(home) = home_override {
+            command.env("CONU_HOME", home);
+        }
+        command.spawn()
+    }
+}
+
+#[cfg(windows)]
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 fn render_stop_report(report: &StopReport, json: bool) -> String {

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -247,15 +247,24 @@ pub fn sync_relay_once(
     wait: Duration,
 ) -> Result<RelaySyncReport, RelayDeliveryError> {
     let init = state::init_state(home_override)?;
-    ensure_relay_dirs(&init.paths)?;
+    sync_relay_once_from_paths(&init.paths, &init.node.node_id, wait)
+}
 
-    let queued_paths = pending_relay_requests(&init.paths)?;
-    let endpoint = relay_endpoint_for_sync(&init.paths, &queued_paths)?;
+/// Connect to the configured relay from already resolved runtime state.
+pub fn sync_relay_once_from_paths(
+    paths: &StatePaths,
+    node_id: &str,
+    wait: Duration,
+) -> Result<RelaySyncReport, RelayDeliveryError> {
+    ensure_relay_dirs(paths)?;
+
+    let queued_paths = pending_relay_requests(paths)?;
+    let endpoint = relay_endpoint_for_sync(paths, &queued_paths)?;
     let token = relay_token();
     let timeout = Duration::from_millis(500);
     let mut client = RelayWebSocketClient::connect(&endpoint, timeout)?;
     client.send(&RelayClientFrame::Hello(RelayHello::new(
-        init.node.node_id.clone(),
+        node_id.to_string(),
         token,
     )?))?;
 
@@ -287,21 +296,16 @@ pub fn sync_relay_once(
             Ok(request) => request,
             Err(error) => {
                 report.rejected += 1;
-                move_relay_request(&init.paths.relay_rejected_dir, &request_path, "rejected")?;
-                append_relay_log(&init.paths, "outbox_rejected", "", "", 0)?;
+                move_relay_request(&paths.relay_rejected_dir, &request_path, "rejected")?;
+                append_relay_log(paths, "outbox_rejected", "", "", 0)?;
                 return Err(error);
             }
         };
         client.send(&RelayClientFrame::Forward(request.to_forward_frame()?))?;
-        drain_relay_frames(
-            &mut client,
-            &init.paths,
-            &mut report,
-            Duration::from_millis(600),
-        )?;
+        drain_relay_frames(&mut client, paths, &mut report, Duration::from_millis(600))?;
     }
 
-    drain_relay_frames(&mut client, &init.paths, &mut report, wait)?;
+    drain_relay_frames(&mut client, paths, &mut report, wait)?;
     Ok(report)
 }
 
@@ -315,6 +319,29 @@ pub fn relay_queue_summary(
         sent: count_files_with_extension(&paths.relay_sent_dir, "sent")?,
         rejected: count_files_with_extension(&paths.relay_rejected_dir, "rejected")?,
     })
+}
+
+/// True when conUD should run the background relay pump.
+pub fn relay_runtime_should_sync_from_paths(
+    paths: &StatePaths,
+) -> Result<bool, RelayDeliveryError> {
+    if !relay_auto_sync_enabled(paths)? {
+        return Ok(false);
+    }
+    if !pending_relay_requests(paths)?.is_empty() {
+        return Ok(true);
+    }
+    if configured_default_relay(paths)?.is_some() {
+        return Ok(true);
+    }
+
+    Ok(trust::list_peers(Some(paths.home.clone()))?
+        .into_iter()
+        .any(|peer| {
+            peer.status == TrustStatus::Trusted
+                && peer.exchange_public_key_hex.is_some()
+                && peer.relay_endpoint.is_some()
+        }))
 }
 
 fn drain_relay_frames(
@@ -670,10 +697,18 @@ fn relay_endpoint_for_sync(
 }
 
 fn configured_relay_endpoint(paths: &StatePaths) -> Result<String, RelayDeliveryError> {
+    if let Some(endpoint) = configured_default_relay(paths)? {
+        return validate_endpoint(endpoint);
+    }
+
+    Ok(DEFAULT_RELAY_ENDPOINT.to_string())
+}
+
+fn configured_default_relay(paths: &StatePaths) -> Result<Option<String>, RelayDeliveryError> {
     let contents = match fs::read_to_string(&paths.config) {
         Ok(contents) => contents,
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            return Ok(DEFAULT_RELAY_ENDPOINT.to_string());
+            return Ok(None);
         }
         Err(error) => {
             return Err(RelayDeliveryError::io(
@@ -684,13 +719,31 @@ fn configured_relay_endpoint(paths: &StatePaths) -> Result<String, RelayDelivery
         }
     };
     let values = parse_key_values(&contents);
-    validate_endpoint(
-        values
-            .get("default_relay")
-            .filter(|value| !value.trim().is_empty())
-            .cloned()
-            .unwrap_or_else(|| DEFAULT_RELAY_ENDPOINT.to_string()),
-    )
+    Ok(values
+        .get("default_relay")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty()))
+}
+
+fn relay_auto_sync_enabled(paths: &StatePaths) -> Result<bool, RelayDeliveryError> {
+    let contents = match fs::read_to_string(&paths.config) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(true),
+        Err(error) => {
+            return Err(RelayDeliveryError::io(
+                "read conU config",
+                &paths.config,
+                error,
+            ));
+        }
+    };
+    let values = parse_key_values(&contents);
+    let value = values
+        .get("relay_auto_sync")
+        .map(|value| value.trim().to_ascii_lowercase())
+        .unwrap_or_else(|| "true".to_string());
+
+    Ok(!matches!(value.as_str(), "false" | "0" | "no" | "off"))
 }
 
 fn relay_token() -> String {
@@ -998,6 +1051,49 @@ mod tests {
             .node
             .expect("node exists")
             .node_id
+    }
+
+    #[test]
+    fn runtime_relay_pump_is_idle_without_relay_or_trusted_peer() {
+        let home = test_home("runtime-idle");
+        let init = state::init_state(Some(home)).expect("state initializes");
+
+        let should_sync =
+            relay_runtime_should_sync_from_paths(&init.paths).expect("relay decision succeeds");
+
+        assert!(!should_sync);
+    }
+
+    #[test]
+    fn runtime_relay_pump_runs_for_configured_relay() {
+        let home = test_home("runtime-configured");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        fs::write(
+            &init.paths.config,
+            "version = \"1\"\ndefault_relay = \"ws://127.0.0.1:8787\"\nrelay_auto_sync = true\n",
+        )
+        .expect("config writes");
+
+        let should_sync =
+            relay_runtime_should_sync_from_paths(&init.paths).expect("relay decision succeeds");
+
+        assert!(should_sync);
+    }
+
+    #[test]
+    fn runtime_relay_pump_respects_auto_sync_disable() {
+        let home = test_home("runtime-disabled");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        fs::write(
+            &init.paths.config,
+            "version = \"1\"\ndefault_relay = \"ws://127.0.0.1:8787\"\nrelay_auto_sync = false\n",
+        )
+        .expect("config writes");
+
+        let should_sync =
+            relay_runtime_should_sync_from_paths(&init.paths).expect("relay decision succeeds");
+
+        assert!(!should_sync);
     }
 
     fn test_home(label: &str) -> PathBuf {

--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -10,14 +10,16 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::state::{self, NodeIdentity, StateError, StatePaths};
-use crate::{agents, messages, sessions};
+use crate::{agents, messages, relay_delivery, sessions};
 
 const STATUS_VERSION: &str = "1";
 const STALE_AFTER_SECS: u64 = 10;
 const LOCAL_ENDPOINT: &str = "file-ipc:runtime/ipc/inbox";
+const RELAY_PUMP_WAIT_MS: u64 = 850;
+const RELAY_PUMP_ERROR_BACKOFF_SECS: u64 = 5;
 
 /// High-level state for the local conUD runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,6 +93,24 @@ pub struct StopReport {
     pub status: RuntimeStatus,
 }
 
+/// Metadata-only summary for one conUD processing tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeProcessReport {
+    pub agents_processed: usize,
+    pub agents_rejected: usize,
+    pub messages_delivered: usize,
+    pub messages_rejected: usize,
+    pub sessions_synced: usize,
+    pub remote_agents_synced: usize,
+    pub relay_attempted: bool,
+    pub relay_connected: bool,
+    pub relay_sent: usize,
+    pub relay_received: usize,
+    pub relay_undelivered: usize,
+    pub relay_rejected: usize,
+    pub relay_error: bool,
+}
+
 /// An acquired local runtime slot.
 #[derive(Debug)]
 pub struct RuntimeLease {
@@ -120,16 +140,50 @@ impl RuntimeLease {
         self.paths.runtime_stop_request.exists()
     }
 
-    /// Sleep and heartbeat until a stop request appears.
-    pub fn serve_until_stop(&self, heartbeat_every: Duration) -> Result<(), RuntimeError> {
-        while !self.stop_requested() {
-            self.heartbeat()?;
+    /// Process local IPC, route/session mirrors, and one bounded relay pump.
+    pub fn process_once(&self, relay_wait: Duration) -> Result<RuntimeProcessReport, RuntimeError> {
+        let agent_report =
             agents::process_gateway_requests_from_paths(&self.paths, &self.node.node_id)
                 .map_err(RuntimeError::Agent)?;
-            messages::process_message_requests_from_paths(&self.paths)
-                .map_err(RuntimeError::Message)?;
-            sessions::sync_remote_sessions_from_paths(&self.paths)
-                .map_err(RuntimeError::Session)?;
+        let message_report = messages::process_message_requests_from_paths(&self.paths)
+            .map_err(RuntimeError::Message)?;
+        let session_report = sessions::sync_remote_sessions_from_paths(&self.paths)
+            .map_err(RuntimeError::Session)?;
+        let mut report = RuntimeProcessReport {
+            agents_processed: agent_report.processed,
+            agents_rejected: agent_report.rejected,
+            messages_delivered: message_report.delivered,
+            messages_rejected: message_report.rejected,
+            sessions_synced: session_report.sessions_synced,
+            remote_agents_synced: session_report.remote_agents_synced,
+            relay_attempted: false,
+            relay_connected: false,
+            relay_sent: 0,
+            relay_received: 0,
+            relay_undelivered: 0,
+            relay_rejected: 0,
+            relay_error: false,
+        };
+
+        self.pump_relay_once(&mut report, relay_wait)?;
+        Ok(report)
+    }
+
+    /// Sleep and heartbeat until a stop request appears.
+    pub fn serve_until_stop(&self, heartbeat_every: Duration) -> Result<(), RuntimeError> {
+        let mut next_relay_attempt = Instant::now();
+
+        while !self.stop_requested() {
+            self.heartbeat()?;
+            if Instant::now() >= next_relay_attempt {
+                let report = self.process_once(Duration::from_millis(RELAY_PUMP_WAIT_MS))?;
+                if report.relay_error {
+                    next_relay_attempt =
+                        Instant::now() + Duration::from_secs(RELAY_PUMP_ERROR_BACKOFF_SECS);
+                }
+            } else {
+                self.process_local_once()?;
+            }
             thread::sleep(heartbeat_every);
         }
 
@@ -170,6 +224,73 @@ impl RuntimeLease {
         self.stopped = true;
 
         Ok(status)
+    }
+
+    fn process_local_once(&self) -> Result<(), RuntimeError> {
+        agents::process_gateway_requests_from_paths(&self.paths, &self.node.node_id)
+            .map_err(RuntimeError::Agent)?;
+        messages::process_message_requests_from_paths(&self.paths)
+            .map_err(RuntimeError::Message)?;
+        sessions::sync_remote_sessions_from_paths(&self.paths).map_err(RuntimeError::Session)?;
+        Ok(())
+    }
+
+    fn pump_relay_once(
+        &self,
+        report: &mut RuntimeProcessReport,
+        wait: Duration,
+    ) -> Result<(), RuntimeError> {
+        match relay_delivery::relay_runtime_should_sync_from_paths(&self.paths) {
+            Ok(true) => {
+                report.relay_attempted = true;
+                match relay_delivery::sync_relay_once_from_paths(
+                    &self.paths,
+                    &self.node.node_id,
+                    wait,
+                ) {
+                    Ok(relay_report) => {
+                        report.relay_connected = relay_report.connected;
+                        report.relay_sent = relay_report.sent;
+                        report.relay_received = relay_report.received;
+                        report.relay_undelivered = relay_report.undelivered;
+                        report.relay_rejected = relay_report.rejected;
+                        if relay_report.sent > 0
+                            || relay_report.received > 0
+                            || relay_report.undelivered > 0
+                            || relay_report.rejected > 0
+                        {
+                            append_log(
+                                &self.paths,
+                                "relay_pump_activity",
+                                self.pid,
+                                &self.node.node_id,
+                            )?;
+                        }
+                    }
+                    Err(_) => {
+                        report.relay_error = true;
+                        append_log(
+                            &self.paths,
+                            "relay_pump_retry",
+                            self.pid,
+                            &self.node.node_id,
+                        )?;
+                    }
+                }
+            }
+            Ok(false) => {}
+            Err(_) => {
+                report.relay_error = true;
+                append_log(
+                    &self.paths,
+                    "relay_pump_retry",
+                    self.pid,
+                    &self.node.node_id,
+                )?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -575,6 +696,19 @@ mod tests {
         assert!(log.contains("payload=not_observed"));
         assert!(!log.contains("private message contents"));
         assert!(!log.contains("Review this code"));
+    }
+
+    #[test]
+    fn process_once_keeps_relay_idle_without_relay_config() {
+        let home = test_home("process-once-relay-idle");
+        let lease = acquire_runtime(Some(home)).expect("runtime starts");
+
+        let report = lease
+            .process_once(Duration::from_millis(1))
+            .expect("runtime tick succeeds");
+
+        assert!(!report.relay_attempted);
+        assert!(!report.relay_error);
     }
 
     #[test]

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -472,7 +472,7 @@ fn render_node_identity(node: &NodeIdentity) -> String {
 
 fn render_config(node: &NodeIdentity) -> String {
     format!(
-        "# conU local config\nversion = \"1\"\nruntime_name = \"{}\"\ndefault_relay = \"\"\n",
+        "# conU local config\nversion = \"1\"\nruntime_name = \"{}\"\ndefault_relay = \"\"\nrelay_auto_sync = true\n",
         escape_file_value(&node.display_name)
     )
 }

--- a/crates/conud/src/main.rs
+++ b/crates/conud/src/main.rs
@@ -75,23 +75,43 @@ fn serve_runtime() -> ExitCode {
 
 fn run_once() -> ExitCode {
     match conu_core::runtime::acquire_runtime(None) {
-        Ok(lease) => match lease.heartbeat().and_then(|_| {
-            conu_core::agents::process_gateway_requests(None)
-                .map_err(conu_core::runtime::RuntimeError::from)?;
-            conu_core::messages::process_message_requests(None)
-                .map_err(conu_core::runtime::RuntimeError::from)?;
-            conu_core::sessions::sync_remote_sessions(None)
-                .map_err(conu_core::runtime::RuntimeError::from)?;
-            lease.stop()
-        }) {
-            Ok(status) => {
-                println!(
-                    "conUD one-shot completed; state {}; payloads not observed",
-                    status.state.as_str()
-                );
-                ExitCode::SUCCESS
-            }
+        Ok(lease) => match lease
+            .heartbeat()
+            .and_then(|_| lease.process_once(Duration::from_millis(250)))
+        {
+            Ok(report) => match lease.stop() {
+                Ok(status) => {
+                    let relay_state = if report.relay_attempted {
+                        if report.relay_error {
+                            "retry_scheduled"
+                        } else if report.relay_connected {
+                            "connected"
+                        } else {
+                            "attempted"
+                        }
+                    } else {
+                        "idle"
+                    };
+
+                    println!(
+                        "conUD one-shot completed; state {}; agents processed {}; messages delivered {}; sessions synced {}; relay {}; relay sent {}; relay received {}; payloads not observed",
+                        status.state.as_str(),
+                        report.agents_processed,
+                        report.messages_delivered,
+                        report.sessions_synced,
+                        relay_state,
+                        report.relay_sent,
+                        report.relay_received
+                    );
+                    ExitCode::SUCCESS
+                }
+                Err(error) => {
+                    eprintln!("conUD one-shot failed: {error}");
+                    ExitCode::from(1)
+                }
+            },
             Err(error) => {
+                println!("conUD one-shot failed before shutdown; payloads not observed");
                 eprintln!("conUD one-shot failed: {error}");
                 ExitCode::from(1)
             }
@@ -159,7 +179,7 @@ fn print_status() -> ExitCode {
 
 fn print_check() {
     println!("{}", conu_core::scaffold_status("conud"));
-    println!("runtime: phase 15 packaging-ready daemon; payloads not observed");
+    println!("runtime: daemon-owned local IPC, sessions, and relay pump; payloads not observed");
 }
 
 fn print_help() {

--- a/docs/internet-relay-test.md
+++ b/docs/internet-relay-test.md
@@ -1,6 +1,6 @@
 # conU Internet Relay Test
 
-This is the practical smoke test for the current relay-backed message MVP. It proves that two conU nodes can exchange public peer cards, trust each other, and move a peer-encrypted message through a WebSocket relay without showing the payload in CLI output or relay logs.
+This is the practical smoke test for the current relay-backed message path. It proves that two conU nodes can exchange public peer cards, trust each other, keep conUD running, and move a peer-encrypted message through a WebSocket relay without showing the payload in CLI output or relay logs.
 
 Current limit: the built-in client supports `ws://` endpoints. For a real internet test, expose the relay port directly or use a tunnel/reverse proxy that accepts TLS publicly and forwards plain WebSocket traffic to `conu-relay`.
 
@@ -29,6 +29,7 @@ Set `default_relay` in each node's `config.toml`:
 ```toml
 version = "1"
 default_relay = "ws://<relay-host>:8787"
+relay_auto_sync = true
 ```
 
 ## 3. Exchange Public Cards
@@ -61,33 +62,30 @@ conu peers trust <node-a-id> "<node-a-name>" --exchange-key <node-a-exchange-key
 
 ## 4. Register Agents
 
+Start conUD on both nodes so the runtime owns local IPC plus relay send/receive:
+
+```powershell
+conu start
+```
+
 On Node A:
 
 ```powershell
 conu agents register agent.a "Agent A" --kind test-agent
-conud --process-ipc
 ```
 
 On Node B:
 
 ```powershell
 conu agents register agent.b "Agent B" --kind test-agent
-conud --process-ipc
 ```
 
 ## 5. Send Through The Relay
 
-On Node B, start a receive sync and keep it open:
-
-```powershell
-conu relay sync --wait-ms 10000
-```
-
-On Node A, queue and flush the message:
+On Node A, queue the message. The running conUD relay pump flushes it and the running Node B conUD receives it:
 
 ```powershell
 "hello over encrypted relay" | conu messages send agent.a agent.b --peer <node-b-id> --stdin
-conu relay sync --wait-ms 3000
 ```
 
 On Node B, inspect the addressed inbox metadata:
@@ -97,6 +95,14 @@ conu messages inbox agent.b --json
 ```
 
 The inbox should show an envelope from `agent.a` to `agent.b` with a byte count and `contentsDisplayed: false`.
+
+If you are testing without a long-running daemon, use the manual fallback: run `conu relay sync --wait-ms 10000` on the receiver while the sender runs `conu relay sync --wait-ms 3000`.
+
+For same-machine validation of the daemon-owned path:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/smoke-relay-daemon.ps1 -Toolchain stable-x86_64-pc-windows-gnu
+```
 
 ## Privacy Checks
 
@@ -112,6 +118,7 @@ Files/logs to spot-check:
 ```powershell
 conu watch
 conu messages receipts --json
+conu relay sync --wait-ms 1000 --json
 ```
 
 The relay and CLI may show node ids, agent ids, envelope ids, byte counts, route labels, and encrypted-body state. They must not show message text, private keys, shared secrets, prompt text, reasoning, files, or tool output.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -55,6 +55,7 @@ logs/messages.log    local delivery events
 logs/sessions.log    remote session sync events
 logs/streams.log     stream lifecycle events
 logs/routes.log      route sync events
+logs/relay-delivery.log relay send/receive events
 ```
 
 All current log files are local text metadata logs. They do not include payload contents.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -14,7 +14,7 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 - Signed local agent cards.
 - Local pairing/trust records with revocation.
 - Metadata-only relay frame contract and standalone WebSocket relay MVP.
-- Peer-card exchange and relay-backed peer-encrypted one-shot message delivery.
+- Peer-card exchange and daemon-pumped relay-backed peer-encrypted one-shot message delivery.
 - Remote session and remote agent metadata mirror for trusted peers.
 - Stream lifecycle metadata, backpressure counters, and private watch animation.
 - Direct QUIC candidate scoring, NAT profile labels, route probes, and relay fallback selection.
@@ -35,7 +35,7 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 
 - File-backed IPC is reliable for development, but not yet a production named-pipe/socket transport.
 - Remote sessions are still metadata mirrors; manual peer-card exchange is the current cross-machine trust path.
-- The relay-backed data plane currently supports one-shot peer-encrypted messages through explicit `conu relay sync`; stream byte routing, reconnect loops, and offline mailbox delivery are not active yet.
+- The relay-backed data plane supports one-shot peer-encrypted messages through the conUD relay pump when a relay or trusted relay peer is configured. Explicit `conu relay sync` remains for manual flush/debug flows. Stream byte routing, persistent relay sessions, hosted relay auth/TLS, and offline mailbox delivery are not active yet.
 - Direct transport is route metadata only. Real QUIC sockets, ICE-style candidate exchange, and NAT hole punching are not active yet.
 - Stream writes count bytes and emit events. They do not persist or relay chunk bytes yet.
 - Pairing is local trust-store groundwork, not full cross-machine rendezvous.
@@ -45,7 +45,7 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 
 ## Release Blockers
 
-- Live relay-backed encrypted stream routing, reconnect loops, and offline mailbox delivery.
+- Live relay-backed encrypted stream routing, persistent relay sessions, hosted retry policy, and offline mailbox delivery.
 - Real direct QUIC transport with peer authentication and NAT traversal.
 - Remote signed agent-card exchange and verification.
 - Capability grants and user-visible permission policy.
@@ -67,6 +67,7 @@ cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
 cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
 cargo +stable-x86_64-pc-windows-gnu test --workspace
 python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py
+powershell -ExecutionPolicy Bypass -File scripts/smoke-relay-daemon.ps1 -Toolchain stable-x86_64-pc-windows-gnu
 conu doctor --json
 git diff --check
 ```
@@ -107,6 +108,6 @@ Each artifact must include only binaries, docs, packaging templates, and `manife
 
 ## Local Release Decision
 
-Current status is `relay_message_mvp_ready_with_known_limits`.
+Current status is `daemon_relay_message_ready_with_known_limits`.
 
-This means a developer can install, initialize, start, pair locally, exchange public peer cards, send a peer-encrypted one-shot message through a reachable `ws://` relay, run readiness checks, and inspect payload-safe logs. It does not mean conU is ready as a hosted public internet network with managed auth, TLS, offline mailbox storage, stream byte routing, or direct QUIC.
+This means a developer can install, initialize, start conUD, pair locally, exchange public peer cards, send a peer-encrypted one-shot message through a reachable `ws://` relay without manual per-message sync, run readiness checks, and inspect payload-safe logs. It does not mean conU is ready as a hosted public internet network with managed auth, TLS, offline mailbox storage, stream byte routing, persistent relay sessions, or direct QUIC.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -7,7 +7,7 @@ Use this checklist before publishing any conU build.
 - Confirm the release version in all Cargo packages.
 - Confirm `plan.md` reflects the completed phase and known gaps.
 - Confirm Phase 14 rooms are not claimed unless implemented.
-- Confirm public internet claims are limited to the current relay message MVP unless hosted relay auth/TLS, reconnect loops, stream byte routing, and direct transport are implemented.
+- Confirm public internet claims are limited to the current daemon-pumped relay message path unless hosted relay auth/TLS, persistent relay sessions, stream byte routing, and direct transport are implemented.
 
 ## Build
 
@@ -35,6 +35,7 @@ cargo test --workspace
 
 ```powershell
 .\scripts\smoke-local.ps1 -Toolchain stable-x86_64-pc-windows-gnu
+.\scripts\smoke-relay-daemon.ps1 -Toolchain stable-x86_64-pc-windows-gnu
 ```
 
 Manual installed smoke:
@@ -49,7 +50,6 @@ conu pair
 conu join <code>
 conu routes sync
 conu identity export
-conu relay sync --wait-ms 1000
 conu connect
 conu stop
 ```
@@ -91,4 +91,4 @@ needs_fix
 blocked
 ```
 
-Current decision target is `relay_message_mvp_ready`. Public hosted/internet release remains blocked until hosted relay auth/TLS, reconnect loops, stream byte routing, direct QUIC, OS-backed key storage, capability policy, and remote signed agent-card exchange are finished.
+Current decision target is `daemon_relay_message_ready`. Public hosted/internet release remains blocked until hosted relay auth/TLS, persistent relay sessions, stream byte routing, direct QUIC, OS-backed key storage, capability policy, and remote signed agent-card exchange are finished.

--- a/docs/sdk-and-mcp.md
+++ b/docs/sdk-and-mcp.md
@@ -92,7 +92,7 @@ The wrapper passes send/stream payload bytes through stdin and returns command o
 
 Route helpers are available as `sync_routes()`, `routes()`, and `route_probes()`. They return route metadata only.
 
-Remote relay helpers are available as `identity_export()`, `trust_peer()`, `send_remote_message()`, and `relay_sync()`. They exchange public peer-card metadata and queue peer-encrypted message bytes without printing payload contents.
+Remote relay helpers are available as `identity_export()`, `trust_peer()`, `send_remote_message()`, and `relay_sync()`. They exchange public peer-card metadata and queue peer-encrypted message bytes without printing payload contents. When conUD is running with relay config, queued remote messages are pumped by the daemon; `relay_sync()` remains useful for manual flush/debug flows.
 
 ## MCP Adapter
 
@@ -154,7 +154,7 @@ Reference: [MCP 2025-11-25 Transports](https://modelcontextprotocol.io/specifica
 ## Current Boundaries
 
 - TypeScript SDK remains future work.
-- Remote relay-backed one-shot message delivery is active through explicit relay sync. Stream byte routing, reconnect loops, offline relay mailbox delivery, and hosted relay auth hardening remain future work.
+- Remote relay-backed one-shot message delivery is active through the conUD relay pump when relay config is present; explicit relay sync remains a manual/debug tool. Stream byte routing, persistent relay sessions, offline relay mailbox delivery, and hosted relay auth hardening remain future work.
 - Route sync selects configured direct QUIC candidates and relay fallback metadata; it does not open a real QUIC socket yet.
 - MCP uses local stdio only; HTTP MCP transport is not implemented.
 - `conu_receive_message` is intentionally explicit because normal CLI and tool metadata views must not display payload contents.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -58,7 +58,7 @@ Message request ids and delivered envelope ids are recorded in `security/replay.
 
 ### Peer Key Agreement Helpers
 
-The security module exposes X25519 key agreement helpers and peer payload encryption helpers used by the relay message MVP. They derive a symmetric key from local exchange material, peer public material, ordered public keys, and context bytes. The derived shared secret is not returned or printed.
+The security module exposes X25519 key agreement helpers and peer payload encryption helpers used by relay message delivery. They derive a symmetric key from local exchange material, peer public material, ordered public keys, and context bytes. The derived shared secret is not returned or printed.
 
 Inbound relay messages are decrypted only after the sender exchange public key matches the locally trusted peer card. The relay sees ciphertext and routing metadata, not plaintext message contents.
 
@@ -87,7 +87,7 @@ Phase 11 hardens the current local product surface, but these items still need d
 
 - OS keychain, DPAPI, Secure Enclave, HSM, or user-managed secret backend for private key protection.
 - Automated key rotation with multi-key read, re-encryption migration, and old-key retirement.
-- Hosted relay auth/TLS hardening, reconnect loops, stream byte routing, and offline relay mailbox delivery.
+- Hosted relay auth/TLS hardening, persistent relay sessions, stream byte routing, and offline relay mailbox delivery.
 - Signed remote agent-card exchange over real sessions instead of derived metadata mirrors.
 - Permission grants that bind trusted peers to specific local agent actions.
 - SDK/MCP permission hardening for multi-tenant or hosted deployments.

--- a/docs/user-install-and-agent-guide.md
+++ b/docs/user-install-and-agent-guide.md
@@ -2,7 +2,7 @@
 
 This guide explains how a user can install the current conU app, start it on their PC, and let local agents use it.
 
-Current version status: Phase 15 is complete for the current local-first app, with an added relay-backed message MVP. conU is usable for local agent registration, local encrypted-at-rest message submission, manual public peer-card exchange, peer-encrypted one-shot relay messages between trusted nodes, stream metadata, trust metadata, direct/relay route metadata, private CLI watch output, Rust SDK calls, a Python wrapper SDK, an MCP stdio adapter, repeatable release builds, service templates, and `conu doctor` readiness checks. It is not yet a managed public hosted internet release.
+Current version status: Phase 15 is complete for the current local-first app, with a relay-backed message path that now runs from conUD when configured. conU is usable for local agent registration, local encrypted-at-rest message submission, manual public peer-card exchange, peer-encrypted one-shot relay messages between trusted nodes, stream metadata, trust metadata, direct/relay route metadata, private CLI watch output, Rust SDK calls, a Python wrapper SDK, an MCP stdio adapter, repeatable release builds, service templates, and `conu doctor` readiness checks. It is not yet a managed public hosted internet release.
 
 ## What Works Today
 
@@ -14,7 +14,7 @@ Current version status: Phase 15 is complete for the current local-first app, wi
 - Store new conU-owned local payload files encrypted at rest.
 - List inbox, receipt, stream, peer, session, and security metadata.
 - Sync and inspect direct QUIC route candidates and relay fallback metadata.
-- Run a standalone `conu-relay` MVP and move peer-encrypted one-shot messages through it.
+- Run a standalone `conu-relay` and let conUD move peer-encrypted one-shot messages through it when relay config or trusted peer relay endpoints exist.
 - Export/import public peer cards for manual cross-machine trust.
 - Let Rust agents use `conu_sdk::ConuClient`.
 - Let Python agents use `sdk/python/conu_sdk`.
@@ -30,7 +30,7 @@ Current version status: Phase 15 is complete for the current local-first app, wi
 - No hosted relay service, TLS client, or managed public relay auth yet. The current client supports reachable `ws://` relay endpoints.
 - No real QUIC socket or NAT hole punching yet; Phase 13 selects configured direct route candidates and relay fallback metadata.
 - Pairing and remote sessions are local metadata groundwork, not full cross-machine rendezvous.
-- Relay-backed one-shot message delivery exists through `conu relay sync`; long-running reconnect loops, stream byte routing, and offline mailbox delivery are not implemented yet.
+- Relay-backed one-shot message delivery exists through the conUD relay pump; persistent relay sessions, stream byte routing, hosted relay auth/TLS, and offline mailbox delivery are not implemented yet.
 - Service templates exist, but users still need to install/register them for their platform.
 - Local private keys are file-backed today; OS keychain/DPAPI/HSM support is still a release blocker.
 
@@ -233,6 +233,7 @@ To test a direct route candidate, add a direct endpoint to `config.toml`:
 
 ```toml
 default_relay = "ws://127.0.0.1:8787"
+relay_auto_sync = true
 nat_profile = "public"
 direct_quic_endpoint = "quic://127.0.0.1:9443"
 ```
@@ -254,24 +255,24 @@ $env:CONU_RELAY_TOKEN = "local-dev-token"
 conu-relay --serve 0.0.0.0:8787
 ```
 
-On each node, set `default_relay` in `config.toml` or pass the relay endpoint when trusting a peer. Then exchange public cards:
+On each node, set `default_relay` in `config.toml` or pass the relay endpoint when trusting a peer. `relay_auto_sync = true` is the default for new state and lets conUD pump relay send/receive automatically when a relay route is configured. Then exchange public cards:
 
 ```powershell
 conu identity export --json
 conu peers trust <peer-node-id> "<peer name>" --exchange-key <exchange-public-key-hex> --relay ws://<relay-host>:8787
 ```
 
-Register a local agent on each side. On the receiving node, keep a sync open:
+Start conUD and register a local agent on each side:
 
 ```powershell
-conu relay sync --wait-ms 10000
+conu start
+conu agents register agent.local "Local Agent" --kind test-agent
 ```
 
 On the sender:
 
 ```powershell
 "opaque bytes for the remote agent" | conu messages send agent.sender agent.remote --peer <receiver-node-id> --stdin
-conu relay sync --wait-ms 3000
 ```
 
 On the receiver:
@@ -280,7 +281,7 @@ On the receiver:
 conu messages inbox agent.remote --json
 ```
 
-The relay sync command shows counts and route metadata only. It does not show message contents. For a full two-terminal walkthrough, see `docs/internet-relay-test.md`.
+The running daemon performs relay send/receive in bounded sync windows and retries on failures. The explicit `conu relay sync` command still exists for manual flushes, debugging, or daemonless scripts; it shows counts and route metadata only. It does not show message contents. For a full two-terminal walkthrough, see `docs/internet-relay-test.md`.
 
 ## Give conU To An Agent
 
@@ -317,7 +318,7 @@ Rules:
 - Exchange public peer cards with conu_export_identity and conu_trust_peer when setting up remote trust.
 - Sync and inspect route metadata with conu_sync_routes and conu_list_routes.
 - Send opaque bytes with conu_send_message.
-- Send remote peer-encrypted bytes with conu_send_remote_message, then call conu_relay_sync.
+- Send remote peer-encrypted bytes with conu_send_remote_message while conUD is running; call conu_relay_sync only for manual flush/debug flows.
 - Read inbox metadata first; request payloadHex only with conu_receive_message when you are the addressed local agent.
 - Use conu_open_stream, conu_write_stream, and conu_close_stream for stream metadata flows.
 - Treat conU as the road, not the conversation.
@@ -390,7 +391,9 @@ Rules:
   conu peers trust <peer-node-id> <display-name> --exchange-key <hex> --relay <ws://host:port>
 - Send remote payload bytes through stdin only:
   <payload bytes> | conu messages send <your-agent-id> <target-agent-id> --peer <peer-node-id> --stdin
-- Flush/receive relay envelopes:
+- Keep conUD running for relay delivery:
+  conu start
+- Optional manual flush/receive:
   conu relay sync --wait-ms 3000
 - Never expect conU CLI output to show message contents.
 - Treat conU as the road, not the conversation.
@@ -418,7 +421,7 @@ These are not hidden bugs; they are the honest state of the current app:
 | Runtime discovery | `conu start` needs `conud` beside `conu` or on PATH | Start can fail after manual binary moves | Install both with Cargo or set `CONUD_EXE` |
 | Agent API | Rust SDK, Python wrapper, and MCP adapter exist; TypeScript is later | Most agents can integrate now, TS apps need wrapper work | Use MCP, Rust SDK, Python SDK, or CLI/stdin |
 | Receiving payloads | CLI intentionally lists inbox metadata only | Agents needing bytes must use explicit receive APIs | Use Rust SDK `receive_message_bytes` or MCP `conu_receive_message` with `includePayload` |
-| Internet messaging | One-shot relay messages work through explicit sync, but no hosted relay/TLS client/reconnect loop exists | Users can test over reachable `ws://`; managed public network is not ready | Run `conu-relay` yourself or expose it through a tunnel/reverse proxy that terminates TLS before conU |
+| Internet messaging | One-shot relay messages work through the conUD relay pump, but no hosted relay/TLS client, persistent relay session, stream byte routing, or offline mailbox exists | Users can test over reachable `ws://`; managed public network is not ready | Run `conu-relay` yourself or expose it through a tunnel/reverse proxy that terminates TLS before conU |
 | Direct transport | Route selection exists, but real QUIC sockets and NAT hole punching do not | Direct routes show as metadata only | Configure direct endpoints for route scoring tests |
 | Pairing | Pair/join are local trust groundwork | Not real cross-machine pairing yet | Use for metadata/trust testing |
 | Service install | Service templates exist but need local edits/admin steps | User must choose service path/user | Use `packaging/windows`, `packaging/linux`, or `packaging/macos` templates |
@@ -461,7 +464,7 @@ conu messages inbox agent.b --json
 To make conU genuinely useful over the internet, the next phase should build:
 
 - Rooms, pub/sub, and multi-agent session metadata.
-- Hosted relay auth/TLS hardening, reconnect loops, offline mailbox, and stream byte delivery.
+- Hosted relay auth/TLS hardening, persistent relay sessions, offline mailbox, and stream byte delivery.
 - Real QUIC socket transport and NAT candidate exchange after the room/session model is stable.
 - TypeScript SDK after the protocol surface stabilizes.
 - Signed installers and OS keychain-backed secret storage after local packaging stabilizes.

--- a/plan.md
+++ b/plan.md
@@ -31,7 +31,7 @@ needs_revision
 Current phase: Phase 14 - Rooms, Pub/Sub, And Multi-Agent Sessions
 Status: not_started
 Last updated: 2026-05-11
-Note: Phase 15 was completed as a user-directed skip-ahead; a post-Phase-15 relay message MVP and CLI polish pass is complete; Phase 14 remains not started.
+Note: Phase 15 was completed as a user-directed skip-ahead; post-Phase-15 relay data-plane, CLI polish, and daemon relay hardening passes are complete; Phase 14 remains not started.
 ```
 
 ## Phase 0 - Project Memory
@@ -1278,7 +1278,7 @@ Validation:
 Known gaps:
 
 - The relay client supports `ws://`; public `wss://` requires a TLS terminator/reverse proxy in front of `conu-relay`.
-- Relay sync is explicit/one-shot today; no long-running reconnect loop or service-owned relay pump is active.
+- Superseded by the daemon relay production hardening pass below: conUD now owns bounded relay sync windows when configured.
 - Relay-backed stream byte routing, offline mailbox delivery, hosted relay auth/rate limits, direct QUIC sockets, NAT traversal, signed remote agent-card exchange, capability policy, and OS-backed key storage remain future work.
 - Phase 14 rooms/pub-sub remains not started.
 
@@ -1286,6 +1286,70 @@ Next recommendation:
 
 - For user testing, run `docs/internet-relay-test.md` locally or over a reachable `ws://` relay.
 - For product hardening, add a conUD-owned relay pump with reconnect/backoff, then stream byte routing and hosted relay auth/TLS strategy.
+
+## Post Phase 15 Daemon Relay Production Hardening
+
+Status: completed
+
+Goal:
+
+Move the relay message path beyond manual MVP sync by letting conUD own bounded relay send/receive windows while preserving payload opacity and adding daemon-level end-to-end smoke coverage.
+
+Completed work:
+
+- Created GitHub issue #36 and branch `codex/relay-daemon-production-hardening`.
+- Added `relay_auto_sync = true` to new local config files.
+- Added conUD runtime processing reports and a daemon relay pump that runs when a relay endpoint or trusted relay peer is configured.
+- Added relay pump retry/backoff behavior so relay connection failures do not crash conUD or block local IPC forever.
+- Kept relay pump logs metadata-only with `payload=not_observed` in runtime logs and encrypted-body-only relay delivery logs.
+- Added `scripts/smoke-relay-daemon.ps1`, which starts a local relay, two isolated conUD runtimes, registers two agents, sends a peer-encrypted remote message without manual `conu relay sync`, waits for delivery, and scans conU-owned state for payload leaks.
+- Hardened Windows daemon launching by routing `conu start` through a no-window background start path.
+- Updated README, user guide, internet relay test, production readiness, SDK/MCP docs, release checklist, observability docs, repo memory, guardrails, repo map, agent gateway contract, and security checklist.
+
+Files changed:
+
+- `README.md`
+- `docs/internet-relay-test.md`
+- `docs/user-install-and-agent-guide.md`
+- `docs/sdk-and-mcp.md`
+- `docs/production-readiness.md`
+- `docs/release-checklist.md`
+- `docs/observability.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/agent-gateway-contract.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `.agents/skills/conu-repo-steward/references/repo-map.md`
+- `.agents/skills/conu-security-guardian/references/privacy-security-checklist.md`
+- `crates/conu-cli/src/lib.rs`
+- `crates/conu-core/src/relay_delivery.rs`
+- `crates/conu-core/src/runtime.rs`
+- `crates/conu-core/src/state.rs`
+- `crates/conud/src/main.rs`
+- `scripts/smoke-relay-daemon.ps1`
+- `plan.md`
+
+Validation:
+
+- `cargo fmt --all -- --check` passed.
+- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings` passed.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed.
+- `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py` passed.
+- `powershell -ExecutionPolicy Bypass -File scripts/smoke-local.ps1 -Toolchain stable-x86_64-pc-windows-gnu` passed.
+- `powershell -ExecutionPolicy Bypass -File scripts/smoke-relay-daemon.ps1 -Toolchain stable-x86_64-pc-windows-gnu` passed and confirmed daemon-owned relay delivery without manual sync.
+- `powershell -ExecutionPolicy Bypass -File scripts/build-release.ps1 -Profile release -Toolchain stable-x86_64-pc-windows-gnu` passed and created `dist/conu-0.1.0-host.zip`.
+- `git diff --check` passed.
+
+Known gaps:
+
+- Relay pump uses bounded reconnect/sync windows, not a single long-lived persistent relay session.
+- Public `wss://` still requires a TLS terminator/reverse proxy in front of `conu-relay`.
+- Relay-backed stream byte routing, offline mailbox delivery, hosted relay auth/rate limits, direct QUIC sockets, NAT traversal, signed remote agent-card exchange, capability policy, and OS-backed key storage remain future work.
+- Phase 14 rooms/pub-sub remains not started.
+
+Next recommendation:
+
+- Run full validation, merge the daemon relay hardening branch, then choose between Phase 14 rooms/pub-sub or deeper hosted relay auth/TLS plus persistent relay session work.
 
 ## Phase Completion Log
 
@@ -1310,4 +1374,5 @@ Add entries here when a phase is completed.
 2026-05-11 - Phase 15 completed as a user-directed skip-ahead. Added doctor readiness checks, release/smoke scripts, packaging templates, CI/release workflows, release checklist, observability docs, strict local-install smoke validation, and GNU-toolchain release validation. Phase 14 remains not started.
 2026-05-11 - Post Phase 15 audit completed. Added clippy-clean polish across runtime, CLI, MCP, CI, and docs while preserving payload privacy and leaving Phase 14 not started.
 2026-05-11 - Post Phase 15 internet data-plane and CLI polish completed. Added public peer-card trust, peer-encrypted relay message queueing, explicit relay sync, richer watch animation, SDK/Python/MCP remote helpers, relay E2E tests, and internet relay test docs. Phase 14 remains not started.
+2026-05-11 - Post Phase 15 daemon relay production hardening completed. Added conUD-owned relay pump, retry/backoff, relay daemon smoke script, Windows start hardening, docs/skill updates, and daemon-owned remote message validation. Phase 14 remains not started.
 ```

--- a/scripts/smoke-relay-daemon.ps1
+++ b/scripts/smoke-relay-daemon.ps1
@@ -1,0 +1,280 @@
+param(
+    [string]$Conu = "target/debug/conu.exe",
+    [string]$Conud = "target/debug/conud.exe",
+    [string]$ConuRelay = "target/debug/conu-relay.exe",
+    [string]$Toolchain = $env:CONU_RUST_TOOLCHAIN,
+    [int]$RelayPort = 0,
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+$repo = Resolve-Path (Join-Path $PSScriptRoot "..")
+$smokeRoot = Join-Path $env:TEMP ("conu-relay-daemon-smoke-" + [guid]::NewGuid().ToString("N"))
+$homeA = Join-Path $smokeRoot "node-a"
+$homeB = Join-Path $smokeRoot "node-b"
+$relayProcess = $null
+$conudProcessA = $null
+$conudProcessB = $null
+$previousRelayToken = $env:CONU_RELAY_TOKEN
+
+function Invoke-SmokeCommand {
+    param(
+        [string]$Name,
+        [scriptblock]$Command
+    )
+
+    & $Command | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Smoke command failed: $Name exited with code $LASTEXITCODE"
+    }
+}
+
+function Get-FreeTcpPort {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $listener.Start()
+    try {
+        return $listener.LocalEndpoint.Port
+    }
+    finally {
+        $listener.Stop()
+    }
+}
+
+function Invoke-Conu {
+    param(
+        [string]$StateHome,
+        [string[]]$Arguments,
+        [string]$InputText = $null
+    )
+
+    $oldHome = $env:CONU_HOME
+    $oldConud = $env:CONUD_EXE
+    try {
+        $env:CONU_HOME = $StateHome
+        $env:CONUD_EXE = $script:ConudPath
+        if ($null -eq $InputText) {
+            $output = & $script:ConuPath @Arguments
+        } else {
+            $output = $InputText | & $script:ConuPath @Arguments
+        }
+        if ($LASTEXITCODE -ne 0) {
+            throw "conu $($Arguments -join ' ') failed with code $LASTEXITCODE`n$($output -join "`n")"
+        }
+        return ($output -join "`n")
+    }
+    finally {
+        if ($null -eq $oldHome) {
+            Remove-Item Env:CONU_HOME -ErrorAction SilentlyContinue
+        } else {
+            $env:CONU_HOME = $oldHome
+        }
+        if ($null -eq $oldConud) {
+            Remove-Item Env:CONUD_EXE -ErrorAction SilentlyContinue
+        } else {
+            $env:CONUD_EXE = $oldConud
+        }
+    }
+}
+
+function Invoke-ConuJson {
+    param(
+        [string]$StateHome,
+        [string[]]$Arguments,
+        [string]$InputText = $null
+    )
+
+    $json = Invoke-Conu -StateHome $StateHome -Arguments $Arguments -InputText $InputText
+    return $json | ConvertFrom-Json
+}
+
+function Write-ConuConfig {
+    param(
+        [string]$StateHome,
+        [string]$Endpoint,
+        [string]$Name
+    )
+
+    $config = @"
+version = "1"
+runtime_name = "$Name"
+default_relay = "$Endpoint"
+relay_auto_sync = true
+"@
+    Set-Content -LiteralPath (Join-Path $StateHome "config.toml") -Value $config -Encoding ASCII
+}
+
+function Stop-ConuRuntime {
+    param(
+        [string]$StateHome,
+        [System.Diagnostics.Process]$Process = $null
+    )
+
+    try {
+        Invoke-Conu -StateHome $StateHome -Arguments @("stop") | Out-Null
+    }
+    catch {
+    }
+    if ($null -ne $Process) {
+        try {
+            if (-not $Process.WaitForExit(5000)) {
+                Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+            }
+        }
+        catch {
+        }
+    }
+}
+
+function Start-ConuRuntime {
+    param([string]$StateHome)
+
+    $oldHome = $env:CONU_HOME
+    $oldConud = $env:CONUD_EXE
+    try {
+        $env:CONU_HOME = $StateHome
+        $env:CONUD_EXE = $script:ConudPath
+        $process = Start-Process -FilePath $script:ConudPath -ArgumentList @("--serve") -WindowStyle Hidden -PassThru
+    }
+    finally {
+        if ($null -eq $oldHome) {
+            Remove-Item Env:CONU_HOME -ErrorAction SilentlyContinue
+        } else {
+            $env:CONU_HOME = $oldHome
+        }
+        if ($null -eq $oldConud) {
+            Remove-Item Env:CONUD_EXE -ErrorAction SilentlyContinue
+        } else {
+            $env:CONUD_EXE = $oldConud
+        }
+    }
+
+    for ($i = 0; $i -lt 30; $i++) {
+        Start-Sleep -Milliseconds 100
+        $status = Invoke-ConuJson -StateHome $StateHome -Arguments @("status", "--json")
+        if ($status.runtime.conud -eq "running") {
+            return $process
+        }
+    }
+
+    throw "conUD did not publish a running heartbeat for $StateHome"
+}
+
+function Wait-ForInbox {
+    param(
+        [string]$StateHome,
+        [string]$AgentId,
+        [int]$TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $inbox = Invoke-ConuJson -StateHome $StateHome -Arguments @("messages", "inbox", $AgentId, "--json")
+        if ($inbox.messages.Count -gt 0) {
+            return $inbox
+        }
+        Start-Sleep -Milliseconds 500
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Timed out waiting for relay-delivered inbox entry for $AgentId"
+}
+
+Push-Location $repo
+try {
+    if (-not $SkipBuild -and $Conu -eq "target/debug/conu.exe" -and $Conud -eq "target/debug/conud.exe" -and $ConuRelay -eq "target/debug/conu-relay.exe") {
+        Invoke-SmokeCommand "cargo build" {
+            if (-not [string]::IsNullOrWhiteSpace($Toolchain)) {
+                cargo "+$Toolchain" build --workspace
+            } else {
+                cargo build --workspace
+            }
+        }
+    }
+
+    $script:ConuPath = (Resolve-Path $Conu).Path
+    $script:ConudPath = (Resolve-Path $Conud).Path
+    $script:RelayPath = (Resolve-Path $ConuRelay).Path
+
+    if ($RelayPort -eq 0) {
+        $RelayPort = Get-FreeTcpPort
+    }
+    $relayEndpoint = "ws://127.0.0.1:$RelayPort"
+    $env:CONU_RELAY_TOKEN = "local-dev-token"
+
+    New-Item -ItemType Directory -Force -Path $homeA, $homeB | Out-Null
+    $relayProcess = Start-Process -FilePath $script:RelayPath -ArgumentList @("--serve", "127.0.0.1:$RelayPort") -WindowStyle Hidden -PassThru
+    Start-Sleep -Milliseconds 750
+    if ($relayProcess.HasExited) {
+        throw "conu-relay exited early with code $($relayProcess.ExitCode)"
+    }
+    Write-Host "relay started at $relayEndpoint"
+
+    Invoke-Conu -StateHome $homeA -Arguments @("init") | Out-Null
+    Invoke-Conu -StateHome $homeB -Arguments @("init") | Out-Null
+    Write-ConuConfig -StateHome $homeA -Endpoint $relayEndpoint -Name "node-a"
+    Write-ConuConfig -StateHome $homeB -Endpoint $relayEndpoint -Name "node-b"
+    Write-Host "nodes initialized"
+
+    $cardA = Invoke-ConuJson -StateHome $homeA -Arguments @("identity", "export", "--json")
+    $cardB = Invoke-ConuJson -StateHome $homeB -Arguments @("identity", "export", "--json")
+
+    Invoke-Conu -StateHome $homeA -Arguments @("peers", "trust", $cardB.nodeId, $cardB.displayName, "--exchange-key", $cardB.exchangePublicKeyHex, "--relay", $relayEndpoint) | Out-Null
+    Invoke-Conu -StateHome $homeB -Arguments @("peers", "trust", $cardA.nodeId, $cardA.displayName, "--exchange-key", $cardA.exchangePublicKeyHex, "--relay", $relayEndpoint) | Out-Null
+    Write-Host "peer cards trusted"
+
+    $conudProcessA = Start-ConuRuntime -StateHome $homeA
+    $conudProcessB = Start-ConuRuntime -StateHome $homeB
+    Write-Host "conUD runtimes started"
+    Invoke-Conu -StateHome $homeA -Arguments @("agents", "register", "agent.daemon.a", "Daemon Agent A", "--kind", "smoke") | Out-Null
+    Invoke-Conu -StateHome $homeB -Arguments @("agents", "register", "agent.daemon.b", "Daemon Agent B", "--kind", "smoke") | Out-Null
+    Write-Host "agents registered"
+
+    $secret = "daemon relay smoke " + [guid]::NewGuid().ToString("N")
+    $send = Invoke-ConuJson -StateHome $homeA -Arguments @("messages", "send", "agent.daemon.a", "agent.daemon.b", "--peer", $cardB.nodeId, "--stdin", "--json") -InputText $secret
+    if ($send.status -ne "queued_remote") {
+        throw "Expected queued_remote status, got $($send.status)"
+    }
+    Write-Host "remote message queued"
+
+    $inbox = Wait-ForInbox -StateHome $homeB -AgentId "agent.daemon.b" -TimeoutSeconds 30
+    Write-Host "remote message delivered"
+    $delivered = @($inbox.messages)[0]
+    if ($delivered.fromAgentId -ne "agent.daemon.a" -or $delivered.toAgentId -ne "agent.daemon.b") {
+        throw "Relay inbox metadata did not match expected agents"
+    }
+    if ($inbox.contentsDisplayed -ne $false) {
+        throw "Relay inbox did not preserve contentsDisplayed=false"
+    }
+
+    $watch = Invoke-Conu -StateHome $homeB -Arguments @("watch")
+    if ($watch.Contains($secret)) {
+        throw "Watch output leaked the smoke payload"
+    }
+
+    $leaks = Get-ChildItem -LiteralPath $smokeRoot -Recurse -File | Select-String -SimpleMatch $secret
+    if ($null -ne $leaks) {
+        throw "Smoke payload appeared in conU-owned state"
+    }
+
+    Write-Host "conU relay daemon smoke passed"
+    Write-Host "relay=$relayEndpoint"
+    Write-Host "nodeA=$homeA"
+    Write-Host "nodeB=$homeB"
+}
+finally {
+    Stop-ConuRuntime -StateHome $homeA -Process $conudProcessA
+    Stop-ConuRuntime -StateHome $homeB -Process $conudProcessB
+    if ($null -ne $relayProcess -and -not $relayProcess.HasExited) {
+        Stop-Process -Id $relayProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+    if ($null -eq $previousRelayToken) {
+        Remove-Item Env:CONU_RELAY_TOKEN -ErrorAction SilentlyContinue
+    } else {
+        $env:CONU_RELAY_TOKEN = $previousRelayToken
+    }
+    $resolvedSmoke = Resolve-Path $smokeRoot -ErrorAction SilentlyContinue
+    if ($null -ne $resolvedSmoke -and $resolvedSmoke.Path.StartsWith([System.IO.Path]::GetTempPath(), [System.StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $resolvedSmoke.Path -Recurse -Force
+    }
+    Pop-Location
+}


### PR DESCRIPTION
## **User description**
Closes #36.\n\n## Summary\n- add a conUD-owned relay pump that runs bounded send/receive sync windows when relay config or trusted relay peer endpoints exist\n- add relay auto-sync config, runtime retry/backoff metadata, and payload-safe relay pump logging\n- add a relay-daemon smoke script that starts a relay plus two conUD runtimes and verifies remote encrypted delivery without manual relay sync\n- update CLI copy, docs, release checklist, plan, and future-agent skills for the production relay flow\n\n## Validation\n- cargo fmt --all -- --check\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu test --workspace\n- python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py\n- powershell -ExecutionPolicy Bypass -File scripts/smoke-local.ps1 -Toolchain stable-x86_64-pc-windows-gnu\n- powershell -ExecutionPolicy Bypass -File scripts/smoke-relay-daemon.ps1 -Toolchain stable-x86_64-pc-windows-gnu\n- powershell -ExecutionPolicy Bypass -File scripts/build-release.ps1 -Profile release -Toolchain stable-x86_64-pc-windows-gnu\n- git diff --check\n\n## Security\n- relay pump logs only metadata and payload=not_observed\n- relay bodies remain peer-encrypted ciphertext only\n- smoke script scans conU-owned state for the test payload and fails on leakage


___

## **CodeAnt-AI Description**
**Let conUD deliver relay messages automatically when relay settings are present**

### What Changed
- conUD now checks for configured relay routes and sends/receives queued relay messages during normal runtime, so users no longer need to run `conu relay sync` for every message
- If relay delivery fails, conUD keeps running and retries later instead of stopping relay-backed message flow
- `conu start`, status output, docs, and readiness checks now describe the automatic relay pump and keep `conu relay sync` as a manual fallback
- Added a relay daemon smoke test that starts two runtimes, sends a peer-encrypted message, and verifies delivery without exposing message text

### Impact
`✅ Fewer manual relay sync steps`
`✅ More reliable remote message delivery`
`✅ Clearer relay startup and status output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=3IuoVdXVozgzznzNfoDjTN87OvI5zC-mN_74rjT1M7g&org=imthegoodboy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
