### PR TITLE
Reject unexpected release archive roots

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -7372,7 +7372,7 @@ fn stage_update_zip_archive(
     let mut archive = zip::ZipArchive::new(reader)
         .map_err(|error| format!("release update ZIP archive is invalid: {error}"))?;
     let staging_dir = UpdateDownloadDir::create()?;
-    let mut scan = UpdateArchiveScan::new(target)?;
+    let mut scan = UpdateArchiveScan::new(target, archive_name)?;
 
     for index in 0..archive.len() {
         let mut file = archive
@@ -7421,7 +7421,7 @@ fn stage_update_tar_gz_archive(
     let decoder = flate2::read::GzDecoder::new(reader);
     let mut archive = tar::Archive::new(decoder);
     let staging_dir = UpdateDownloadDir::create()?;
-    let mut scan = UpdateArchiveScan::new(target)?;
+    let mut scan = UpdateArchiveScan::new(target, archive_name)?;
     let entries = archive
         .entries()
         .map_err(|error| format!("release update tar archive is invalid: {error}"))?;
@@ -7478,6 +7478,8 @@ fn stage_update_tar_gz_archive(
 
 struct UpdateArchiveScan {
     target: String,
+    expected_root: String,
+    root_style: Option<UpdateArchiveRootStyle>,
     expected_binaries: Vec<(String, String)>,
     paths: HashSet<String>,
     binaries: Vec<StagedUpdateBinary>,
@@ -7487,15 +7489,24 @@ struct UpdateArchiveScan {
     unpacked_bytes: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdateArchiveRootStyle {
+    Rooted,
+    Rootless,
+}
+
 impl UpdateArchiveScan {
-    fn new(target: &str) -> Result<Self, String> {
+    fn new(target: &str, archive_name: &str) -> Result<Self, String> {
         let suffix = update_binary_suffix_for_target(target)?;
+        let expected_root = expected_update_archive_root(archive_name)?;
         let expected_binaries = UPDATE_BINARY_NAMES
             .iter()
             .map(|name| ((*name).to_string(), format!("bin/{}{}", name, suffix)))
             .collect();
         Ok(Self {
             target: target.to_string(),
+            expected_root,
+            root_style: None,
             expected_binaries,
             paths: HashSet::new(),
             binaries: Vec::new(),
@@ -7524,7 +7535,11 @@ impl UpdateArchiveScan {
                 "release update archive member is too large: {raw_name}"
             ));
         }
-        let normalized = normalize_update_archive_member(raw_name)?;
+        let (normalized, root_style) =
+            normalize_update_archive_member(raw_name, &self.expected_root)?;
+        if let Some(root_style) = root_style {
+            self.record_root_style(archive_name, raw_name, root_style)?;
+        }
         if normalized.is_empty() {
             return Ok(normalized);
         }
@@ -7546,6 +7561,24 @@ impl UpdateArchiveScan {
             self.reject_unexpected_binary_path(&normalized)?;
         }
         Ok(normalized)
+    }
+
+    fn record_root_style(
+        &mut self,
+        archive_name: &str,
+        raw_name: &str,
+        root_style: UpdateArchiveRootStyle,
+    ) -> Result<(), String> {
+        if let Some(existing) = self.root_style {
+            if existing != root_style {
+                return Err(format!(
+                    "release update archive {archive_name} mixes rooted and rootless members: {raw_name}"
+                ));
+            }
+        } else {
+            self.root_style = Some(root_style);
+        }
+        Ok(())
     }
 
     fn reject_unexpected_binary_path(&self, normalized: &str) -> Result<(), String> {
@@ -7647,7 +7680,21 @@ impl UpdateArchiveScan {
     }
 }
 
-fn normalize_update_archive_member(name: &str) -> Result<String, String> {
+fn expected_update_archive_root(archive_name: &str) -> Result<String, String> {
+    let root = archive_name
+        .strip_suffix(".tar.gz")
+        .or_else(|| archive_name.strip_suffix(".zip"))
+        .ok_or_else(|| {
+            format!("release update artifact {archive_name} must be a .tar.gz or .zip archive")
+        })?;
+    validate_public_asset_name(root, "release update archive root")?;
+    Ok(root.to_string())
+}
+
+fn normalize_update_archive_member(
+    name: &str,
+    expected_root: &str,
+) -> Result<(String, Option<UpdateArchiveRootStyle>), String> {
     let normalized = name.replace('\\', "/");
     if normalized.contains(':') || normalized.contains('\0') {
         return Err(format!(
@@ -7680,10 +7727,23 @@ fn normalize_update_archive_member(name: &str) -> Result<String, String> {
             }
         }
     }
-    if parts.first().is_some_and(|part| part.starts_with("conu-")) {
+    let root_style = if let Some(first) = parts.first() {
+        if first == expected_root {
+            Some(UpdateArchiveRootStyle::Rooted)
+        } else if first.starts_with("conu-") {
+            return Err(format!(
+                "release update archive contains unexpected root {first}; expected {expected_root}"
+            ));
+        } else {
+            Some(UpdateArchiveRootStyle::Rootless)
+        }
+    } else {
+        None
+    };
+    if root_style == Some(UpdateArchiveRootStyle::Rooted) {
         parts.remove(0);
     }
-    Ok(parts.join("/"))
+    Ok((parts.join("/"), root_style))
 }
 
 fn read_update_archive_member_limited<R: Read>(
@@ -10880,6 +10940,69 @@ mod tests {
     }
 
     #[test]
+    fn update_apply_rejects_unexpected_archive_root_before_install() {
+        let target = update_apply_test_target();
+        let filename = update_archive_fixture_name(&target);
+        let wrong_root = format!("conu-9.9.9-{target}");
+        let archive_bytes = update_archive_fixture_bytes_with_root(&target, &wrong_root, false);
+        let archive_sha = sha256_hex(&archive_bytes);
+        let home = temp_home("update-apply-wrong-root");
+        let policy =
+            write_update_policy_fixture_for_asset(&home, false, &archive_sha, &target, &filename);
+        let artifact = write_update_artifact_fixture(&home, &filename, &archive_bytes);
+        let install_dir = home.join("install-bin");
+
+        let output = run([
+            "update",
+            "apply",
+            "--policy-file",
+            policy.to_str().expect("policy path"),
+            "--artifact-file",
+            artifact.to_str().expect("artifact path"),
+            "--install-dir",
+            install_dir.to_str().expect("install path"),
+            "--dry-run",
+            "--json",
+        ]);
+
+        assert_eq!(output.code, 1);
+        assert!(output.stderr.contains("unexpected root"));
+        assert!(!output.stderr.contains("fixture binary bytes"));
+        assert!(!install_dir.exists());
+    }
+
+    #[test]
+    fn update_apply_rejects_mixed_rooted_and_rootless_archive_before_install() {
+        let target = update_apply_test_target();
+        let filename = update_archive_fixture_name(&target);
+        let archive_bytes = update_archive_fixture_bytes_with_mixed_root(&target);
+        let archive_sha = sha256_hex(&archive_bytes);
+        let home = temp_home("update-apply-mixed-root");
+        let policy =
+            write_update_policy_fixture_for_asset(&home, false, &archive_sha, &target, &filename);
+        let artifact = write_update_artifact_fixture(&home, &filename, &archive_bytes);
+        let install_dir = home.join("install-bin");
+
+        let output = run([
+            "update",
+            "apply",
+            "--policy-file",
+            policy.to_str().expect("policy path"),
+            "--artifact-file",
+            artifact.to_str().expect("artifact path"),
+            "--install-dir",
+            install_dir.to_str().expect("install path"),
+            "--dry-run",
+            "--json",
+        ]);
+
+        assert_eq!(output.code, 1);
+        assert!(output.stderr.contains("mixes rooted and rootless"));
+        assert!(!output.stderr.contains("fixture binary bytes"));
+        assert!(!install_dir.exists());
+    }
+
+    #[test]
     fn update_apply_requires_dry_run_or_confirm() {
         let output = run([
             "update",
@@ -12353,9 +12476,17 @@ mod tests {
     }
 
     fn update_archive_fixture_bytes(target: &str, unsafe_member: bool) -> Vec<u8> {
+        let root = format!("conu-0.1.0-{target}");
+        update_archive_fixture_bytes_with_root(target, &root, unsafe_member)
+    }
+
+    fn update_archive_fixture_bytes_with_root(
+        target: &str,
+        root: &str,
+        unsafe_member: bool,
+    ) -> Vec<u8> {
         let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
         let mut builder = tar::Builder::new(encoder);
-        let root = format!("conu-0.1.0-{target}");
         let manifest = format!(
             "version = \"0.1.0\"\ntarget = \"{target}\"\npayload_contents_included = false\n"
         );
@@ -12376,6 +12507,30 @@ mod tests {
         if unsafe_member {
             append_update_archive_fixture_file(&mut builder, "../bin/conu", b"escape", 0o755);
         }
+        builder.finish().expect("tar builder finishes");
+        let encoder = builder.into_inner().expect("tar encoder returns");
+        encoder.finish().expect("gzip finishes")
+    }
+
+    fn update_archive_fixture_bytes_with_mixed_root(target: &str) -> Vec<u8> {
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        let root = format!("conu-0.1.0-{target}");
+        let manifest = format!(
+            "version = \"0.1.0\"\ntarget = \"{target}\"\npayload_contents_included = false\n"
+        );
+        append_update_archive_fixture_file(
+            &mut builder,
+            &format!("{root}/manifest.toml"),
+            manifest.as_bytes(),
+            0o644,
+        );
+        append_update_archive_fixture_file(
+            &mut builder,
+            &format!("bin/{}", update_binary_filename("conu")),
+            &update_archive_binary_bytes("conu"),
+            0o755,
+        );
         builder.finish().expect("tar builder finishes");
         let encoder = builder.into_inner().expect("tar encoder returns");
         encoder.finish().expect("gzip finishes")

--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 VERIFIER_PATH = ROOT / "scripts" / "verify-release-artifacts.py"
-PREFIX = "conu-0.1.0-test"
 REQUIRED_FILES = {
     "manifest.toml": b'payload_contents_included = false\n',
     "bin/conu": b"placeholder",
@@ -50,10 +49,22 @@ def write_checksum(path: Path, archive_name: str | None = None, hash_text: str |
     path.with_name(f"{path.name}.sha256").write_text(f"{digest}  {name}\n", encoding="ascii")
 
 
-def write_zip(path: Path, extra: dict[str, bytes] | None = None) -> None:
+def archive_prefix(path: Path) -> str:
+    if path.name.endswith(".tar.gz"):
+        return path.name[: -len(".tar.gz")]
+    return path.stem
+
+
+def write_zip(
+    path: Path,
+    extra: dict[str, bytes] | None = None,
+    *,
+    prefix: str | None = None,
+) -> None:
+    prefix = prefix or archive_prefix(path)
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
         for name, content in REQUIRED_FILES.items():
-            package.writestr(f"{PREFIX}/{name}", content)
+            package.writestr(f"{prefix}/{name}", content)
         for name, content in (extra or {}).items():
             package.writestr(name, content)
     write_checksum(path)
@@ -119,11 +130,12 @@ def corrupt_zip_member_data(path: Path, member_name: str) -> None:
     raise AssertionError(f"zip member not found for corruption: {member_name}")
 
 
-def write_tar(path: Path) -> None:
+def write_tar(path: Path, *, prefix: str | None = None) -> None:
+    prefix = prefix or archive_prefix(path)
     with tarfile.open(path, "w:gz") as package:
         for name, content in REQUIRED_FILES.items():
             data = io.BytesIO(content)
-            info = tarfile.TarInfo(f"{PREFIX}/{name}")
+            info = tarfile.TarInfo(f"{prefix}/{name}")
             info.size = len(content)
             package.addfile(info, data)
     write_checksum(path)
@@ -195,7 +207,7 @@ def main() -> int:
         )
 
         duplicate = root / "conu-0.1.0-duplicate.zip"
-        write_zip(duplicate, {"manifest.toml": b"duplicate"})
+        write_zip(duplicate, {f"{archive_prefix(duplicate)}/./manifest.toml": b"duplicate"})
         expect_failure(
             "duplicate normalized path",
             lambda: verifier.archive_members(duplicate),
@@ -204,7 +216,7 @@ def main() -> int:
 
         encrypted = root / "conu-0.1.0-encrypted.zip"
         write_zip(encrypted)
-        mark_zip_member_encrypted(encrypted, f"{PREFIX}/bin/conu")
+        mark_zip_member_encrypted(encrypted, f"{archive_prefix(encrypted)}/bin/conu")
         expect_failure(
             "encrypted zip member",
             lambda: verifier.archive_members(encrypted),
@@ -213,7 +225,7 @@ def main() -> int:
 
         corrupt_member = root / "conu-0.1.0-corrupt-member.zip"
         write_zip(corrupt_member)
-        corrupt_zip_member_data(corrupt_member, f"{PREFIX}/bin/conu")
+        corrupt_zip_member_data(corrupt_member, f"{archive_prefix(corrupt_member)}/bin/conu")
         expect_failure(
             "corrupt zip member",
             lambda: verifier.archive_members(corrupt_member),
@@ -221,7 +233,7 @@ def main() -> int:
         )
 
         forbidden = root / "conu-0.1.0-forbidden.zip"
-        write_zip(forbidden, {f"{PREFIX}/.conu/node.toml": b"state"})
+        write_zip(forbidden, {f"{archive_prefix(forbidden)}/.conu/node.toml": b"state"})
         expect_failure(
             "forbidden state path",
             lambda: verify_archive(verifier, forbidden),
@@ -229,15 +241,31 @@ def main() -> int:
         )
 
         forbidden_dir = root / "conu-0.1.0-forbidden-dir.zip"
-        write_zip(forbidden_dir, {f"{PREFIX}/security/": b""})
+        write_zip(forbidden_dir, {f"{archive_prefix(forbidden_dir)}/security/": b""})
         expect_failure(
             "forbidden state directory",
             lambda: verify_archive(verifier, forbidden_dir),
             "forbidden state path",
         )
 
+        wrong_root = root / "conu-0.1.0-wrong-root.zip"
+        write_zip(wrong_root, prefix="conu-9.9.9-test")
+        expect_failure(
+            "unexpected archive root",
+            lambda: verifier.archive_members(wrong_root),
+            "unexpected archive root",
+        )
+
+        mixed_root = root / "conu-0.1.0-mixed-root.zip"
+        write_zip(mixed_root, {"bin/conu": b"rootless duplicate"})
+        expect_failure(
+            "mixed rooted and rootless archive paths",
+            lambda: verifier.archive_members(mixed_root),
+            "mixes rooted and rootless",
+        )
+
         data_dir = root / "conu-0.1.0-data-dir.zip"
-        write_zip(data_dir, {f"{PREFIX}/docs/": b"payload"})
+        write_zip(data_dir, {f"{archive_prefix(data_dir)}/docs/": b"payload"})
         expect_failure(
             "data-bearing directory",
             lambda: verifier.archive_members(data_dir),

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -129,6 +129,7 @@ def archive_members(archive: Path) -> ArchiveMembers:
     archive_size = archive.stat().st_size
     if archive_size > MAX_ARCHIVE_BYTES:
         raise SystemExit(f"{archive.name} is larger than {MAX_ARCHIVE_BYTES} bytes")
+    expected_root = expected_archive_root(archive.name)
 
     if archive.suffix == ".zip":
         with zipfile.ZipFile(archive) as package:
@@ -136,16 +137,19 @@ def archive_members(archive: Path) -> ArchiveMembers:
             manifest: bytes | None = None
             total_uncompressed = 0
             entry_count = 0
+            root_style: str | None = None
             for member in package.infolist():
                 if member.is_dir():
                     if member.file_size != 0:
                         raise SystemExit(
                             f"{archive.name} contains directory member with data: {member.filename}"
                         )
-                    _, total_uncompressed, entry_count = record_entry(
+                    _, total_uncompressed, entry_count, root_style = record_entry(
                         archive.name,
                         paths,
                         member.filename,
+                        expected_root,
+                        root_style,
                         0,
                         total_uncompressed,
                         entry_count,
@@ -165,10 +169,12 @@ def archive_members(archive: Path) -> ArchiveMembers:
                     raise SystemExit(
                         f"{archive.name} contains unsupported zip member: {member.filename}"
                     )
-                normalized, total_uncompressed, entry_count = record_entry(
+                normalized, total_uncompressed, entry_count, root_style = record_entry(
                     archive.name,
                     paths,
                     member.filename,
+                    expected_root,
+                    root_style,
                     member.file_size,
                     total_uncompressed,
                     entry_count,
@@ -184,12 +190,15 @@ def archive_members(archive: Path) -> ArchiveMembers:
             manifest: bytes | None = None
             total_uncompressed = 0
             entry_count = 0
+            root_style: str | None = None
             for member in package:
                 if member.isdir():
-                    _, total_uncompressed, entry_count = record_entry(
+                    _, total_uncompressed, entry_count, root_style = record_entry(
                         archive.name,
                         paths,
                         member.name,
+                        expected_root,
+                        root_style,
                         0,
                         total_uncompressed,
                         entry_count,
@@ -200,10 +209,12 @@ def archive_members(archive: Path) -> ArchiveMembers:
                     raise SystemExit(
                         f"{archive.name} contains unsupported non-file member: {member.name}"
                     )
-                normalized, total_uncompressed, entry_count = record_entry(
+                normalized, total_uncompressed, entry_count, root_style = record_entry(
                     archive.name,
                     paths,
                     member.name,
+                    expected_root,
+                    root_style,
                     member.size,
                     total_uncompressed,
                     entry_count,
@@ -226,12 +237,14 @@ def record_entry(
     archive_name: str,
     paths: set[str],
     raw_name: str,
+    expected_root: str,
+    root_style: str | None,
     size: int,
     total_uncompressed: int,
     entry_count: int,
     *,
     allow_empty: bool = False,
-) -> tuple[str, int, int]:
+) -> tuple[str, int, int, str | None]:
     if size < 0:
         raise SystemExit(f"{archive_name} contains member with invalid size: {raw_name}")
     if size > MAX_MEMBER_BYTES:
@@ -241,10 +254,13 @@ def record_entry(
     if entry_count > MAX_MEMBER_COUNT:
         raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
 
-    normalized = normalize_member(raw_name)
+    normalized, member_root_style = normalize_member(raw_name, expected_root)
+    root_style = update_archive_root_style(
+        archive_name, raw_name, root_style, member_root_style
+    )
     if not normalized:
         if allow_empty:
-            return normalized, total_uncompressed, entry_count
+            return normalized, total_uncompressed, entry_count, root_style
         raise SystemExit(f"{archive_name} contains empty archive path: {raw_name}")
     if normalized in paths:
         raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
@@ -256,7 +272,7 @@ def record_entry(
         raise SystemExit(
             f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
         )
-    return normalized, total_uncompressed, entry_count
+    return normalized, total_uncompressed, entry_count, root_style
 
 
 def read_zip_member(
@@ -298,15 +314,47 @@ def read_limited(archive_name: str, member_name: str, handle, limit: int) -> byt
     return content
 
 
-def normalize_member(name: str) -> str:
+def expected_archive_root(archive_name: str) -> str:
+    if archive_name.endswith(".tar.gz"):
+        return archive_name[: -len(".tar.gz")]
+    if archive_name.endswith(".zip"):
+        return archive_name[: -len(".zip")]
+    raise SystemExit(f"unsupported release archive {archive_name}")
+
+
+def normalize_member(name: str, expected_root: str) -> tuple[str, str | None]:
     normalized = name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
     if path.is_absolute() or ".." in parts:
         raise SystemExit(f"unsafe archive path: {name}")
-    if parts and parts[0].startswith("conu-"):
-        parts = parts[1:]
-    return "/".join(parts)
+    root_style = None
+    if parts:
+        if parts[0] == expected_root:
+            root_style = "rooted"
+            parts = parts[1:]
+        elif parts[0].startswith("conu-"):
+            raise SystemExit(
+                f"unexpected archive root: {parts[0]} (expected {expected_root})"
+            )
+        else:
+            root_style = "rootless"
+    return "/".join(parts), root_style
+
+
+def update_archive_root_style(
+    archive_name: str,
+    raw_name: str,
+    current: str | None,
+    member_style: str | None,
+) -> str | None:
+    if member_style is None:
+        return current
+    if current is not None and current != member_style:
+        raise SystemExit(
+            f"{archive_name} mixes rooted and rootless archive paths: {raw_name}"
+        )
+    return member_style
 
 
 def verify_members(archive: Path, members: ArchiveMembers) -> None:


### PR DESCRIPTION
## **User description**
## Summary
- make installed `conu update apply` accept only rootless archives or the exact expected `conu-<version>-<target>` archive root
- reject unexpected `conu-*` roots and mixed rooted/rootless layouts before staging or installing binaries
- apply the same expected-root rule in `scripts/verify-release-artifacts.py` so release artifacts fail before upload
- add verifier and conu-cli regressions for unexpected roots and mixed layouts

## Security review
- payload exposure risk: low; validation reads release archive metadata and staged binaries only, and tests keep payload/sentinel text out of output
- trust/permission risk: reduced; update apply and release verification now fail closed on unexpected archive layout roots
- storage/logging risk: low; no new persistent storage or archive content logging
- relay/network risk: none; this only affects local release artifact verification/update apply
- required fixes: none known

## Validation
- `python -m py_compile scripts/verify-release-artifacts.py scripts/check-release-artifact-verifier.py`
- `python scripts/check-release-artifact-verifier.py`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy -p conu-cli --all-targets -- -D warnings`
- `wsl bash -lc "cd /mnt/c/Users/parth/Desktop/conU && cargo test -p conu-cli update_apply_"`
- `wsl bash -lc "cd /mnt/c/Users/parth/Desktop/conU && cargo test -p conu-cli"`
- `powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

Closes #300


___

## **CodeAnt-AI Description**
**Reject release archives with the wrong folder layout**

### What Changed
- Update installation now stops before unpacking if a release archive uses an unexpected top-level folder name
- Archives that mix rooted files and rootless files are rejected instead of being installed
- Release artifact checks now enforce the same folder-layout rules before upload
- Regression checks cover wrong roots, mixed layouts, and avoid printing archive payload text on failure

### Impact
`✅ Fewer bad release archives accepted`
`✅ Safer update installs`
`✅ Earlier release verification failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
