### PR TITLE
Add production readiness verification gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,7 @@ jobs:
         run: python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py
       - name: Doctor smoke
         run: cargo run -p conu-cli -- doctor --json
+      - name: Production readiness smoke gate
+        if: matrix.os == 'windows-2025-vs2026'
+        shell: pwsh
+        run: ./scripts/verify-production-readiness.ps1 -SmokeOnly

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ On Windows machines without Visual Studio C++ Build Tools, use the GNU Rust tool
 rustup toolchain install stable-x86_64-pc-windows-gnu
 cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
 cargo +stable-x86_64-pc-windows-gnu test --workspace
+powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -Toolchain stable-x86_64-pc-windows-gnu
 powershell -ExecutionPolicy Bypass -File scripts/smoke-identity-retirement.ps1 -Toolchain stable-x86_64-pc-windows-gnu
 powershell -ExecutionPolicy Bypass -File scripts/smoke-relay-daemon.ps1 -Toolchain stable-x86_64-pc-windows-gnu
 ```

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -99,7 +99,15 @@ For hands-on install and agent usage instructions, see `docs/user-install-and-ag
 
 ## Validation Baseline
 
-Before merging production-affecting work, run:
+Before merging production-affecting work or cutting a release candidate, run the executable gate:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -Toolchain stable-x86_64-pc-windows-gnu
+```
+
+The gate runs the baseline checks below, then exercises local install, identity-retirement, relay-daemon delivery, and hosted-readiness smoke coverage with temporary state only. CI also runs `scripts/verify-production-readiness.ps1 -SmokeOnly` on the Windows Rust job so the smoke/readiness workflow is continuously checked without duplicating the full Rust matrix on every OS.
+
+The full gate covers:
 
 ```bash
 cargo fmt --all -- --check

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,6 +8,7 @@ Use this checklist before publishing any conU build.
 - Confirm `packaging/npm/conu-cli/package.json` has the same version.
 - Confirm `sdk/typescript/package.json` has the same version if publishing the TypeScript/JavaScript SDK package.
 - Run `python scripts/verify-release-versions.py`; on `v*` tag builds the CI/release package gates also compare the tag version to the Cargo/npm package version.
+- Run `powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -Toolchain stable-x86_64-pc-windows-gnu` before a release candidate; CI runs the same script in `-SmokeOnly` mode on Windows to keep the production smoke/readiness path exercised.
 - Confirm `plan.md` reflects the completed phase and known gaps.
 - Confirm Phase 14 room claims stay scoped to implemented local metadata/fanout, relay-backed room-event fanout, and local room topic policy behavior. Do not claim hosted multi-tenant room permission administration.
 - Confirm relay hosting docs mention `CONU_RELAY_MAX_CONNECTIONS`, `CONU_RELAY_MAX_CONNECTIONS_PER_IP`, `CONU_RELAY_MAX_FRAMES_PER_MINUTE`, `CONU_RELAY_IDLE_TIMEOUT_SECONDS`, `CONU_RELAY_SESSION_TTL_SECONDS`, optional `CONU_RELAY_SESSION_STATE_DIR`, `conu-relay --session-audit`, `conu-relay --admin-session-audit`, `CONU_RELAY_MAX_OFFLINE_ENVELOPES_PER_NODE`, `CONU_RELAY_OFFLINE_ENVELOPE_TTL_SECONDS`, optional `CONU_RELAY_MAILBOX_DIR`, `conu-relay --mailbox-audit`, `conu-relay --admin-mailbox-audit`, `conu-relay --admin-mailbox-purge`, optional mailbox `--retention-policy-file` policy files, optional `CONU_RELAY_ACCOUNTING_DIR`, `CONU_RELAY_ACCOUNTING_WINDOW_SECONDS`, `CONU_RELAY_MAX_ENVELOPES_SENT_PER_NODE`, `CONU_RELAY_MAX_BYTES_SENT_PER_NODE`, optional `CONU_RELAY_ABUSE_DIR`, `CONU_RELAY_ABUSE_WINDOW_SECONDS`, `conu-relay --abuse-threshold-report`, `conu-relay --admin-abuse-threshold-report`, optional threshold `--thresholds-file` policy files, optional threshold `--fail-on-threshold` exit code behavior, optional full-admin `CONU_RELAY_ADMIN_TOKEN`, optional scoped `CONU_RELAY_ADMIN_TOKENS_FILE`, `conu-relay --admin-token-audit` for payload-safe scoped admin-token manifest checks, `conu-relay --hosted-readiness` for payload-safe local startup/release preflights with reusable retention/threshold policy files and `--fail-on-warning`, `conu-relay --hosted-fleet-dashboard` for guarded multi-relay metadata aggregation with optional reusable mailbox retention policy gates, optional reusable abuse threshold policy checks, `--fail-on-retention`, and `--fail-on-threshold`, `conu-relay --hosted-fleet-account-audit [--node <node-id>]` for read-only guarded local fleet account or account/node consistency warnings, `conu-relay --hosted-fleet-tenant-upsert` and `conu-relay --hosted-fleet-tenant-revoke` for dry-run/confirm guarded local fleet tenant account lifecycle, `conu-relay --hosted-fleet-account-suspend [--node <node-id>]` for dry-run/confirm guarded local fleet account or account/node suspension, account/action-scoped online credential lifecycle, online tenant lifecycle, hosted account suspension, session-state audits, dashboard snapshots/threshold reports, and online mailbox audit/purge, and optional `CONU_RELAY_TENANTS_FILE` for metadata-only hosted tenant checks.
