### PR TITLE
Update release artifact actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,11 +146,11 @@ jobs:
       - name: Verify release artifact
         run: python scripts/verify-release-artifacts.py dist
       - name: Attest release artifact provenance
-        uses: actions/attest@v4
+        uses: actions/attest@v4.1.0
         with:
           subject-path: ${{ matrix.artifact }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: conu-${{ matrix.name }}
           path: ${{ matrix.artifact }}
@@ -165,7 +165,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with:
           path: dist
           merge-multiple: true

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -167,7 +167,7 @@ gh attestation verify ./conu-0.1.0-linux-x64.tar.gz -R imthegoodboy/conU
 ## GitHub
 
 - CI passed on pull request or equivalent local validation is recorded, including the Rust OS matrix and the package job for `sdk/typescript` plus `packaging/npm/conu-cli`.
-- CI and release workflows use GitHub JavaScript action versions that declare the Node 24 action runtime, avoiding Node 20 action-runtime deprecation warnings.
+- CI and release workflows use GitHub JavaScript action versions that declare the Node 24 action runtime, avoiding Node 20 action-runtime deprecation warnings. Self-hosted runners must be new enough for those actions before release workflows are moved off GitHub-hosted runners.
 - PR body lists validation commands.
 - The `Release Artifacts` workflow is green for the release tag.
 - GitHub Release has platform-named archives plus matching `.sha256` files before npm publishing.

--- a/plan.md
+++ b/plan.md
@@ -4512,6 +4512,7 @@ Current status:
 
 - Created GitHub issue #107 for GitHub Actions Node 24 runtime hardening.
 - Created branch `codex/actions-node24-runtime` from `main`.
+- Merged PR #108 and preserved the local and remote feature branch.
 - Confirmed `actions/checkout` latest release `v6.0.2` declares `using: node24` in `action.yml`.
 - Confirmed `actions/setup-node` latest release `v6.4.0` declares `using: node24` in `action.yml`.
 - Updated `.github/workflows/ci.yml` from `actions/checkout@v4` and `actions/setup-node@v4` to v6.
@@ -4536,7 +4537,41 @@ Known gaps:
 
 Next recommendation:
 
-- Open and merge a PR for issue #107 while preserving the local and remote feature branch. Then continue with release workflow hardening, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
+- Continue with release workflow hardening, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
+
+## Post Phase 15 Release Artifact Action Runtime Hardening (Completed)
+
+Objective: keep release artifact upload/download/provenance steps on GitHub JavaScript action versions that declare the Node 24 action runtime and preserve release artifact integrity checks.
+
+Current status:
+
+- Created GitHub issue #109 for release artifact action runtime hardening.
+- Created branch `codex/release-actions-node24` from `main`.
+- Confirmed `actions/upload-artifact` latest release `v7.0.1` declares `using: 'node24'` in `action.yml`.
+- Confirmed `actions/download-artifact` latest release `v8.0.1` declares `using: 'node24'` in `action.yml`.
+- Confirmed `actions/attest` latest release `v4.1.0` declares `using: node24` in `action.yml`.
+- Updated `.github/workflows/release.yml` artifact provenance/upload/download steps to `actions/attest@v4.1.0`, `actions/upload-artifact@v7.0.1`, and `actions/download-artifact@v8.0.1`.
+- Updated the release checklist with the self-hosted runner caveat for Node 24-runtime GitHub actions.
+
+Validation:
+
+- `gh api repos/actions/upload-artifact/releases/latest --jq '.tag_name'` returned `v7.0.1`.
+- `gh api repos/actions/download-artifact/releases/latest --jq '.tag_name'` returned `v8.0.1`.
+- `gh api repos/actions/attest/releases/latest --jq '.tag_name'` returned `v4.1.0`.
+- Decoded upstream `action.yml` files for all three action versions declare Node 24 runtimes.
+- Python YAML parse passed for `.github/workflows/ci.yml` and `.github/workflows/release.yml`.
+- `rg -n "actions/(upload-artifact|download-artifact)@v4|actions/attest@v4$" .github/workflows` returned no matches.
+- `npm run check --prefix sdk\typescript` passed.
+- `npm run check --prefix packaging\npm\conu-cli` passed.
+- `git diff --check` passed.
+
+Known gaps:
+
+- This update hardens release action runtime compatibility only. It does not smoke the full multi-platform release workflow locally, configure signing secrets, publish a release tag, or change the known hosted/distributed product gaps.
+
+Next recommendation:
+
+- Open and merge a PR for issue #109 while preserving the local and remote feature branch. Then continue with release workflow smoke, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 
 ## Phase Completion Log
 
@@ -4627,4 +4662,5 @@ Add entries here when a phase is completed.
 2026-05-22 - Post Phase 15 hosted admin-token manifest audit completed. Added payload-safe local `conu-relay --admin-token-audit --admin-tokens-file <path> [--bind-addr <addr>] [--account <id>] [--json]`, metadata-only admin-token audit structs/counts, host:port-only bind parser hardening, stricter false display guard support for key material/session id/ciphertext markers, docs/skills/plan updates, full GNU workspace validation, Python/package checks, conu-relay build, CLI help smoke, local admin-token audit smoke, and diff check. Next: distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 2026-05-22 - Post Phase 15 hosted relay readiness preflight completed. Added payload-safe local `conu-relay --hosted-readiness` to combine credential, admin-token, tenant, session-state, mailbox, accounting, abuse, and bind checks with JSON/text output, warning counts, display guards, and optional `--fail-on-warning` exit code 3 after preserving stdout. Updated docs/skills/plan and validated with GNU fmt/check/clippy/workspace tests, focused readiness test, Python compile, TypeScript/package checks, conu-relay build, local readiness/fail-on-warning smoke, and diff check. Next: distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 2026-05-22 - Post Phase 15 GitHub Actions Node 24 runtime hardening completed. Updated CI and release workflows to `actions/checkout@v6` and `actions/setup-node@v6`, confirmed both current action releases declare Node 24 runtimes, updated release checklist, and validated YAML parse, package checks, no stale v4/v5 action references, and diff check. Next: release workflow hardening, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
+2026-05-22 - Post Phase 15 release artifact action runtime hardening completed. Updated release artifact provenance/upload/download steps to `actions/attest@v4.1.0`, `actions/upload-artifact@v7.0.1`, and `actions/download-artifact@v8.0.1` after confirming those upstream action metadata files declare Node 24 runtimes. Updated release checklist with the self-hosted runner caveat and validated YAML parse, package checks, no stale artifact action references, and diff check. Next: release workflow smoke, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 ```


### PR DESCRIPTION
## **User description**
## Summary
- Update release artifact provenance/upload/download actions to Node 24-runtime releases.
- Pin `actions/attest@v4.1.0`, `actions/upload-artifact@v7.0.1`, and `actions/download-artifact@v8.0.1`.
- Record the self-hosted runner caveat in the release checklist and plan.

Closes #109

## Validation
- `gh api repos/actions/upload-artifact/releases/latest --jq '.tag_name'` returned `v7.0.1`
- `gh api repos/actions/download-artifact/releases/latest --jq '.tag_name'` returned `v8.0.1`
- `gh api repos/actions/attest/releases/latest --jq '.tag_name'` returned `v4.1.0`
- Decoded upstream `action.yml` files for all three action versions declare Node 24 runtimes
- Python YAML parse for `.github/workflows/ci.yml` and `.github/workflows/release.yml`
- `rg -n "actions/(upload-artifact|download-artifact)@v4|actions/attest@v4$" .github/workflows` returned no matches
- `npm run check --prefix sdk\typescript`
- `npm run check --prefix packaging\npm\conu-cli`
- `git diff --check`

## Security Review
- Payload exposure risk: none; release workflow action-version change only.
- Trust/permission risk: low; job permissions are unchanged.
- Storage/logging risk: low; artifact verification remains before upload and after download.
- Relay/network risk: none; no runtime code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions used in release workflows to ensure compatibility with current platform requirements.
  * Updated release checklist documentation to specify minimum runtime requirements for CI and release workflows.
  * Documented completion of infrastructure hardening work for release artifact handling and GitHub Actions compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

___

## **CodeAnt-AI Description**
**Update release artifact actions to Node 24-compatible versions**

### What Changed
- Release artifact provenance, upload, and download steps now use current GitHub action releases that run on Node 24.
- The release checklist now warns that self-hosted runners must support these action versions before moving release workflows off GitHub-hosted runners.

### Impact
`✅ Fewer release workflow runtime warnings`
`✅ Safer GitHub release artifact handling`
`✅ Clearer self-hosted runner readiness checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates three GitHub Actions in the release workflow from `@v4` major-version tags to fully-pinned Node 24-runtime releases: `actions/attest@v4.1.0`, `actions/upload-artifact@v7.0.1`, and `actions/download-artifact@v8.0.1`. It also records the self-hosted runner Node 24 requirement in the release checklist.

- `.github/workflows/release.yml`: replaces three unpinned major-version tags with pinned patch versions; `upload-artifact@v7` and `download-artifact@v8` are the correct paired versions for the Node 24 runtime.
- `docs/release-checklist.md`: adds a caveat that self-hosted runners must be new enough to support these Node 24-runtime actions before workflows are moved off GitHub-hosted runners.
- `plan.md`: logs completion of the release artifact action runtime hardening phase and updates the next-steps section.

<h3>Confidence Score: 5/5</h3>

Safe to merge — three action version pins in the release workflow, no logic changes, no permission changes.

The change is a mechanical version bump of three first-party GitHub Actions. The upload-artifact@v7 / download-artifact@v8 pairing is the correct matched combination for the Node 24 runtime. Required attestation permissions (id-token: write, attestations: write) were already present on the build job and are untouched. The if-no-files-found: error guard and merge-multiple: true parameters carry over unchanged. The release checklist and plan additions are documentation only.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Three artifact action version bumps: attest@v4→v4.1.0, upload-artifact@v4→v7.0.1, download-artifact@v4→v8.0.1; paired v7/v8 upload/download versions are the correct Node 24-runtime combination; required id-token: write and attestations: write permissions on the build job remain in place. |
| docs/release-checklist.md | Appends self-hosted runner Node 24 caveat to the existing GitHub Actions runtime checklist item; documentation-only change with no logic impact. |
| plan.md | Adds a completed-phase log entry and updates the next-steps bullet; purely informational, no executable code. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant B as build job (matrix)
    participant AA as actions/attest@v4.1.0
    participant UA as actions/upload-artifact@v7.0.1
    participant GH as GitHub Artifact Store
    participant DA as actions/download-artifact@v8.0.1
    participant R as github-release job

    B->>B: "Build & verify artifact"
    B->>AA: Attest provenance (subject-path: matrix.artifact)
    AA-->>B: Attestation recorded
    B->>UA: Upload artifact (name: conu-$matrix.name)
    UA->>GH: Store artifact (Node 24 runtime)
    GH-->>UA: Stored
    R->>DA: Download all artifacts (path: dist, merge-multiple: true)
    DA->>GH: Fetch artifacts (Node 24 runtime)
    GH-->>DA: Artifacts returned
    DA-->>R: dist/ populated
    R->>R: "Verify & publish GitHub Release"
```

<sub>Reviews (1): Last reviewed commit: ["Update release artifact actions to Node ..."](https://github.com/imthegoodboy/conu/commit/ba573af7d429900cd6e68273b502536c35c3f09b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33377644)</sub>

<!-- /greptile_comment -->