### PR TITLE
Add safe release secret setup tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: python scripts/check-linux-signing-secrets-preflight-regression.py
       - name: GitHub release secret readiness regression
         run: python scripts/check-github-release-secret-readiness-regression.py
+      - name: GitHub release secret setup regression
+        run: python scripts/set-github-release-secrets-regression.py
       - name: RPM package signing regression
         run: python scripts/check-rpm-package-signing.py
       - name: Linux release signing regression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,8 @@ jobs:
         run: python scripts/check-linux-signing-secrets-preflight-regression.py
       - name: GitHub release secret readiness regression
         run: python scripts/check-github-release-secret-readiness-regression.py
+      - name: GitHub release secret setup regression
+        run: python scripts/set-github-release-secrets-regression.py
       - name: RPM package signing regression
         run: python scripts/check-rpm-package-signing.py
       - name: Linux release signing regression

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -12,6 +12,8 @@ Use this checklist before publishing any conU build.
 - Run `python scripts/check-release-artifact-smoke-preflight.py`; CI and release package gates use the same regression check to prove archive smoke validation fails closed on missing binary directories, missing binaries, and non-file binary paths before execution.
 - Run `python scripts/check-package-manager-manifests.py`; CI and release package gates use the same regression check to prove generated Homebrew/Scoop/winget/Chocolatey/Debian/RPM files plus APT/RPM repository metadata require strict release checksums plus safe Windows and Linux archive layouts, including native Debian package checks with `dpkg-deb`, APT/RPM metadata hash checks, and RPM spec plus optional RPM asset checks with `rpmbuild`/`createrepo_c` when those tools are available.
 - Run `python scripts/check-linux-signing-secrets-preflight-regression.py`; CI and release package gates use the same regression check to prove Linux signing secrets fail closed when missing, malformed, fingerprint-mismatched, or unusable for probe signing.
+- Run `python scripts/set-github-release-secrets-regression.py`; CI and release package gates use the same regression check to prove release secret setup reads local values from the environment, sends them to `gh secret set` through stdin rather than command arguments, and reports only secret names.
+- Run `python scripts/check-github-release-secret-readiness.py --repo <owner/name>` before creating a release tag; it reports only configured or missing secret names.
 - Run `python scripts/check-rpm-package-signing.py`; CI and release package gates use the same regression check to prove generated RPM package payloads can be signed with the fingerprint-pinned Linux GPG key, verified with native RPM tooling, refreshed with strict `.rpm.sha256` sidecars, used to generate RPM repository metadata, and failed closed on missing or mismatched fingerprint secrets.
 - Run `python scripts/check-linux-release-signing.py`; CI and release package gates use the same regression check to prove Linux detached signing selects only Linux archives, generated Debian/RPM packages, and APT/RPM repository metadata, verifies generated `.asc` signatures, and fails closed when signing secrets are missing or the configured key fingerprint mismatches.
 - Run `python scripts/check-linux-repository-signing.py`; CI and release package gates use the same regression check to prove generated APT metadata ZIPs receive valid `InRelease` and `Release.gpg` signatures, generated RPM metadata ZIPs receive valid `repodata/repomd.xml.asc` signatures, `.sha256` sidecars are refreshed, unrelated release assets are not mutated, and missing or mismatched signing fingerprint secrets fail closed.
@@ -182,6 +184,10 @@ conu stop
   `CONU_MACOS_NOTARY_TEAM_ID`, `CONU_MACOS_NOTARY_PASSWORD`,
   `CONU_LINUX_GPG_PRIVATE_KEY_BASE64`, `CONU_LINUX_GPG_PASSPHRASE`,
   `CONU_LINUX_GPG_KEY_ID`, and `CONU_LINUX_GPG_KEY_FINGERPRINT`.
+- After exporting the required values locally, run
+  `python scripts/set-github-release-secrets.py --repo <owner/name> --dry-run`,
+  then rerun without `--dry-run` to configure the repository secrets through
+  GitHub CLI stdin without printing values.
 - Tagged release preflight imports the configured Linux GPG private key into a
   temporary keyring, verifies `CONU_LINUX_GPG_KEY_ID` resolves to
   `CONU_LINUX_GPG_KEY_FINGERPRINT`, and probe-signs a temporary file before

--- a/scripts/check-github-release-secret-readiness-regression.py
+++ b/scripts/check-github-release-secret-readiness-regression.py
@@ -51,6 +51,8 @@ def run_audit_tests(module) -> None:
 
 
 def run_gh_payload_tests(module) -> None:
