### PR TITLE
Harden repository metadata signing paths

### DIFF
--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -126,6 +126,7 @@ def main() -> int:
 
 def run_zip_ingestion_preflights() -> None:
     signer = load_signer()
+    run_source_file_preflights(signer)
     with tempfile.TemporaryDirectory(prefix="conu-repository-signing-zip-check-") as temp_text:
         temp = Path(temp_text)
         metadata = temp / APT_METADATA
@@ -178,6 +179,137 @@ def run_zip_ingestion_preflights() -> None:
         )
 
 
+def run_source_file_preflights(signer) -> None:
+    with tempfile.TemporaryDirectory(prefix="conu-repository-signing-file-check-") as temp_text:
+        temp = Path(temp_text)
+
+        valid = temp / "valid"
+        valid.mkdir()
+        apt = valid / APT_METADATA
+        rpm = valid / RPM_METADATA
+        write_apt_metadata_zip(apt)
+        write_rpm_metadata_zip(rpm)
+        write_sha256_sidecar(apt)
+        write_sha256_sidecar(rpm)
+        apt_bundles, rpm_bundles = signer.repository_metadata_assets(valid)
+        if apt_bundles != (apt,) or rpm_bundles != (rpm,):
+            raise AssertionError("repository signer did not select expected metadata bundles")
+
+        directory_source = temp / "directory-source"
+        directory_source.mkdir()
+        (directory_source / APT_METADATA).mkdir()
+        expect_action_failure(
+            lambda: signer.repository_metadata_assets(directory_source),
+            "must be a regular file",
+            "repository signing directory source",
+        )
+
+        empty_source = temp / "empty-source"
+        empty_source.mkdir()
+        (empty_source / APT_METADATA).write_bytes(b"")
+        expect_action_failure(
+            lambda: signer.repository_metadata_assets(empty_source),
+            "must not be empty",
+            "repository signing empty source",
+        )
+
+        oversized_source = temp / "oversized-source"
+        oversized_source.mkdir()
+        oversized_metadata = oversized_source / APT_METADATA
+        write_apt_metadata_zip(oversized_metadata)
+        expect_constant_failure(
+            signer,
+            "MAX_REPOSITORY_METADATA_BUNDLE_BYTES",
+            max(0, oversized_metadata.stat().st_size - 1),
+            lambda: signer.repository_metadata_assets(oversized_source),
+            "is too large",
+            "repository signing source size bound",
+        )
+
+        aggregate_source = temp / "aggregate-source"
+        aggregate_source.mkdir()
+        aggregate_apt = aggregate_source / APT_METADATA
+        aggregate_rpm = aggregate_source / RPM_METADATA
+        write_apt_metadata_zip(aggregate_apt)
+        write_rpm_metadata_zip(aggregate_rpm)
+        expect_constant_failure(
+            signer,
+            "MAX_TOTAL_REPOSITORY_METADATA_BUNDLE_BYTES",
+            aggregate_apt.stat().st_size,
+            lambda: signer.repository_metadata_assets(aggregate_source),
+            "repository metadata bundles exceed",
+            "repository signing aggregate source size bound",
+        )
+
+        sidecar_directory = temp / "sidecar-directory"
+        sidecar_directory.mkdir()
+        sidecar_bundle = sidecar_directory / APT_METADATA
+        write_apt_metadata_zip(sidecar_bundle)
+        sidecar_bundle.with_name(f"{sidecar_bundle.name}.sha256").mkdir()
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(sidecar_bundle, "APT repository metadata bundle"),
+            "must be a regular file",
+            "repository signing sidecar directory",
+        )
+
+        sidecar_output_directory = temp / "sidecar-output-directory"
+        sidecar_output_directory.mkdir()
+        output_bundle = sidecar_output_directory / APT_METADATA
+        write_apt_metadata_zip(output_bundle)
+        output_bundle.with_name(f"{output_bundle.name}.sha256").mkdir()
+        expect_action_failure(
+            lambda: signer.write_sha256_sidecar(output_bundle),
+            "must be a regular file",
+            "repository signing sidecar output directory",
+        )
+
+        symlink_source = temp / "symlink-source"
+        symlink_source.mkdir()
+        real_source = symlink_source / "real.zip"
+        linked_source = symlink_source / APT_METADATA
+        write_apt_metadata_zip(real_source)
+        if try_symlink(linked_source, real_source):
+            expect_action_failure(
+                lambda: signer.repository_metadata_assets(symlink_source),
+                "must not be a symlink",
+                "repository signing symlink source",
+            )
+
+        symlink_sidecar = temp / "symlink-sidecar"
+        symlink_sidecar.mkdir()
+        symlink_bundle = symlink_sidecar / APT_METADATA
+        symlink_target = symlink_sidecar / "real.sha256"
+        symlink_output = symlink_bundle.with_name(f"{symlink_bundle.name}.sha256")
+        write_apt_metadata_zip(symlink_bundle)
+        write_sha256_sidecar(symlink_bundle, sidecar=symlink_target)
+        if try_symlink(symlink_output, symlink_target):
+            expect_action_failure(
+                lambda: signer.verify_sha256_sidecar(
+                    symlink_bundle,
+                    "APT repository metadata bundle",
+                ),
+                "must not be a symlink",
+                "repository signing symlink sidecar",
+            )
+            expect_action_failure(
+                lambda: signer.write_sha256_sidecar(symlink_bundle),
+                "must not be a symlink",
+                "repository signing symlink sidecar output",
+            )
+
+        symlink_output_bundle = temp / "symlink-output-bundle"
+        symlink_output_bundle.mkdir()
+        real_output_bundle = symlink_output_bundle / "real.zip"
+        linked_output_bundle = symlink_output_bundle / APT_METADATA
+        write_apt_metadata_zip(real_output_bundle)
+        if try_symlink(linked_output_bundle, real_output_bundle):
+            expect_action_failure(
+                lambda: signer.write_zip_members(linked_output_bundle, {"Release": b"x\n"}),
+                "must not be a symlink",
+                "repository signing symlink bundle output",
+            )
+
+
 def load_signer():
     script_dir = ROOT / "scripts"
     sys.path.insert(0, str(script_dir))
