### PR TITLE
Handle host archives in npm download smoke

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -132,6 +132,7 @@ conu stop
 - macOS launchd template is present and documents the required user/state path edits.
 - Docker relay template is present and documents current relay limits and knobs.
 - npm launcher package passes `npm run check` from `packaging/npm/conu-cli`; the local npm launcher install smoke copies release binaries into the package vendor directory, and the download install smoke verifies the default HTTPS-or-loopback archive download policy, bounded timeout/size behavior, `.sha256` check, archive-member preflight, extraction, npm bin shims, and `ready_for_local_use` launcher path.
+- Local `dist/` directories may include `conu-<version>-host` archives for developer builds; the npm download smoke skips those aliases when the matching platform-named npm asset and checksum are present.
 - TypeScript/JavaScript SDK package passes `npm run check --prefix sdk/typescript`.
 
 ## Platform Signing

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -81,6 +81,8 @@ temporary localhost HTTP server, installs the package with `CONU_NPM_DIST_BASE`,
 and exercises the default HTTPS-or-loopback download policy, bounded
 timeout/size behavior, `.sha256` verification, archive-member preflight,
 extraction, and launcher readiness path without publishing assets.
+When a local `dist/` also contains a `conu-<version>-host` archive, the download
+smoke treats the platform-named npm asset as canonical and skips the host alias.
 Tagged release builds also create GitHub artifact attestations for each platform
 archive and checksum file.
 See `docs/platform-code-signing.md` for signing secrets and verification

--- a/plan.md
+++ b/plan.md
@@ -456,6 +456,42 @@ Next:
 
 - Open PR for issue #172, run PR CI and branch `Release Artifacts`, then merge without deleting branches if checks stay green.
 
+## Post Phase 15 - npm Download Smoke Host Archive Handling
+
+Status: completed
+
+Goal:
+
+Make the documented npm download smoke command reliable when a local `dist/` contains both a developer `conu-<version>-host` archive and the platform-named archive that the npm installer actually downloads.
+
+Completed work:
+
+- Issue #174 tracks npm download smoke host-archive handling, and branch `npm-download-smoke-host-archives` carries the implementation.
+- Updated `scripts/smoke-npm-launcher-download.py` to derive the canonical npm asset name from the `@conu/cli` package version plus the current platform.
+- The smoke now skips a current-platform `target = "host"` archive when the matching platform-named npm asset and checksum exist, while still failing clearly if a current-platform archive uses a name the npm installer cannot download.
+- Updated packaging and release-checklist docs so maintainers know local host archive aliases are skipped by the npm download smoke.
+
+Files changed:
+
+- `docs/release-checklist.md`
+- `packaging/README.md`
+- `scripts/smoke-npm-launcher-download.py`
+- `plan.md`
+
+Validation:
+
+- `python scripts\smoke-npm-launcher-download.py dist` passed against the mixed local `dist/` containing both `conu-0.1.0-host.zip` and `conu-0.1.0-windows-x64.zip`; it skipped the host alias and verified the platform-named npm download install.
+- `python -m py_compile scripts\smoke-npm-launcher-download.py scripts\smoke-npm-launcher-local.py` passed.
+- `git diff --check` passed.
+
+Known gaps:
+
+- This fixes local release-smoke robustness only. It does not publish npm packages, add OS package-manager installers, configure signing/npm secrets, implement managed public relay hosting, or close the known distributed hosted runtime gaps.
+
+Next:
+
+- Open PR for issue #174, run PR CI and branch `Release Artifacts`, then merge without deleting branches if checks stay green.
+
 ## Phase 0 - Project Memory
 
 Status: completed

--- a/scripts/smoke-npm-launcher-download.py
+++ b/scripts/smoke-npm-launcher-download.py
@@ -7,6 +7,7 @@ import argparse
 import functools
 import http.server
 import importlib.util
+import json
 import os
 import socketserver
 import sys
@@ -37,6 +38,7 @@ def main() -> int:
     local_smoke = load_local_smoke_helpers()
     node = local_smoke.require_tool("node")
     npm = local_smoke.require_tool("npm", "npm.cmd")
+    expected_asset_name = npm_asset_name(package_dir, local_smoke)
 
     archives = sorted(dist.glob("*.zip")) + sorted(dist.glob("*.tar.gz"))
     if not archives:
@@ -53,6 +55,25 @@ def main() -> int:
                     skipped += 1
                     print(f"skipping {archive.name}: target {target!r} is not this runner")
                     continue
+
+                if archive.name != expected_asset_name:
+                    expected_archive = dist / expected_asset_name
+                    expected_checksum = expected_archive.with_name(f"{expected_archive.name}.sha256")
+                    if (
+                        target.lower() == "host"
+                        and expected_archive.exists()
+                        and expected_checksum.exists()
+                    ):
+                        skipped += 1
+                        print(
+                            f"skipping {archive.name}: host archive alias; "
+                            f"npm downloads {expected_asset_name}"
+                        )
+                        continue
+                    raise SystemExit(
+                        f"{archive.name} targets this runner, but the npm installer downloads "
+                        f"{expected_asset_name}; provide that platform-named archive and checksum"
+                    )
 
                 checksum = archive.with_name(f"{archive.name}.sha256")
                 if not checksum.exists():
@@ -86,6 +107,17 @@ def load_local_smoke_helpers():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def npm_asset_name(package_dir: Path, local_smoke) -> str:
+    manifest = json.loads(package_dir.joinpath("package.json").read_text(encoding="utf-8"))
+    version = manifest.get("version")
+    if not isinstance(version, str) or not version:
+        raise SystemExit(f"{package_dir / 'package.json'} missing package version")
+
+    platform_key = local_smoke.npm_platform_key()
+    extension = ".tar.gz" if platform_key.startswith("linux-") else ".zip"
+    return f"conu-{version}-{platform_key}{extension}"
 
 
 def install_npm_package_from_release_base(


### PR DESCRIPTION
## **User description**
## Summary
- make the npm download smoke derive the canonical platform asset that npm actually downloads
- skip local `target = "host"` archive aliases when the matching platform-named asset and checksum exist
- document the mixed local `dist/` behavior in packaging/release docs and plan

Closes #174

## Validation
- python scripts\smoke-npm-launcher-download.py dist
- python -m py_compile scripts\smoke-npm-launcher-download.py scripts\smoke-npm-launcher-local.py
- git diff --check

## PR/Security Review
- payload exposure risk: low; smoke still verifies launcher readiness without displaying payload contents
- trust/permission risk: none; validation tooling only, no runtime trust changes
- storage/logging risk: low; temporary npm install state remains under temp directories
- relay/network risk: none; local localhost artifact server smoke only


___

## **CodeAnt-AI Description**
**Make npm download smoke ignore host alias archives when a platform-named release is available**

### What Changed
- The npm download smoke now uses the package version and current platform to identify the archive npm actually downloads.
- When a local `dist/` contains both a `conu-<version>-host` archive and the matching platform-named archive with its checksum, the smoke skips the host alias instead of failing.
- If a current-platform archive is named differently from the npm download target and no matching platform-named asset is present, the smoke now stops with a clear error.
- Packaging and release docs now explain that local host alias archives may be skipped during this smoke test.

### Impact
`✅ Fewer false failures in local release smoke tests`
`✅ Reliable npm download checks for mixed dist/ directories`
`✅ Clearer guidance for release builds with host alias archives`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
