### PR TITLE
Harden release smoke manifest reads

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -74,6 +74,91 @@ def main() -> int:
         )
 
     with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-duplicate.zip"
+        write_zip_entries(
+            archive,
+            [
+                ("manifest.toml", 'target = "host"\n'),
+                ("bin/conu", "first"),
+                ("bin/./conu", "second"),
+            ],
+        )
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "duplicate archive path",
+            "duplicate path during manifest read",
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-too-large.zip"
+        write_zip(archive, {"manifest.toml": 'target = "host"\n'})
+        original_limit = smoke.MAX_MEMBER_BYTES
+        smoke.MAX_MEMBER_BYTES = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.read_manifest_target(archive),
+                "member is too large",
+                "oversized manifest read member",
+            )
+        finally:
+            smoke.MAX_MEMBER_BYTES = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-too-many.zip"
+        write_zip_entries(archive, [("manifest.toml", 'target = "host"\n'), ("bin/conu", "x")])
+        original_limit = smoke.MAX_MEMBER_COUNT
+        smoke.MAX_MEMBER_COUNT = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.read_manifest_target(archive),
+                "contains more than",
+                "manifest read member count bound",
+            )
+        finally:
+            smoke.MAX_MEMBER_COUNT = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-total.zip"
+        write_zip(archive, {"manifest.toml": 'target = "host"\n'})
+        original_limit = smoke.MAX_TOTAL_UNCOMPRESSED_BYTES
+        smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.read_manifest_target(archive),
+                "uncompressed contents exceed",
+                "manifest read total size bound",
+            )
+        finally:
+            smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-unsupported.zip"
+        info = zipfile.ZipInfo("device")
+        info.external_attr = (stat.S_IFCHR | 0o644) << 16
+        write_zip_infos(
+            archive,
+            [
+                (zipfile.ZipInfo("manifest.toml"), b'target = "host"\n'),
+                (info, b"device"),
+            ],
+        )
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "unsupported zip member",
+            "unsupported member during manifest read",
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-encrypted.zip"
+        write_zip_entries(archive, [("manifest.toml", 'target = "host"\n'), ("bin/conu", "x")])
+        mark_zip_member_encrypted(archive, "bin/conu")
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "encrypted zip member",
+            "encrypted member during manifest read",
+        )
+
+    with fixture_dir() as root:
         archive = Path("conu-0.1.0-test.zip")
         expected_root = root / "conu-0.1.0-test"
         expected_root.mkdir()
@@ -208,6 +293,38 @@ def write_zip_infos(path: Path, entries: list[tuple[zipfile.ZipInfo, bytes]]) ->
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
         for info, content in entries:
             package.writestr(info, content)
+
+
+def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature == 0x04034B50:
+            name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+            extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            name_start = offset + 30
+            name_end = name_start + name_length
+            compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 6 : offset + 8], "little") | 0x1
+                data[offset + 6 : offset + 8] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + compressed_size
+            continue
+        if signature == 0x02014B50:
+            name_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            extra_length = int.from_bytes(data[offset + 30 : offset + 32], "little")
+            comment_length = int.from_bytes(data[offset + 32 : offset + 34], "little")
+            name_start = offset + 46
+            name_end = name_start + name_length
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 8 : offset + 10], "little") | 0x1
+                data[offset + 8 : offset + 10] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + comment_length
+            continue
+        offset += 1
+    path.write_bytes(data)
 
 
 def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:

--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -74,6 +74,91 @@ def main() -> int:
         )
 
     with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-duplicate.zip"
