### PR TITLE
Harden Linux signing file handling

### DIFF
--- a/scripts/check-linux-release-signing.py
+++ b/scripts/check-linux-release-signing.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import base64
+import importlib.util
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -41,6 +43,8 @@ UNSIGNED_FIXTURES = (
 
 
 def main() -> int:
+    run_source_selection_checks()
+
     gpg = shutil.which("gpg")
     if gpg is None:
         print("Linux release signing regression skipped: gpg is unavailable")
@@ -227,6 +231,116 @@ def main() -> int:
 
     print("Linux release signing regression checks passed")
     return 0
+
+
+def run_source_selection_checks() -> None:
+    signer = load_signer_module()
+    with tempfile.TemporaryDirectory(prefix="conu-linux-signing-selection-") as temp_text:
+        temp = Path(temp_text)
+        dist = temp / "dist"
+        dist.mkdir()
+
+        asset = dist / SIGNABLE_FIXTURES[0]
+        asset.write_bytes(b"linux asset fixture\n")
+        selected = signer.signable_linux_assets(dist)
+        if selected != (asset,):
+            raise AssertionError("signable asset selection returned unexpected files")
+
+        empty_dist = temp / "empty-dist"
+        empty_dist.mkdir()
+        empty_asset = empty_dist / SIGNABLE_FIXTURES[0]
+        empty_asset.write_bytes(b"")
+        expect_module_failure(
+            "empty signable asset",
+            lambda: signer.signable_linux_assets(empty_dist),
+            "must not be empty",
+        )
+
+        expect_module_failure_with_limit(
+            signer,
+            "signable asset size bound",
+            "MAX_SIGNABLE_ASSET_BYTES",
+            1,
+            lambda: signer.signable_linux_assets(dist),
+            "is too large",
+        )
+
+        expect_module_failure_with_limit(
+            signer,
+            "aggregate signable asset size bound",
+            "MAX_TOTAL_SIGNABLE_ASSET_BYTES",
+            1,
+            lambda: signer.signable_linux_assets(dist),
+            "signable Linux release assets exceed",
+        )
+
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            expect_module_failure(
+                "symlinked signable asset",
+                lambda: signer.validate_signable_asset(
+                    asset,
+                    signer.SignableAssetBudget(),
+                ),
+                "must not be a symlink",
+            )
+
+        signature = dist / f"{asset.name}.asc"
+        signature.write_bytes(b"existing signature\n")
+        signer.prepare_signature_output(signature)
+
+        empty_signature = dist / f"{asset.name}.empty.asc"
+        empty_signature.write_bytes(b"")
+        expect_module_failure(
+            "empty generated signature",
+            lambda: signer.validate_signature_output(empty_signature),
+            "must not be empty",
+        )
+
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            expect_module_failure(
+                "symlinked signature output",
+                lambda: signer.prepare_signature_output(signature),
+                "must not be a symlink",
+            )
+
+
+def load_signer_module():
+    spec = importlib.util.spec_from_file_location("sign_linux_release_assets", SIGNER)
+    if spec is None or spec.loader is None:
+        raise AssertionError("could not load Linux release signer module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def expect_module_failure(description: str, action, expected: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        rendered = str(exc)
+        if expected not in rendered:
+            raise AssertionError(
+                f"{description} failed with {rendered!r}, expected {expected!r}"
+            ) from exc
+        return
+    raise AssertionError(f"{description} unexpectedly passed")
+
+
+def expect_module_failure_with_limit(
+    signer,
+    description: str,
+    attr: str,
+    value: int,
+    action,
+    expected: str,
+) -> None:
+    original = getattr(signer, attr)
+    setattr(signer, attr, value)
+    try:
+        expect_module_failure(description, action, expected)
+    finally:
+        setattr(signer, attr, original)
 
 
 def create_test_key(gpg: str, home: Path) -> str:

--- a/scripts/sign-linux-release-assets.py
+++ b/scripts/sign-linux-release-assets.py
@@ -8,9 +8,11 @@ import base64
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from linux_gpg_common import (
@@ -21,6 +23,9 @@ from linux_gpg_common import (
 
 
 MAX_SIGNING_KEY_BYTES = 1024 * 1024
+MAX_SIGNABLE_ASSET_BYTES = 2 * 1024 * 1024 * 1024
+MAX_TOTAL_SIGNABLE_ASSET_BYTES = 10 * 1024 * 1024 * 1024
+MAX_DETACHED_SIGNATURE_BYTES = 1024 * 1024
 LINUX_ARCHIVE_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-linux-(x64|arm64)\.tar\.gz$")
 DEBIAN_PACKAGE_RE = re.compile(r"^conu_[0-9A-Za-z.+_~-]+_(amd64|arm64)\.deb$")
 RPM_PACKAGE_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-1\.(x86_64|aarch64)\.rpm$")
@@ -36,6 +41,19 @@ UPDATE_POLICY_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-update-policy\.json$")
 PACKAGE_MANAGER_SUBMISSIONS_RE = re.compile(
     r"^conu-[0-9A-Za-z.+_~-]+-package-manager-submissions\.zip$"
 )
+
+
+@dataclass
+class SignableAssetBudget:
+    total_bytes: int = 0
+
+    def add(self, size: int) -> None:
+        self.total_bytes += size
+        if self.total_bytes > MAX_TOTAL_SIGNABLE_ASSET_BYTES:
+            raise SystemExit(
+                "signable Linux release assets exceed "
+                f"{MAX_TOTAL_SIGNABLE_ASSET_BYTES} bytes"
+            )
 
 
 def main() -> int:
@@ -75,6 +93,7 @@ def main() -> int:
         verify_imported_secret_key_fingerprint(gpg, env, key_id, expected_fingerprint)
         for asset in assets:
             signature = asset.with_name(f"{asset.name}.asc")
+            prepare_signature_output(signature)
             run_gpg(
                 gpg,
                 env,
@@ -93,6 +112,7 @@ def main() -> int:
                 ],
                 input_bytes=(passphrase + "\n").encode("utf-8"),
             )
+            validate_signature_output(signature)
             run_gpg(gpg, env, ["--verify", str(signature), str(asset)])
 
     print(
@@ -186,39 +206,107 @@ def signable_linux_assets(
             "choose only one Linux release asset signing filter at a time"
         )
     assets = []
+    budget = SignableAssetBudget()
     for path in sorted(dist.iterdir(), key=lambda candidate: candidate.name):
-        if not path.is_file():
-            continue
         name = path.name
-        if only_hosted_repository_bundles:
-            if HOSTED_REPOSITORY_RE.fullmatch(name):
-                assets.append(path)
-            continue
-        if only_hosted_repository_sites:
-            if HOSTED_REPOSITORY_SITE_RE.fullmatch(name):
-                assets.append(path)
-            continue
-        if only_update_policies:
-            if UPDATE_POLICY_RE.fullmatch(name):
-                assets.append(path)
-            continue
-        if only_package_manager_submissions:
-            if PACKAGE_MANAGER_SUBMISSIONS_RE.fullmatch(name):
-                assets.append(path)
-            continue
-        if (
-            LINUX_ARCHIVE_RE.fullmatch(name)
-            or DEBIAN_PACKAGE_RE.fullmatch(name)
-            or RPM_PACKAGE_RE.fullmatch(name)
-            or APT_METADATA_RE.fullmatch(name)
-            or RPM_METADATA_RE.fullmatch(name)
-            or HOSTED_REPOSITORY_RE.fullmatch(name)
-            or HOSTED_REPOSITORY_SITE_RE.fullmatch(name)
-            or UPDATE_POLICY_RE.fullmatch(name)
-            or PACKAGE_MANAGER_SUBMISSIONS_RE.fullmatch(name)
+        if is_signable_asset_name(
+            name,
+            only_hosted_repository_bundles=only_hosted_repository_bundles,
+            only_hosted_repository_sites=only_hosted_repository_sites,
+            only_update_policies=only_update_policies,
+            only_package_manager_submissions=only_package_manager_submissions,
         ):
+            validate_signable_asset(path, budget)
             assets.append(path)
     return tuple(assets)
+
+
+def is_signable_asset_name(
+    name: str,
+    *,
+    only_hosted_repository_bundles: bool = False,
+    only_hosted_repository_sites: bool = False,
+    only_update_policies: bool = False,
+    only_package_manager_submissions: bool = False,
+) -> bool:
+    if only_hosted_repository_bundles:
+        return HOSTED_REPOSITORY_RE.fullmatch(name) is not None
+    if only_hosted_repository_sites:
+        return HOSTED_REPOSITORY_SITE_RE.fullmatch(name) is not None
+    if only_update_policies:
+        return UPDATE_POLICY_RE.fullmatch(name) is not None
+    if only_package_manager_submissions:
+        return PACKAGE_MANAGER_SUBMISSIONS_RE.fullmatch(name) is not None
+    return any(
+        pattern.fullmatch(name)
+        for pattern in (
+            LINUX_ARCHIVE_RE,
+            DEBIAN_PACKAGE_RE,
+            RPM_PACKAGE_RE,
+            APT_METADATA_RE,
+            RPM_METADATA_RE,
+            HOSTED_REPOSITORY_RE,
+            HOSTED_REPOSITORY_SITE_RE,
+            UPDATE_POLICY_RE,
+            PACKAGE_MANAGER_SUBMISSIONS_RE,
+        )
+    )
+
+
+def validate_signable_asset(path: Path, budget: SignableAssetBudget) -> int:
+    size = validate_regular_file(
+        path,
+        f"signable Linux release asset {path.name}",
+        max_bytes=MAX_SIGNABLE_ASSET_BYTES,
+        allow_empty=False,
+    )
+    budget.add(size)
+    return size
+
+
+def prepare_signature_output(signature: Path) -> None:
+    if signature.is_symlink():
+        raise SystemExit(f"detached signature output must not be a symlink: {signature.name}")
+    if not signature.exists():
+        return
+    validate_regular_file(
+        signature,
+        f"detached signature output {signature.name}",
+        max_bytes=MAX_DETACHED_SIGNATURE_BYTES,
+        allow_empty=True,
+    )
+
+
+def validate_signature_output(signature: Path) -> int:
+    return validate_regular_file(
+        signature,
+        f"detached signature output {signature.name}",
+        max_bytes=MAX_DETACHED_SIGNATURE_BYTES,
+        allow_empty=False,
+    )
+
+
+def validate_regular_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+) -> int:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"missing {label}: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular file: {path.name}")
+    size = metadata.st_size
+    if not allow_empty and size == 0:
+        raise SystemExit(f"{label} must not be empty: {path.name}")
+    if size > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+    return size
 
 
 def run_gpg(


### PR DESCRIPTION
## **User description**
## Summary
- reject symlinked, non-regular, empty, oversized, or aggregate-oversized signable Linux release assets before GPG runs
- reject unsafe existing detached-signature output paths and validate generated signature files
- add Linux signing regression coverage for source selection and signature-output safety even when local GPG is unavailable

Fixes #316

## Validation
- python -m py_compile scripts\\sign-linux-release-assets.py scripts\\check-linux-release-signing.py
- python scripts\\check-linux-release-signing.py
- python scripts\\check-linux-signing-secrets-preflight-regression.py
- python scripts\\check-rpm-package-signing.py
- python scripts\\check-linux-repository-signing.py
- python scripts\\check-github-release-assets-published-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check


___

## **CodeAnt-AI Description**
**Harden Linux release signing so only safe files are signed**

### What Changed
- Linux signing now rejects unsafe release assets and signature files, including symlinks, non-regular files, empty files, and oversized files
- The signing step now checks the detached signature path before writing and confirms the generated signature is valid afterward
- Linux signing regression checks now cover asset selection limits and unsafe output paths, even when GPG is not available

### Impact
`✅ Fewer unsafe release assets being signed`
`✅ Safer Linux signing output files`
`✅ Clearer signing failures for invalid release files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
