### PR TITLE
Add CI package validation

### DIFF
--- a/.agents/repo/ABOUT.md
+++ b/.agents/repo/ABOUT.md
@@ -88,7 +88,7 @@ Implemented so far:
 - release build scripts under `scripts/`
 - packaging templates under `packaging/`, including Windows install, Linux systemd, macOS launchd, Docker relay, and npm launcher templates
 - platform-named release artifacts with SHA-256 checksum support
-- GitHub CI and release artifact workflows
+- GitHub CI and release artifact workflows, including Rust OS-matrix checks plus TypeScript SDK and npm launcher package checks
 - release checklist and observability docs
 - payload-safe status and agent registry reporting
 - payload-safe runtime and agent metadata logs

--- a/.agents/skills/conu-builder/references/implementation-guardrails.md
+++ b/.agents/skills/conu-builder/references/implementation-guardrails.md
@@ -184,7 +184,7 @@ Do not add proc-macro/build-script-heavy dependencies unless validation can stil
 - Windows service, Linux systemd, and macOS launchd files are templates until a signed installer configures platform-specific users and paths.
 - Docker relay templates are acceptable for controlled self-hosted tests. Relay clients accept `wss://` through platform TLS verification, but the bundled relay server still requires TLS termination in front of it; public hosted relay claims still require managed account auth, online credential issuance APIs, distributed hosted monitoring/accounting, and distributed hosted session state.
 - A local release may be marked ready only with documented limits. Do not claim public hosted internet readiness until hosted account auth, distributed hosted session state, distributed hosted accounting dashboards, hosted mailbox retention policy, multi-tenant hosted permission administration, and non-Windows OS-backed key storage are implemented.
-- CI/release workflows must run metadata-only checks and must not upload conU state directories or logs as artifacts.
+- CI/release workflows must run metadata-only checks, including package checks for `sdk/typescript` and `packaging/npm/conu-cli`, and must not upload conU state directories or logs as artifacts.
 
 ## Privacy Rules
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,19 @@ on:
   pull_request:
 
 jobs:
