### PR TITLE
Harden package-manager archive ingestion

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -9,6 +9,7 @@ import importlib.util
 import io
 import json
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -254,6 +255,22 @@ def expect_failure(description: str, action, expected: str) -> None:
             ) from exc
         return
     raise AssertionError(f"{description} unexpectedly passed")
+
+
+def expect_failure_with_limit(
+    generator,
+    limit_name: str,
+    value: int,
+    description: str,
+    action,
+    expected: str,
+) -> None:
+    original = getattr(generator, limit_name)
+    setattr(generator, limit_name, value)
+    try:
+        expect_failure(description, action, expected)
+    finally:
+        setattr(generator, limit_name, original)
 
 
 def assert_no_forbidden_output(path: Path, temp: Path) -> None:
@@ -687,6 +704,38 @@ def assert_zip_no_forbidden_output(path: Path, temp: Path) -> None:
         assert_no_forbidden_text(text, f"{path.name}:{name}", temp)
 
 
+def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature == 0x04034B50:
+            name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+            extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            name_start = offset + 30
+            name_end = name_start + name_length
+            compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 6 : offset + 8], "little") | 0x1
+                data[offset + 6 : offset + 8] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + compressed_size
+            continue
+        if signature == 0x02014B50:
+            name_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+            extra_length = int.from_bytes(data[offset + 30 : offset + 32], "little")
+            comment_length = int.from_bytes(data[offset + 32 : offset + 34], "little")
+            name_start = offset + 46
+            name_end = name_start + name_length
+            if data[name_start:name_end] == target:
+                flags = int.from_bytes(data[offset + 8 : offset + 10], "little") | 0x1
+                data[offset + 8 : offset + 10] = flags.to_bytes(2, "little")
+            offset = name_end + extra_length + comment_length
+            continue
+        offset += 1
+    path.write_bytes(data)
+
+
 def main() -> int:
     generator = load_generator()
     if generator.validate_version("1.2.3-rc.1+build.5") != "1.2.3-rc.1+build.5":
@@ -701,6 +750,32 @@ def main() -> int:
         rootless_dist.mkdir()
         hashes = write_dist(rootless_dist, rooted_windows=False)
         generate(generator, rootless_dist, rootless_out)
+
+        expect_failure_with_limit(
+            generator,
+            "MAX_RELEASE_ARCHIVE_BYTES",
+            1,
+            "oversized release asset",
+            lambda: generator.load_release_assets(
+                rootless_dist,
+                VERSION,
+                "imthegoodboy/conU",
+                f"v{VERSION}",
+            ),
+            "release asset is larger than 1 bytes",
+        )
+
+        expect_failure_with_limit(
+            generator,
+            "MAX_RELEASE_MEMBER_COUNT",
+            1,
+            "windows archive member count bound",
+            lambda: generator.detect_windows_extract_dir(
+                rootless_dist / TARGETS["windows-x64"],
+                VERSION,
+            ),
+            "contains more than 1 entries",
+        )
 
         homebrew = (rootless_out / HOMEBREW_FILENAME).read_text(encoding="ascii")
         if "class Conu < Formula" not in homebrew:
@@ -967,6 +1042,122 @@ def main() -> int:
                 "linux-x64",
             ),
             "linux release asset is not a readable tar.gz",
