### PR TITLE
Harden release smoke extraction bounds

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import stat
 import tempfile
 import zipfile
 from pathlib import Path
@@ -91,6 +92,74 @@ def main() -> int:
             "unexpected extracted root",
         )
 
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-duplicate.zip"
+        write_zip_entries(
+            archive,
+            [
+                ("bin/conu", "first"),
+                ("bin/./conu", "second"),
+            ],
+        )
+        expect_action_failure(
+            lambda: smoke.extract_archive(archive, root / "extract-duplicate"),
+            "duplicate archive path",
+            "duplicate extracted path",
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-too-large.zip"
+        write_zip(archive, {"bin/conu": "too large"})
+        original_limit = smoke.MAX_MEMBER_BYTES
+        smoke.MAX_MEMBER_BYTES = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.extract_archive(archive, root / "extract-large"),
+                "member is too large",
+                "oversized extracted member",
+            )
+        finally:
+            smoke.MAX_MEMBER_BYTES = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-too-many.zip"
+        write_zip_entries(archive, [("one", "1"), ("two", "2")])
+        original_limit = smoke.MAX_MEMBER_COUNT
+        smoke.MAX_MEMBER_COUNT = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.extract_archive(archive, root / "extract-many"),
+                "contains more than",
+                "extracted entry count bound",
+            )
+        finally:
+            smoke.MAX_MEMBER_COUNT = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-total.zip"
+        write_zip_entries(archive, [("one", "1"), ("two", "2")])
+        original_limit = smoke.MAX_TOTAL_UNCOMPRESSED_BYTES
+        smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.extract_archive(archive, root / "extract-total"),
+                "uncompressed contents exceed",
+                "extracted total size bound",
+            )
+        finally:
+            smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-unsupported.zip"
+        info = zipfile.ZipInfo("device")
+        info.external_attr = (stat.S_IFCHR | 0o644) << 16
+        write_zip_infos(archive, [(info, b"device")])
+        expect_action_failure(
+            lambda: smoke.extract_archive(archive, root / "extract-unsupported"),
+            "unsupported zip member",
+            "unsupported zip member type",
+        )
+
     print("npm launcher local smoke preflight check passed")
     return 0
 
@@ -124,11 +193,21 @@ def write_binaries(bin_dir: Path, smoke, skip: str | None = None) -> None:
 
 
 def write_zip(path: Path, members: dict[str, bytes | str]) -> None:
+    write_zip_entries(path, list(members.items()))
+
+
+def write_zip_entries(path: Path, entries: list[tuple[str, bytes | str]]) -> None:
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
-        for name, content in members.items():
+        for name, content in entries:
             if isinstance(content, str):
                 content = content.encode("utf-8")
             package.writestr(name, content)
+
+
+def write_zip_infos(path: Path, entries: list[tuple[zipfile.ZipInfo, bytes]]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
+        for info, content in entries:
+            package.writestr(info, content)
 
 
 def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:

--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import stat
 import tempfile
 import zipfile
 from pathlib import Path
@@ -91,6 +92,74 @@ def main() -> int:
             "unexpected extracted root",
         )
 
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-duplicate.zip"
+        write_zip_entries(
+            archive,
+            [
+                ("bin/conu", "first"),
+                ("bin/./conu", "second"),
+            ],
+        )
+        expect_action_failure(
+            lambda: smoke.extract_archive(archive, root / "extract-duplicate"),
+            "duplicate archive path",
+            "duplicate extracted path",
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-too-large.zip"
+        write_zip(archive, {"bin/conu": "too large"})
+        original_limit = smoke.MAX_MEMBER_BYTES
+        smoke.MAX_MEMBER_BYTES = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.extract_archive(archive, root / "extract-large"),
+                "member is too large",
+                "oversized extracted member",
+            )
+        finally:
+            smoke.MAX_MEMBER_BYTES = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-too-many.zip"
+        write_zip_entries(archive, [("one", "1"), ("two", "2")])
+        original_limit = smoke.MAX_MEMBER_COUNT
+        smoke.MAX_MEMBER_COUNT = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.extract_archive(archive, root / "extract-many"),
+                "contains more than",
+                "extracted entry count bound",
+            )
+        finally:
+            smoke.MAX_MEMBER_COUNT = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-total.zip"
+        write_zip_entries(archive, [("one", "1"), ("two", "2")])
+        original_limit = smoke.MAX_TOTAL_UNCOMPRESSED_BYTES
+        smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.extract_archive(archive, root / "extract-total"),
+                "uncompressed contents exceed",
+                "extracted total size bound",
+            )
+        finally:
+            smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-unsupported.zip"
+        info = zipfile.ZipInfo("device")
+        info.external_attr = (stat.S_IFCHR | 0o644) << 16
+        write_zip_infos(archive, [(info, b"device")])
+        expect_action_failure(
+            lambda: smoke.extract_archive(archive, root / "extract-unsupported"),
+            "unsupported zip member",
+            "unsupported zip member type",
+        )
+
     print("release artifact smoke preflight check passed")
     return 0
 
