### PR TITLE
Harden release smoke archive root checks

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import tempfile
+import zipfile
 from pathlib import Path
 
 
@@ -40,6 +41,56 @@ def main() -> int:
             "directory named as binary",
         )
 
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-test.zip"
+        write_zip(archive, {"conu-0.1.0-test/manifest.toml": 'target = "host"\n'})
+        target = smoke.read_manifest_target(archive)
+        if target != "host":
+            raise SystemExit(f"rooted manifest target: expected host, got {target}")
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-test.zip"
+        write_zip(archive, {"conu-9.9.9-test/manifest.toml": 'target = "host"\n'})
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "unexpected archive root",
+            "unexpected manifest root",
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-mixed.zip"
+        write_zip(
+            archive,
+            {
+                "manifest.toml": 'target = "host"\n',
+                "conu-0.1.0-mixed/bin/conu": "placeholder",
+            },
+        )
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "mixes rooted and rootless",
+            "mixed manifest root style",
+        )
+
+    with fixture_dir() as root:
+        archive = Path("conu-0.1.0-test.zip")
+        expected_root = root / "conu-0.1.0-test"
+        expected_root.mkdir()
+        expected_root.joinpath("manifest.toml").write_text('target = "host"\n', encoding="utf-8")
+        resolved = smoke.find_package_root(archive, root)
+        if resolved != expected_root:
+            raise SystemExit(f"rooted package root: expected {expected_root}, got {resolved}")
+
+    with fixture_dir() as root:
+        wrong_root = root / "conu-9.9.9-test"
+        wrong_root.mkdir()
+        wrong_root.joinpath("manifest.toml").write_text('target = "host"\n', encoding="utf-8")
+        expect_action_failure(
+            lambda: smoke.find_package_root(Path("conu-0.1.0-test.zip"), root),
+            "unexpected archive root",
+            "unexpected extracted root",
+        )
+
     print("npm launcher local smoke preflight check passed")
     return 0
 
@@ -72,9 +123,25 @@ def write_binaries(bin_dir: Path, smoke, skip: str | None = None) -> None:
         bin_dir.joinpath(f"{name}{suffix}").write_text(name, encoding="utf-8")
 
 
+def write_zip(path: Path, members: dict[str, bytes | str]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
+        for name, content in members.items():
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            package.writestr(name, content)
+
+
 def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:
+    expect_action_failure(
+        lambda: smoke.verify_archive_binaries(Path("fixture.zip"), bin_dir),
+        expected,
+        label,
+    )
+
+
+def expect_action_failure(action, expected: str, label: str) -> None:
     try:
-        smoke.verify_archive_binaries(Path("fixture.zip"), bin_dir)
+        action()
     except SystemExit as exc:
         message = str(exc)
         if expected in message:

--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import tempfile
+import zipfile
 from pathlib import Path
 
 
@@ -40,6 +41,56 @@ def main() -> int:
             "directory named as binary",
         )
 
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-test.zip"
+        write_zip(archive, {"conu-0.1.0-test/manifest.toml": 'target = "host"\n'})
+        target = smoke.read_manifest_target(archive)
+        if target != "host":
+            raise SystemExit(f"rooted manifest target: expected host, got {target}")
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-test.zip"
+        write_zip(archive, {"conu-9.9.9-test/manifest.toml": 'target = "host"\n'})
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "unexpected archive root",
+            "unexpected manifest root",
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-mixed.zip"
+        write_zip(
+            archive,
+            {
+                "manifest.toml": 'target = "host"\n',
+                "conu-0.1.0-mixed/bin/conu": "placeholder",
+            },
+        )
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "mixes rooted and rootless",
+            "mixed manifest root style",
+        )
+
+    with fixture_dir() as root:
+        archive = Path("conu-0.1.0-test.zip")
+        expected_root = root / "conu-0.1.0-test"
+        expected_root.mkdir()
+        expected_root.joinpath("manifest.toml").write_text('target = "host"\n', encoding="utf-8")
+        resolved = smoke.find_package_root(archive, root)
+        if resolved != expected_root:
+            raise SystemExit(f"rooted package root: expected {expected_root}, got {resolved}")
+
+    with fixture_dir() as root:
+        wrong_root = root / "conu-9.9.9-test"
+        wrong_root.mkdir()
+        wrong_root.joinpath("manifest.toml").write_text('target = "host"\n', encoding="utf-8")
+        expect_action_failure(
+            lambda: smoke.find_package_root(Path("conu-0.1.0-test.zip"), root),
+            "unexpected archive root",
+            "unexpected extracted root",
+        )
+
     print("release artifact smoke preflight check passed")
     return 0
 