+        write_zip_entries(
+            archive,
+            [
+                ("manifest.toml", 'target = "host"\n'),
+                ("bin/conu", "first"),
+                ("bin/./conu", "second"),
+            ],
+        )
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "duplicate archive path",
+            "duplicate path during manifest read",
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-too-large.zip"
+        write_zip(archive, {"manifest.toml": 'target = "host"\n'})
+        original_limit = smoke.MAX_MEMBER_BYTES
+        smoke.MAX_MEMBER_BYTES = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.read_manifest_target(archive),
+                "member is too large",
+                "oversized manifest read member",
+            )
+        finally:
+            smoke.MAX_MEMBER_BYTES = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-too-many.zip"
+        write_zip_entries(archive, [("manifest.toml", 'target = "host"\n'), ("bin/conu", "x")])
+        original_limit = smoke.MAX_MEMBER_COUNT
+        smoke.MAX_MEMBER_COUNT = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.read_manifest_target(archive),
+                "contains more than",
+                "manifest read member count bound",
+            )
+        finally:
+            smoke.MAX_MEMBER_COUNT = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-total.zip"
+        write_zip(archive, {"manifest.toml": 'target = "host"\n'})
+        original_limit = smoke.MAX_TOTAL_UNCOMPRESSED_BYTES
+        smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = 1
+        try:
+            expect_action_failure(
+                lambda: smoke.read_manifest_target(archive),
+                "uncompressed contents exceed",
+                "manifest read total size bound",
+            )
+        finally:
+            smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = original_limit
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-unsupported.zip"
+        info = zipfile.ZipInfo("device")
+        info.external_attr = (stat.S_IFCHR | 0o644) << 16
+        write_zip_infos(
+            archive,
+            [
+                (zipfile.ZipInfo("manifest.toml"), b'target = "host"\n'),
+                (info, b"device"),
+            ],
+        )
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "unsupported zip member",
+            "unsupported member during manifest read",
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-encrypted.zip"
+        write_zip_entries(archive, [("manifest.toml", 'target = "host"\n'), ("bin/conu", "x")])
+        mark_zip_member_encrypted(archive, "bin/conu")
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "encrypted zip member",
+            "encrypted member during manifest read",
+        )
+
+    with fixture_dir() as root:
         archive = Path("conu-0.1.0-test.zip")
         expected_root = root / "conu-0.1.0-test"
         expected_root.mkdir()
@@ -208,6 +293,38 @@ def write_zip_infos(path: Path, entries: list[tuple[zipfile.ZipInfo, bytes]]) ->
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
         for info, content in entries:
             package.writestr(info, content)
+
+
+def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature == 0x04034B50:
+            name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+            extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            name_start = offset + 30
+            name_end = name_start + name_length
+            compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 6 : offset + 8], "little") | 0x1
+                data[offset + 6 : offset + 8] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + compressed_size
+            continue
+        if signature == 0x02014B50:
+            name_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            extra_length = int.from_bytes(data[offset + 30 : offset + 32], "little")
+            comment_length = int.from_bytes(data[offset + 32 : offset + 34], "little")
+            name_start = offset + 46
+            name_end = name_start + name_length
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 8 : offset + 10], "little") | 0x1
+                data[offset + 8 : offset + 10] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + comment_length
+            continue
+        offset += 1
+    path.write_bytes(data)
 
 
 def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -108,17 +108,21 @@ def read_manifest_target(archive: Path) -> str:
 
 def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
     expected_root = expected_archive_root(archive)
+    state = ExtractState()
     if archive.suffix == ".zip":
         with zipfile.ZipFile(archive) as package:
             found: bytes | None = None
             root_style: str | None = None
             for member in package.infolist():