@@ -32,13 +33,7 @@ Use this checklist before publishing any conU build.
 Windows:
 
 ```powershell
-cargo fmt --all -- --check
-python scripts\verify-release-versions.py
-cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
-cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
-cargo +stable-x86_64-pc-windows-gnu test --workspace
-npm run check --prefix sdk/typescript
-npm run check --prefix packaging/npm/conu-cli
+powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -Toolchain stable-x86_64-pc-windows-gnu
 .\scripts\build-release.ps1 -Toolchain stable-x86_64-pc-windows-gnu
 .\scripts\build-release.ps1 -Toolchain stable-x86_64-pc-windows-gnu -PackageSuffix windows-x64
 python scripts\verify-release-artifacts.py dist

--- a/plan.md
+++ b/plan.md
@@ -111,7 +111,7 @@ Turn the release-candidate validation baseline into one executable production-re
 
 Completed work:
 
-- Issue #158 tracks the production readiness verification gate.
+- Issue #158 tracks the production readiness verification gate, and PR #159 carries the implementation.
 - Added `scripts/verify-production-readiness.ps1` with a full release-candidate mode and a CI-friendly `-SmokeOnly` mode.
 - The full gate runs formatting, Rust check/clippy/test/build, Python compile, release version consistency, TypeScript SDK check, npm launcher check, local smoke, identity archive retirement smoke, relay daemon smoke, hosted-readiness fixture validation, and `git diff --check`.
 - The hosted-readiness fixture builds temporary credential, tenant, scoped admin-token, mailbox retention, accounting, abuse, and threshold stores, runs `conu-relay --hosted-readiness --json --fail-on-warning`, requires `status=ready` with zero warnings, and checks that fixture token material is not displayed.
@@ -130,6 +130,7 @@ Files changed:
 Validation:
 
 - `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes` passed.
+- PowerShell parser validation for `scripts\verify-production-readiness.ps1` passed.
 - `cargo fmt --all -- --check` passed.
 - `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets` passed.
 - `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings` passed.

--- a/plan.md
+++ b/plan.md
@@ -101,6 +101,53 @@ Next:
 
 - Continue the remaining hosted/distributed product gaps: distributed hosted accounting dashboards, adaptive abuse automation, distributed multi-instance session migration, ICE/STUN/TURN managed direct NAT traversal, managed hosted identity/key administration, remote/distributed tenant lifecycle workflow automation, tenant-wide hosted dashboard workflow services, and remote relay/cross-region mailbox retention orchestration.
 
+## Post Phase 15 - Production Readiness Verification Gate
+
+Status: completed
+
+Goal:
+
+Turn the release-candidate validation baseline into one executable production-readiness gate so maintainers and future agents can verify formatting, Rust/package checks, local smoke flows, relay delivery, and hosted-readiness preflights from a single command.
+
+Completed work:
+
+- Issue #158 tracks the production readiness verification gate.
+- Added `scripts/verify-production-readiness.ps1` with a full release-candidate mode and a CI-friendly `-SmokeOnly` mode.
+- The full gate runs formatting, Rust check/clippy/test/build, Python compile, release version consistency, TypeScript SDK check, npm launcher check, local smoke, identity archive retirement smoke, relay daemon smoke, hosted-readiness fixture validation, and `git diff --check`.
+- The hosted-readiness fixture builds temporary credential, tenant, scoped admin-token, mailbox retention, accounting, abuse, and threshold stores, runs `conu-relay --hosted-readiness --json --fail-on-warning`, requires `status=ready` with zero warnings, and checks that fixture token material is not displayed.
+- CI now runs `scripts/verify-production-readiness.ps1 -SmokeOnly` on the Windows Rust job so the production smoke/readiness path stays covered without duplicating the full Rust matrix on every OS.
+- Updated README, production readiness docs, and release checklist to make the executable gate the release-candidate entry point.
+
+Files changed:
+
+- `.github/workflows/ci.yml`
+- `README.md`
+- `docs/production-readiness.md`
+- `docs/release-checklist.md`
+- `scripts/verify-production-readiness.ps1`
+- `plan.md`
+
+Validation:
+
+- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes` passed.
+- `cargo fmt --all -- --check` passed.
+- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets` passed.
+- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings` passed.
+- `python -m py_compile scripts\verify-release-versions.py scripts\verify-release-artifacts.py sdk\python\conu_sdk\__init__.py examples\python\local_agent_pair.py` passed.
+- `python scripts\verify-release-versions.py` passed.
+- `npm run check --prefix sdk/typescript` passed.
+- `npm run check --prefix packaging/npm/conu-cli` passed.
+- `git diff --check` passed.
+- Local linked runtime tests and full `-SmokeOnly` execution are still blocked on this machine by missing `dlltool.exe`/MSVC linker support for linked test binaries; PR Windows CI is expected to cover the new smoke gate with a current build.
+
+Known gaps:
+
+- This gate makes the existing release-candidate baseline executable; it does not itself implement distributed hosted dashboards, adaptive abuse automation, distributed multi-instance session migration, ICE/STUN/TURN managed direct NAT traversal, managed hosted identity/key administration, remote/distributed tenant lifecycle workflow automation, tenant-wide hosted dashboard workflow services, or remote relay/cross-region mailbox retention orchestration.
+
+Next:
+
+- Continue closing the hosted/distributed product gaps, using `scripts/verify-production-readiness.ps1` as the release-candidate gate for future production-affecting changes.
+
 ## Phase 0 - Project Memory
 
 Status: completed

