### PR TITLE
Harden RPM package signing paths

### DIFF
--- a/scripts/check-rpm-package-signing.py
+++ b/scripts/check-rpm-package-signing.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import base64
 import gzip
 import hashlib
+import importlib.util
 import io
 import os
 import shutil
@@ -40,6 +41,8 @@ RPM_PACKAGES = (
 
 
 def main() -> int:
+    run_source_file_preflights()
+
     missing_tools = [
         name
         for name, available in (
@@ -191,9 +194,187 @@ def main() -> int:
     return 0
 
 
-def write_checksum(path: Path, archive_name: str | None = None) -> str:
+def run_source_file_preflights() -> None:
+    signer = load_signer()
+    with tempfile.TemporaryDirectory(prefix="conu-rpm-package-signing-file-check-") as temp_text:
+        temp = Path(temp_text)
+
+        valid = temp / "valid"
+        valid.mkdir()
+        rpm_x64 = valid / RPM_PACKAGES[0]
+        rpm_arm64 = valid / RPM_PACKAGES[1]
+        rpm_x64.write_bytes(b"rpm x64 fixture\n")
+        rpm_arm64.write_bytes(b"rpm arm64 fixture\n")
+        write_checksum(rpm_x64)
+        write_checksum(rpm_arm64)
+        packages = signer.rpm_package_assets(valid)
+        if packages != (rpm_arm64, rpm_x64):
+            raise AssertionError("RPM signer did not select expected package assets")
+
+        directory_source = temp / "directory-source"
+        directory_source.mkdir()
+        (directory_source / RPM_PACKAGES[0]).mkdir()
+        expect_action_failure(
+            lambda: signer.rpm_package_assets(directory_source),
+            "must be a regular file",
+            "RPM signing directory source",
+        )
+
+        empty_source = temp / "empty-source"
+        empty_source.mkdir()
+        (empty_source / RPM_PACKAGES[0]).write_bytes(b"")
+        expect_action_failure(
+            lambda: signer.rpm_package_assets(empty_source),
+            "must not be empty",
+            "RPM signing empty source",
+        )
+
+        oversized_source = temp / "oversized-source"
+        oversized_source.mkdir()
+        oversized_package = oversized_source / RPM_PACKAGES[0]
+        oversized_package.write_bytes(b"rpm fixture\n")
+        expect_constant_failure(
+            signer,
+            "MAX_RPM_PACKAGE_BYTES",
+            max(0, oversized_package.stat().st_size - 1),
+            lambda: signer.rpm_package_assets(oversized_source),
+            "is too large",
+            "RPM signing source size bound",
+        )
+
+        aggregate_source = temp / "aggregate-source"
+        aggregate_source.mkdir()
+        aggregate_x64 = aggregate_source / RPM_PACKAGES[0]
+        aggregate_arm64 = aggregate_source / RPM_PACKAGES[1]
+        aggregate_x64.write_bytes(b"rpm x64 fixture\n")
+        aggregate_arm64.write_bytes(b"rpm arm64 fixture\n")
+        expect_constant_failure(
+            signer,
+            "MAX_TOTAL_RPM_PACKAGE_BYTES",
+            aggregate_arm64.stat().st_size,
+            lambda: signer.rpm_package_assets(aggregate_source),
+            "RPM package assets exceed",
+            "RPM signing aggregate source size bound",
+        )
+
+        sidecar_directory = temp / "sidecar-directory"
+        sidecar_directory.mkdir()
+        sidecar_package = sidecar_directory / RPM_PACKAGES[0]
+        sidecar_package.write_bytes(b"rpm fixture\n")
+        sidecar_package.with_name(f"{sidecar_package.name}.sha256").mkdir()
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(sidecar_package, "generated RPM package"),
+            "must be a regular file",
+            "RPM signing sidecar directory",
+        )
+
+        sidecar_output_directory = temp / "sidecar-output-directory"
+        sidecar_output_directory.mkdir()
+        output_package = sidecar_output_directory / RPM_PACKAGES[0]
+        output_package.write_bytes(b"rpm fixture\n")
+        output_package.with_name(f"{output_package.name}.sha256").mkdir()
+        expect_action_failure(
+            lambda: signer.write_sha256_sidecar(output_package),
+            "must be a regular file",
+            "RPM signing sidecar output directory",
+        )
+
+        symlink_source = temp / "symlink-source"
+        symlink_source.mkdir()
+        real_source = symlink_source / "real.rpm"
+        linked_source = symlink_source / RPM_PACKAGES[0]
+        real_source.write_bytes(b"rpm fixture\n")
+        if try_symlink(linked_source, real_source):
+            expect_action_failure(
+                lambda: signer.rpm_package_assets(symlink_source),
+                "must not be a symlink",
+                "RPM signing symlink source",
+            )
+
+        symlink_sidecar = temp / "symlink-sidecar"
+        symlink_sidecar.mkdir()
+        symlink_package = symlink_sidecar / RPM_PACKAGES[0]
+        symlink_target = symlink_sidecar / "real.sha256"
+        symlink_output = symlink_package.with_name(f"{symlink_package.name}.sha256")
+        symlink_package.write_bytes(b"rpm fixture\n")
+        write_checksum(symlink_package, sidecar=symlink_target)
+        if try_symlink(symlink_output, symlink_target):
+            expect_action_failure(
+                lambda: signer.verify_sha256_sidecar(
+                    symlink_package,
+                    "generated RPM package",
+                ),
+                "must not be a symlink",
+                "RPM signing symlink sidecar",
+            )
+            expect_action_failure(
+                lambda: signer.write_sha256_sidecar(symlink_package),
+                "must not be a symlink",
+                "RPM signing symlink sidecar output",
+            )
+
+
+def load_signer():
+    script_dir = ROOT / "scripts"
+    sys.path.insert(0, str(script_dir))
+    try:
+        spec = importlib.util.spec_from_file_location("sign_rpm_packages", SIGNER)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load RPM package signer")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        try:
+            sys.path.remove(str(script_dir))
+        except ValueError:
+            pass
+
+
+def expect_constant_failure(
+    signer,
+    constant_name: str,
+    value: int,
+    action,
+    expected: str,
+    label: str,
+) -> None:
+    original = getattr(signer, constant_name)
+    setattr(signer, constant_name, value)
+    try:
+        expect_action_failure(action, expected, label)
+    finally:
+        setattr(signer, constant_name, original)
+
+
+def expect_action_failure(action, expected: str, label: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+        if expected in message:
+            return
+        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+    raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def try_symlink(link: Path, target: Path) -> bool:
+    try:
+        link.symlink_to(target)
+        return True
+    except (NotImplementedError, OSError):
+        return False
+
+
+def write_checksum(
+    path: Path,
+    archive_name: str | None = None,
+    *,
+    sidecar: Path | None = None,
+) -> str:
     digest = hashlib.sha256(path.read_bytes()).hexdigest()
-    path.with_name(f"{path.name}.sha256").write_text(
+    (sidecar or path.with_name(f"{path.name}.sha256")).write_text(
         f"{digest}  {archive_name or path.name}\n",
         encoding="ascii",
         newline="\n",

--- a/scripts/sign-rpm-packages.py
+++ b/scripts/sign-rpm-packages.py
@@ -9,9 +9,11 @@ import hashlib
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from linux_gpg_common import (
@@ -23,10 +25,24 @@ from linux_gpg_common import (
 
 MAX_SIGNING_KEY_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
+MAX_RPM_PACKAGE_BYTES = 2 * 1024 * 1024 * 1024
+MAX_TOTAL_RPM_PACKAGE_BYTES = 4 * 1024 * 1024 * 1024
 HASH_CHUNK_BYTES = 1024 * 1024
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
 RPM_PACKAGE_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-1\.(x86_64|aarch64)\.rpm$")
 SIGNATURE_OUTPUT_RE = re.compile(r"(signature|pgp|rsa|dsa|openpgp)", re.IGNORECASE)
+
+
+@dataclass
+class RpmPackageBudget:
+    total_bytes: int = 0
+
+    def add(self, size: int) -> None:
+        self.total_bytes += size
+        if self.total_bytes > MAX_TOTAL_RPM_PACKAGE_BYTES:
+            raise SystemExit(
+                f"RPM package assets exceed {MAX_TOTAL_RPM_PACKAGE_BYTES} bytes"
+            )
 
 
 def main() -> int:
@@ -34,6 +50,12 @@ def main() -> int:
     dist = args.dist.resolve()
     if not dist.exists() or not dist.is_dir():
         raise SystemExit(f"release dist directory does not exist: {dist}")
+
+    packages = rpm_package_assets(dist)
+    if not packages:
+        raise SystemExit(f"no generated conU RPM package assets found in {dist}")
+    for package in packages:
+        verify_sha256_sidecar(package, "generated RPM package")
 
     gpg = shutil.which("gpg")
     if gpg is None:
@@ -51,12 +73,6 @@ def main() -> int:
     if not key_id:
         raise SystemExit(f"{args.key_id_env} must not be empty")
     expected_fingerprint = read_expected_fingerprint(os.environ, args.fingerprint_env)
-
-    packages = rpm_package_assets(dist)
-    if not packages:
-        raise SystemExit(f"no generated conU RPM package assets found in {dist}")
-    for package in packages:
-        verify_sha256_sidecar(package, "generated RPM package")
 
     with tempfile.TemporaryDirectory(prefix="conu-rpm-package-signing-") as temp_text:
         temp = Path(temp_text)
@@ -81,7 +97,9 @@ def main() -> int:
         warm_gpg_agent(gpg, env, key_id, passphrase, temp)
 
         for package in packages:
+            validate_rpm_package(package)
             sign_rpm_package(signer, env, gpg, gnupg_home, key_id, package)
+            validate_rpm_package(package)
             verify_rpm_signature(verifier, env, rpmdb, package)
             write_sha256_sidecar(package)
 
@@ -132,19 +150,23 @@ def read_secret_key(name: str) -> bytes:
 
 
 def rpm_package_assets(dist: Path) -> tuple[Path, ...]:
-    return tuple(
-        path
-        for path in sorted(dist.iterdir(), key=lambda candidate: candidate.name)
-        if path.is_file() and RPM_PACKAGE_RE.fullmatch(path.name)
-    )
+    packages: list[Path] = []
+    budget = RpmPackageBudget()
+    for path in sorted(dist.iterdir(), key=lambda candidate: candidate.name):
+        if RPM_PACKAGE_RE.fullmatch(path.name):
+            validate_rpm_package(path, budget)
+            packages.append(path)
+    return tuple(packages)
 
 
 def verify_sha256_sidecar(path: Path, label: str) -> str:
     sidecar = path.with_name(f"{path.name}.sha256")
-    if not sidecar.exists() or not sidecar.is_file():
-        raise SystemExit(f"missing SHA-256 sidecar for {label}: {path.name}")
-    if sidecar.stat().st_size > MAX_CHECKSUM_BYTES:
-        raise SystemExit(f"SHA-256 sidecar is too large for {label}: {path.name}")
+    validate_regular_file(
+        sidecar,
+        f"SHA-256 sidecar for {label} {path.name}",
+        max_bytes=MAX_CHECKSUM_BYTES,
+        allow_empty=False,
+    )
     try:
         checksum_text = sidecar.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -163,11 +185,85 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
 
 
 def write_sha256_sidecar(path: Path) -> None:
-    path.with_name(f"{path.name}.sha256").write_text(
-        f"{sha256_file(path)}  {path.name}\n",
-        encoding="ascii",
-        newline="\n",
+    sidecar = path.with_name(f"{path.name}.sha256")
+    if sidecar.exists() or sidecar.is_symlink():
+        validate_regular_file(
+            sidecar,
+            f"SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=True,
+        )
+    text = f"{sha256_file(path)}  {path.name}\n"
+    temp_path = temporary_sibling_path(sidecar)
+    try:
+        temp_path.write_text(text, encoding="ascii", newline="\n")
+        temp_path.chmod(0o644)
+        validate_regular_file(
+            temp_path,
+            f"temporary SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=False,
+        )
+        os.replace(temp_path, sidecar)
+        validate_regular_file(
+            sidecar,
+            f"SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=False,
+        )
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def validate_rpm_package(
+    path: Path,
+    budget: RpmPackageBudget | None = None,
+) -> int:
+    size = validate_regular_file(
+        path,
+        f"RPM package asset {path.name}",
+        max_bytes=MAX_RPM_PACKAGE_BYTES,
+        allow_empty=False,
     )
+    if budget is not None:
+        budget.add(size)
+    return size
+
+
+def validate_regular_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+) -> int:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"missing {label}: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular file: {path.name}")
+    size = metadata.st_size
+    if not allow_empty and size == 0:
+        raise SystemExit(f"{label} must not be empty: {path.name}")
+    if size > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+    return size
+
+
+def temporary_sibling_path(path: Path) -> Path:
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        delete=False,
+    ) as handle:
+        return Path(handle.name)
 
 
 def sha256_file(path: Path) -> str:


### PR DESCRIPTION
## **User description**
Fixes #320

Summary:
- Reject symlinked, non-regular, empty, oversized, and aggregate-oversized RPM package assets before native RPM/GPG signing work.
- Validate checksum sidecar inputs and refuse unsafe sidecar output paths.
- Refresh signed RPM checksum sidecars through bounded temporary files and atomic replacement.
- Add regression coverage for RPM source, sidecar, symlink, and size-bound preflights that runs before native tool availability skips.

Validation:
- python -m py_compile scripts/sign-rpm-packages.py scripts/check-rpm-package-signing.py
- python scripts/check-rpm-package-signing.py (native signing subtest skipped locally because gpg/rpm tools are unavailable; new source preflights ran)
- python scripts/check-package-manager-manifests.py
- python scripts/check-linux-release-signing.py (skipped locally because gpg is unavailable)
- python scripts/check-linux-repository-signing.py (skipped locally because gpg is unavailable)
- python scripts/check-linux-gpg-public-key-export.py (skipped locally because gpg is unavailable)
- python scripts/check-github-release-assets-published-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check


___

## **CodeAnt-AI Description**
**Reject unsafe RPM package files before signing and refresh checksum sidecars safely**

### What Changed
- RPM package signing now stops on symlinks, non-regular files, empty files, oversized files, and oversized total package sets before signing begins
- Existing checksum sidecars are now checked as regular files, and new sidecars are written through a temporary file before replacing the old one
- Regression checks now cover bad package inputs, bad sidecars, symlink cases, and size limits before any native signing tools are required

### Impact
`✅ Fewer failed RPM signing runs`
`✅ Safer package publishing`
`✅ Clearer validation of broken release assets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of RPM packages with stricter size limit enforcement and budget tracking.
  * Improved error handling for invalid file inputs, including symlinks and oversized packages.
  * Strengthened SHA-256 checksum validation and atomic file writing for greater reliability.

* **Tests**
  * Added comprehensive preflight validation checks for RPM signing operations, covering edge cases and constraint violations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->