-                if member.filename.endswith("/"):
-                    continue
-                normalized, member_style = normalize_member(member.filename, expected_root)
-                root_style = update_archive_root_style(
-                    archive.name, member.filename, root_style, member_style
+                normalized, root_style, is_file = validate_zip_member_for_read(
+                    archive.name,
+                    member,
+                    expected_root,
+                    state,
+                    root_style,
                 )
+                if not is_file:
+                    continue
                 if normalized == normalized_name:
                     if found is not None:
                         raise SystemExit(
@@ -128,16 +132,19 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
             return found
 
     if archive.name.endswith(".tar.gz"):
-        with tarfile.open(archive, "r:gz") as package:
+        with tarfile.open(archive, "r|gz") as package:
             found: bytes | None = None
             root_style: str | None = None
-            for member in package.getmembers():
-                if not member.isfile():
-                    continue
-                normalized, member_style = normalize_member(member.name, expected_root)
-                root_style = update_archive_root_style(
-                    archive.name, member.name, root_style, member_style
+            for member in package:
+                normalized, root_style, is_file = validate_tar_member_for_read(
+                    archive.name,
+                    member,
+                    expected_root,
+                    state,
+                    root_style,
                 )
+                if not is_file:
+                    continue
                 if normalized == normalized_name:
                     if found is not None:
                         raise SystemExit(
@@ -148,6 +155,107 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
             return found
 
     raise SystemExit(f"unsupported release archive {archive.name}")
+
+
+def validate_zip_member_for_read(
+    archive_name: str,
+    member: zipfile.ZipInfo,
+    expected_root: str,
+    state: ExtractState,
+    root_style: str | None,
+) -> tuple[str, str | None, bool]:
+    if member.flag_bits & 0x1:
+        raise SystemExit(f"{archive_name} contains encrypted zip member: {member.filename}")
+    file_type = (member.external_attr >> 16) & 0o170000
+    is_directory = member.is_dir() or file_type == stat.S_IFDIR
+    if file_type == stat.S_IFLNK:
+        raise SystemExit(f"{archive_name} contains unsupported link member: {member.filename}")
+    if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+        raise SystemExit(f"{archive_name} contains unsupported zip member: {member.filename}")
+    if is_directory and member.file_size != 0:
+        raise SystemExit(
+            f"{archive_name} contains directory member with data: {member.filename}"
+        )
+    normalized, root_style = validate_archive_read_entry(
+        archive_name,
+        member.filename,
+        0 if is_directory else member.file_size,
+        state,
+        expected_root,
+        root_style,
+        allow_empty=is_directory,
+    )
+    return normalized, root_style, not is_directory
+
+
+def validate_tar_member_for_read(
+    archive_name: str,
+    member: tarfile.TarInfo,
+    expected_root: str,
+    state: ExtractState,
+    root_style: str | None,
+) -> tuple[str, str | None, bool]:
+    if member.isdir():
+        if member.size != 0:
+            raise SystemExit(f"{archive_name} contains directory member with data: {member.name}")
+        normalized, root_style = validate_archive_read_entry(
+            archive_name,
+            member.name,
+            0,
+            state,
+            expected_root,
+            root_style,
+            allow_empty=True,
+        )
+        return normalized, root_style, False
+    if not member.isfile():
+        raise SystemExit(f"{archive_name} contains unsupported non-file member: {member.name}")
+    normalized, root_style = validate_archive_read_entry(
+        archive_name,
+        member.name,
+        member.size,
+        state,
+        expected_root,
+        root_style,
+    )
+    return normalized, root_style, True
+
+
+def validate_archive_read_entry(
+    archive_name: str,
+    member_name: str,
+    size: int,
+    state: ExtractState,
+    expected_root: str,
+    root_style: str | None,
+    *,
+    allow_empty: bool = False,
+) -> tuple[str, str | None]:
+    if size < 0:
+        raise SystemExit(f"{archive_name} contains member with invalid size: {member_name}")
+    if size > MAX_MEMBER_BYTES:
+        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+
+    state.entry_count += 1
+    if state.entry_count > MAX_MEMBER_COUNT:
+        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+
+    normalized, member_style = normalize_member(member_name, expected_root)
+    root_style = update_archive_root_style(archive_name, member_name, root_style, member_style)
+    if not normalized:
+        if allow_empty:
+            return normalized, root_style
+        raise SystemExit(f"{archive_name} contains empty archive path: {member_name}")
+
+    state.total_uncompressed += size
+    if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
+        raise SystemExit(
+            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        )
+    if normalized in state.paths:
+        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+    state.paths.add(normalized)
+    return normalized, root_style
 
 
 def expected_archive_root(archive: Path) -> str:
@@ -270,8 +378,8 @@ def extract_archive(archive: Path, destination: Path) -> None:
         return
 
     if archive.name.endswith(".tar.gz"):
-        with tarfile.open(archive, "r:gz") as package:
-            for member in package.getmembers():
+        with tarfile.open(archive, "r|gz") as package:
+            for member in package:
                 if member.isdir():
                     if member.size != 0:
                         raise SystemExit(

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -80,17 +80,21 @@ def read_manifest_target(archive: Path) -> str:
 
 def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
     expected_root = expected_archive_root(archive)
+    state = ExtractState()
     if archive.suffix == ".zip":
         with zipfile.ZipFile(archive) as package:
             found: bytes | None = None
             root_style: str | None = None
             for member in package.infolist():
-                if member.filename.endswith("/"):
-                    continue
-                normalized, member_style = normalize_member(member.filename, expected_root)
-                root_style = update_archive_root_style(
-                    archive.name, member.filename, root_style, member_style
+                normalized, root_style, is_file = validate_zip_member_for_read(
+                    archive.name,
+                    member,
+                    expected_root,
+                    state,
+                    root_style,
                 )
+                if not is_file:
+                    continue
                 if normalized == normalized_name:
                     if found is not None:
                         raise SystemExit(
@@ -100,16 +104,19 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
             return found
 
     if archive.name.endswith(".tar.gz"):
-        with tarfile.open(archive, "r:gz") as package:
+        with tarfile.open(archive, "r|gz") as package:
             found: bytes | None = None
             root_style: str | None = None
-            for member in package.getmembers():
-                if not member.isfile():
-                    continue
-                normalized, member_style = normalize_member(member.name, expected_root)
-                root_style = update_archive_root_style(
-                    archive.name, member.name, root_style, member_style
+            for member in package:
+                normalized, root_style, is_file = validate_tar_member_for_read(
+                    archive.name,
+                    member,
+                    expected_root,
+                    state,
+                    root_style,
                 )
+                if not is_file:
+                    continue
                 if normalized == normalized_name:
                     if found is not None:
                         raise SystemExit(
@@ -120,6 +127,107 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
             return found
 
     raise SystemExit(f"unsupported release archive {archive.name}")
+
+
+def validate_zip_member_for_read(
+    archive_name: str,
+    member: zipfile.ZipInfo,
+    expected_root: str,
+    state: ExtractState,
+    root_style: str | None,
+) -> tuple[str, str | None, bool]:
+    if member.flag_bits & 0x1:
+        raise SystemExit(f"{archive_name} contains encrypted zip member: {member.filename}")
+    file_type = (member.external_attr >> 16) & 0o170000
+    is_directory = member.is_dir() or file_type == stat.S_IFDIR
+    if file_type == stat.S_IFLNK:
+        raise SystemExit(f"{archive_name} contains unsupported link member: {member.filename}")
+    if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+        raise SystemExit(f"{archive_name} contains unsupported zip member: {member.filename}")
+    if is_directory and member.file_size != 0:
+        raise SystemExit(
+            f"{archive_name} contains directory member with data: {member.filename}"
+        )
+    normalized, root_style = validate_archive_read_entry(
+        archive_name,
+        member.filename,
+        0 if is_directory else member.file_size,
+        state,
+        expected_root,
+        root_style,
+        allow_empty=is_directory,
+    )
+    return normalized, root_style, not is_directory
+
+
+def validate_tar_member_for_read(
+    archive_name: str,
+    member: tarfile.TarInfo,
+    expected_root: str,
+    state: ExtractState,
+    root_style: str | None,
+) -> tuple[str, str | None, bool]:
+    if member.isdir():
+        if member.size != 0:
+            raise SystemExit(f"{archive_name} contains directory member with data: {member.name}")
+        normalized, root_style = validate_archive_read_entry(
+            archive_name,
+            member.name,
+            0,
+            state,
+            expected_root,
+            root_style,
+            allow_empty=True,
+        )
+        return normalized, root_style, False
+    if not member.isfile():
+        raise SystemExit(f"{archive_name} contains unsupported non-file member: {member.name}")
+    normalized, root_style = validate_archive_read_entry(
+        archive_name,
+        member.name,
+        member.size,
+        state,
+        expected_root,
+        root_style,
+    )
+    return normalized, root_style, True
+
+
+def validate_archive_read_entry(
+    archive_name: str,
+    member_name: str,
+    size: int,
+    state: ExtractState,
+    expected_root: str,
+    root_style: str | None,
+    *,
+    allow_empty: bool = False,
+) -> tuple[str, str | None]:
+    if size < 0:
+        raise SystemExit(f"{archive_name} contains member with invalid size: {member_name}")
+    if size > MAX_MEMBER_BYTES:
+        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+
+    state.entry_count += 1
+    if state.entry_count > MAX_MEMBER_COUNT:
+        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+
+    normalized, member_style = normalize_member(member_name, expected_root)
+    root_style = update_archive_root_style(archive_name, member_name, root_style, member_style)
+    if not normalized:
+        if allow_empty:
+            return normalized, root_style
+        raise SystemExit(f"{archive_name} contains empty archive path: {member_name}")
+
+    state.total_uncompressed += size
+    if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
+        raise SystemExit(
+            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        )
+    if normalized in state.paths:
+        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+    state.paths.add(normalized)
+    return normalized, root_style
 
 
 def expected_archive_root(archive: Path) -> str:
@@ -242,8 +350,8 @@ def extract_archive(archive: Path, destination: Path) -> None:
         return
 
     if archive.name.endswith(".tar.gz"):
-        with tarfile.open(archive, "r:gz") as package:
-            for member in package.getmembers():
+        with tarfile.open(archive, "r|gz") as package:
+            for member in package:
                 if member.isdir():
                     if member.size != 0:
                         raise SystemExit(


### PR DESCRIPTION
## Summary
- validate the early manifest.toml archive scan with member-count, member-size, total-size, duplicate-path, root-style, encryption, and unsupported-entry checks
- stream tar.gz member scans for manifest reads and smoke extraction so entry limits apply during iteration
- add regression coverage for manifest-read failures in direct release and npm local smoke preflights

Fixes #306

## Validation
- python -m py_compile scripts/smoke-release-artifacts.py scripts/smoke-npm-launcher-local.py scripts/smoke-npm-launcher-download.py scripts/check-release-artifact-smoke-preflight.py scripts/check-npm-launcher-local-smoke-preflight.py
- python scripts/check-release-artifact-smoke-preflight.py
- python scripts/check-npm-launcher-local-smoke-preflight.py
- python scripts/check-release-artifact-verifier.py
- npm run check --prefix packaging/npm/conu-cli
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced validation test coverage for archive integrity checks across npm launcher and release artifact processes.
  * Improved error detection and rejection of encrypted, corrupted, or non-compliant archive members.
  * Strengthened enforcement of size and entry count limits during archive processing to ensure release quality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->