@@ -124,11 +193,21 @@ def write_binaries(bin_dir: Path, smoke, skip: str | None = None) -> None:
 
 
 def write_zip(path: Path, members: dict[str, bytes | str]) -> None:
+    write_zip_entries(path, list(members.items()))
+
+
+def write_zip_entries(path: Path, entries: list[tuple[str, bytes | str]]) -> None:
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
-        for name, content in members.items():
+        for name, content in entries:
             if isinstance(content, str):
                 content = content.encode("utf-8")
             package.writestr(name, content)
+
+
+def write_zip_infos(path: Path, entries: list[tuple[zipfile.ZipInfo, bytes]]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
+        for info, content in entries:
+            package.writestr(info, content)
 
 
 def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -19,6 +19,16 @@ from pathlib import Path, PurePosixPath
 
 REQUIRED_BINARIES = ("conu", "conud", "conu-relay", "conu-mcp")
 DEFAULT_PACKAGE_DIR = Path("packaging/npm/conu-cli")
+MAX_MEMBER_BYTES = 512_000_000
+MAX_MEMBER_COUNT = 10_000
+MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+
+
+class ExtractState:
+    def __init__(self) -> None:
+        self.paths: set[str] = set()
+        self.entry_count = 0
+        self.total_uncompressed = 0
 
 
 def main() -> int:
@@ -214,17 +224,44 @@ def archive_stem(archive: Path) -> str:
 
 def extract_archive(archive: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
+    state = ExtractState()
     if archive.suffix == ".zip":
         with zipfile.ZipFile(archive) as package:
             for member in package.infolist():
                 if member.filename.endswith("/"):
+                    if member.file_size != 0:
+                        raise SystemExit(
+                            f"{archive.name} contains directory member with data: "
+                            f"{member.filename}"
+                        )
+                    validate_extract_entry(
+                        archive.name,
+                        member.filename,
+                        0,
+                        state,
+                        allow_empty=True,
+                    )
                     continue
+                if member.flag_bits & 0x1:
+                    raise SystemExit(
+                        f"{archive.name} contains encrypted zip member: {member.filename}"
+                    )
                 file_type = (member.external_attr >> 16) & 0o170000
                 if file_type == stat.S_IFLNK:
                     raise SystemExit(
                         f"{archive.name} contains unsupported link member: {member.filename}"
                     )
-                output_path = safe_extract_path(destination, member.filename)
+                if file_type not in {0, stat.S_IFREG}:
+                    raise SystemExit(
+                        f"{archive.name} contains unsupported zip member: {member.filename}"
+                    )
+                output_path = checked_extract_path(
+                    archive.name,
+                    destination,
+                    member.filename,
+                    member.file_size,
+                    state,
+                )
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 output_path.write_bytes(package.read(member))
                 unix_mode = (member.external_attr >> 16) & 0o777
@@ -236,12 +273,29 @@ def extract_archive(archive: Path, destination: Path) -> None:
         with tarfile.open(archive, "r:gz") as package:
             for member in package.getmembers():
                 if member.isdir():
+                    if member.size != 0:
+                        raise SystemExit(
+                            f"{archive.name} contains directory member with data: {member.name}"
+                        )
+                    validate_extract_entry(
+                        archive.name,
+                        member.name,
+                        0,
+                        state,
+                        allow_empty=True,
+                    )
                     continue
                 if not member.isfile():
                     raise SystemExit(
                         f"{archive.name} contains unsupported non-file member: {member.name}"
                     )
-                output_path = safe_extract_path(destination, member.name)
+                output_path = checked_extract_path(
+                    archive.name,
+                    destination,
+                    member.name,
+                    member.size,
+                    state,
+                )
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 file_object = package.extractfile(member)
                 if file_object is None:
@@ -253,20 +307,64 @@ def extract_archive(archive: Path, destination: Path) -> None:
     raise SystemExit(f"unsupported release archive {archive.name}")
 
 
-def safe_extract_path(destination: Path, member_name: str) -> Path:
-    normalized = member_name.replace("\\", "/")
-    path = PurePosixPath(normalized)
-    parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe archive path: {member_name}")
-
-    output_path = (destination / Path(*parts)).resolve()
+def checked_extract_path(
+    archive_name: str,
+    destination: Path,
+    member_name: str,
+    size: int,
+    state: ExtractState,
+) -> Path:
+    normalized = validate_extract_entry(archive_name, member_name, size, state)
+    output_path = (destination / Path(*PurePosixPath(normalized).parts)).resolve()
     destination_resolved = destination.resolve()
     try:
         output_path.relative_to(destination_resolved)
     except ValueError as exc:
         raise SystemExit(f"unsafe archive path: {member_name}") from exc
     return output_path
+
+
+def validate_extract_entry(
+    archive_name: str,
+    member_name: str,
+    size: int,
+    state: ExtractState,
+    *,
+    allow_empty: bool = False,
+) -> str:
+    if size < 0:
+        raise SystemExit(f"{archive_name} contains member with invalid size: {member_name}")
+    if size > MAX_MEMBER_BYTES:
+        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+
+    state.entry_count += 1
+    if state.entry_count > MAX_MEMBER_COUNT:
+        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+
+    normalized = normalize_extract_path(member_name)
+    if not normalized:
+        if allow_empty:
+            return normalized
+        raise SystemExit(f"{archive_name} contains empty archive path: {member_name}")
+
+    state.total_uncompressed += size
+    if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
+        raise SystemExit(
+            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        )
+    if normalized in state.paths:
+        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+    state.paths.add(normalized)
+    return normalized
+
+
+def normalize_extract_path(member_name: str) -> str:
+    normalized = member_name.replace("\\", "/")
+    path = PurePosixPath(normalized)
+    parts = [part for part in path.parts if part not in {"", ".", "/"}]
+    if path.is_absolute() or ".." in parts:
+        raise SystemExit(f"unsafe archive path: {member_name}")
+    return "/".join(parts)
 
 
 def find_package_root(archive: Path, extract_dir: Path) -> Path:

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -18,6 +18,16 @@ from pathlib import Path, PurePosixPath
 
 
 REQUIRED_BINARIES = ("conu", "conud", "conu-relay", "conu-mcp")
+MAX_MEMBER_BYTES = 512_000_000
+MAX_MEMBER_COUNT = 10_000
+MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+
+
+class ExtractState:
+    def __init__(self) -> None:
+        self.paths: set[str] = set()
+        self.entry_count = 0
+        self.total_uncompressed = 0
 
 
 def main() -> int:
@@ -186,17 +196,44 @@ def archive_stem(archive: Path) -> str:
 
 def extract_archive(archive: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
+    state = ExtractState()
     if archive.suffix == ".zip":
         with zipfile.ZipFile(archive) as package:
             for member in package.infolist():
                 if member.filename.endswith("/"):
+                    if member.file_size != 0:
+                        raise SystemExit(
+                            f"{archive.name} contains directory member with data: "
+                            f"{member.filename}"
+                        )
+                    validate_extract_entry(
+                        archive.name,
+                        member.filename,
+                        0,
+                        state,
+                        allow_empty=True,
+                    )
                     continue
+                if member.flag_bits & 0x1:
+                    raise SystemExit(
+                        f"{archive.name} contains encrypted zip member: {member.filename}"
+                    )
                 file_type = (member.external_attr >> 16) & 0o170000
                 if file_type == stat.S_IFLNK:
                     raise SystemExit(
                         f"{archive.name} contains unsupported link member: {member.filename}"
                     )
-                output_path = safe_extract_path(destination, member.filename)
+                if file_type not in {0, stat.S_IFREG}:
+                    raise SystemExit(
+                        f"{archive.name} contains unsupported zip member: {member.filename}"
+                    )
+                output_path = checked_extract_path(
+                    archive.name,
+                    destination,
+                    member.filename,
+                    member.file_size,
+                    state,
+                )
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 output_path.write_bytes(package.read(member))
                 unix_mode = (member.external_attr >> 16) & 0o777
@@ -208,12 +245,29 @@ def extract_archive(archive: Path, destination: Path) -> None:
         with tarfile.open(archive, "r:gz") as package:
             for member in package.getmembers():
                 if member.isdir():
+                    if member.size != 0:
+                        raise SystemExit(
+                            f"{archive.name} contains directory member with data: {member.name}"
+                        )
+                    validate_extract_entry(
+                        archive.name,
+                        member.name,
+                        0,
+                        state,
+                        allow_empty=True,
+                    )
                     continue
                 if not member.isfile():
                     raise SystemExit(
                         f"{archive.name} contains unsupported non-file member: {member.name}"
                     )
-                output_path = safe_extract_path(destination, member.name)
+                output_path = checked_extract_path(
+                    archive.name,
+                    destination,
+                    member.name,
+                    member.size,
+                    state,
+                )
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 file_object = package.extractfile(member)
                 if file_object is None:
@@ -225,20 +279,64 @@ def extract_archive(archive: Path, destination: Path) -> None:
     raise SystemExit(f"unsupported release archive {archive.name}")
 
 
-def safe_extract_path(destination: Path, member_name: str) -> Path:
-    normalized = member_name.replace("\\", "/")
-    path = PurePosixPath(normalized)
-    parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe archive path: {member_name}")
-
-    output_path = (destination / Path(*parts)).resolve()
+def checked_extract_path(
+    archive_name: str,
+    destination: Path,
+    member_name: str,
+    size: int,
+    state: ExtractState,
+) -> Path:
+    normalized = validate_extract_entry(archive_name, member_name, size, state)
+    output_path = (destination / Path(*PurePosixPath(normalized).parts)).resolve()
     destination_resolved = destination.resolve()
     try:
         output_path.relative_to(destination_resolved)
     except ValueError as exc:
         raise SystemExit(f"unsafe archive path: {member_name}") from exc
     return output_path
+
+
+def validate_extract_entry(
+    archive_name: str,
+    member_name: str,
+    size: int,
+    state: ExtractState,
+    *,
+    allow_empty: bool = False,
+) -> str:
+    if size < 0:
+        raise SystemExit(f"{archive_name} contains member with invalid size: {member_name}")
+    if size > MAX_MEMBER_BYTES:
+        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+
+    state.entry_count += 1
+    if state.entry_count > MAX_MEMBER_COUNT:
+        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+
+    normalized = normalize_extract_path(member_name)
+    if not normalized:
+        if allow_empty:
+            return normalized
+        raise SystemExit(f"{archive_name} contains empty archive path: {member_name}")
+
+    state.total_uncompressed += size
+    if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
+        raise SystemExit(
+            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        )
+    if normalized in state.paths:
+        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+    state.paths.add(normalized)
+    return normalized
+
+
+def normalize_extract_path(member_name: str) -> str:
+    normalized = member_name.replace("\\", "/")
+    path = PurePosixPath(normalized)
+    parts = [part for part in path.parts if part not in {"", ".", "/"}]
+    if path.is_absolute() or ".." in parts:
+        raise SystemExit(f"unsafe archive path: {member_name}")
+    return "/".join(parts)
 
 
 def smoke_extracted_package(archive: Path, smoke_dir: Path, temp_root: Path) -> None:


### PR DESCRIPTION
## **User description**
## Summary
- add bounded extraction state to direct release smoke and npm launcher local/download smoke helpers
- reject excessive member count, oversized members, excessive total uncompressed bytes, duplicate normalized paths, encrypted ZIP members, unsupported ZIP types, and data-bearing directories before extracting
- extend smoke preflight regressions for duplicate extraction paths and extraction bounds

## Validation
- python -m py_compile scripts/smoke-release-artifacts.py scripts/smoke-npm-launcher-local.py scripts/smoke-npm-launcher-download.py scripts/check-release-artifact-smoke-preflight.py scripts/check-npm-launcher-local-smoke-preflight.py
- python scripts/check-release-artifact-smoke-preflight.py
- python scripts/check-npm-launcher-local-smoke-preflight.py
- python scripts/check-release-artifact-verifier.py
- npm run check --prefix packaging/npm/conu-cli
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Closes #304


___

## **CodeAnt-AI Description**
**Harden release archive extraction against unsafe or oversized contents**

### What Changed
- Release archive smoke checks now reject oversized files, archives with too many entries, and archives whose total extracted size is too large
- Extraction now fails on duplicate paths, encrypted ZIP members, unsupported ZIP member types, and directories that contain data
- Added regression checks for duplicate paths, size limits, entry-count limits, total size limits, and unsupported ZIP member types

### Impact
`✅ Fewer release smoke failures from malformed archives`
`✅ Safer extraction of shipped binaries`
`✅ Clearer errors for invalid release packages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