+  packages:
+    name: Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: TypeScript SDK check
+        run: npm run check --prefix sdk/typescript
+      - name: npm launcher check
+        run: npm run check --prefix packaging/npm/conu-cli
+
   rust:
     name: Rust (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -13,6 +13,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use conu_protocol::OpaquePayload;
@@ -867,7 +868,13 @@ fn drain_relay_frames(
     while start.elapsed() < wait {
         match client.read()? {
             Some(frame) => handle_relay_frame(paths, report, frame)?,
-            None => break,
+            None => {
+                let remaining = wait.saturating_sub(start.elapsed());
+                if remaining.is_zero() {
+                    break;
+                }
+                thread::sleep(remaining.min(Duration::from_millis(25)));
+            }
         }
     }
 

--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -1901,7 +1901,11 @@ impl RelayHubState {
         }
 
         for (node_id, mut envelopes) in loaded {
-            envelopes.sort_by_key(|envelope| envelope.queued_at_millis);
+            envelopes.sort_by(|left, right| {
+                left.queued_at_nanos
+                    .cmp(&right.queued_at_nanos)
+                    .then_with(|| left.forwarded.envelope_id.cmp(&right.forwarded.envelope_id))
+            });
             while envelopes.len() > policy.max_envelopes_per_node {
                 if let Some(entry) = envelopes.pop() {
                     remove_entry_storage(&entry).map_err(|error| {
@@ -1953,8 +1957,10 @@ impl RelayHubState {
             return Err("mailbox_full");
         }
 
+        let queued_at_nanos = current_unix_nanos();
         let mut envelope = QueuedRelayEnvelope {
-            queued_at_millis: current_unix_millis(),
+            queued_at_millis: queued_at_nanos / 1_000_000,
+            queued_at_nanos,
             storage_path: None,
             forwarded,
         };
@@ -2156,6 +2162,7 @@ impl RelayAccountingRecord {
 #[derive(Debug)]
 struct QueuedRelayEnvelope {
     queued_at_millis: u128,
+    queued_at_nanos: u128,
     storage_path: Option<PathBuf>,
     forwarded: RelayForwarded,
 }
@@ -2427,7 +2434,7 @@ fn persist_mailbox_entry(
     fs::create_dir_all(&node_dir).map_err(|_| "mailbox_unavailable")?;
     let path = node_dir.join(format!(
         "{}-{}.mailbox",
-        current_unix_nanos(),
+        entry.queued_at_nanos,
         sanitize_identifier(&entry.forwarded.envelope_id)
     ));
     let contents = render_mailbox_file(entry);
@@ -2447,8 +2454,8 @@ fn render_mailbox_file(entry: &QueuedRelayEnvelope) -> String {
         entry.forwarded.clone(),
     )));
     format!(
-        "version = \"{}\"\nqueued_at_millis = {}\nframe = {}\npayload_displayed = false\n",
-        RELAY_MAILBOX_FILE_VERSION, entry.queued_at_millis, frame
+        "version = \"{}\"\nqueued_at_millis = {}\nqueued_at_nanos = {}\nframe = {}\npayload_displayed = false\n",
+        RELAY_MAILBOX_FILE_VERSION, entry.queued_at_millis, entry.queued_at_nanos, frame
     )
 }
 
@@ -2462,6 +2469,10 @@ fn read_mailbox_file(path: &Path) -> Result<Option<QueuedRelayEnvelope>, RelayEr
     let queued_at_millis = mailbox_value(&contents, "queued_at_millis")
         .and_then(|value| value.parse::<u128>().ok())
         .ok_or_else(|| RelayError::Protocol("relay mailbox entry is invalid".to_string()))?;
+    let queued_at_nanos = mailbox_value(&contents, "queued_at_nanos")
+        .and_then(|value| value.parse::<u128>().ok())
+        .or_else(|| mailbox_file_sequence(path))
+        .unwrap_or_else(|| queued_at_millis.saturating_mul(1_000_000));
     let frame = mailbox_value(&contents, "frame")
         .ok_or_else(|| RelayError::Protocol("relay mailbox entry is invalid".to_string()))?;
     let forwarded = match parse_server_frame(&frame) {
@@ -2474,9 +2485,17 @@ fn read_mailbox_file(path: &Path) -> Result<Option<QueuedRelayEnvelope>, RelayEr
 
     Ok(Some(QueuedRelayEnvelope {
         queued_at_millis,
+        queued_at_nanos,
         storage_path: Some(path.to_path_buf()),
         forwarded,
     }))
+}
+
+fn mailbox_file_sequence(path: &Path) -> Option<u128> {
+    path.file_stem()
+        .and_then(|value| value.to_str())
+        .and_then(|value| value.split_once('-').map(|(sequence, _)| sequence))
+        .and_then(|value| value.parse::<u128>().ok())
 }
 
 fn persist_accounting_record(

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -52,7 +52,7 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 - Linux systemd and macOS launchd service templates.
 - Docker relay hosting template.
 - npm native launcher package template under `packaging/npm/conu-cli`.
-- GitHub CI and release artifact workflows.
+- GitHub CI and release artifact workflows, including Rust matrix checks, Python wrapper compile, TypeScript SDK check, and npm launcher check.
 - Release checklist and observability docs.
 - Payload-safe logs, receipts, watch output, and CLI JSON.
 - Phase 11 security audit command, Phase 12 SDK/MCP receive path, Phase 13 route manager, and Phase 15 packaging layer.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -112,7 +112,7 @@ conu stop
 
 ## GitHub
 
-- CI passed on pull request or equivalent local validation is recorded.
+- CI passed on pull request or equivalent local validation is recorded, including the Rust OS matrix and the package job for `sdk/typescript` plus `packaging/npm/conu-cli`.
 - PR body lists validation commands.
 - GitHub Release has platform-named archives plus matching `.sha256` files before npm publishing.
 - `@conu/cli` is published only after the matching GitHub Release assets are available.

--- a/plan.md
+++ b/plan.md
@@ -31,7 +31,7 @@ needs_revision
 Current phase: Phase 14 - Rooms, Pub/Sub, And Multi-Agent Sessions
 Status: completed
 Last updated: 2026-05-21
-Note: Phase 14 and Phase 15 are complete for the current local-first app. Post-Phase-15 relay data-plane, CLI polish, daemon relay hardening, distribution/hosting, Phase 14 local rooms/pub-sub, relay abuse-control, reusable daemon relay-session, same-process same-node relay-session resume, public-bind token-guard, `wss://` relay-client, static scoped relay credential/session-policy, offline scoped relay credential issuance, relay credential manifest upsert/rotate/revoke helpers, live-reloaded hashed relay credential manifest, relay accounting/quotas, direct route selection guard, payload-safe local log rotation, structured telemetry snapshot, identity-key rotation with peer-card refresh, identity archive retirement after peer-card refresh, storage-key rotation/re-encryption migration, storage-key retirement, relay-backed stream-chunk, relay-backed room-event fanout, room topic policy, bounded offline relay mailbox, durable relay mailbox storage, durable mailbox FIFO reload ordering, Windows DPAPI secret wrapping, stored relay client credential, signed peer-card, local capability-enforcement, signed remote agent-card, peer-scoped permission-policy, automatic encrypted signed agent-card exchange, TypeScript/JavaScript SDK wrapper, and GitHub CI package-validation passes are complete. Public hosted internet readiness remains scoped by the known managed hosted account auth, online credential issuance APIs, distributed hosted session state, distributed hosted accounting/dashboards, direct transport, multi-tenant hosted permission administration, managed hosted identity/key administration, and non-Windows keychain gaps.
+Note: Phase 14 and Phase 15 are complete for the current local-first app. Post-Phase-15 relay data-plane, CLI polish, daemon relay hardening, distribution/hosting, Phase 14 local rooms/pub-sub, relay abuse-control, reusable daemon relay-session, same-process same-node relay-session resume, public-bind token-guard, `wss://` relay-client, static scoped relay credential/session-policy, offline scoped relay credential issuance, relay credential manifest upsert/rotate/revoke helpers, live-reloaded hashed relay credential manifest, relay accounting/quotas, direct route selection guard, payload-safe local log rotation, structured telemetry snapshot, identity-key rotation with peer-card refresh, identity archive retirement after peer-card refresh, storage-key rotation/re-encryption migration, storage-key retirement, relay-backed stream-chunk, relay-backed room-event fanout, room topic policy, bounded offline relay mailbox, durable relay mailbox storage, durable mailbox FIFO reload ordering, bounded relay sync wait handling, Windows DPAPI secret wrapping, stored relay client credential, signed peer-card, local capability-enforcement, signed remote agent-card, peer-scoped permission-policy, automatic encrypted signed agent-card exchange, TypeScript/JavaScript SDK wrapper, and GitHub CI package-validation passes are complete. Public hosted internet readiness remains scoped by the known managed hosted account auth, online credential issuance APIs, distributed hosted session state, distributed hosted accounting/dashboards, direct transport, multi-tenant hosted permission administration, managed hosted identity/key administration, and non-Windows keychain gaps.
 ```
 
 ## Phase 0 - Project Memory
@@ -3486,11 +3486,13 @@ Summary:
 - Added a dedicated GitHub Actions package-validation job that installs Node 20 and runs the TypeScript SDK package check plus the npm native launcher package check on every push and pull request.
 - Kept Python wrapper compile coverage in the existing Rust OS matrix.
 - Stabilized durable relay mailbox reload ordering by persisting a nanosecond enqueue sequence and using it when applying current mailbox caps, preserving FIFO behavior even when several envelopes share the same millisecond timestamp.
+- Fixed relay sync wait handling so one-shot sync continues polling through the caller's bounded wait instead of returning on the first empty read timeout.
 - Updated production-readiness docs, release checklist, repo memory, and implementation guardrails so package checks are part of the expected CI gate rather than only local release practice.
 
 Files changed:
 
 - `.github/workflows/ci.yml`
+- `crates/conu-core/src/relay_delivery.rs`
 - `crates/conu-relay/src/lib.rs`
 - `docs/production-readiness.md`
 - `docs/release-checklist.md`
@@ -3505,6 +3507,7 @@ Validation:
 - `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py` passed locally.
 - `cargo fmt --all -- --check` passed locally.
 - `cargo +stable-x86_64-pc-windows-gnu test -p conu-relay --lib relay_file_backed_mailbox_load_respects_current_cap_without_payloads` passed locally.
+- `cargo +stable-x86_64-pc-windows-gnu test -p conu-relay --lib relay_delivers_peer_encrypted_message_between_two_state_homes` passed locally.
 - `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed locally.
 - `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings` passed locally.
 - `git diff --check` passed locally.
@@ -3575,5 +3578,5 @@ Add entries here when a phase is completed.
 2026-05-21 - Post Phase 15 identity-key rotation completed. Added `conu security rotate identity --confirm-peer-refresh`, archived old signing/exchange keys with secret-backend protection, refreshed active peer-card material, old exchange-key decrypt compatibility during refresh, payload-safe CLI/JSON reports, docs/skill updates, and validation. Next: managed hosted identity/key administration, non-Windows keychain support, direct QUIC/NAT traversal, and managed hosted account APIs.
 2026-05-21 - Post Phase 15 identity archive retirement completed. Added `conu security retire identity --confirm-peer-refresh-complete`, payload-safe archive retirement reports, active-key preservation with old-key decrypt compatibility removal after refresh, docs/skill updates, and validation. Next: managed hosted identity/key administration, non-Windows keychain support, direct QUIC/NAT traversal, and managed hosted account APIs.
 2026-05-21 - Post Phase 15 TypeScript SDK wrapper completed. Added dependency-free `@conu/sdk` wrapper around installed `conu`/`conud`, stdin-only payload helpers, TypeScript declarations, smoke tests, a local example, docs/skill updates, and full validation. Next: TypeScript explicit receive helper or managed hosted relay/account work.
-2026-05-21 - Post Phase 15 GitHub CI package validation completed. Added a Node 20 package job for `sdk/typescript` and `packaging/npm/conu-cli`, documented package checks as a CI gate, stabilized durable relay mailbox FIFO reload ordering exposed by GitHub CI, and validated package/Python/Rust checks locally. Next: TypeScript explicit receive helper or managed hosted relay/account work.
+2026-05-21 - Post Phase 15 GitHub CI package validation completed. Added a Node 20 package job for `sdk/typescript` and `packaging/npm/conu-cli`, documented package checks as a CI gate, stabilized durable relay mailbox FIFO reload ordering and relay sync bounded-wait handling exposed by GitHub CI, and validated package/Python/Rust checks locally. Next: TypeScript explicit receive helper or managed hosted relay/account work.
 ```

--- a/plan.md
+++ b/plan.md
@@ -31,7 +31,7 @@ needs_revision
 Current phase: Phase 14 - Rooms, Pub/Sub, And Multi-Agent Sessions
 Status: completed
 Last updated: 2026-05-21
-Note: Phase 14 and Phase 15 are complete for the current local-first app. Post-Phase-15 relay data-plane, CLI polish, daemon relay hardening, distribution/hosting, Phase 14 local rooms/pub-sub, relay abuse-control, reusable daemon relay-session, same-process same-node relay-session resume, public-bind token-guard, `wss://` relay-client, static scoped relay credential/session-policy, offline scoped relay credential issuance, relay credential manifest upsert/rotate/revoke helpers, live-reloaded hashed relay credential manifest, relay accounting/quotas, direct route selection guard, payload-safe local log rotation, structured telemetry snapshot, identity-key rotation with peer-card refresh, identity archive retirement after peer-card refresh, storage-key rotation/re-encryption migration, storage-key retirement, relay-backed stream-chunk, relay-backed room-event fanout, room topic policy, bounded offline relay mailbox, durable relay mailbox storage, Windows DPAPI secret wrapping, stored relay client credential, signed peer-card, local capability-enforcement, signed remote agent-card, peer-scoped permission-policy, automatic encrypted signed agent-card exchange, and TypeScript/JavaScript SDK wrapper passes are complete. Public hosted internet readiness remains scoped by the known managed hosted account auth, online credential issuance APIs, distributed hosted session state, distributed hosted accounting/dashboards, direct transport, multi-tenant hosted permission administration, managed hosted identity/key administration, and non-Windows keychain gaps.
+Note: Phase 14 and Phase 15 are complete for the current local-first app. Post-Phase-15 relay data-plane, CLI polish, daemon relay hardening, distribution/hosting, Phase 14 local rooms/pub-sub, relay abuse-control, reusable daemon relay-session, same-process same-node relay-session resume, public-bind token-guard, `wss://` relay-client, static scoped relay credential/session-policy, offline scoped relay credential issuance, relay credential manifest upsert/rotate/revoke helpers, live-reloaded hashed relay credential manifest, relay accounting/quotas, direct route selection guard, payload-safe local log rotation, structured telemetry snapshot, identity-key rotation with peer-card refresh, identity archive retirement after peer-card refresh, storage-key rotation/re-encryption migration, storage-key retirement, relay-backed stream-chunk, relay-backed room-event fanout, room topic policy, bounded offline relay mailbox, durable relay mailbox storage, Windows DPAPI secret wrapping, stored relay client credential, signed peer-card, local capability-enforcement, signed remote agent-card, peer-scoped permission-policy, automatic encrypted signed agent-card exchange, TypeScript/JavaScript SDK wrapper, and GitHub CI package-validation passes are complete. Public hosted internet readiness remains scoped by the known managed hosted account auth, online credential issuance APIs, distributed hosted session state, distributed hosted accounting/dashboards, direct transport, multi-tenant hosted permission administration, managed hosted identity/key administration, and non-Windows keychain gaps.
 ```
 
 ## Phase 0 - Project Memory
@@ -3477,6 +3477,42 @@ Next recommendation:
 
 - Open a PR for the TypeScript SDK wrapper slice, then prioritize either a TypeScript explicit receive helper or managed hosted relay/account work depending on the next release target.
 
+## Post Phase 15 GitHub CI Package Validation
+
+Status: completed
+
+Summary:
+
+- Added a dedicated GitHub Actions package-validation job that installs Node 20 and runs the TypeScript SDK package check plus the npm native launcher package check on every push and pull request.
+- Kept Python wrapper compile coverage in the existing Rust OS matrix.
+- Updated production-readiness docs, release checklist, repo memory, and implementation guardrails so package checks are part of the expected CI gate rather than only local release practice.
+
+Files changed:
+
+- `.github/workflows/ci.yml`
+- `docs/production-readiness.md`
+- `docs/release-checklist.md`
+- `.agents/repo/ABOUT.md`
+- `.agents/skills/conu-builder/references/implementation-guardrails.md`
+- `plan.md`
+
+Validation:
+
+- `npm run check --prefix sdk/typescript` passed locally.
+- `npm run check --prefix packaging/npm/conu-cli` passed locally.
+- `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py` passed locally.
+- `cargo fmt --all -- --check` passed locally.
+- `git diff --check` passed locally.
+
+Known gaps:
+
+- The CI package job validates syntax and package install logic only; it does not publish `@conu/sdk` or `@conu/cli`.
+- GitHub Release asset publication, npm publication, signed installers, managed hosted account auth, online credential issuance APIs, distributed hosted session/accounting state, hosted telemetry/dashboards, direct transport, hosted multi-tenant permission administration, and non-Windows keychain support remain future work.
+
+Next recommendation:
+
+- Open a PR for package CI validation and let GitHub prove the new job, then prioritize either a TypeScript explicit receive helper or managed hosted relay/account work.
+
 ## Phase Completion Log
 
 Add entries here when a phase is completed.
@@ -3534,4 +3570,5 @@ Add entries here when a phase is completed.
 2026-05-21 - Post Phase 15 identity-key rotation completed. Added `conu security rotate identity --confirm-peer-refresh`, archived old signing/exchange keys with secret-backend protection, refreshed active peer-card material, old exchange-key decrypt compatibility during refresh, payload-safe CLI/JSON reports, docs/skill updates, and validation. Next: managed hosted identity/key administration, non-Windows keychain support, direct QUIC/NAT traversal, and managed hosted account APIs.
 2026-05-21 - Post Phase 15 identity archive retirement completed. Added `conu security retire identity --confirm-peer-refresh-complete`, payload-safe archive retirement reports, active-key preservation with old-key decrypt compatibility removal after refresh, docs/skill updates, and validation. Next: managed hosted identity/key administration, non-Windows keychain support, direct QUIC/NAT traversal, and managed hosted account APIs.
 2026-05-21 - Post Phase 15 TypeScript SDK wrapper completed. Added dependency-free `@conu/sdk` wrapper around installed `conu`/`conud`, stdin-only payload helpers, TypeScript declarations, smoke tests, a local example, docs/skill updates, and full validation. Next: TypeScript explicit receive helper or managed hosted relay/account work.
+2026-05-21 - Post Phase 15 GitHub CI package validation completed. Added a Node 20 package job for `sdk/typescript` and `packaging/npm/conu-cli`, documented package checks as a CI gate, and validated package/Python checks locally. Next: TypeScript explicit receive helper or managed hosted relay/account work.
 ```

--- a/plan.md
+++ b/plan.md
@@ -31,7 +31,7 @@ needs_revision
 Current phase: Phase 14 - Rooms, Pub/Sub, And Multi-Agent Sessions
 Status: completed
 Last updated: 2026-05-21
-Note: Phase 14 and Phase 15 are complete for the current local-first app. Post-Phase-15 relay data-plane, CLI polish, daemon relay hardening, distribution/hosting, Phase 14 local rooms/pub-sub, relay abuse-control, reusable daemon relay-session, same-process same-node relay-session resume, public-bind token-guard, `wss://` relay-client, static scoped relay credential/session-policy, offline scoped relay credential issuance, relay credential manifest upsert/rotate/revoke helpers, live-reloaded hashed relay credential manifest, relay accounting/quotas, direct route selection guard, payload-safe local log rotation, structured telemetry snapshot, identity-key rotation with peer-card refresh, identity archive retirement after peer-card refresh, storage-key rotation/re-encryption migration, storage-key retirement, relay-backed stream-chunk, relay-backed room-event fanout, room topic policy, bounded offline relay mailbox, durable relay mailbox storage, Windows DPAPI secret wrapping, stored relay client credential, signed peer-card, local capability-enforcement, signed remote agent-card, peer-scoped permission-policy, automatic encrypted signed agent-card exchange, TypeScript/JavaScript SDK wrapper, and GitHub CI package-validation passes are complete. Public hosted internet readiness remains scoped by the known managed hosted account auth, online credential issuance APIs, distributed hosted session state, distributed hosted accounting/dashboards, direct transport, multi-tenant hosted permission administration, managed hosted identity/key administration, and non-Windows keychain gaps.
+Note: Phase 14 and Phase 15 are complete for the current local-first app. Post-Phase-15 relay data-plane, CLI polish, daemon relay hardening, distribution/hosting, Phase 14 local rooms/pub-sub, relay abuse-control, reusable daemon relay-session, same-process same-node relay-session resume, public-bind token-guard, `wss://` relay-client, static scoped relay credential/session-policy, offline scoped relay credential issuance, relay credential manifest upsert/rotate/revoke helpers, live-reloaded hashed relay credential manifest, relay accounting/quotas, direct route selection guard, payload-safe local log rotation, structured telemetry snapshot, identity-key rotation with peer-card refresh, identity archive retirement after peer-card refresh, storage-key rotation/re-encryption migration, storage-key retirement, relay-backed stream-chunk, relay-backed room-event fanout, room topic policy, bounded offline relay mailbox, durable relay mailbox storage, durable mailbox FIFO reload ordering, Windows DPAPI secret wrapping, stored relay client credential, signed peer-card, local capability-enforcement, signed remote agent-card, peer-scoped permission-policy, automatic encrypted signed agent-card exchange, TypeScript/JavaScript SDK wrapper, and GitHub CI package-validation passes are complete. Public hosted internet readiness remains scoped by the known managed hosted account auth, online credential issuance APIs, distributed hosted session state, distributed hosted accounting/dashboards, direct transport, multi-tenant hosted permission administration, managed hosted identity/key administration, and non-Windows keychain gaps.
 ```
 
 ## Phase 0 - Project Memory
@@ -3485,11 +3485,13 @@ Summary:
 
 - Added a dedicated GitHub Actions package-validation job that installs Node 20 and runs the TypeScript SDK package check plus the npm native launcher package check on every push and pull request.
 - Kept Python wrapper compile coverage in the existing Rust OS matrix.
+- Stabilized durable relay mailbox reload ordering by persisting a nanosecond enqueue sequence and using it when applying current mailbox caps, preserving FIFO behavior even when several envelopes share the same millisecond timestamp.
 - Updated production-readiness docs, release checklist, repo memory, and implementation guardrails so package checks are part of the expected CI gate rather than only local release practice.
 
 Files changed:
 
 - `.github/workflows/ci.yml`
+- `crates/conu-relay/src/lib.rs`
 - `docs/production-readiness.md`
 - `docs/release-checklist.md`
 - `.agents/repo/ABOUT.md`
@@ -3502,6 +3504,9 @@ Validation:
 - `npm run check --prefix packaging/npm/conu-cli` passed locally.
 - `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py` passed locally.
 - `cargo fmt --all -- --check` passed locally.
+- `cargo +stable-x86_64-pc-windows-gnu test -p conu-relay --lib relay_file_backed_mailbox_load_respects_current_cap_without_payloads` passed locally.
+- `cargo +stable-x86_64-pc-windows-gnu test --workspace` passed locally.
+- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings` passed locally.
 - `git diff --check` passed locally.
 
 Known gaps:
@@ -3570,5 +3575,5 @@ Add entries here when a phase is completed.
 2026-05-21 - Post Phase 15 identity-key rotation completed. Added `conu security rotate identity --confirm-peer-refresh`, archived old signing/exchange keys with secret-backend protection, refreshed active peer-card material, old exchange-key decrypt compatibility during refresh, payload-safe CLI/JSON reports, docs/skill updates, and validation. Next: managed hosted identity/key administration, non-Windows keychain support, direct QUIC/NAT traversal, and managed hosted account APIs.
 2026-05-21 - Post Phase 15 identity archive retirement completed. Added `conu security retire identity --confirm-peer-refresh-complete`, payload-safe archive retirement reports, active-key preservation with old-key decrypt compatibility removal after refresh, docs/skill updates, and validation. Next: managed hosted identity/key administration, non-Windows keychain support, direct QUIC/NAT traversal, and managed hosted account APIs.
 2026-05-21 - Post Phase 15 TypeScript SDK wrapper completed. Added dependency-free `@conu/sdk` wrapper around installed `conu`/`conud`, stdin-only payload helpers, TypeScript declarations, smoke tests, a local example, docs/skill updates, and full validation. Next: TypeScript explicit receive helper or managed hosted relay/account work.
-2026-05-21 - Post Phase 15 GitHub CI package validation completed. Added a Node 20 package job for `sdk/typescript` and `packaging/npm/conu-cli`, documented package checks as a CI gate, and validated package/Python checks locally. Next: TypeScript explicit receive helper or managed hosted relay/account work.
+2026-05-21 - Post Phase 15 GitHub CI package validation completed. Added a Node 20 package job for `sdk/typescript` and `packaging/npm/conu-cli`, documented package checks as a CI gate, stabilized durable relay mailbox FIFO reload ordering exposed by GitHub CI, and validated package/Python/Rust checks locally. Next: TypeScript explicit receive helper or managed hosted relay/account work.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- Adds a dedicated GitHub Actions package job using Node 20.
- Runs `npm run check --prefix sdk/typescript` and `npm run check --prefix packaging/npm/conu-cli` on every push/PR.
- Updates production-readiness docs, release checklist, repo memory, guardrails, and `plan.md` so package checks are an expected CI gate.

## Local Validation
- `npm run check --prefix sdk/typescript`
- `npm run check --prefix packaging/npm/conu-cli`
- `python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py`
- `cargo fmt --all -- --check`
- `git diff --check`

## Security / Privacy
- No runtime payload path changed.
- CI package checks are metadata-only and do not upload conU state, logs, keys, inboxes, or payload-bearing artifacts.

___

## **CodeAnt-AI Description**
**Add a GitHub CI package check for the TypeScript SDK and npm launcher**

### What Changed
- GitHub CI now runs a separate package check on every push and pull request for the TypeScript SDK and the npm launcher package
- The release checklist, production-readiness notes, guardrails, repo memory, and project plan now treat these package checks as part of the expected CI gate

### Impact
`✅ Earlier detection of broken package checks`
`✅ Fewer release surprises from SDK or CLI packaging issues`
`✅ Clearer CI expectations for package validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions `packages` job that validates the TypeScript SDK and npm launcher on every push and pull request, and bundles two Rust correctness fixes: nanosecond-precision mailbox FIFO ordering and a relay sync polling fix. Documentation, guardrails, and the release checklist are updated to treat package checks as an expected CI gate.

- **CI workflow** (`ci.yml`): new `packages` job installs Node 20 and runs `npm run check` for `sdk/typescript` (Node syntax check + smoke test) and `packaging/npm/conu-cli` (install-script dry-run); neither script requires external devDependencies so no `npm ci` step is needed.
- **Relay mailbox ordering** (`crates/conu-relay/src/lib.rs`): `QueuedRelayEnvelope` gains a `queued_at_nanos` field; the cap-enforcement sort switches from millisecond to nanosecond granularity with `envelope_id` as a stable tiebreaker; the mailbox filename is now derived from the stored timestamp rather than a fresh clock call; backward-compatible deserialization falls back to the filename sequence or `millis * 1_000_000`.
- **Relay sync polling** (`crates/conu-core/src/relay_delivery.rs`): `drain_relay_frames` now sleeps up to 25 ms per slice and continues polling for the full bounded `wait` window instead of returning immediately on the first empty read.

<h3>Confidence Score: 5/5</h3>

Safe to merge; CI and documentation changes are additive, and both Rust fixes are well-scoped correctness improvements with backward-compatible file format handling.

The two Rust changes fix real correctness issues without touching any public API or persisted protocol version; the backward-compatible fallback chain ensures existing mailbox files are decoded correctly. The CI addition is purely additive and uses only Node built-ins with no risk of broken installs or leaked secrets.

No files require special attention; the most complex change is `crates/conu-relay/src/lib.rs` and its nanosecond-ordering logic and fallback chain read cleanly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds a `packages` job running Node 20 to validate TypeScript SDK and npm launcher; neither check script requires external npm dependencies so `npm ci` is unnecessary, but only Node 20 is tested against packages that declare `engines.node >=18` and `>=16` respectively. |
| crates/conu-relay/src/lib.rs | Adds nanosecond-precision `queued_at_nanos` to `QueuedRelayEnvelope` for stable FIFO sort; persists it to the mailbox file format (version still "1"); backward-compatible read falls back to filename sequence then millis*1M; also fixes the filename to use the stored timestamp rather than a fresh `current_unix_nanos()` call. |
| crates/conu-core/src/relay_delivery.rs | Fixes `drain_relay_frames` to continue polling for the full `wait` duration with 25 ms sleep slices instead of returning immediately on the first empty read from the WebSocket client. |
| docs/release-checklist.md | Adds package job reference to the CI checklist item so releases must include the new packages check. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Load mailbox files from disk] --> B{File version == 1?}
    B -- No --> C[Skip file]
    B -- Yes --> D[Parse queued_at_millis]
    D --> E{queued_at_nanos in file?}
    E -- Yes --> F[Use queued_at_nanos from file]
    E -- No --> G{nanos parseable from filename?}
    G -- Yes --> H[Use filename sequence as queued_at_nanos]
    G -- No --> I[Fallback: queued_at_millis x 1_000_000]
    F --> J[Push to per-node envelope list]
    H --> J
    I --> J
    J --> K[Sort ascending by queued_at_nanos, tiebreak: envelope_id]
    K --> L{len > max_envelopes_per_node?}
    L -- Yes --> M[pop newest envelope, delete storage file]
    M --> L
    L -- No --> N[Insert into in-memory mailbox VecDeque]
```

<sub>Reviews (3): Last reviewed commit: ["Honor relay sync bounded wait"](https://github.com/imthegoodboy/conu/commit/b27ad08520d688c779cc41824cc5b859776749ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33177089)</sub>

<!-- /greptile_comment -->