+    helper = sys.modules["github_release_secrets"]
+
     def fake_secret_list(args, **_kwargs):
         if args[1:4] != ["secret", "list", "--repo"]:
             raise AssertionError(f"unexpected gh args: {args!r}")
@@ -61,11 +63,11 @@ def run_gh_payload_tests(module) -> None:
         return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
 
     original_run = subprocess.run
-    module.subprocess.run = fake_secret_list
+    helper.subprocess.run = fake_secret_list
     try:
         names = module.load_secret_names("owner/repo", "gh")
     finally:
-        module.subprocess.run = original_run
+        helper.subprocess.run = original_run
 
     if names != set(module.REQUIRED_RELEASE_SECRETS):
         raise AssertionError("loaded secret names did not match required names")
@@ -76,30 +78,32 @@ def run_gh_payload_tests(module) -> None:
 
 
 def run_error_tests(module) -> None:
+    helper = sys.modules["github_release_secrets"]
+
     def invalid_json(*_args, **_kwargs):
         return SimpleNamespace(returncode=0, stdout="{not-json", stderr="")
 
     original_run = subprocess.run
-    module.subprocess.run = invalid_json
+    helper.subprocess.run = invalid_json
     try:
         assert_raises(
             lambda: module.load_secret_names("owner/repo", "gh"),
             "invalid JSON",
         )
     finally:
-        module.subprocess.run = original_run
+        helper.subprocess.run = original_run
 
     def failed_command(*_args, **_kwargs):
         return SimpleNamespace(returncode=1, stdout="", stderr=SENSITIVE_SENTINEL)
 
-    module.subprocess.run = failed_command
+    helper.subprocess.run = failed_command
     try:
         assert_raises(
             lambda: module.load_secret_names("owner/repo", "gh"),
             "gh secret list failed",
         )
     finally:
-        module.subprocess.run = original_run
+        helper.subprocess.run = original_run
 
 
 def main() -> int:

--- a/scripts/check-github-release-secret-readiness.py
+++ b/scripts/check-github-release-secret-readiness.py
@@ -5,128 +5,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import shutil
-import subprocess
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
-
-REQUIRED_RELEASE_SECRETS: tuple[str, ...] = (
-    "CONU_WINDOWS_SIGN_CERT_PFX_BASE64",
-    "CONU_WINDOWS_SIGN_CERT_PASSWORD",
-    "CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64",
-    "CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD",
-    "CONU_MACOS_CODESIGN_IDENTITY",
-    "CONU_MACOS_NOTARY_APPLE_ID",
-    "CONU_MACOS_NOTARY_TEAM_ID",
-    "CONU_MACOS_NOTARY_PASSWORD",
-    "CONU_LINUX_GPG_PRIVATE_KEY_BASE64",
-    "CONU_LINUX_GPG_PASSPHRASE",
-    "CONU_LINUX_GPG_KEY_ID",
-    "CONU_LINUX_GPG_KEY_FINGERPRINT",
-    "NPM_TOKEN",
+from github_release_secrets import (
+    REQUIRED_RELEASE_SECRETS,
+    SecretReadiness,
+    audit_secret_names,
+    find_gh,
+    infer_repo,
+    load_secret_names,
 )
-
-
-@dataclass(frozen=True)
-class SecretReadiness:
-    repo: str
-    required: tuple[str, ...]
-    present: tuple[str, ...]
-    missing: tuple[str, ...]
-
-    @property
-    def ready(self) -> bool:
-        return not self.missing
-
-    def as_json(self) -> dict[str, Any]:
-        return {
-            "repo": self.repo,
-            "ready": self.ready,
-            "required": list(self.required),
-            "present": list(self.present),
-            "missing": list(self.missing),
-        }
-
-
-def find_gh() -> str:
-    candidates = ("gh.exe", "gh") if sys.platform == "win32" else ("gh",)
-    for candidate in candidates:
-        path = shutil.which(candidate)
-        if path:
-            return path
-    raise ValueError("GitHub CLI executable was not found on PATH")
-
-
-def run_gh_json(gh: str, args: list[str], description: str) -> Any:
-    result = subprocess.run(
-        [gh, *args],
-        check=False,
-        encoding="utf-8",
-        errors="replace",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    if result.returncode != 0:
-        raise ValueError(
-            f"{description} failed with exit code {result.returncode}; run gh auth status"
-        )
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"{description} returned invalid JSON: {exc}") from exc
-
-
-def infer_repo(gh: str) -> str:
-    env_repo = os.environ.get("GH_REPO", "").strip()
-    if env_repo:
-        return env_repo
-
-    payload = run_gh_json(
-        gh,
-        ["repo", "view", "--json", "nameWithOwner"],
-        "gh repo view",
-    )
-    if not isinstance(payload, dict):
-        raise ValueError("gh repo view returned an unexpected payload")
-    repo = payload.get("nameWithOwner")
-    if not isinstance(repo, str) or not repo.strip():
-        raise ValueError("gh repo view did not return nameWithOwner")
-    return repo.strip()
-
-
-def load_secret_names(repo: str, gh: str) -> set[str]:
-    payload = run_gh_json(
-        gh,
-        ["secret", "list", "--repo", repo, "--json", "name"],
-        "gh secret list",
-    )
-    if not isinstance(payload, list):
-        raise ValueError("gh secret list returned an unexpected payload")
-
-    names: set[str] = set()
-    for item in payload:
-        if not isinstance(item, dict):
-            raise ValueError("gh secret list returned a non-object secret entry")
-        name = item.get("name")
-        if not isinstance(name, str) or not name.strip():
-            raise ValueError("gh secret list returned a secret entry without a name")
-        names.add(name.strip())
-    return names
-
-
-def audit_secret_names(repo: str, configured_names: set[str]) -> SecretReadiness:
-    present = tuple(name for name in REQUIRED_RELEASE_SECRETS if name in configured_names)
-    missing = tuple(name for name in REQUIRED_RELEASE_SECRETS if name not in configured_names)
-    return SecretReadiness(
-        repo=repo,
-        required=REQUIRED_RELEASE_SECRETS,
-        present=present,
-        missing=missing,
-    )
 
 
 def print_text_report(report: SecretReadiness) -> None:

--- a/scripts/github_release_secrets.py
+++ b/scripts/github_release_secrets.py
@@ -1,0 +1,126 @@
+"""Shared GitHub release-secret metadata and GitHub CLI helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+REQUIRED_RELEASE_SECRETS: tuple[str, ...] = (
+    "CONU_WINDOWS_SIGN_CERT_PFX_BASE64",
+    "CONU_WINDOWS_SIGN_CERT_PASSWORD",
+    "CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64",
+    "CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD",
+    "CONU_MACOS_CODESIGN_IDENTITY",
+    "CONU_MACOS_NOTARY_APPLE_ID",
+    "CONU_MACOS_NOTARY_TEAM_ID",
+    "CONU_MACOS_NOTARY_PASSWORD",
+    "CONU_LINUX_GPG_PRIVATE_KEY_BASE64",
+    "CONU_LINUX_GPG_PASSPHRASE",
+    "CONU_LINUX_GPG_KEY_ID",
+    "CONU_LINUX_GPG_KEY_FINGERPRINT",
+    "NPM_TOKEN",
+)
+
+
+@dataclass(frozen=True)
+class SecretReadiness:
+    repo: str
+    required: tuple[str, ...]
+    present: tuple[str, ...]
+    missing: tuple[str, ...]
+
+    @property
+    def ready(self) -> bool:
+        return not self.missing
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "repo": self.repo,
+            "ready": self.ready,
+            "required": list(self.required),
+            "present": list(self.present),
+            "missing": list(self.missing),
+        }
+
+
+def find_gh() -> str:
+    candidates = ("gh.exe", "gh") if sys.platform == "win32" else ("gh",)
+    for candidate in candidates:
+        path = shutil.which(candidate)
+        if path:
+            return path
+    raise ValueError("GitHub CLI executable was not found on PATH")
+
+
+def run_gh_json(gh: str, args: list[str], description: str) -> Any:
+    result = subprocess.run(
+        [gh, *args],
+        check=False,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            f"{description} failed with exit code {result.returncode}; run gh auth status"
+        )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{description} returned invalid JSON: {exc}") from exc
+
+
+def infer_repo(gh: str) -> str:
+    env_repo = os.environ.get("GH_REPO", "").strip()
+    if env_repo:
+        return env_repo
+
+    payload = run_gh_json(
+        gh,
+        ["repo", "view", "--json", "nameWithOwner"],
+        "gh repo view",
+    )
+    if not isinstance(payload, dict):
+        raise ValueError("gh repo view returned an unexpected payload")
+    repo = payload.get("nameWithOwner")
+    if not isinstance(repo, str) or not repo.strip():
+        raise ValueError("gh repo view did not return nameWithOwner")
+    return repo.strip()
+
+
+def load_secret_names(repo: str, gh: str) -> set[str]:
+    payload = run_gh_json(
+        gh,
+        ["secret", "list", "--repo", repo, "--json", "name"],
+        "gh secret list",
+    )
+    if not isinstance(payload, list):
+        raise ValueError("gh secret list returned an unexpected payload")
+
+    names: set[str] = set()
+    for item in payload:
+        if not isinstance(item, dict):
+            raise ValueError("gh secret list returned a non-object secret entry")
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("gh secret list returned a secret entry without a name")
+        names.add(name.strip())
+    return names
+
+
+def audit_secret_names(repo: str, configured_names: set[str]) -> SecretReadiness:
+    present = tuple(name for name in REQUIRED_RELEASE_SECRETS if name in configured_names)
+    missing = tuple(name for name in REQUIRED_RELEASE_SECRETS if name not in configured_names)
+    return SecretReadiness(
+        repo=repo,
+        required=REQUIRED_RELEASE_SECRETS,
+        present=present,
+        missing=missing,
+    )

--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Regression checks for GitHub release-secret setup behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT = Path(__file__).with_name("set-github-release-secrets.py")
+SENSITIVE_SENTINEL = "do-not-print-or-argv-this-secret-value"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("set_github_release_secrets", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load GitHub release secret setup module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_raises(func, pattern: str) -> None:
+    try:
+        func()
+    except ValueError as exc:
+        if pattern not in str(exc):
+            raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
+        return
+    raise AssertionError(f"expected ValueError containing {pattern!r}")
+
+
+def with_required_env(module, value: str):
+    original = {name: os.environ.get(name) for name in module.REQUIRED_RELEASE_SECRETS}
+    for name in module.REQUIRED_RELEASE_SECRETS:
+        os.environ[name] = value
+    return original
+
+
+def restore_env(original: dict[str, str | None]) -> None:
+    for name, value in original.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+
+def run_env_collection_tests(module) -> None:
+    original = {name: os.environ.get(name) for name in module.REQUIRED_RELEASE_SECRETS}
+    try:
+        for name in module.REQUIRED_RELEASE_SECRETS:
+            os.environ.pop(name, None)
+        values, missing = module.collect_env_values(module.REQUIRED_RELEASE_SECRETS)
+        if values:
+            raise AssertionError("missing environment should not produce secret values")
+        if missing != module.REQUIRED_RELEASE_SECRETS:
+            raise AssertionError("all required secrets should be reported missing")
+
+        os.environ[module.REQUIRED_RELEASE_SECRETS[0]] = SENSITIVE_SENTINEL
+        values, missing = module.collect_env_values(module.REQUIRED_RELEASE_SECRETS)
+        if values[module.REQUIRED_RELEASE_SECRETS[0]] != SENSITIVE_SENTINEL:
+            raise AssertionError("expected configured environment value to be loaded")
+        if SENSITIVE_SENTINEL in "\n".join(missing):
+            raise AssertionError("missing-name report leaked a secret value")
+    finally:
+        restore_env(original)
+
+
+def run_secret_set_tests(module) -> None:
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    original_run = subprocess.run
+    module.subprocess.run = fake_run
+    try:
+        module.set_secret("gh", "owner/repo", "NPM_TOKEN", SENSITIVE_SENTINEL)
+    finally:
+        module.subprocess.run = original_run
+
+    if len(calls) != 1:
+        raise AssertionError(f"expected one gh secret set call, got {len(calls)}")
+    args, kwargs = calls[0]
+    rendered_args = " ".join(args)
+    if SENSITIVE_SENTINEL in rendered_args:
+        raise AssertionError("secret value was passed in command arguments")
+    if kwargs.get("input") != SENSITIVE_SENTINEL:
+        raise AssertionError("secret value was not passed through stdin")
+
+    def failed_run(*_args, **_kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr=SENSITIVE_SENTINEL)
+
+    module.subprocess.run = failed_run
+    try:
+        assert_raises(
+            lambda: module.set_secret("gh", "owner/repo", "NPM_TOKEN", SENSITIVE_SENTINEL),
+            "failed with exit code 1",
+        )
+    finally:
+        module.subprocess.run = original_run
+
+
+def run_dry_run_tests(module) -> None:
+    original = with_required_env(module, SENSITIVE_SENTINEL)
+    try:
+        values, missing = module.collect_env_values(module.REQUIRED_RELEASE_SECRETS)
+        if missing:
+            raise AssertionError("all required environment values should be present")
+
+        partial = dict(values)
+        missing_name = module.REQUIRED_RELEASE_SECRETS[0]
+        partial.pop(missing_name)
+        assert_raises(
+            lambda: module.configure_release_secrets("owner/repo", "gh", partial, dry_run=True),
+            missing_name,
+        )
+
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        original_run = subprocess.run
+        module.subprocess.run = fake_run
+        try:
+            configured = module.configure_release_secrets("owner/repo", "gh", values, dry_run=True)
+        finally:
+            module.subprocess.run = original_run
+
+        if configured != module.REQUIRED_RELEASE_SECRETS:
+            raise AssertionError("dry run should report every required secret name")
+        if calls:
+            raise AssertionError("dry run must not call gh secret set")
+    finally:
+        restore_env(original)
+
+
+def run_missing_report_tests(module) -> None:
+    buffer = io.StringIO()
+    module.print_secret_names("missing:", ("NPM_TOKEN",), buffer)
+    rendered = buffer.getvalue()
+    if "NPM_TOKEN" not in rendered:
+        raise AssertionError("secret name should be reported")
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("secret report leaked a secret value")
+
+
+def main() -> int:
+    module = load_module()
+    run_env_collection_tests(module)
+    run_secret_set_tests(module)
+    run_dry_run_tests(module)
+    run_missing_report_tests(module)
+    print("GitHub release secret setup regression checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Configure required GitHub Actions release secrets from local environment values."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from github_release_secrets import REQUIRED_RELEASE_SECRETS, find_gh, infer_repo
+
+
+def collect_env_values(names: tuple[str, ...]) -> tuple[dict[str, str], tuple[str, ...]]:
+    values: dict[str, str] = {}
+    missing: list[str] = []
+    for name in names:
+        value = os.environ.get(name)
+        if value is None or value == "":
+            missing.append(name)
+        else:
+            values[name] = value
+    return values, tuple(missing)
+
+
+def set_secret(gh: str, repo: str, name: str, value: str) -> None:
+    result = subprocess.run(
+        [gh, "secret", "set", name, "--repo", repo],
+        check=False,
+        encoding="utf-8",
+        errors="replace",
+        input=value,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise ValueError(f"gh secret set {name} failed with exit code {result.returncode}")
+
+
+def print_secret_names(label: str, names: tuple[str, ...], stream) -> None:
+    print(label, file=stream)
+    for name in names:
+        print(f"- {name}", file=stream)
+
+
+def configure_release_secrets(
+    repo: str,
+    gh: str,
+    values: dict[str, str],
+    dry_run: bool,
+) -> tuple[str, ...]:
+    missing = tuple(name for name in REQUIRED_RELEASE_SECRETS if name not in values)
+    if missing:
+        raise ValueError("missing local environment values: " + ", ".join(missing))
+
+    names = tuple(name for name in REQUIRED_RELEASE_SECRETS if name in values)
+    if dry_run:
+        return names
+
+    for name in names:
+        set_secret(gh, repo, name, values[name])
+    return names
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default="",
+        help="GitHub repository in owner/name form; defaults to GH_REPO or gh repo view",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate local environment values and print secret names without writing them",
+    )
+    parser.add_argument(
+        "--gh",
+        default="",
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        repo_root = Path(__file__).resolve().parents[1]
+        os.chdir(repo_root)
+
+        values, missing = collect_env_values(REQUIRED_RELEASE_SECRETS)
+        if missing:
+            print_secret_names(
+                "GitHub release secret setup failed: missing local environment values:",
+                missing,
+                sys.stderr,
+            )
+            return 1
+
+        gh = args.gh or find_gh()
+        repo = args.repo.strip() or infer_repo(gh)
+        configured = configure_release_secrets(repo, gh, values, args.dry_run)
+    except (OSError, ValueError) as exc:
+        print(f"GitHub release secret setup failed: {exc}", file=sys.stderr)
+        return 1
+
+    action = "would configure" if args.dry_run else "configured"
+    print(
+        f"GitHub release secret setup {action} {len(configured)} "
+        f"required secret names for {repo}"
+    )
+    for name in configured:
+        print(f"{action}: {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-production-readiness.ps1
+++ b/scripts/verify-production-readiness.ps1
@@ -248,7 +248,7 @@ try {
 
     if (-not $SmokeOnly -and -not $SkipPackages) {
         Invoke-ReadinessStep "python compile" {
-            & python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py scripts/verify-release-versions.py scripts/verify-release-artifacts.py scripts/verify-npm-package-contents.py scripts/generate-package-manager-manifests.py scripts/check-package-manager-manifests.py scripts/linux_gpg_common.py scripts/check-linux-signing-secrets-preflight.py scripts/check-linux-signing-secrets-preflight-regression.py scripts/check-github-release-secret-readiness.py scripts/check-github-release-secret-readiness-regression.py scripts/sign-rpm-packages.py scripts/check-rpm-package-signing.py scripts/sign-linux-release-assets.py scripts/check-linux-release-signing.py scripts/sign-linux-repository-metadata.py scripts/check-linux-repository-signing.py scripts/export-linux-gpg-public-key.py scripts/check-linux-gpg-public-key-export.py scripts/check-release-artifact-verifier.py scripts/check-release-artifact-smoke-preflight.py scripts/check-npm-launcher-local-smoke-preflight.py scripts/check-npm-publish-preflight.py scripts/check-npm-publish-preflight-regression.py
+            & python -m py_compile sdk/python/conu_sdk/__init__.py examples/python/local_agent_pair.py scripts/verify-release-versions.py scripts/verify-release-artifacts.py scripts/verify-npm-package-contents.py scripts/generate-package-manager-manifests.py scripts/check-package-manager-manifests.py scripts/linux_gpg_common.py scripts/check-linux-signing-secrets-preflight.py scripts/check-linux-signing-secrets-preflight-regression.py scripts/github_release_secrets.py scripts/check-github-release-secret-readiness.py scripts/check-github-release-secret-readiness-regression.py scripts/set-github-release-secrets.py scripts/set-github-release-secrets-regression.py scripts/sign-rpm-packages.py scripts/check-rpm-package-signing.py scripts/sign-linux-release-assets.py scripts/check-linux-release-signing.py scripts/sign-linux-repository-metadata.py scripts/check-linux-repository-signing.py scripts/export-linux-gpg-public-key.py scripts/check-linux-gpg-public-key-export.py scripts/check-release-artifact-verifier.py scripts/check-release-artifact-smoke-preflight.py scripts/check-npm-launcher-local-smoke-preflight.py scripts/check-npm-publish-preflight.py scripts/check-npm-publish-preflight-regression.py
         }
         Invoke-ReadinessStep "release version consistency" {
             & python scripts/verify-release-versions.py
@@ -267,6 +267,9 @@ try {
         }
         Invoke-ReadinessStep "GitHub release secret readiness regression" {
             & python scripts/check-github-release-secret-readiness-regression.py
+        }
+        Invoke-ReadinessStep "GitHub release secret setup regression" {
+            & python scripts/set-github-release-secrets-regression.py
         }
         Invoke-ReadinessStep "RPM package signing regression" {
             & python scripts/check-rpm-package-signing.py


### PR DESCRIPTION
## **User description**
## Summary
- share the required release secret list between readiness and setup tooling
- add a GitHub CLI setup script that reads required release secret values from local environment variables and sends values to gh secret set over stdin, not argv
- add regression coverage for missing env values, dry-run behavior, command argument secrecy, and failure redaction
- wire the setup regression into CI, release package checks, and production readiness verification

## Validation
- python -m py_compile scripts/github_release_secrets.py scripts/check-github-release-secret-readiness.py scripts/check-github-release-secret-readiness-regression.py scripts/set-github-release-secrets.py scripts/set-github-release-secrets-regression.py
- python scripts/check-github-release-secret-readiness-regression.py
- python scripts/set-github-release-secrets-regression.py
- python scripts/set-github-release-secrets.py --repo imthegoodboy/conU --dry-run with fake local env values; output showed only secret names
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes
- workflow YAML parsed
- git diff --check

Closes #224


___

## **CodeAnt-AI Description**
**Add a safe GitHub release secret setup command and document it**

### What Changed
- Added a command to load required release secret values from local environment variables and send them to GitHub without showing the values in the command line or output.
- Dry-run mode now checks for missing values and prints only the secret names it would configure.
- Added regression checks for missing environment values, dry-run behavior, stdin-based secret setup, and redacted failure output.
- Included the new secret setup checks in CI, release readiness verification, and the release checklist.

### Impact
`✅ Safer release secret setup`
`✅ Fewer secret leaks in logs and process arguments`
`✅ Clearer release setup steps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