@@ -72,9 +123,25 @@ def write_binaries(bin_dir: Path, smoke, skip: str | None = None) -> None:
         bin_dir.joinpath(f"{name}{suffix}").write_text(name, encoding="utf-8")
 
 
+def write_zip(path: Path, members: dict[str, bytes | str]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
+        for name, content in members.items():
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            package.writestr(name, content)
+
+
 def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:
+    expect_action_failure(
+        lambda: smoke.verify_archive_binaries(Path("fixture.zip"), bin_dir),
+        expected,
+        label,
+    )
+
+
+def expect_action_failure(action, expected: str, label: str) -> None:
     try:
-        smoke.verify_archive_binaries(Path("fixture.zip"), bin_dir)
+        action()
     except SystemExit as exc:
         message = str(exc)
         if expected in message:

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -57,7 +57,7 @@ def main() -> int:
 
             extract_dir = temp_root / archive_stem(archive)
             extract_archive(archive, extract_dir)
-            bin_dir = find_package_root(extract_dir) / "bin"
+            bin_dir = find_package_root(archive, extract_dir) / "bin"
             verify_archive_binaries(archive, bin_dir)
 
             prefix = temp_root / f"{archive_stem(archive)}-npm"
@@ -97,37 +97,86 @@ def read_manifest_target(archive: Path) -> str:
 
 
 def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
+    expected_root = expected_archive_root(archive)
     if archive.suffix == ".zip":
         with zipfile.ZipFile(archive) as package:
+            found: bytes | None = None
+            root_style: str | None = None
             for member in package.infolist():
                 if member.filename.endswith("/"):
                     continue
-                if normalize_member(member.filename) == normalized_name:
-                    return package.read(member)
-        return None
+                normalized, member_style = normalize_member(member.filename, expected_root)
+                root_style = update_archive_root_style(
+                    archive.name, member.filename, root_style, member_style
+                )
+                if normalized == normalized_name:
+                    if found is not None:
+                        raise SystemExit(
+                            f"{archive.name} contains duplicate archive path: {normalized_name}"
+                        )
+                    found = package.read(member)
+            return found
 
     if archive.name.endswith(".tar.gz"):
         with tarfile.open(archive, "r:gz") as package:
+            found: bytes | None = None
+            root_style: str | None = None
             for member in package.getmembers():
                 if not member.isfile():
                     continue
-                if normalize_member(member.name) == normalized_name:
+                normalized, member_style = normalize_member(member.name, expected_root)
+                root_style = update_archive_root_style(
+                    archive.name, member.name, root_style, member_style
+                )
+                if normalized == normalized_name:
+                    if found is not None:
+                        raise SystemExit(
+                            f"{archive.name} contains duplicate archive path: {normalized_name}"
+                        )
                     file_object = package.extractfile(member)
-                    return file_object.read() if file_object is not None else None
-        return None
+                    found = file_object.read() if file_object is not None else None
+            return found
 
     raise SystemExit(f"unsupported release archive {archive.name}")
 
 
-def normalize_member(name: str) -> str:
+def expected_archive_root(archive: Path) -> str:
+    return archive_stem(archive)
+
+
+def normalize_member(name: str, expected_root: str) -> tuple[str, str | None]:
     normalized = name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
     if path.is_absolute() or ".." in parts:
         raise SystemExit(f"unsafe archive path: {name}")
-    if parts and parts[0].startswith("conu-"):
-        parts = parts[1:]
-    return "/".join(parts)
+    root_style = None
+    if parts:
+        if parts[0] == expected_root:
+            root_style = "rooted"
+            parts = parts[1:]
+        elif parts[0].startswith("conu-"):
+            raise SystemExit(
+                f"unexpected archive root: {parts[0]} (expected {expected_root})"
+            )
+        else:
+            root_style = "rootless"
+    return "/".join(parts), root_style
+
+
+def update_archive_root_style(
+    archive_name: str,
+    raw_name: str,
+    current: str | None,
+    member_style: str | None,
+) -> str | None:
+    if member_style is None:
+        return current
+    if current is not None and current != member_style:
+        raise SystemExit(
+            f"{archive_name} mixes rooted and rootless archive paths: {raw_name}"
+        )
+    return member_style
 
 
 def target_is_current_platform(target: str) -> bool:
@@ -220,15 +269,34 @@ def safe_extract_path(destination: Path, member_name: str) -> Path:
     return output_path
 
 
-def find_package_root(extract_dir: Path) -> Path:
-    candidates = [
-        path
+def find_package_root(archive: Path, extract_dir: Path) -> Path:
+    expected_root = expected_archive_root(archive)
+    rootless_manifest = extract_dir / "manifest.toml"
+    rooted_dir = extract_dir / expected_root
+    rooted_manifest = rooted_dir / "manifest.toml"
+    has_rootless = rootless_manifest.is_file()
+    has_rooted = rooted_manifest.is_file()
+
+    if has_rootless and has_rooted:
+        raise SystemExit(f"{archive.name} mixes rooted and rootless archive paths")
+    if has_rooted:
+        return rooted_dir
+    if has_rootless:
+        return extract_dir
+
+    unexpected_roots = sorted(
+        path.name
         for path in extract_dir.iterdir()
         if path.is_dir() and path.name.startswith("conu-")
-    ]
-    if len(candidates) == 1:
-        return candidates[0]
-    return extract_dir
+    )
+    if unexpected_roots:
+        raise SystemExit(
+            f"{archive.name} contains unexpected archive root: "
+            f"{unexpected_roots[0]} (expected {expected_root})"
+        )
+    raise SystemExit(
+        f"{archive.name} missing manifest.toml at expected release root {expected_root}"
+    )
 
 
 def verify_archive_binaries(archive: Path, bin_dir: Path) -> None:

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -69,37 +69,86 @@ def read_manifest_target(archive: Path) -> str:
 
 
 def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
+    expected_root = expected_archive_root(archive)
     if archive.suffix == ".zip":
         with zipfile.ZipFile(archive) as package:
+            found: bytes | None = None
+            root_style: str | None = None
             for member in package.infolist():
                 if member.filename.endswith("/"):
                     continue
-                if normalize_member(member.filename) == normalized_name:
-                    return package.read(member)
-        return None
+                normalized, member_style = normalize_member(member.filename, expected_root)
+                root_style = update_archive_root_style(
+                    archive.name, member.filename, root_style, member_style
+                )
+                if normalized == normalized_name:
+                    if found is not None:
+                        raise SystemExit(
+                            f"{archive.name} contains duplicate archive path: {normalized_name}"
+                        )
+                    found = package.read(member)
+            return found
 
     if archive.name.endswith(".tar.gz"):
         with tarfile.open(archive, "r:gz") as package:
+            found: bytes | None = None
+            root_style: str | None = None
             for member in package.getmembers():
                 if not member.isfile():
                     continue
-                if normalize_member(member.name) == normalized_name:
+                normalized, member_style = normalize_member(member.name, expected_root)
+                root_style = update_archive_root_style(
+                    archive.name, member.name, root_style, member_style
+                )
+                if normalized == normalized_name:
+                    if found is not None:
+                        raise SystemExit(
+                            f"{archive.name} contains duplicate archive path: {normalized_name}"
+                        )
                     file_object = package.extractfile(member)
-                    return file_object.read() if file_object is not None else None
-        return None
+                    found = file_object.read() if file_object is not None else None
+            return found
 
     raise SystemExit(f"unsupported release archive {archive.name}")
 
 
-def normalize_member(name: str) -> str:
+def expected_archive_root(archive: Path) -> str:
+    return archive_stem(archive)
+
+
+def normalize_member(name: str, expected_root: str) -> tuple[str, str | None]:
     normalized = name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
     if path.is_absolute() or ".." in parts:
         raise SystemExit(f"unsafe archive path: {name}")
-    if parts and parts[0].startswith("conu-"):
-        parts = parts[1:]
-    return "/".join(parts)
+    root_style = None
+    if parts:
+        if parts[0] == expected_root:
+            root_style = "rooted"
+            parts = parts[1:]
+        elif parts[0].startswith("conu-"):
+            raise SystemExit(
+                f"unexpected archive root: {parts[0]} (expected {expected_root})"
+            )
+        else:
+            root_style = "rootless"
+    return "/".join(parts), root_style
+
+
+def update_archive_root_style(
+    archive_name: str,
+    raw_name: str,
+    current: str | None,
+    member_style: str | None,
+) -> str | None:
+    if member_style is None:
+        return current
+    if current is not None and current != member_style:
+        raise SystemExit(
+            f"{archive_name} mixes rooted and rootless archive paths: {raw_name}"
+        )
+    return member_style
 
 
 def target_is_current_platform(target: str) -> bool:
@@ -193,7 +242,7 @@ def safe_extract_path(destination: Path, member_name: str) -> Path:
 
 
 def smoke_extracted_package(archive: Path, smoke_dir: Path, temp_root: Path) -> None:
-    package_root = find_package_root(smoke_dir)
+    package_root = find_package_root(archive, smoke_dir)
     bin_dir = package_root / "bin"
     binaries = verify_archive_binaries(archive, bin_dir)
 
@@ -244,15 +293,34 @@ def smoke_extracted_package(archive: Path, smoke_dir: Path, temp_root: Path) -> 
     print(f"smoked {archive.name}: packaged conu doctor is ready_for_local_use")
 
 
-def find_package_root(smoke_dir: Path) -> Path:
-    candidates = [
-        path
+def find_package_root(archive: Path, smoke_dir: Path) -> Path:
+    expected_root = expected_archive_root(archive)
+    rootless_manifest = smoke_dir / "manifest.toml"
+    rooted_dir = smoke_dir / expected_root
+    rooted_manifest = rooted_dir / "manifest.toml"
+    has_rootless = rootless_manifest.is_file()
+    has_rooted = rooted_manifest.is_file()
+
+    if has_rootless and has_rooted:
+        raise SystemExit(f"{archive.name} mixes rooted and rootless archive paths")
+    if has_rooted:
+        return rooted_dir
+    if has_rootless:
+        return smoke_dir
+
+    unexpected_roots = sorted(
+        path.name
         for path in smoke_dir.iterdir()
         if path.is_dir() and path.name.startswith("conu-")
-    ]
-    if len(candidates) == 1:
-        return candidates[0]
-    return smoke_dir
+    )
+    if unexpected_roots:
+        raise SystemExit(
+            f"{archive.name} contains unexpected archive root: "
+            f"{unexpected_roots[0]} (expected {expected_root})"
+        )
+    raise SystemExit(
+        f"{archive.name} missing manifest.toml at expected release root {expected_root}"
+    )
 
 
 def verify_archive_binaries(archive: Path, bin_dir: Path) -> dict[str, Path]:


### PR DESCRIPTION
## **User description**
## Summary
- enforce exact expected conu-<version>-<target> archive roots in direct release smoke manifest scanning
- enforce the same exact rooted/rootless package root selection in npm launcher local/download smoke helpers
- add preflight regressions for rooted manifests, unexpected roots, mixed rooted/rootless layouts, and extracted unexpected roots

## Validation
- python -m py_compile scripts/smoke-release-artifacts.py scripts/smoke-npm-launcher-local.py scripts/smoke-npm-launcher-download.py scripts/check-release-artifact-smoke-preflight.py scripts/check-npm-launcher-local-smoke-preflight.py
- python scripts/check-release-artifact-smoke-preflight.py
- python scripts/check-npm-launcher-local-smoke-preflight.py
- python scripts/check-release-artifact-verifier.py
- npm run check --prefix packaging/npm/conu-cli
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Closes #302


___

## **CodeAnt-AI Description**
**Require release archives to use the expected package root and reject mixed layouts**

### What Changed
- Release smoke checks now fail when an archive uses the wrong top-level folder, mixes rooted and rootless files, or contains duplicate file paths.
- The same root checks now apply when validating extracted release archives and npm launcher smoke packages.
- Preflight checks now cover rooted archives, unexpected roots, mixed layouts, and unexpected extracted roots.

### Impact
`✅ Fewer release smoke false passes`
`✅ Clearer archive structure errors`
`✅ Safer npm launcher package validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release artifact validation with improved manifest and package-root resolution checks for various archive layouts.
  * Strengthened archive integrity verification to detect malformed structures, duplicate entries, and inconsistent directory layouts.
  * Improved error messages and failure handling during preflight validation steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->