### PR TITLE
Pin GitHub Actions runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2025-vs2026, macos-15]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         include:
           - name: windows-x64
-            os: windows-latest
+            os: windows-2025-vs2026
             script: powershell -ExecutionPolicy Bypass -File scripts/build-release.ps1 -PackageSuffix windows-x64
             artifact: |
               dist/*.zip
@@ -65,7 +65,7 @@ jobs:
               dist/*.tar.gz
               dist/*.tar.gz.sha256
           - name: macos-arm64
-            os: macos-latest
+            os: macos-15
             script: PACKAGE_SUFFIX=macos-arm64 sh scripts/build-release.sh
             artifact: |
               dist/*.zip

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -168,6 +168,7 @@ gh attestation verify ./conu-0.1.0-linux-x64.tar.gz -R imthegoodboy/conU
 
 - CI passed on pull request or equivalent local validation is recorded, including the Rust OS matrix and the package job for `sdk/typescript` plus `packaging/npm/conu-cli`.
 - CI and release workflows use GitHub JavaScript action versions that declare the Node 24 action runtime, avoiding Node 20 action-runtime deprecation warnings. Self-hosted runners must be new enough for those actions before release workflows are moved off GitHub-hosted runners.
+- Migration-sensitive GitHub-hosted runner labels are explicit: Windows release/CI jobs run on `windows-2025-vs2026` while the Visual Studio 2026 migration is active, macOS arm64 jobs run on `macos-15`, and macOS x64 release jobs run on `macos-15-intel`. Revisit the Windows label after GitHub completes the June 2026 migration.
 - After changing CI or release action versions, run the `Release Artifacts` workflow with `workflow_dispatch` on `main`, verify package checks, every platform build, artifact attestations, and artifact uploads pass, and confirm GitHub Release/npm publication jobs skip on the non-tag run.
 - PR body lists validation commands.
 - The `Release Artifacts` workflow is green for the release tag.

--- a/plan.md
+++ b/plan.md
@@ -4602,7 +4602,7 @@ Next recommendation:
 
 - Issue #111 was closed by PR #112, and `codex/release-workflow-smoke-record` remains preserved locally and on origin. Continue with GitHub Actions runner-image migration hardening, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 
-## Post Phase 15 GitHub Actions Runner Image Pinning (In Progress)
+## Post Phase 15 GitHub Actions Runner Image Pinning (Completed)
 
 Objective: remove GitHub-hosted runner image migration warnings and make CI/release platform labels explicit before the June 2026 Windows/macOS hosted-runner migrations.
 
@@ -4616,6 +4616,7 @@ Current status:
 - Updated `.github/workflows/ci.yml` to run Rust CI on `ubuntu-latest`, `windows-2025-vs2026`, and `macos-15`.
 - Updated `.github/workflows/release.yml` so `windows-x64` uses `windows-2025-vs2026` and `macos-arm64` uses `macos-15`; `macos-x64` already used `macos-15-intel`.
 - Updated the release checklist with the explicit runner labels and the reminder to revisit the Windows label after the June 2026 migration completes.
+- User preference captured for future work: create new branches without the `codex/` prefix. Existing preserved `codex/*` branches are not deleted.
 
 Validation:
 
@@ -4624,7 +4625,9 @@ Validation:
 - `npm run check --prefix sdk\typescript` passed.
 - `npm run check --prefix packaging\npm\conu-cli` passed.
 - `git diff --check` passed.
-- Pending PR CI and a branch `Release Artifacts` workflow_dispatch smoke run.
+- PR #114 CI passed: Packages, CodeRabbit, Rust on `ubuntu-latest`, Rust on `windows-2025-vs2026`, and Rust on `macos-15`.
+- Branch `Release Artifacts` workflow_dispatch run `https://github.com/imthegoodboy/conU/actions/runs/26265326440` completed successfully.
+- The branch release smoke passed package checks plus `windows-x64`, `linux-x64`, `linux-arm64`, `macos-arm64`, and `macos-x64` builds; `Publish GitHub Release` and `Publish npm Packages` skipped on the non-tag branch run.
 
 Known gaps:
 
@@ -4632,7 +4635,7 @@ Known gaps:
 
 Next recommendation:
 
-- Validate the runner-label branch through PR CI and a release workflow smoke run. If both pass, merge while preserving the local and remote branch.
+- Merge PR #114 for issue #113 while preserving the local and remote branch. Then continue with distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 
 ## Phase Completion Log
 
@@ -4725,4 +4728,5 @@ Add entries here when a phase is completed.
 2026-05-22 - Post Phase 15 GitHub Actions Node 24 runtime hardening completed. Updated CI and release workflows to `actions/checkout@v6` and `actions/setup-node@v6`, confirmed both current action releases declare Node 24 runtimes, updated release checklist, and validated YAML parse, package checks, no stale v4/v5 action references, and diff check. Next: release workflow hardening, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 2026-05-22 - Post Phase 15 release artifact action runtime hardening completed. Updated release artifact provenance/upload/download steps to `actions/attest@v4.1.0`, `actions/upload-artifact@v7.0.1`, and `actions/download-artifact@v8.0.1` after confirming those upstream action metadata files declare Node 24 runtimes. Updated release checklist with the self-hosted runner caveat and validated YAML parse, package checks, no stale artifact action references, and diff check. Next: release workflow smoke, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 2026-05-22 - Post Phase 15 release workflow smoke validation completed. Ran `Release Artifacts` through `workflow_dispatch` on `main` after the Node 24 action updates; package checks and all five platform artifact builds passed, artifact uploads were present, GitHub Release/npm publication jobs skipped as expected on the non-tag run, and post-merge CI was green. Next: tagged release signing/publication verification when release secrets are configured, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
+2026-05-22 - Post Phase 15 GitHub Actions runner image pinning completed. Pinned CI/release Windows jobs to `windows-2025-vs2026`, pinned macOS arm64 jobs to `macos-15`, kept macOS x64 release on `macos-15-intel`, removed floating Windows/macOS workflow labels, updated release checklist, validated local workflow/package checks, passed PR CI on the explicit labels, and passed a branch `Release Artifacts` smoke run across all five platform builds. Next: revisit the Windows label after GitHub completes the June 2026 migration, tagged release signing/publication verification when release secrets are configured, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
 ```

--- a/plan.md
+++ b/plan.md
@@ -4635,7 +4635,7 @@ Known gaps:
 
 Next recommendation:
 
-- Merge PR #114 for issue #113 while preserving the local and remote branch. Then continue with distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
+- Continue with distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal. Preserve local and remote work branches.
 
 ## Phase Completion Log
 

--- a/plan.md
+++ b/plan.md
@@ -4600,7 +4600,39 @@ Known gaps:
 
 Next recommendation:
 
-- Merge the smoke-record PR for issue #111 while preserving the local and remote branch. Then continue with distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
+- Issue #111 was closed by PR #112, and `codex/release-workflow-smoke-record` remains preserved locally and on origin. Continue with GitHub Actions runner-image migration hardening, distributed hosted dashboards/adaptive abuse workflows, distributed tenant workflow automation, distributed multi-instance session migration, managed hosted identity/key administration, distributed hosted mailbox retention orchestration, or ICE/STUN/TURN managed traversal.
+
+## Post Phase 15 GitHub Actions Runner Image Pinning (In Progress)
+
+Objective: remove GitHub-hosted runner image migration warnings and make CI/release platform labels explicit before the June 2026 Windows/macOS hosted-runner migrations.
+
+Current status:
+
+- Created GitHub issue #113 for runner-image pinning.
+- Created branch `codex/pin-actions-runner-images` from `main`.
+- Observed post-merge CI run `https://github.com/imthegoodboy/conU/actions/runs/26265143809` reporting the GitHub notice that `windows-latest` requests are being redirected to `windows-2025-vs2026` by June 15, 2026.
+- Verified the May 14, 2026 GitHub Actions changelog: `windows-latest`/`windows-2025` migrate to Visual Studio 2026 by June 15, 2026, and `macos-latest` begins migrating to macOS 26 on June 15, 2026.
+- Verified the `actions/runner-images` label table includes `windows-2025-vs2026`, `macos-15`, and `macos-15-intel`.
+- Updated `.github/workflows/ci.yml` to run Rust CI on `ubuntu-latest`, `windows-2025-vs2026`, and `macos-15`.
+- Updated `.github/workflows/release.yml` so `windows-x64` uses `windows-2025-vs2026` and `macos-arm64` uses `macos-15`; `macos-x64` already used `macos-15-intel`.
+- Updated the release checklist with the explicit runner labels and the reminder to revisit the Windows label after the June 2026 migration completes.
+
+Validation:
+
+- Python YAML parse passed for `.github/workflows/ci.yml` and `.github/workflows/release.yml`.
+- `rg -n "windows-latest|macos-latest" .github/workflows` returned no matches.
+- `npm run check --prefix sdk\typescript` passed.
+- `npm run check --prefix packaging\npm\conu-cli` passed.
+- `git diff --check` passed.
+- Pending PR CI and a branch `Release Artifacts` workflow_dispatch smoke run.
+
+Known gaps:
+
+- This runner-image update does not configure release signing secrets, publish a release tag, publish npm packages, or change the known hosted/distributed product gaps.
+
+Next recommendation:
+
+- Validate the runner-label branch through PR CI and a release workflow smoke run. If both pass, merge while preserving the local and remote branch.
 
 ## Phase Completion Log
 


### PR DESCRIPTION
## Summary
- pin CI Rust jobs from floating `windows-latest`/`macos-latest` to explicit `windows-2025-vs2026` and `macos-15` labels
- pin release `windows-x64` and `macos-arm64` jobs to the same explicit migration-safe labels
- update release checklist and plan.md with the June 2026 runner migration rationale, validation, and future branch naming preference

## Validation
- Python YAML parse for `.github/workflows/ci.yml` and `.github/workflows/release.yml`
- `rg -n "windows-latest|macos-latest" .github/workflows` returned no matches
- `npm run check --prefix sdk/typescript`
- `npm run check --prefix packaging/npm/conu-cli`
- `git diff --check`
- PR CI passed: Packages, CodeRabbit, Rust on `ubuntu-latest`, Rust on `windows-2025-vs2026`, Rust on `macos-15`
- Branch `Release Artifacts` workflow_dispatch smoke passed: https://github.com/imthegoodboy/conU/actions/runs/26265326440

References:
- https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations
- https://github.com/actions/runner-images

Closes #113