### PR TITLE
Stabilize relay counter window tests

### DIFF
--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -9689,7 +9689,7 @@ token_displayed = true\n",
 
     #[test]
     fn relay_accounting_quota_rejects_sender_without_payloads() {
-        let accounting_policy = RelayAccountingPolicy::new(Duration::from_secs(60), Some(1), None)
+        let accounting_policy = RelayAccountingPolicy::new(stable_counter_window(), Some(1), None)
             .expect("accounting policy");
         let relay = spawn_relay(
             RelayConfig::new("127.0.0.1:0", "test-token")
@@ -9862,7 +9862,7 @@ token_displayed = true\n",
         let accounting_dir = test_home("relay-accounting-quota").join("accounting");
         let accounting_storage =
             RelayAccountingStorage::file_backed(accounting_dir).expect("storage config");
-        let accounting_policy = RelayAccountingPolicy::new(Duration::from_secs(60), Some(1), None)
+        let accounting_policy = RelayAccountingPolicy::new(stable_counter_window(), Some(1), None)
             .expect("accounting policy");
         let mut state = RelayAccountingState::load(&accounting_storage, accounting_policy)
             .expect("accounting loads");
@@ -9889,13 +9889,16 @@ token_displayed = true\n",
         let abuse_dir = test_home("relay-abuse-dashboard").join("abuse");
         let abuse_storage =
             RelayAbuseStorage::file_backed(abuse_dir.clone()).expect("abuse storage config");
-        let accounting_policy = RelayAccountingPolicy::new(Duration::from_secs(60), Some(2), None)
-            .expect("accounting policy");
+        let counter_window = stable_counter_window();
+        let abuse_policy = RelayAbusePolicy::new(counter_window).expect("abuse policy");
+        let accounting_policy =
+            RelayAccountingPolicy::new(counter_window, Some(2), None).expect("accounting policy");
         let mailbox_policy =
             RelayMailboxPolicy::new(1, Duration::from_secs(60)).expect("mailbox policy");
         let relay = spawn_relay(
             RelayConfig::new("127.0.0.1:0", "test-token")
                 .expect("valid config")
+                .with_abuse_policy(abuse_policy)
                 .with_abuse_storage(abuse_storage.clone())
                 .with_accounting_policy(accounting_policy)
                 .with_mailbox_policy(mailbox_policy),
@@ -9962,6 +9965,7 @@ token_displayed = true\n",
         let rate_relay = spawn_relay(
             RelayConfig::new("127.0.0.1:0", "test-token")
                 .expect("valid config")
+                .with_abuse_policy(abuse_policy)
                 .with_abuse_storage(abuse_storage.clone())
                 .with_limits(RelayLimits::new(8, 8, 1).expect("limits")),
         )
@@ -9989,6 +9993,7 @@ token_displayed = true\n",
         let expiring_relay = spawn_relay(
             RelayConfig::new("127.0.0.1:0", "test-token")
                 .expect("valid config")
+                .with_abuse_policy(abuse_policy)
                 .with_abuse_storage(abuse_storage.clone())
                 .with_session_policy(session_policy),
         )
@@ -11566,5 +11571,9 @@ token_displayed = false\n"
             process::id(),
             current_unix_nanos()
         ))
+    }
+
+    fn stable_counter_window() -> Duration {
+        Duration::from_secs(10 * 365 * 24 * 60 * 60)
     }
 }


### PR DESCRIPTION
## **User description**
Fixes #155.\n\n## Summary\n- use a long test-only counter window for relay quota/accounting assertions\n- apply the same stable abuse counter window across the multi-relay abuse aggregation test\n- leave production relay accounting and abuse defaults unchanged\n\n## Validation\n- cargo fmt --all\n- cargo fmt --all -- --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-relay --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-relay --all-targets -- -D warnings\n- git diff --check\n- codex review --uncommitted\n\n## Local test note\n- cargo +stable-x86_64-pc-windows-gnu test -p conu-relay relay_file_backed_abuse_records_denials_without_secret_material --lib -- --nocapture is blocked locally because dlltool.exe is missing while compiling getrandom/windows-sys; GitHub Windows CI is the runtime test gate.\n\nBranches are intentionally preserved after merge.


___

## **CodeAnt-AI Description**
**Stabilize relay counter-based tests**

### What Changed
- Several relay quota and abuse tests now use a long-lived test counter window so they stop failing when the window would otherwise roll over during the test run
- Abuse-related test cases now run with the same abuse policy setup across denied-message, rate-limit, and session-expiry checks
- Production relay settings are unchanged

### Impact
`✅ Fewer flaky relay test failures`
`✅ More stable CI for quota and abuse checks`
`✅ No change to production relay behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
