### PR TITLE
Harden update public host IP checks

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
-use std::net::{IpAddr, TcpStream, ToSocketAddrs};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
@@ -8759,17 +8759,95 @@ fn connect_update_public_tcp(
 
 fn is_public_ip(ip: IpAddr) -> bool {
     match ip {
-        IpAddr::V4(ip) => {
-            !(ip.is_private()
-                || ip.is_loopback()
-                || ip.is_link_local()
-                || ip.is_broadcast()
-                || ip.is_documentation()
-                || ip.is_unspecified()
-                || ip.is_multicast())
-        }
-        IpAddr::V6(ip) => !(ip.is_loopback() || ip.is_unspecified() || ip.is_multicast()),
+        IpAddr::V4(ip) => is_public_ipv4(ip),
+        IpAddr::V6(ip) => is_public_ipv6(ip),
     }
+}
+
+fn is_public_ipv4(ip: Ipv4Addr) -> bool {
+    let [first, second, third, _fourth] = ip.octets();
+    !(first == 0
+        || ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || (first == 100 && (64..=127).contains(&second))
+        || (first == 192 && second == 0 && third == 0)
+        || (first == 192 && second == 88 && third == 99)
+        || (first == 198 && (second == 18 || second == 19))
+        || first >= 240)
+}
+
+fn is_public_ipv6(ip: Ipv6Addr) -> bool {
+    if ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || is_ipv6_unique_local(ip)
+        || is_ipv6_link_local(ip)
+        || is_ipv6_site_local(ip)
+        || is_ipv6_documentation(ip)
+        || is_ipv6_discard_only(ip)
+        || is_ipv6_protocol_assignment(ip)
+        || is_ipv6_6to4(ip)
+    {
+        return false;
+    }
+
+    if let Some(mapped) = ip.to_ipv4_mapped() {
+        return is_public_ipv4(mapped);
+    }
+    if let Some(compatible) = ipv4_compatible_address(ip) {
+        return is_public_ipv4(compatible);
+    }
+
+    true
+}
+
+fn is_ipv6_unique_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
+}
+
+fn is_ipv6_link_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfe80
+}
+
+fn is_ipv6_site_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfec0
+}
+
+fn is_ipv6_documentation(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x2001 && segments[1] == 0x0db8
+}
+
+fn is_ipv6_discard_only(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0
+}
+
+fn is_ipv6_protocol_assignment(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x2001 && segments[1] <= 0x01ff
+}
+
+fn is_ipv6_6to4(ip: Ipv6Addr) -> bool {
+    ip.segments()[0] == 0x2002
+}
+
+fn ipv4_compatible_address(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    let segments = ip.segments();
+    if segments[..6].iter().any(|segment| *segment != 0) {
+        return None;
+    }
+    Some(Ipv4Addr::new(
+        (segments[6] >> 8) as u8,
+        segments[6] as u8,
+        (segments[7] >> 8) as u8,
+        segments[7] as u8,
+    ))
 }
 
 fn asset_name_from_update_url(url: &str, label: &str) -> Result<String, String> {
@@ -10423,6 +10501,67 @@ mod tests {
 
         assert_eq!(output.code, 1);
         assert!(output.stderr.contains("host must be public"));
+    }
+
+    #[test]
+    fn update_check_rejects_non_public_ipv6_remote_policy_urls() {
+        for host in [
+            "[fc00::1]",
+            "[fd12:3456:789a::1]",
+            "[fe80::1]",
+            "[fec0::1]",
+            "[2001:db8::1]",
+            "[::ffff:127.0.0.1]",
+            "[::ffff:10.0.0.1]",
+            "[::127.0.0.1]",
+        ] {
+            let url = format!("https://{host}/conu-0.1.0-update-policy.json");
+            let output = run(["update", "check", "--policy-url", url.as_str()]);
+
+            assert_eq!(output.code, 1, "{host}: {}", output.stderr);
+            assert!(output.stderr.contains("host must be public"));
+            assert!(!output.stderr.contains("private message contents"));
+        }
+    }
+
+    #[test]
+    fn update_public_ip_filter_rejects_non_global_special_ranges() {
+        for value in [
+            "0.1.2.3",
+            "100.64.0.1",
+            "192.0.0.1",
+            "192.88.99.1",
+            "198.18.0.1",
+            "240.0.0.1",
+            "::",
+            "::1",
+            "fc00::1",
+            "fd12:3456:789a::1",
+            "fe80::1",
+            "fec0::1",
+            "100::1",
+            "2001::1",
+            "2001:db8::1",
+            "2002::1",
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+            "::10.0.0.1",
+        ] {
+            let ip = value.parse::<IpAddr>().expect("test IP parses");
+            assert!(!is_public_ip(ip), "{value} should be non-public");
+        }
+
+        for value in [
+            "1.1.1.1",
+            "8.8.8.8",
+            "2606:4700:4700::1111",
+            "2001:4860:4860::8888",
+            "::ffff:8.8.8.8",
+            "::8.8.8.8",
+        ] {
+            let ip = value.parse::<IpAddr>().expect("test IP parses");
+            assert!(is_public_ip(ip), "{value} should be public");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- tighten the release update client's shared public-IP predicate for remote policy/artifact downloads
- reject non-global IPv4 ranges, IPv6 unique-local/link-local/site-local/documentation/special ranges, and IPv4-mapped/private IPv6 forms
- add regressions for non-public IPv6 remote policy URLs and the shared public-IP filter

## Security review
- payload exposure risk: low; change only validates update URLs/IPs and does not inspect or print payload contents
- trust/permission risk: reduced; remote update downloads fail closed for non-public literal/resolved IPs
- storage/logging risk: low; no new persistent storage or log body output
- relay/network risk: reduced for update downloads; no relay protocol changes
- required fixes: none known

## Validation
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy -p conu-cli --all-targets -- -D warnings`
- `wsl bash -lc "cd /mnt/c/Users/parth/Desktop/conU && cargo test -p conu-cli update_"`
- `wsl bash -lc "cd /mnt/c/Users/parth/Desktop/conU && cargo test -p conu-cli"`
- `powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

Closes #298


___

## **CodeAnt-AI Description**
Tighten public IP checks for update downloads

### What Changed
- Update checks now block more non-public host addresses, including private, local, documentation, special-use, and reserved IPv4 ranges
- IPv6 update URLs are now rejected when they point to unique-local, link-local, site-local, documentation, discard-only, 6to4, or IPv4-mapped private addresses
- Added coverage for both blocked and allowed address cases to keep remote update checks from accepting unsafe hosts

### Impact
`✅ Fewer unsafe update downloads`
`✅ Stronger protection against local-network policy URLs`
`✅ Clearer rejection of reserved and private IP addresses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
