### PR TITLE
Harden hosted repository ZIP ingestion

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import gzip
 import hashlib
 import io
+import importlib.util
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -102,8 +104,69 @@ def main() -> int:
             "unsafe repository metadata zip path",
         )
 
+        generator = load_generator()
+        expect_zip_bound_failure(
+            generator,
+            dist / APT_METADATA,
+            "MAX_ZIP_MEMBER_BYTES",
+            1,
+            "zip member is too large",
+            "metadata zip member size bound",
+        )
+        expect_zip_bound_failure(
+            generator,
+            dist / APT_METADATA,
+            "MAX_ZIP_MEMBERS",
+            1,
+            "contains more than",
+            "metadata zip member count bound",
+        )
+        expect_zip_bound_failure(
+            generator,
+            dist / APT_METADATA,
+            "MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES",
+            1,
+            "uncompressed ZIP contents exceed",
+            "metadata zip total size bound",
+        )
+
+        encrypted_zip = temp / "encrypted-zip"
+        shutil.copytree(dist, encrypted_zip)
+        mark_zip_member_encrypted(encrypted_zip / APT_METADATA, "Packages")
+        expect_action_failure(
+            lambda: generator.read_zip_members(encrypted_zip / APT_METADATA),
+            "encrypted zip member",
+            "encrypted repository metadata member",
+        )
+
+        unsupported_zip = temp / "unsupported-zip"
+        shutil.copytree(dist, unsupported_zip)
+        with zipfile.ZipFile(unsupported_zip / APT_METADATA, "w", compression=zipfile.ZIP_STORED) as archive:
+            info = zipfile.ZipInfo("Packages", ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_STORED
+            info.external_attr = (stat.S_IFCHR | 0o644) << 16
+            archive.writestr(info, b"device\n")
+        expect_action_failure(
+            lambda: generator.read_zip_members(unsupported_zip / APT_METADATA),
+            "unsupported zip member",
+            "unsupported repository metadata member",
+        )
+
     print("Hosted Linux repository regression checks passed")
     return 0
+
+
+def load_generator():
+    spec = importlib.util.spec_from_file_location(
+        "generate_hosted_linux_repositories",
+        GENERATOR,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load hosted Linux repository generator")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def run_generator(dist: Path, output: Path) -> str:
@@ -147,6 +210,37 @@ def expect_failure(description: str, dist: Path, expected: str) -> None:
         raise AssertionError(
             f"{description} failed with {failed.stdout!r}, expected {expected!r}"
         )
+
+
+def expect_zip_bound_failure(
+    generator,
+    archive: Path,
+    constant_name: str,
+    value: int,
+    expected: str,
+    label: str,
+) -> None:
+    original = getattr(generator, constant_name)
+    setattr(generator, constant_name, value)
+    try:
+        expect_action_failure(
+            lambda: generator.read_zip_members(archive),
+            expected,
+            label,
+        )
+    finally:
+        setattr(generator, constant_name, original)
+
+
+def expect_action_failure(action, expected: str, label: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+        if expected in message:
+            return
+        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+    raise AssertionError(f"{label}: expected failure containing {expected!r}")
 
 
 def write_signed_dist(dist: Path) -> None:
@@ -399,6 +493,38 @@ def write_zip_bytes(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
     info.compress_type = zipfile.ZIP_STORED
     info.external_attr = 0o644 << 16
     archive.writestr(info, data)
+
+
+def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature == 0x04034B50:
+            name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+            extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            name_start = offset + 30
+            name_end = name_start + name_length
+            compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 6 : offset + 8], "little") | 0x1
+                data[offset + 6 : offset + 8] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + compressed_size
+            continue
+        if signature == 0x02014B50:
+            name_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            extra_length = int.from_bytes(data[offset + 30 : offset + 32], "little")
+            comment_length = int.from_bytes(data[offset + 32 : offset + 34], "little")
+            name_start = offset + 46
+            name_end = name_start + name_length
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 8 : offset + 10], "little") | 0x1
+                data[offset + 8 : offset + 10] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + comment_length
+            continue
+        offset += 1
+    path.write_bytes(data)
 
 
 def deterministic_gzip(data: bytes) -> bytes:

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.util
 import json
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -46,6 +47,53 @@ def main() -> int:
 
         run_preparer(dist, pages)
         assert_pages_output(pages, site)