+        )
+
+        encrypted_windows = temp / "encrypted-windows"
+        encrypted_windows.mkdir()
+        write_dist(encrypted_windows)
+        encrypted_archive = encrypted_windows / TARGETS["windows-x64"]
+        mark_zip_member_encrypted(encrypted_archive, "bin/conu.exe")
+        expect_failure(
+            "encrypted windows zip member",
+            lambda: generator.detect_windows_extract_dir(encrypted_archive, VERSION),
+            "contains encrypted zip member",
+        )
+
+        unsupported_windows = temp / "unsupported-windows"
+        unsupported_windows.mkdir()
+        write_dist(unsupported_windows)
+        unsupported_archive = unsupported_windows / TARGETS["windows-x64"]
+        with zipfile.ZipFile(unsupported_archive, "a", compression=zipfile.ZIP_STORED) as package:
+            info = zipfile.ZipInfo("device")
+            info.external_attr = stat.S_IFCHR << 16
+            package.writestr(info, b"device\n")
+        expect_failure(
+            "unsupported windows zip member",
+            lambda: generator.detect_windows_extract_dir(unsupported_archive, VERSION),
+            "contains unsupported zip member",
+        )
+
+        mixed_windows = temp / "mixed-windows"
+        mixed_windows.mkdir()
+        write_dist(mixed_windows)
+        mixed_archive = mixed_windows / TARGETS["windows-x64"]
+        with zipfile.ZipFile(mixed_archive, "a", compression=zipfile.ZIP_STORED) as package:
+            package.writestr(f"conu-{VERSION}-windows-x64/README.md", "# conU\n")
+        expect_failure(
+            "mixed rooted windows archive",
+            lambda: generator.detect_windows_extract_dir(mixed_archive, VERSION),
+            "mixes rooted and rootless archive paths",
+        )
+
+        expect_failure_with_limit(
+            generator,
+            "MAX_RELEASE_MEMBER_BYTES",
+            1,
+            "linux archive member size bound",
+            lambda: generator.extract_linux_binaries(
+                rootless_dist / TARGETS["linux-x64"],
+                VERSION,
+                "linux-x64",
+            ),
+            "member is too large",
+        )
+
+        expect_failure_with_limit(
+            generator,
+            "MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES",
+            1,
+            "linux archive total uncompressed bound",
+            lambda: generator.extract_linux_binaries(
+                rootless_dist / TARGETS["linux-x64"],
+                VERSION,
+                "linux-x64",
+            ),
+            "uncompressed contents exceed 1 bytes",
+        )
+
+        unsupported_linux = temp / "unsupported-linux"
+        unsupported_linux.mkdir()
+        unsupported_linux_archive = unsupported_linux / TARGETS["linux-x64"]
+        with tarfile.open(unsupported_linux_archive, "w:gz") as package:
+            for binary in LINUX_BINARIES:
+                data = f"{binary}-linux-x64\n".encode("ascii")
+                info = tarfile.TarInfo(f"bin/{binary}")
+                info.size = len(data)
+                info.mode = 0o755
+                info.mtime = 1577836800
+                package.addfile(info, io.BytesIO(data))
+            link = tarfile.TarInfo("bin/linked-conu")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "bin/conu"
+            link.mtime = 1577836800
+            package.addfile(link)
+        expect_failure(
+            "unsupported linux tar member",
+            lambda: generator.extract_linux_binaries(
+                unsupported_linux_archive,
+                VERSION,
+                "linux-x64",
+            ),
+            "contains unsupported non-file member",
+        )
+
+        mixed_linux = temp / "mixed-linux"
+        mixed_linux.mkdir()
+        mixed_linux_archive = mixed_linux / TARGETS["linux-x64"]
+        with tarfile.open(mixed_linux_archive, "w:gz") as package:
+            for binary in LINUX_BINARIES:
+                data = f"{binary}-linux-x64\n".encode("ascii")
+                info = tarfile.TarInfo(f"bin/{binary}")
+                info.size = len(data)
+                info.mode = 0o755
+                info.mtime = 1577836800
+                package.addfile(info, io.BytesIO(data))
+            rooted_data = b"# conU\n"
+            rooted_info = tarfile.TarInfo(f"conu-{VERSION}-linux-x64/README.md")
+            rooted_info.size = len(rooted_data)
+            rooted_info.mode = 0o644
+            rooted_info.mtime = 1577836800
+            package.addfile(rooted_info, io.BytesIO(rooted_data))
+        expect_failure(
+            "mixed rooted linux archive",
+            lambda: generator.extract_linux_binaries(
+                mixed_linux_archive,
+                VERSION,
+                "linux-x64",
+            ),
+            "mixes rooted and rootless archive paths",
         )
 
     print("package-manager manifest generation regressions passed")

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -11,6 +11,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -45,7 +46,18 @@ STATIC_OUTPUT_FILENAMES = (
 )
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 SOURCE_EPOCH = 1577836800
-MAX_PACKAGE_BINARY_BYTES = 512_000_000
+MAX_RELEASE_ARCHIVE_BYTES = 1_000_000_000
+MAX_RELEASE_MEMBER_BYTES = 512_000_000
+MAX_RELEASE_MEMBER_COUNT = 10_000
+MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+MAX_PACKAGE_BINARY_BYTES = MAX_RELEASE_MEMBER_BYTES
+
+
+@dataclass
+class ArchiveScanState:
+    paths: set[str]
+    entry_count: int = 0
+    total_uncompressed: int = 0
 
 
 @dataclass(frozen=True)