@@ -219,6 +351,22 @@ def expect_zip_bound_failure(
         setattr(signer, constant_name, original)
 
 
+def expect_constant_failure(
+    signer,
+    constant_name: str,
+    value: int,
+    action,
+    expected: str,
+    label: str,
+) -> None:
+    original = getattr(signer, constant_name)
+    setattr(signer, constant_name, value)
+    try:
+        expect_action_failure(action, expected, label)
+    finally:
+        setattr(signer, constant_name, original)
+
+
 def expect_action_failure(action, expected: str, label: str) -> None:
     try:
         action()
@@ -228,6 +376,14 @@ def expect_action_failure(action, expected: str, label: str) -> None:
             return
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def try_symlink(link: Path, target: Path) -> bool:
+    try:
+        link.symlink_to(target)
+        return True
+    except (NotImplementedError, OSError):
+        return False
 
 
 def write_apt_metadata_zip(path: Path) -> None:
@@ -365,8 +521,8 @@ def assert_zip_member_normalized(archive: zipfile.ZipFile, name: str) -> None:
         raise AssertionError(f"{name} had mode {oct(mode)}")
 
 
-def write_sha256_sidecar(path: Path) -> None:
-    path.with_name(f"{path.name}.sha256").write_text(
+def write_sha256_sidecar(path: Path, *, sidecar: Path | None = None) -> None:
+    (sidecar or path.with_name(f"{path.name}.sha256")).write_text(
         f"{sha256_file(path)}  {path.name}\n",
         encoding="ascii",
         newline="\n",

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 from linux_gpg_common import (
@@ -26,13 +27,29 @@ from linux_gpg_common import (
 CHECKSUM_RE = re.compile(r"^([0-9a-f]{64})  ([^ \t\r\n]+)\n$")
 MAX_SIGNING_KEY_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
+MAX_REPOSITORY_METADATA_BUNDLE_BYTES = 512_000_000
+MAX_TOTAL_REPOSITORY_METADATA_BUNDLE_BYTES = 1_000_000_000
 MAX_ZIP_MEMBER_BYTES = 512_000_000
 MAX_ZIP_MEMBERS = 10_000
 MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+MAX_GENERATED_SIGNATURE_BYTES = 1024 * 1024
 HASH_CHUNK_BYTES = 1024 * 1024
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 APT_METADATA_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-apt-repository-metadata\.zip$")
 RPM_METADATA_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-rpm-repository-metadata\.zip$")
+
+
+@dataclass
+class RepositoryMetadataBudget:
+    total_bytes: int = 0
+
+    def add(self, size: int) -> None:
+        self.total_bytes += size
+        if self.total_bytes > MAX_TOTAL_REPOSITORY_METADATA_BUNDLE_BYTES:
+            raise SystemExit(
+                "repository metadata bundles exceed "
+                f"{MAX_TOTAL_REPOSITORY_METADATA_BUNDLE_BYTES} bytes"
+            )
 
 
 def main() -> int:
@@ -52,10 +69,13 @@ def main() -> int:
         raise SystemExit(f"{args.key_id_env} must not be empty")
     expected_fingerprint = read_expected_fingerprint(os.environ, args.fingerprint_env)
 
-    apt_bundles = repository_metadata_assets(dist, APT_METADATA_RE)
-    rpm_bundles = repository_metadata_assets(dist, RPM_METADATA_RE)
+    apt_bundles, rpm_bundles = repository_metadata_assets(dist)
     if not apt_bundles and not rpm_bundles:
         raise SystemExit(f"no generated APT/RPM repository metadata bundles found in {dist}")
+    for bundle in apt_bundles:
+        verify_sha256_sidecar(bundle, "APT repository metadata bundle")
+    for bundle in rpm_bundles:
+        verify_sha256_sidecar(bundle, "RPM repository metadata bundle")
 
     signed: list[Path] = []
     with tempfile.TemporaryDirectory(prefix="conu-repository-signing-") as gnupg_home_text:
@@ -67,13 +87,11 @@ def main() -> int:
         verify_imported_secret_key_fingerprint(gpg, env, key_id, expected_fingerprint)
 
         for bundle in apt_bundles:
-            verify_sha256_sidecar(bundle, "APT repository metadata bundle")
             sign_apt_bundle(gpg, env, key_id, passphrase, bundle)
             write_sha256_sidecar(bundle)
             signed.append(bundle)
 
         for bundle in rpm_bundles:
-            verify_sha256_sidecar(bundle, "RPM repository metadata bundle")
             sign_rpm_bundle(gpg, env, key_id, passphrase, bundle)
             write_sha256_sidecar(bundle)
             signed.append(bundle)
@@ -124,12 +142,18 @@ def read_secret_key(name: str) -> bytes:
     return decoded
 
 
-def repository_metadata_assets(dist: Path, pattern: re.Pattern[str]) -> tuple[Path, ...]:
-    return tuple(
-        path
-        for path in sorted(dist.iterdir(), key=lambda candidate: candidate.name)
-        if path.is_file() and pattern.fullmatch(path.name)
-    )
+def repository_metadata_assets(dist: Path) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
+    apt_bundles: list[Path] = []
+    rpm_bundles: list[Path] = []
+    budget = RepositoryMetadataBudget()
+    for path in sorted(dist.iterdir(), key=lambda candidate: candidate.name):
+        if APT_METADATA_RE.fullmatch(path.name):
+            validate_repository_metadata_bundle(path, budget)
+            apt_bundles.append(path)
+        elif RPM_METADATA_RE.fullmatch(path.name):
+            validate_repository_metadata_bundle(path, budget)
+            rpm_bundles.append(path)
+    return tuple(apt_bundles), tuple(rpm_bundles)
 
 
 def sign_apt_bundle(
@@ -193,8 +217,14 @@ def sign_apt_bundle(
         run_gpg(gpg, env, ["--verify", str(inrelease_path)])
         run_gpg(gpg, env, ["--verify", str(release_gpg_path), str(release_path)])
 
-        members["InRelease"] = inrelease_path.read_bytes()
-        members["Release.gpg"] = release_gpg_path.read_bytes()
+        members["InRelease"] = read_generated_signature(
+            inrelease_path,
+            f"generated InRelease signature for {bundle.name}",
+        )
+        members["Release.gpg"] = read_generated_signature(
+            release_gpg_path,
+            f"generated Release.gpg signature for {bundle.name}",
+        )
 
     write_zip_members(bundle, members)
 
@@ -237,7 +267,10 @@ def sign_rpm_bundle(
             input_bytes=(passphrase + "\n").encode("utf-8"),
         )
         run_gpg(gpg, env, ["--verify", str(signature_path), str(repomd_path)])
-        members["repodata/repomd.xml.asc"] = signature_path.read_bytes()
+        members["repodata/repomd.xml.asc"] = read_generated_signature(
+            signature_path,
+            f"generated repomd.xml.asc signature for {bundle.name}",
+        )
 
     write_zip_members(bundle, members)
 
@@ -298,14 +331,41 @@ def normalize_zip_path(raw_name: str) -> str:
 
 
 def write_zip_members(bundle: Path, members: dict[str, bytes]) -> None:
+    validate_regular_file(
+        bundle,
+        f"repository metadata bundle output {bundle.name}",
+        max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+        allow_empty=False,
+    )
     order = [name for name in members if not signature_member(name)]
     for signature in ("InRelease", "Release.gpg", "repodata/repomd.xml.asc"):
         if signature in members:
             order.append(signature)
 
-    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_STORED) as archive:
-        for name in order:
-            write_deterministic_zip_bytes(archive, name, members[name])
+    temp_path = temporary_sibling_path(bundle)
+    try:
+        with zipfile.ZipFile(temp_path, "w", compression=zipfile.ZIP_STORED) as archive:
+            for name in order:
+                write_deterministic_zip_bytes(archive, name, members[name])
+        temp_path.chmod(0o644)
+        validate_regular_file(
+            temp_path,
+            f"rewritten repository metadata bundle {bundle.name}",
+            max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+            allow_empty=False,
+        )
+        os.replace(temp_path, bundle)
+        validate_regular_file(
+            bundle,
+            f"repository metadata bundle output {bundle.name}",
+            max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+            allow_empty=False,
+        )
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def signature_member(name: str) -> bool:
@@ -321,10 +381,12 @@ def write_deterministic_zip_bytes(archive: zipfile.ZipFile, name: str, data: byt
 
 def verify_sha256_sidecar(path: Path, label: str) -> None:
     sidecar = path.with_name(f"{path.name}.sha256")
-    if not sidecar.exists() or not sidecar.is_file():
-        raise SystemExit(f"missing SHA-256 sidecar for {label}: {path.name}")
-    if sidecar.stat().st_size > MAX_CHECKSUM_BYTES:
-        raise SystemExit(f"SHA-256 sidecar is too large for {label}: {path.name}")
+    validate_regular_file(
+        sidecar,
+        f"SHA-256 sidecar for {label} {path.name}",
+        max_bytes=MAX_CHECKSUM_BYTES,
+        allow_empty=False,
+    )
     try:
         checksum_text = sidecar.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -341,11 +403,95 @@ def verify_sha256_sidecar(path: Path, label: str) -> None:
 
 
 def write_sha256_sidecar(path: Path) -> None:
-    path.with_name(f"{path.name}.sha256").write_text(
-        f"{sha256_file(path)}  {path.name}\n",
-        encoding="ascii",
-        newline="\n",
+    sidecar = path.with_name(f"{path.name}.sha256")
+    if sidecar.exists() or sidecar.is_symlink():
+        validate_regular_file(
+            sidecar,
+            f"SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=True,
+        )
+    text = f"{sha256_file(path)}  {path.name}\n"
+    temp_path = temporary_sibling_path(sidecar)
+    try:
+        temp_path.write_text(text, encoding="ascii", newline="\n")
+        temp_path.chmod(0o644)
+        validate_regular_file(
+            temp_path,
+            f"temporary SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=False,
+        )
+        os.replace(temp_path, sidecar)
+        validate_regular_file(
+            sidecar,
+            f"SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=False,
+        )
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def validate_repository_metadata_bundle(
+    path: Path,
+    budget: RepositoryMetadataBudget | None = None,
+) -> int:
+    size = validate_regular_file(
+        path,
+        f"repository metadata bundle {path.name}",
+        max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+        allow_empty=False,
     )
+    if budget is not None:
+        budget.add(size)
+    return size
+
+
+def read_generated_signature(path: Path, label: str) -> bytes:
+    validate_regular_file(
+        path,
+        label,
+        max_bytes=MAX_GENERATED_SIGNATURE_BYTES,
+        allow_empty=False,
+    )
+    return path.read_bytes()
+
+
+def validate_regular_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+) -> int:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"missing {label}: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular file: {path.name}")
+    size = metadata.st_size
+    if not allow_empty and size == 0:
+        raise SystemExit(f"{label} must not be empty: {path.name}")
+    if size > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+    return size
+
+
+def temporary_sibling_path(path: Path) -> Path:
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        delete=False,
+    ) as handle:
+        return Path(handle.name)
 
 
 def sha256_file(path: Path) -> str:


### PR DESCRIPTION
## **User description**
Fixes #318

Summary:
- Reject symlinked, non-regular, empty, oversized, and aggregate-oversized APT/RPM repository metadata bundles before GPG signing work.
- Validate checksum sidecar inputs and refuse unsafe sidecar output paths.
- Rewrite signed metadata ZIPs and checksum sidecars through bounded temporary files, then atomically replace release assets.
- Add regression coverage for source, sidecar, symlink, and ZIP ingestion bounds.

Validation:
- python -m py_compile scripts/sign-linux-repository-metadata.py scripts/check-linux-repository-signing.py
- python scripts/check-linux-repository-signing.py (GPG signing subtest skipped locally because gpg is unavailable; preflight checks ran)
- python scripts/check-linux-release-signing.py (skipped locally because gpg is unavailable)
- python scripts/check-linux-gpg-public-key-export.py (skipped locally because gpg is unavailable)
- python scripts/check-rpm-package-signing.py (skipped locally because gpg/rpm tools are unavailable)
- python scripts/check-github-release-assets-published-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check


___

## **CodeAnt-AI Description**
**Reject unsafe repository metadata files before signing**

### What Changed
- Repository metadata signing now only accepts regular, non-empty files and rejects symlinks, directories, empty files, and oversized bundles before signing starts
- It now enforces a total size limit across all repository metadata bundles, preventing overly large upload sets from being processed
- SHA-256 sidecars and generated signed files are now written through temporary files and replaced atomically, reducing the chance of partial outputs
- Sidecar files are also checked more strictly so invalid, missing, or symlinked checksum files are refused

### Impact
`✅ Fewer failed repository publishes`
`✅ Safer handling of uploaded release artifacts`
`✅ Lower risk of partial or tampered signing outputs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