+
+        preparer = load_pages_preparer()
+        expect_zip_bound_failure(
+            preparer,
+            site,
+            "MAX_SITE_MEMBER_BYTES",
+            1,
+            "member is too large",
+            "Pages site member size bound",
+        )
+        expect_zip_bound_failure(
+            preparer,
+            site,
+            "MAX_SITE_MEMBERS",
+            1,
+            "too many members",
+            "Pages site member count bound",
+        )
+        expect_zip_bound_failure(
+            preparer,
+            site,
+            "MAX_SITE_TOTAL_UNCOMPRESSED_BYTES",
+            1,
+            "uncompressed contents exceed",
+            "Pages site total size bound",
+        )
+
+        encrypted_site = temp / "encrypted-site.zip"
+        shutil.copy2(site, encrypted_site)
+        mark_zip_member_encrypted(encrypted_site, "index.html")
+        expect_action_failure(
+            lambda: preparer.read_site_members(encrypted_site),
+            "encrypted zip member",
+            "encrypted Pages site member",
+        )
+
+        unsupported_site = temp / "unsupported-site.zip"
+        with zipfile.ZipFile(unsupported_site, "w", compression=zipfile.ZIP_STORED) as archive:
+            info = zipfile.ZipInfo("index.html", ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_STORED
+            info.external_attr = (stat.S_IFCHR | 0o644) << 16
+            archive.writestr(info, b"device\n")
+        expect_action_failure(
+            lambda: preparer.read_site_members(unsupported_site),
+            "unsupported member type",
+            "unsupported Pages site member",
+        )
 
         missing_checksum = temp / "missing-checksum"
         shutil.copytree(dist, missing_checksum)
@@ -191,6 +239,19 @@ def load_site_checker():
     return module
 
 
+def load_pages_preparer():
+    spec = importlib.util.spec_from_file_location(
+        "prepare_hosted_linux_repository_pages",
+        PAGES_PREPARER,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load hosted Linux repository Pages preparer")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def run_preparer(site: Path, output_dir: Path) -> str:
     return subprocess.run(
         [
@@ -228,6 +289,37 @@ def expect_failure(description: str, site: Path, output_dir: Path, expected: str
         raise AssertionError(
             f"{description} failed with {failed.stdout!r}, expected {expected!r}"
         )
+
+
+def expect_zip_bound_failure(
+    preparer,
+    site: Path,
+    constant_name: str,
+    value: int,
+    expected: str,
+    label: str,
+) -> None:
+    original = getattr(preparer, constant_name)
+    setattr(preparer, constant_name, value)
+    try:
+        expect_action_failure(
+            lambda: preparer.read_site_members(site),
+            expected,
+            label,
+        )
+    finally:
+        setattr(preparer, constant_name, original)
+
+
+def expect_action_failure(action, expected: str, label: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+        if expected in message:
+            return
+        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+    raise AssertionError(f"{label}: expected failure containing {expected!r}")
 
 
 def assert_pages_output(pages: Path, site: Path) -> None:
@@ -336,6 +428,38 @@ def write_checksum(path: Path) -> None:
         encoding="ascii",
         newline="\n",
     )
+
+
+def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature == 0x04034B50:
+            name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+            extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            name_start = offset + 30
+            name_end = name_start + name_length
+            compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 6 : offset + 8], "little") | 0x1
+                data[offset + 6 : offset + 8] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + compressed_size
+            continue
+        if signature == 0x02014B50:
+            name_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            extra_length = int.from_bytes(data[offset + 30 : offset + 32], "little")
+            comment_length = int.from_bytes(data[offset + 32 : offset + 34], "little")
+            name_start = offset + 46
+            name_end = name_start + name_length
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 8 : offset + 10], "little") | 0x1
+                data[offset + 8 : offset + 10] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + comment_length
+            continue
+        offset += 1
+    path.write_bytes(data)
 
 
 if __name__ == "__main__":

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.util
 import json
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -96,6 +97,53 @@ def main() -> int:
         assert_sha256_sidecar(site)
         assert_site_bundle(site, hosted_bundle)
 
+        site_generator = load_site_generator()
+        expect_zip_bound_failure(
+            site_generator,
+            hosted_bundle,
+            "MAX_ZIP_MEMBER_BYTES",
+            1,
+            "zip member is too large",
+            "hosted bundle member size bound",
+        )
+        expect_zip_bound_failure(
+            site_generator,
+            hosted_bundle,
+            "MAX_ZIP_MEMBERS",
+            1,
+            "contains more than",
+            "hosted bundle member count bound",
+        )
+        expect_zip_bound_failure(
+            site_generator,
+            hosted_bundle,
+            "MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES",
+            1,
+            "uncompressed ZIP contents exceed",
+            "hosted bundle total size bound",
+        )
+
+        encrypted_bundle = temp / "encrypted-hosted-bundle.zip"
+        shutil.copy2(hosted_bundle, encrypted_bundle)
+        mark_zip_member_encrypted(encrypted_bundle, "apt/Packages")
+        expect_action_failure(
+            lambda: site_generator.read_hosted_bundle(encrypted_bundle),
+            "encrypted zip member",
+            "encrypted hosted bundle member",
+        )
+
+        unsupported_bundle = temp / "unsupported-hosted-bundle.zip"
+        with zipfile.ZipFile(unsupported_bundle, "w", compression=zipfile.ZIP_STORED) as archive:
+            info = zipfile.ZipInfo("README.txt", ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_STORED
+            info.external_attr = (stat.S_IFCHR | 0o644) << 16
+            archive.writestr(info, b"device\n")
+        expect_action_failure(
+            lambda: site_generator.read_hosted_bundle(unsupported_bundle),
+            "unsupported zip member",
+            "unsupported hosted bundle member",
+        )
+
         run_generator(dist, repeat, BASE_URL)
         if site.read_bytes() != (repeat / SITE_BUNDLE).read_bytes():
             raise AssertionError("hosted Linux repository site artifact was not deterministic")
@@ -156,6 +204,19 @@ def load_bundle_checker():
     return module
 
 
+def load_site_generator():
+    spec = importlib.util.spec_from_file_location(
+        "generate_hosted_linux_repository_site",
+        SITE_GENERATOR,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load hosted Linux repository site generator")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def run_generator(dist: Path, output: Path, base_url: str) -> str:
     return subprocess.run(
         [
@@ -201,6 +262,37 @@ def expect_failure(description: str, dist: Path, base_url: str, expected: str) -
         raise AssertionError(
             f"{description} failed with {failed.stdout!r}, expected {expected!r}"
         )
+
+
+def expect_zip_bound_failure(
+    site_generator,
+    archive: Path,
+    constant_name: str,
+    value: int,
+    expected: str,
+    label: str,
+) -> None:
+    original = getattr(site_generator, constant_name)
+    setattr(site_generator, constant_name, value)
+    try:
+        expect_action_failure(
+            lambda: site_generator.read_hosted_bundle(archive),
+            expected,
+            label,
+        )
+    finally:
+        setattr(site_generator, constant_name, original)
+
+
+def expect_action_failure(action, expected: str, label: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+        if expected in message:
+            return
+        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+    raise AssertionError(f"{label}: expected failure containing {expected!r}")
 
 
 def assert_site_bundle(site: Path, hosted_bundle: Path) -> None:
@@ -413,6 +505,38 @@ def write_zip_bytes(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
     info.compress_type = zipfile.ZIP_STORED
     info.external_attr = 0o644 << 16
     archive.writestr(info, data)
+
+
+def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature == 0x04034B50:
+            name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+            extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            name_start = offset + 30
+            name_end = name_start + name_length
+            compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 6 : offset + 8], "little") | 0x1
+                data[offset + 6 : offset + 8] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + compressed_size
+            continue
+        if signature == 0x02014B50:
+            name_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            extra_length = int.from_bytes(data[offset + 30 : offset + 32], "little")
+            comment_length = int.from_bytes(data[offset + 32 : offset + 34], "little")
+            name_start = offset + 46
+            name_end = name_start + name_length
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 8 : offset + 10], "little") | 0x1
+                data[offset + 8 : offset + 10] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + comment_length
+            continue
+        offset += 1
+    path.write_bytes(data)
 
 
 if __name__ == "__main__":

--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import base64
 import gzip
 import hashlib
+import importlib.util
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -26,6 +28,8 @@ RPM_METADATA = f"conu-{VERSION}-rpm-repository-metadata.zip"
 
 
 def main() -> int:
+    run_zip_ingestion_preflights()
+
     gpg = shutil.which("gpg")
     if gpg is None:
         print("Linux repository signing regression skipped: gpg is unavailable")
@@ -120,6 +124,112 @@ def main() -> int:
     return 0
 
 
+def run_zip_ingestion_preflights() -> None:
+    signer = load_signer()
+    with tempfile.TemporaryDirectory(prefix="conu-repository-signing-zip-check-") as temp_text:
+        temp = Path(temp_text)
+        metadata = temp / APT_METADATA
+        write_apt_metadata_zip(metadata)
+
+        expect_zip_bound_failure(
+            signer,
+            metadata,
+            "MAX_ZIP_MEMBER_BYTES",
+            1,
+            "zip member is too large",
+            "repository signing member size bound",
+        )
+        expect_zip_bound_failure(
+            signer,
+            metadata,
+            "MAX_ZIP_MEMBERS",
+            1,
+            "contains more than",
+            "repository signing member count bound",
+        )
+        expect_zip_bound_failure(
+            signer,
+            metadata,
+            "MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES",
+            1,
+            "uncompressed ZIP contents exceed",
+            "repository signing total size bound",
+        )
+
+        encrypted = temp / "encrypted.zip"
+        shutil.copy2(metadata, encrypted)
+        mark_zip_member_encrypted(encrypted, "Release")
+        expect_action_failure(
+            lambda: signer.read_zip_members(encrypted),
+            "encrypted zip member",
+            "repository signing encrypted member",
+        )
+
+        unsupported = temp / "unsupported.zip"
+        with zipfile.ZipFile(unsupported, "w", compression=zipfile.ZIP_STORED) as archive:
+            info = zipfile.ZipInfo("Release", (2020, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_STORED
+            info.external_attr = (stat.S_IFCHR | 0o644) << 16
+            archive.writestr(info, b"device\n")
+        expect_action_failure(
+            lambda: signer.read_zip_members(unsupported),
+            "unsupported zip member",
+            "repository signing unsupported member",
+        )
+
+
+def load_signer():
+    script_dir = ROOT / "scripts"
+    sys.path.insert(0, str(script_dir))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "sign_linux_repository_metadata",
+            SIGNER,
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load Linux repository metadata signer")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        try:
+            sys.path.remove(str(script_dir))
+        except ValueError:
+            pass
+
+
+def expect_zip_bound_failure(
+    signer,
+    archive: Path,
+    constant_name: str,
+    value: int,
+    expected: str,
+    label: str,
+) -> None:
+    original = getattr(signer, constant_name)
+    setattr(signer, constant_name, value)
+    try:
+        expect_action_failure(
+            lambda: signer.read_zip_members(archive),
+            expected,
+            label,
+        )
+    finally:
+        setattr(signer, constant_name, original)
+
+
+def expect_action_failure(action, expected: str, label: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+        if expected in message:
+            return
+        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+    raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
 def write_apt_metadata_zip(path: Path) -> None:
     packages = b"Package: conu\nVersion: 0.1.0\nArchitecture: amd64\n\n"
     packages_gz = deterministic_gzip(packages)
@@ -176,6 +286,38 @@ def write_zip_bytes(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
     info.compress_type = zipfile.ZIP_STORED
     info.external_attr = 0o644 << 16
     archive.writestr(info, data)
+
+
+def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature == 0x04034B50:
+            name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+            extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            name_start = offset + 30
+            name_end = name_start + name_length
+            compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 6 : offset + 8], "little") | 0x1
+                data[offset + 6 : offset + 8] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + compressed_size
+            continue
+        if signature == 0x02014B50:
+            name_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            extra_length = int.from_bytes(data[offset + 30 : offset + 32], "little")
+            comment_length = int.from_bytes(data[offset + 32 : offset + 34], "little")
+            name_start = offset + 46
+            name_end = name_start + name_length
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 8 : offset + 10], "little") | 0x1
+                data[offset + 8 : offset + 10] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + comment_length
+            continue
+        offset += 1
+    path.write_bytes(data)
 
 
 def verify_apt_signatures(gpg: str, home: Path, bundle: Path, temp: Path) -> None:

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -8,6 +8,7 @@ import gzip
 import hashlib
 import json
 import re
+import stat
 import sys
 import zipfile
 from dataclasses import dataclass
@@ -21,6 +22,9 @@ HASH_CHUNK_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
 MAX_SIGNATURE_BYTES = 1024 * 1024
 MAX_PUBLIC_KEY_BYTES = 1024 * 1024
+MAX_ZIP_MEMBER_BYTES = 512_000_000
+MAX_ZIP_MEMBERS = 10_000
+MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 DEBIAN_ARCHES = {
     "linux-x64": "amd64",
@@ -320,11 +324,15 @@ def find_primary_metadata_member(bundle: Path, members: dict[str, bytes]) -> str
 
 def read_zip_members(bundle: Path) -> dict[str, bytes]:
     members: dict[str, bytes] = {}
+    total_uncompressed = 0
     try:
         with zipfile.ZipFile(bundle) as archive:
-            for member in archive.infolist():
+            infos = archive.infolist()
+            if len(infos) > MAX_ZIP_MEMBERS:
+                raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
+            for member in infos:
                 name = normalize_zip_path(member.filename)
-                if member.is_dir():
+                if not validate_zip_member_for_read(bundle.name, member, name):
                     continue
                 if name in members:
                     raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
@@ -333,10 +341,34 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                     or name.startswith("repodata/")
                 ):
                     raise SystemExit(f"{bundle.name} contains unexpected zip member: {name}")
+                total_uncompressed += member.file_size
+                if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
+                    raise SystemExit(
+                        f"{bundle.name} uncompressed ZIP contents exceed "
+                        f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                    )
                 members[name] = archive.read(member)
     except zipfile.BadZipFile as exc:
         raise SystemExit(f"{bundle.name} is not a readable zip archive") from exc
     return members
+
+
+def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name: str) -> bool:
+    if member.flag_bits & 0x1:
+        raise SystemExit(f"{bundle_name} contains encrypted zip member: {name}")
+    file_type = (member.external_attr >> 16) & 0o170000
+    is_directory = member.is_dir() or file_type == stat.S_IFDIR
+    if file_type == stat.S_IFLNK:
+        raise SystemExit(f"{bundle_name} contains unsupported link member: {name}")
+    if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+        raise SystemExit(f"{bundle_name} contains unsupported zip member: {name}")
+    if is_directory:
+        if member.file_size != 0:
+            raise SystemExit(f"{bundle_name} contains directory member with data: {name}")
+        return False
+    if member.file_size > MAX_ZIP_MEMBER_BYTES:
+        raise SystemExit(f"{bundle_name} zip member is too large: {name}")
+    return True
 
 
 def normalize_zip_path(raw_name: str) -> str:

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 import sys
 import zipfile
 from pathlib import Path, PurePosixPath
@@ -19,6 +20,9 @@ SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?
 HASH_CHUNK_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
 MAX_SIGNATURE_BYTES = 1024 * 1024
+MAX_ZIP_MEMBER_BYTES = 512_000_000
+MAX_ZIP_MEMBERS = 10_000
+MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
@@ -203,18 +207,46 @@ def require_detached_signature(path: Path) -> Path:
 
 def read_hosted_bundle(bundle: Path) -> dict[str, bytes]:
     members: dict[str, bytes] = {}
+    total_uncompressed = 0
     try:
         with zipfile.ZipFile(bundle) as archive:
-            for member in archive.infolist():
+            infos = archive.infolist()
+            if len(infos) > MAX_ZIP_MEMBERS:
+                raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
+            for member in infos:
                 name = normalize_zip_path(member.filename)
-                if member.is_dir():
+                if not validate_zip_member_for_read(bundle.name, member, name):
                     continue
                 if name in members:
                     raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
+                total_uncompressed += member.file_size
+                if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
+                    raise SystemExit(
+                        f"{bundle.name} uncompressed ZIP contents exceed "
+                        f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                    )
                 members[name] = archive.read(member)
     except zipfile.BadZipFile as exc:
         raise SystemExit(f"{bundle.name} is not a readable zip archive") from exc
     return members
+
+
+def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name: str) -> bool:
+    if member.flag_bits & 0x1:
+        raise SystemExit(f"{bundle_name} contains encrypted zip member: {name}")
+    file_type = (member.external_attr >> 16) & 0o170000
+    is_directory = member.is_dir() or file_type == stat.S_IFDIR
+    if file_type == stat.S_IFLNK:
+        raise SystemExit(f"{bundle_name} contains unsupported link member: {name}")
+    if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+        raise SystemExit(f"{bundle_name} contains unsupported zip member: {name}")
+    if is_directory:
+        if member.file_size != 0:
+            raise SystemExit(f"{bundle_name} contains directory member with data: {name}")
+        return False
+    if member.file_size > MAX_ZIP_MEMBER_BYTES:
+        raise SystemExit(f"{bundle_name} zip member is too large: {name}")
+    return True
 
 
 def normalize_zip_path(raw_name: str) -> str:

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import re
+import stat
 import sys
 import zipfile
 from pathlib import Path, PurePosixPath
@@ -22,7 +23,9 @@ HASH_CHUNK_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
 MAX_SIGNATURE_BYTES = 1024 * 1024
 MAX_SITE_ZIP_BYTES = 2 * 1024 * 1024 * 1024
+MAX_SITE_MEMBER_BYTES = 512_000_000
 MAX_SITE_MEMBERS = 10000
+MAX_SITE_TOTAL_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
 CACHE_CONTROL_RULES = (
@@ -211,6 +214,7 @@ def prepare_output_dir(output_dir: Path) -> None:
 
 def read_site_members(site_zip: Path) -> dict[str, bytes]:
     members: dict[str, bytes] = {}
+    total_uncompressed = 0
     try:
         with zipfile.ZipFile(site_zip) as archive:
             infos = archive.infolist()
@@ -218,11 +222,16 @@ def read_site_members(site_zip: Path) -> dict[str, bytes]:
                 raise SystemExit(f"{site_zip.name} has too many members for Pages deployment")
             for info in infos:
                 name = normalize_zip_path(info.filename)
-                if info.is_dir():
+                if not validate_zip_member_for_read(site_zip.name, info, name):
                     continue
-                reject_unsupported_member_type(info, name)
                 if name in members:
                     raise SystemExit(f"{site_zip.name} contains duplicate zip member: {name}")
+                total_uncompressed += info.file_size
+                if total_uncompressed > MAX_SITE_TOTAL_UNCOMPRESSED_BYTES:
+                    raise SystemExit(
+                        f"{site_zip.name} uncompressed contents exceed "
+                        f"{MAX_SITE_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                    )
                 members[name] = archive.read(info)
     except zipfile.BadZipFile as exc:
         raise SystemExit(f"{site_zip.name} is not a readable zip archive") from exc
@@ -244,11 +253,22 @@ def normalize_zip_path(raw_name: str) -> str:
     return "/".join(parts)
 
 
-def reject_unsupported_member_type(info: zipfile.ZipInfo, name: str) -> None:
-    mode = (info.external_attr >> 16) & 0o177777
-    file_type = mode & 0o170000
-    if file_type not in (0, 0o100000):
+def validate_zip_member_for_read(site_name: str, info: zipfile.ZipInfo, name: str) -> bool:
+    if info.flag_bits & 0x1:
+        raise SystemExit(f"{site_name} contains encrypted zip member: {name}")
+    file_type = (info.external_attr >> 16) & 0o170000
+    is_directory = info.is_dir() or file_type == stat.S_IFDIR
+    if file_type == stat.S_IFLNK:
+        raise SystemExit(f"hosted repository site contains unsupported link member: {name}")
+    if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
         raise SystemExit(f"hosted repository site contains unsupported member type: {name}")
+    if is_directory:
+        if info.file_size != 0:
+            raise SystemExit(f"{site_name} contains directory member with data: {name}")
+        return False
+    if info.file_size > MAX_SITE_MEMBER_BYTES:
+        raise SystemExit(f"{site_name} member is too large for Pages deployment: {name}")
+    return True
 
 
 def validate_site_members(site_name: str, version: str, members: dict[str, bytes]) -> None:

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -9,6 +9,7 @@ import hashlib
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,9 @@ from linux_gpg_common import (
 CHECKSUM_RE = re.compile(r"^([0-9a-f]{64})  ([^ \t\r\n]+)\n$")
 MAX_SIGNING_KEY_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
+MAX_ZIP_MEMBER_BYTES = 512_000_000
+MAX_ZIP_MEMBERS = 10_000
+MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 HASH_CHUNK_BYTES = 1024 * 1024
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 APT_METADATA_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-apt-repository-metadata\.zip$")
@@ -240,18 +244,46 @@ def sign_rpm_bundle(
 
 def read_zip_members(bundle: Path) -> dict[str, bytes]:
     members: dict[str, bytes] = {}
+    total_uncompressed = 0
     try:
         with zipfile.ZipFile(bundle) as archive:
-            for member in archive.infolist():
+            infos = archive.infolist()
+            if len(infos) > MAX_ZIP_MEMBERS:
+                raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
+            for member in infos:
                 name = normalize_zip_path(member.filename)
-                if member.is_dir():
+                if not validate_zip_member_for_read(bundle.name, member, name):
                     continue
                 if name in members:
                     raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
+                total_uncompressed += member.file_size
+                if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
+                    raise SystemExit(
+                        f"{bundle.name} uncompressed ZIP contents exceed "
+                        f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                    )
                 members[name] = archive.read(member)
     except zipfile.BadZipFile as exc:
         raise SystemExit(f"{bundle.name} is not a readable zip archive") from exc
     return members
+
+
+def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name: str) -> bool:
+    if member.flag_bits & 0x1:
+        raise SystemExit(f"{bundle_name} contains encrypted zip member: {name}")
+    file_type = (member.external_attr >> 16) & 0o170000
+    is_directory = member.is_dir() or file_type == stat.S_IFDIR
+    if file_type == stat.S_IFLNK:
+        raise SystemExit(f"{bundle_name} contains unsupported link member: {name}")
+    if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+        raise SystemExit(f"{bundle_name} contains unsupported zip member: {name}")
+    if is_directory:
+        if member.file_size != 0:
+            raise SystemExit(f"{bundle_name} contains directory member with data: {name}")
+        return False
+    if member.file_size > MAX_ZIP_MEMBER_BYTES:
+        raise SystemExit(f"{bundle_name} zip member is too large: {name}")
+    return True
 
 
 def normalize_zip_path(raw_name: str) -> str:


### PR DESCRIPTION
## **User description**
## Summary
- add fail-closed ZIP member count, per-member size, total-uncompressed size, encrypted member, and unsupported member type checks to hosted repository bundle/site readers and Linux repository metadata signing inputs
- add the same bounds to hosted Linux repository Pages preparation before extracting site members
- add focused regressions for size/count/total bounds, encrypted ZIP entries, and unsupported ZIP member types

Fixes #308

## Validation
- python -m py_compile scripts/generate-hosted-linux-repositories.py scripts/generate-hosted-linux-repository-site.py scripts/prepare-hosted-linux-repository-pages.py scripts/sign-linux-repository-metadata.py scripts/check-hosted-linux-repositories.py scripts/check-hosted-linux-repository-site.py scripts/check-hosted-linux-repository-pages.py scripts/check-linux-repository-signing.py
- python scripts/check-hosted-linux-repositories.py
- python scripts/check-hosted-linux-repository-site.py
- python scripts/check-hosted-linux-repository-pages.py
- python scripts/check-linux-repository-signing.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check


___

## **CodeAnt-AI Description**
**Reject unsafe ZIP contents during hosted repository generation and publishing**

### What Changed
- Hosted repository ZIP files now fail if they contain encrypted entries, symlinks, unsupported file types, oversized members, too many files, or too much total unpacked data
- Pages preparation applies the same ZIP safety checks before extracting a hosted site
- Regression checks now cover these unsafe ZIP cases across repository generation, site creation, signing, and Pages preparation

### Impact
`✅ Safer hosted repository uploads`
`✅ Fewer ZIP extraction failures`
`✅ Clearer rejection of malformed repository artifacts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