@@ -343,6 +355,7 @@ def load_release_assets(
         archive = dist / filename
         if not archive.exists() or not archive.is_file():
             raise SystemExit(f"missing required release asset for {target}: {filename}")
+        validate_release_asset_size(archive)
         sha256 = read_verified_checksum(archive)
         url = f"https://github.com/{repo}/releases/download/{tag}/{filename}"
         assets[target] = ReleaseAsset(
@@ -352,6 +365,14 @@ def load_release_assets(
             url=url,
         )
     return assets
+
+
+def validate_release_asset_size(archive: Path) -> None:
+    size = archive.stat().st_size
+    if size > MAX_RELEASE_ARCHIVE_BYTES:
+        raise SystemExit(
+            f"release asset is larger than {MAX_RELEASE_ARCHIVE_BYTES} bytes: {archive.name}"
+        )
 
 
 def read_verified_checksum(archive: Path) -> str:
@@ -392,96 +413,232 @@ def sha256_file(path: Path) -> str:
 
 def detect_windows_extract_dir(archive: Path, version: str) -> str | None:
     root = f"conu-{version}-windows-x64"
-    root_prefix = f"{root}/"
     rootless_bins = {f"bin/{binary}.exe" for binary in EXPECTED_BINARIES}
-    rooted_bins = {f"{root_prefix}bin/{binary}.exe" for binary in EXPECTED_BINARIES}
+    state = ArchiveScanState(paths=set())
+    root_style: str | None = None
+    file_paths: set[str] = set()
 
     try:
         with zipfile.ZipFile(archive) as package:
-            paths = {
-                normalize_zip_path(member.filename)
-                for member in package.infolist()
-                if not member.is_dir()
-            }
+            infos = package.infolist()
+            if len(infos) > MAX_RELEASE_MEMBER_COUNT:
+                raise SystemExit(
+                    f"{archive.name} contains more than {MAX_RELEASE_MEMBER_COUNT} entries"
+                )
+            for member in infos:
+                normalized, root_style, is_file = validate_zip_release_member_for_scan(
+                    archive.name,
+                    member,
+                    root,
+                    state,
+                    root_style,
+                )
+                if is_file:
+                    file_paths.add(normalized)
     except zipfile.BadZipFile as exc:
         raise SystemExit(f"windows release asset is not a readable zip: {archive.name}") from exc
 
-    if rootless_bins <= paths:
+    if rootless_bins <= file_paths:
+        if root_style == "rooted":
+            return root
         return None
-    if rooted_bins <= paths:
-        return root
     raise SystemExit(
         f"{archive.name} does not contain expected rootless or {root}/bin Windows binaries"
     )
 
 
-def normalize_zip_path(raw_name: str) -> str:
+def validate_zip_release_member_for_scan(
+    archive_name: str,
+    member: zipfile.ZipInfo,
+    expected_root: str,
+    state: ArchiveScanState,
+    root_style: str | None,
+) -> tuple[str, str | None, bool]:
+    raw_name = member.filename
+    if member.flag_bits & 0x1:
+        raise SystemExit(f"{archive_name} contains encrypted zip member: {raw_name}")
+    file_type = (member.external_attr >> 16) & 0o170000
+    is_directory = member.is_dir() or file_type == stat.S_IFDIR
+    if file_type == stat.S_IFLNK:
+        raise SystemExit(f"{archive_name} contains unsupported link member: {raw_name}")
+    if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+        raise SystemExit(f"{archive_name} contains unsupported zip member: {raw_name}")
+    if is_directory:
+        if member.file_size != 0:
+            raise SystemExit(f"{archive_name} contains directory member with data: {raw_name}")
+        normalized, root_style = record_release_archive_member(
+            archive_name,
+            raw_name,
+            expected_root,
+            0,
+            state,
+            root_style,
+            allow_empty=True,
+        )
+        return normalized, root_style, False
+    normalized, root_style = record_release_archive_member(
+        archive_name,
+        raw_name,
+        expected_root,
+        member.file_size,
+        state,
+        root_style,
+    )
+    return normalized, root_style, True
+
+
+def record_release_archive_member(
+    archive_name: str,
+    raw_name: str,
+    expected_root: str,
+    size: int,
+    state: ArchiveScanState,
+    root_style: str | None,
+    *,
+    allow_empty: bool = False,
+) -> tuple[str, str | None]:
+    if size < 0:
+        raise SystemExit(f"{archive_name} contains member with invalid size: {raw_name}")
+    if size > MAX_RELEASE_MEMBER_BYTES:
+        raise SystemExit(f"{archive_name} member is too large: {raw_name}")
+
+    state.entry_count += 1
+    if state.entry_count > MAX_RELEASE_MEMBER_COUNT:
+        raise SystemExit(f"{archive_name} contains more than {MAX_RELEASE_MEMBER_COUNT} entries")
+
+    normalized, member_style = normalize_release_member_path(raw_name, expected_root)
+    root_style = update_release_root_style(archive_name, raw_name, root_style, member_style)
+    if not normalized:
+        if allow_empty:
+            return normalized, root_style
+        raise SystemExit(f"{archive_name} contains empty archive path: {raw_name}")
+
+    if normalized in state.paths:
+        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+    state.paths.add(normalized)
+
+    state.total_uncompressed += size
+    if state.total_uncompressed > MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES:
+        raise SystemExit(
+            f"{archive_name} uncompressed contents exceed "
+            f"{MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        )
+    return normalized, root_style
+
+
+def normalize_release_member_path(raw_name: str, expected_root: str) -> tuple[str, str | None]:
     normalized = raw_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
     if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe zip path in package-manager asset: {raw_name}")
-    return "/".join(parts)
+        raise SystemExit(f"unsafe archive path in package-manager asset: {raw_name}")
+    root_style = None
+    if parts:
+        if parts[0] == expected_root:
+            root_style = "rooted"
+            parts = parts[1:]
+        elif parts[0].startswith("conu-"):
+            raise SystemExit(
+                f"unexpected archive root in package-manager asset: {parts[0]} "
+                f"(expected {expected_root})"
+            )
+        else:
+            root_style = "rootless"
+    return "/".join(parts), root_style
+
+
+def update_release_root_style(
+    archive_name: str,
+    raw_name: str,
+    current: str | None,
+    member_style: str | None,
+) -> str | None:
+    if member_style is None:
+        return current
+    if current is not None and current != member_style:
+        raise SystemExit(f"{archive_name} mixes rooted and rootless archive paths: {raw_name}")
+    return member_style
 
 
 def extract_linux_binaries(archive: Path, version: str, target: str) -> dict[str, bytes]:
     root = f"conu-{version}-{target}"
-    root_prefix = f"{root}/"
     rootless_bins = {f"bin/{binary}" for binary in EXPECTED_BINARIES}
-    rooted_bins = {f"{root_prefix}bin/{binary}" for binary in EXPECTED_BINARIES}
-    wanted = rootless_bins | rooted_bins
-    paths: set[str] = set()
+    state = ArchiveScanState(paths=set())
+    file_paths: set[str] = set()
+    root_style: str | None = None
     extracted: dict[str, bytes] = {}
 
     try:
-        with tarfile.open(archive, "r:gz") as package:
-            for member in package.getmembers():
-                normalized = normalize_tar_path(member.name)
-                if not normalized:
-                    continue
-                if normalized in paths:
-                    raise SystemExit(f"{archive.name} contains duplicate tar path: {normalized}")
-                paths.add(normalized)
-                if normalized not in wanted:
+        with tarfile.open(archive, "r|gz") as package:
+            for member in package:
+                if member.isdir():
+                    if member.size != 0:
+                        raise SystemExit(
+                            f"{archive.name} contains directory member with data: {member.name}"
+                        )
+                    _, root_style = record_release_archive_member(
+                        archive.name,
+                        member.name,
+                        root,
+                        0,
+                        state,
+                        root_style,
+                        allow_empty=True,
+                    )
                     continue
                 if not member.isfile():
-                    raise SystemExit(f"{archive.name} contains non-file binary path: {member.name}")
-                if member.size < 0:
-                    raise SystemExit(f"{archive.name} contains binary with invalid size: {member.name}")
-                if member.size > MAX_PACKAGE_BINARY_BYTES:
-                    raise SystemExit(f"{archive.name} contains oversized binary: {member.name}")
+                    raise SystemExit(
+                        f"{archive.name} contains unsupported non-file member: {member.name}"
+                    )
+                normalized, root_style = record_release_archive_member(
+                    archive.name,
+                    member.name,
+                    root,
+                    member.size,
+                    state,
+                    root_style,
+                )
+                if not normalized:
+                    continue
+                file_paths.add(normalized)
+                if normalized not in rootless_bins:
+                    continue
                 handle = package.extractfile(member)
                 if handle is None:
                     raise SystemExit(f"{archive.name} could not read binary: {member.name}")
-                extracted[normalized] = handle.read()
+                extracted[normalized] = read_limited_release_member(
+                    archive.name,
+                    member.name,
+                    handle,
+                    MAX_PACKAGE_BINARY_BYTES,
+                )
     except (tarfile.TarError, EOFError, OSError, zlib.error) as exc:
         raise SystemExit(f"linux release asset is not a readable tar.gz: {archive.name}") from exc
 
-    if rootless_bins <= paths:
-        prefix = ""
-    elif rooted_bins <= paths:
-        prefix = root_prefix
-    else:
+    if not rootless_bins <= file_paths:
         raise SystemExit(
             f"{archive.name} does not contain expected rootless or {root}/bin Linux binaries"
         )
 
     binaries: dict[str, bytes] = {}
     for binary in EXPECTED_BINARIES:
-        path = f"{prefix}bin/{binary}"
+        path = f"bin/{binary}"
         if path not in extracted:
             raise SystemExit(f"{archive.name} could not extract expected binary: {path}")
         binaries[binary] = extracted[path]
     return binaries
 
 
-def normalize_tar_path(raw_name: str) -> str:
-    normalized = raw_name.replace("\\", "/")
-    path = PurePosixPath(normalized)
-    parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe tar path in package-manager asset: {raw_name}")
-    return "/".join(parts)
+def read_limited_release_member(
+    archive_name: str,
+    member_name: str,
+    handle,
+    limit: int,
+) -> bytes:
+    content = handle.read(limit + 1)
+    if len(content) > limit:
+        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+    return content
 
 
 def render_homebrew_formula(version: str, repo: str, assets: dict[str, ReleaseAsset]) -> str:


### PR DESCRIPTION
## **User description**
## Summary
- add package-manager release archive size, member count, per-member, and total-uncompressed bounds
- reject encrypted/unsupported ZIP entries, unsupported TAR entries, duplicate paths, unsafe roots, and mixed rooted/rootless release layouts before package-manager artifact generation
- add regression coverage for bounded and malformed ZIP/TAR inputs

Fixes #310

## Validation
- python -m py_compile scripts/generate-package-manager-manifests.py scripts/check-package-manager-manifests.py
- python scripts/check-package-manager-manifests.py
- python scripts/check-package-manager-submissions.py
- python scripts/check-release-artifact-verifier.py
- python scripts/check-release-artifact-smoke-preflight.py
- npm run check --prefix packaging/npm/conu-cli
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check


___

## **CodeAnt-AI Description**
**Harden package-manager archive checks**

### What Changed
- Package-manager release assets are now rejected if the archive itself is too large, if it contains too many entries, or if any file is larger than the allowed limit
- Windows ZIP releases now fail fast for encrypted files, unsupported entry types, duplicate paths, and archives that mix rooted and rootless layouts
- Linux TAR releases now fail fast for unsupported non-file entries, duplicate paths, and archives that mix rooted and rootless layouts
- Regression checks were added for the new size limits and invalid archive cases

### Impact
`✅ Fewer package-manager publish failures`
`✅ Safer release archive imports`
`✅ Clearer archive validation errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