--- a/scripts/verify-production-readiness.ps1
+++ b/scripts/verify-production-readiness.ps1
@@ -43,11 +43,11 @@ function Invoke-PwshScript {
     param(
         [string]$Name,
         [string]$Path,
-        [string[]]$Arguments
+        [hashtable]$Parameters = @{}
     )
 
     Invoke-ReadinessStep $Name {
-        & $Path @Arguments
+        & $Path @Parameters
     }
 }
 
@@ -265,9 +265,22 @@ try {
 
     if (-not $SkipSmokes) {
         $smokeToolchain = Get-EffectiveSmokeToolchain
-        Invoke-PwshScript "local smoke" (Join-Path $repo "scripts/smoke-local.ps1") @("-Conu", $conu, "-Conud", $conud, "-Toolchain", $smokeToolchain, "-SkipBuild")
-        Invoke-PwshScript "identity retirement smoke" (Join-Path $repo "scripts/smoke-identity-retirement.ps1") @("-Toolchain", $smokeToolchain)
-        Invoke-PwshScript "relay daemon smoke" (Join-Path $repo "scripts/smoke-relay-daemon.ps1") @("-Conu", $conu, "-Conud", $conud, "-ConuRelay", $conuRelay, "-Toolchain", $smokeToolchain, "-SkipBuild")
+        Invoke-PwshScript "local smoke" (Join-Path $repo "scripts/smoke-local.ps1") @{
+            Conu = $conu
+            Conud = $conud
+            Toolchain = $smokeToolchain
+            SkipBuild = $true
+        }
+        Invoke-PwshScript "identity retirement smoke" (Join-Path $repo "scripts/smoke-identity-retirement.ps1") @{
+            Toolchain = $smokeToolchain
+        }
+        Invoke-PwshScript "relay daemon smoke" (Join-Path $repo "scripts/smoke-relay-daemon.ps1") @{
+            Conu = $conu
+            Conud = $conud
+            ConuRelay = $conuRelay
+            Toolchain = $smokeToolchain
+            SkipBuild = $true
+        }
         Invoke-HostedReadinessFixture -ConuRelay $conuRelay
     }
 

--- a/scripts/verify-production-readiness.ps1
+++ b/scripts/verify-production-readiness.ps1
@@ -1,0 +1,285 @@
+param(
+    [string]$Toolchain = $env:CONU_RUST_TOOLCHAIN,
+    [switch]$SmokeOnly,
+    [switch]$SkipRust,
+    [switch]$SkipPackages,
+    [switch]$SkipSmokes
+)
+
+$ErrorActionPreference = "Stop"
+
+$repo = Resolve-Path (Join-Path $PSScriptRoot "..")
+$tempRoot = $null
+
+function Invoke-ReadinessStep {
+    param(
+        [string]$Name,
+        [scriptblock]$Command
+    )
+
+    Write-Host "==> $Name"
+    & $Command
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Name failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Invoke-CargoStep {
+    param(
+        [string]$Name,
+        [string[]]$CargoArgs
+    )
+
+    Invoke-ReadinessStep $Name {
+        if (-not [string]::IsNullOrWhiteSpace($Toolchain)) {
+            & cargo "+$Toolchain" @CargoArgs
+        } else {
+            & cargo @CargoArgs
+        }
+    }
+}
+
+function Invoke-PwshScript {
+    param(
+        [string]$Name,
+        [string]$Path,
+        [string[]]$Arguments
+    )
+
+    Invoke-ReadinessStep $Name {
+        & $Path @Arguments
+    }
+}
+
+function Get-BinaryPath {
+    param([string]$Name)
+
+    $suffix = if ($IsWindows -or $env:OS -eq "Windows_NT") { ".exe" } else { "" }
+    return Join-Path $repo "target/debug/$Name$suffix"
+}
+
+function Get-EffectiveSmokeToolchain {
+    if (-not [string]::IsNullOrWhiteSpace($Toolchain)) {
+        return $Toolchain
+    }
+    return "stable"
+}
+
+function ConvertTo-Hex {
+    param([byte[]]$Bytes)
+
+    $builder = [System.Text.StringBuilder]::new($Bytes.Length * 2)
+    foreach ($byte in $Bytes) {
+        [void]$builder.AppendFormat("{0:x2}", $byte)
+    }
+    return $builder.ToString()
+}
+
+function Get-Sha256Hex {
+    param([string]$Value)
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        return ConvertTo-Hex -Bytes $sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Value))
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Write-AdminTokensFixture {
+    param(
+        [string]$Path,
+        [string]$AdminToken
+    )
+
+    $hash = Get-Sha256Hex -Value $AdminToken
+    $contents = @"
+version = "1"
+
+[[admin_token]]
+account_id = "account.prod"
+token_sha256_hex = "$hash"
+token_length = $($AdminToken.Length)
+status = "active"
+scope_credentials = true
+scope_tenants = true
+scope_dashboard = true
+scope_sessions = true
+scope_mailbox_audit = true
+scope_mailbox_purge = true
+payload_displayed = false
+token_displayed = false
+token_hash_displayed = false
+key_material_displayed = false
+session_id_displayed = false
+ciphertext_displayed = false
+contents_displayed = false
+"@
+    Set-Content -LiteralPath $Path -Value $contents -Encoding ASCII
+    return $hash
+}
+
+function Write-PolicyFixtures {
+    param(
+        [string]$RetentionPolicyPath,
+        [string]$ThresholdsPath
+    )
+
+    $guards = @"
+payload_displayed = false
+token_displayed = false
+token_hash_displayed = false
+key_material_displayed = false
+session_id_displayed = false
+ciphertext_displayed = false
+contents_displayed = false
+"@
+    Set-Content -LiteralPath $RetentionPolicyPath -Value "version = `"1`"`nttl_seconds = 3600`n$guards" -Encoding ASCII
+    Set-Content -LiteralPath $ThresholdsPath -Value "version = `"1`"`nmax_rate_limited_sessions = 100`n$guards" -Encoding ASCII
+}
+
+function Invoke-HostedReadinessFixture {
+    param([string]$ConuRelay)
+
+    $fixtureRoot = Join-Path $tempRoot "hosted-readiness"
+    $credentialsFile = Join-Path $fixtureRoot "credentials.toml"
+    $tokenFile = Join-Path $fixtureRoot "node-prod.token"
+    $adminTokensFile = Join-Path $fixtureRoot "admin-tokens.toml"
+    $tenantsFile = Join-Path $fixtureRoot "tenants.toml"
+    $sessionDir = Join-Path $fixtureRoot "sessions"
+    $mailboxDir = Join-Path $fixtureRoot "mailbox"
+    $accountingDir = Join-Path $fixtureRoot "accounting"
+    $abuseDir = Join-Path $fixtureRoot "abuse"
+    $retentionPolicyFile = Join-Path $fixtureRoot "mailbox-retention.toml"
+    $thresholdsFile = Join-Path $fixtureRoot "abuse-thresholds.toml"
+    $adminToken = "conu-readiness-admin-token-1234567890abcdef"
+
+    New-Item -ItemType Directory -Force -Path $fixtureRoot, $sessionDir, $mailboxDir, $accountingDir, $abuseDir | Out-Null
+    $adminHash = Write-AdminTokensFixture -Path $adminTokensFile -AdminToken $adminToken
+    Write-PolicyFixtures -RetentionPolicyPath $retentionPolicyFile -ThresholdsPath $thresholdsFile
+
+    Invoke-ReadinessStep "hosted readiness fixture credential" {
+        & $ConuRelay --issue-credential node.prod --token-out $tokenFile --credentials-file $credentialsFile --json | Out-Null
+    }
+    Invoke-ReadinessStep "hosted readiness fixture tenant" {
+        & $ConuRelay --tenant-upsert account.prod --tenants-file $tenantsFile --json | Out-Null
+    }
+    Invoke-ReadinessStep "hosted readiness fixture tenant node" {
+        & $ConuRelay --tenant-node-upsert account.prod node.prod --tenants-file $tenantsFile --messages true --streams true --rooms true --files false --mailbox true --json | Out-Null
+    }
+
+    $nodeToken = (Get-Content -LiteralPath $tokenFile -Raw).Trim()
+    if ([string]::IsNullOrWhiteSpace($nodeToken)) {
+        throw "hosted readiness fixture credential token was empty"
+    }
+    $nodeHash = Get-Sha256Hex -Value $nodeToken
+    $readinessOutput = & $ConuRelay `
+        --hosted-readiness `
+        --bind-addr 127.0.0.1:0 `
+        --credentials-file $credentialsFile `
+        --tenants-file $tenantsFile `
+        --admin-tokens-file $adminTokensFile `
+        --session-state-dir $sessionDir `
+        --mailbox-dir $mailboxDir `
+        --retention-policy-file $retentionPolicyFile `
+        --accounting-dir $accountingDir `
+        --abuse-dir $abuseDir `
+        --thresholds-file $thresholdsFile `
+        --json `
+        --fail-on-warning
+    if ($LASTEXITCODE -ne 0) {
+        throw "hosted readiness fixture failed with exit code $LASTEXITCODE"
+    }
+
+    $joined = $readinessOutput -join "`n"
+    foreach ($secret in @($adminToken, $adminHash, $nodeToken, $nodeHash)) {
+        if ($joined.Contains($secret)) {
+            throw "hosted readiness output exposed fixture token material"
+        }
+    }
+    $report = $joined | ConvertFrom-Json
+    if ($report.status -ne "ready") {
+        throw "hosted readiness fixture expected ready status, got $($report.status)"
+    }
+    if ($report.warningCount -ne 0) {
+        throw "hosted readiness fixture expected zero warnings, got $($report.warningCount)"
+    }
+    $displayGuardsClean = $report.checks.displayGuardsClean
+    if ($null -eq $displayGuardsClean) {
+        throw "hosted readiness fixture did not include checks.displayGuardsClean"
+    }
+    if ($displayGuardsClean -ne $true) {
+        throw "hosted readiness fixture display guards were not clean"
+    }
+    foreach ($field in @(
+        "payloadDisplayed",
+        "tokenDisplayed",
+        "tokenHashDisplayed",
+        "keyMaterialDisplayed",
+        "sessionIdDisplayed",
+        "ciphertextDisplayed",
+        "contentsDisplayed"
+    )) {
+        if ($report.$field -ne $false) {
+            throw "hosted readiness fixture expected $field=false"
+        }
+    }
+}
+
+Push-Location $repo
+try {
+    $tempBase = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+    $tempRoot = Join-Path $tempBase ("conu-production-readiness-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+
+    if (-not $SmokeOnly -and -not $SkipRust) {
+        Invoke-CargoStep "cargo fmt" @("fmt", "--all", "--", "--check")
+        Invoke-CargoStep "cargo check" @("check", "--workspace", "--all-targets")
+        Invoke-CargoStep "cargo clippy" @("clippy", "--workspace", "--all-targets", "--", "-D", "warnings")
+        Invoke-CargoStep "cargo test" @("test", "--workspace")
+    }
+
+    if (-not $SkipRust) {
+        Invoke-CargoStep "cargo build" @("build", "--workspace")
+    }
+
+    if (-not $SmokeOnly -and -not $SkipPackages) {
+        Invoke-ReadinessStep "python compile" {
+            & python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py scripts/verify-release-versions.py scripts/verify-release-artifacts.py
+        }
+        Invoke-ReadinessStep "release version consistency" {
+            & python scripts/verify-release-versions.py
+        }
+        Invoke-ReadinessStep "TypeScript SDK check" {
+            & npm run check --prefix sdk/typescript
+        }
+        Invoke-ReadinessStep "npm launcher check" {
+            & npm run check --prefix packaging/npm/conu-cli
+        }
+    }
+
+    $conu = Get-BinaryPath "conu"
+    $conud = Get-BinaryPath "conud"
+    $conuRelay = Get-BinaryPath "conu-relay"
+
+    if (-not $SkipSmokes) {
+        $smokeToolchain = Get-EffectiveSmokeToolchain
+        Invoke-PwshScript "local smoke" (Join-Path $repo "scripts/smoke-local.ps1") @("-Conu", $conu, "-Conud", $conud, "-Toolchain", $smokeToolchain, "-SkipBuild")
+        Invoke-PwshScript "identity retirement smoke" (Join-Path $repo "scripts/smoke-identity-retirement.ps1") @("-Toolchain", $smokeToolchain)
+        Invoke-PwshScript "relay daemon smoke" (Join-Path $repo "scripts/smoke-relay-daemon.ps1") @("-Conu", $conu, "-Conud", $conud, "-ConuRelay", $conuRelay, "-Toolchain", $smokeToolchain, "-SkipBuild")
+        Invoke-HostedReadinessFixture -ConuRelay $conuRelay
+    }
+
+    Invoke-ReadinessStep "git diff whitespace check" {
+        & git diff --check
+    }
+
+    Write-Host "conU production readiness verification passed"
+}
+finally {
+    if ($tempRoot -and (Test-Path -LiteralPath $tempRoot)) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+    Pop-Location
+}


### PR DESCRIPTION
## **User description**
Fixes #158

## Summary
- Add `scripts/verify-production-readiness.ps1` as the single release-candidate verification gate.
- Cover Rust formatting/check/clippy/test/build, Python compile, release-version consistency, TypeScript SDK checks, npm launcher checks, local smoke flows, identity-retirement smoke, relay-daemon smoke, hosted-readiness fixture validation, and whitespace checks.
- Run the gate in `-SmokeOnly` mode on the Windows Rust CI job and document it in the README, production-readiness guide, release checklist, and plan.

## Validation
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes`
- PowerShell parser check for `scripts\verify-production-readiness.ps1`
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `python -m py_compile scripts\verify-release-versions.py scripts\verify-release-artifacts.py sdk\python\conu_sdk\__init__.py examples\python\local_agent_pair.py`
- `python scripts\verify-release-versions.py`
- `npm run check --prefix sdk/typescript`
- `npm run check --prefix packaging/npm/conu-cli`
- `git diff --check`

## Local limitation
- Full linked runtime tests and full `-SmokeOnly` execution are not proven on this machine because local linker support is incomplete (`dlltool.exe`/MSVC linker availability). The PR Windows CI job now runs the smoke gate with a fresh build.


___

## **CodeAnt-AI Description**
**Add one command for production readiness checks before a release candidate**

### What Changed
- Added a single Windows PowerShell gate that runs the release-candidate checks from one command
- The full gate now covers Rust checks, Python compile checks, version consistency, TypeScript SDK checks, npm launcher checks, local smoke flows, relay daemon smoke, identity retirement smoke, hosted-readiness validation, and whitespace checks
- CI now runs the smoke-only version of this gate on the Windows Rust job
- Updated the README, production readiness guide, release checklist, and plan to point to the new gate

### Impact
`✅ One release-candidate check command`
`✅ Earlier smoke coverage on Windows`
`✅ Fewer missed readiness checks before release`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
