### PR TITLE
Harden Linux public key export outputs

### DIFF
--- a/scripts/check-linux-gpg-public-key-export.py
+++ b/scripts/check-linux-gpg-public-key-export.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -19,9 +20,12 @@ PASSPHRASE = "conu-linux-public-key-regression-passphrase"
 USER_ID = "conU Linux Public Key Regression <noreply@github.com>"
 PUBLIC_KEY_ASSET = "conu-linux-gpg-key.asc"
 WRONG_FINGERPRINT = "F" * 40
+PUBLIC_KEY_FIXTURE = b"-----BEGIN PGP PUBLIC KEY BLOCK-----\nfixture\n"
 
 
 def main() -> int:
+    run_output_file_preflights()
+
     gpg = shutil.which("gpg")
     if gpg is None:
         print("Linux GPG public-key export regression skipped: gpg is unavailable")
@@ -120,6 +124,148 @@ def main() -> int:
 
     print("Linux GPG public-key export regression checks passed")
     return 0
+
+
+def run_output_file_preflights() -> None:
+    exporter = load_exporter()
+    with tempfile.TemporaryDirectory(prefix="conu-linux-public-key-output-check-") as temp_text:
+        temp = Path(temp_text)
+
+        output = temp / PUBLIC_KEY_ASSET
+        exporter.write_public_key_asset(output, PUBLIC_KEY_FIXTURE)
+        exporter.write_sha256_sidecar(output)
+        if output.read_bytes() != PUBLIC_KEY_FIXTURE:
+            raise AssertionError("public-key exporter did not write the expected fixture bytes")
+        assert_sha256_sidecar(output)
+
+        expect_action_failure(
+            lambda: exporter.validate_public_key_bytes(b""),
+            "was empty",
+            "public-key empty output bound",
+        )
+        expect_action_failure(
+            lambda: exporter.validate_public_key_bytes(b"not a public key\n"),
+            "not an armored public key",
+            "public-key armor validation",
+        )
+        expect_action_failure(
+            lambda: exporter.validate_public_key_bytes(
+                b"-----BEGIN PGP PUBLIC KEY BLOCK-----\n"
+                b"-----BEGIN PGP PRIVATE KEY BLOCK-----\n"
+            ),
+            "private key material",
+            "public-key private material validation",
+        )
+        expect_constant_failure(
+            exporter,
+            "MAX_PUBLIC_KEY_BYTES",
+            len(PUBLIC_KEY_FIXTURE) - 1,
+            lambda: exporter.write_public_key_asset(temp / "oversized.asc", PUBLIC_KEY_FIXTURE),
+            "exceeds",
+            "public-key size bound",
+        )
+
+        output_directory = temp / "output-directory.asc"
+        output_directory.mkdir()
+        expect_action_failure(
+            lambda: exporter.write_public_key_asset(output_directory, PUBLIC_KEY_FIXTURE),
+            "must be a regular file",
+            "public-key output directory",
+        )
+
+        sidecar_directory_output = temp / "sidecar-directory.asc"
+        exporter.write_public_key_asset(sidecar_directory_output, PUBLIC_KEY_FIXTURE)
+        sidecar_directory_output.with_name(f"{sidecar_directory_output.name}.sha256").mkdir()
+        expect_action_failure(
+            lambda: exporter.write_sha256_sidecar(sidecar_directory_output),
+            "must be a regular file",
+            "public-key sidecar output directory",
+        )
+
+        symlink_output_target = temp / "real-output.asc"
+        symlink_output_target.write_bytes(PUBLIC_KEY_FIXTURE)
+        symlink_output = temp / "symlink-output.asc"
+        if try_symlink(symlink_output, symlink_output_target):
+            expect_action_failure(
+                lambda: exporter.write_public_key_asset(symlink_output, PUBLIC_KEY_FIXTURE),
+                "must not be a symlink",
+                "public-key symlink output",
+            )
+
+        symlink_sidecar_output = temp / "symlink-sidecar.asc"
+        symlink_sidecar_target = temp / "real-output.asc.sha256"
+        exporter.write_public_key_asset(symlink_sidecar_output, PUBLIC_KEY_FIXTURE)
+        write_sidecar_fixture(symlink_sidecar_output, symlink_sidecar_target)
+        symlink_sidecar = symlink_sidecar_output.with_name(
+            f"{symlink_sidecar_output.name}.sha256"
+        )
+        if try_symlink(symlink_sidecar, symlink_sidecar_target):
+            expect_action_failure(
+                lambda: exporter.write_sha256_sidecar(symlink_sidecar_output),
+                "must not be a symlink",
+                "public-key symlink sidecar output",
+            )
+
+
+def load_exporter():
+    script_dir = ROOT / "scripts"
+    sys.path.insert(0, str(script_dir))
+    try:
+        spec = importlib.util.spec_from_file_location("export_linux_gpg_public_key", EXPORTER)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load Linux public-key exporter")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        try:
+            sys.path.remove(str(script_dir))
+        except ValueError:
+            pass
+
+
+def expect_constant_failure(
+    module,
+    constant_name: str,
+    value: int,
+    action,
+    expected: str,
+    label: str,
+) -> None:
+    original = getattr(module, constant_name)
+    setattr(module, constant_name, value)
+    try:
+        expect_action_failure(action, expected, label)
+    finally:
+        setattr(module, constant_name, original)
+
+
+def expect_action_failure(action, expected: str, label: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+        if expected in message:
+            return
+        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+    raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def try_symlink(link: Path, target: Path) -> bool:
+    try:
+        link.symlink_to(target)
+        return True
+    except (NotImplementedError, OSError):
+        return False
+
+
+def write_sidecar_fixture(path: Path, sidecar: Path) -> None:
+    sidecar.write_text(
+        f"{sha256_file(path)}  {path.name}\n",
+        encoding="ascii",
+        newline="\n",
+    )
 
 
 def assert_sha256_sidecar(path: Path) -> None:

--- a/scripts/export-linux-gpg-public-key.py
+++ b/scripts/export-linux-gpg-public-key.py
@@ -8,6 +8,7 @@ import base64
 import hashlib
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -22,6 +23,8 @@ from linux_gpg_common import (
 
 DEFAULT_OUTPUT_NAME = "conu-linux-gpg-key.asc"
 MAX_SIGNING_KEY_BYTES = 1024 * 1024
+MAX_PUBLIC_KEY_BYTES = 1024 * 1024
+MAX_CHECKSUM_BYTES = 4096
 HASH_CHUNK_BYTES = 1024 * 1024
 
 
@@ -31,6 +34,8 @@ def main() -> int:
     if not dist.exists() or not dist.is_dir():
         raise SystemExit(f"release dist directory does not exist: {dist}")
     output_name = validate_output_name(args.output_name)
+    output = dist / output_name
+    prepare_public_key_output(output)
 
     gpg = shutil.which("gpg")
     if gpg is None:
@@ -52,13 +57,8 @@ def main() -> int:
         verify_imported_secret_key_fingerprint(gpg, env, key_id, expected_fingerprint)
         public_key = run_gpg(gpg, env, ["--armor", "--export", key_id])
 
-    if b"BEGIN PGP PUBLIC KEY BLOCK" not in public_key:
-        raise SystemExit("exported Linux GPG key was not an armored public key")
-    if b"PRIVATE KEY BLOCK" in public_key:
-        raise SystemExit("refusing to write private key material as a public-key asset")
-
-    output = dist / output_name
-    output.write_bytes(public_key)
+    validate_public_key_bytes(public_key)
+    write_public_key_asset(output, public_key)
     write_sha256_sidecar(output)
     print(f"exported Linux release public key: {output.name}, {output.name}.sha256")
     return 0
@@ -119,12 +119,119 @@ def read_secret_key(name: str) -> bytes:
     return decoded
 
 
+def validate_public_key_bytes(public_key: bytes) -> None:
+    if not public_key:
+        raise SystemExit("exported Linux GPG key was empty")
+    if len(public_key) > MAX_PUBLIC_KEY_BYTES:
+        raise SystemExit(f"exported Linux GPG key exceeds {MAX_PUBLIC_KEY_BYTES} bytes")
+    if b"BEGIN PGP PUBLIC KEY BLOCK" not in public_key:
+        raise SystemExit("exported Linux GPG key was not an armored public key")
+    if b"PRIVATE KEY BLOCK" in public_key:
+        raise SystemExit("refusing to write private key material as a public-key asset")
+
+
+def prepare_public_key_output(path: Path) -> None:
+    if path.exists() or path.is_symlink():
+        validate_regular_file(
+            path,
+            f"Linux public-key output {path.name}",
+            max_bytes=MAX_PUBLIC_KEY_BYTES,
+            allow_empty=True,
+        )
+
+
+def write_public_key_asset(path: Path, public_key: bytes) -> None:
+    validate_public_key_bytes(public_key)
+    prepare_public_key_output(path)
+    temp_path = temporary_sibling_path(path)
+    try:
+        temp_path.write_bytes(public_key)
+        temp_path.chmod(0o644)
+        validate_regular_file(
+            temp_path,
+            f"temporary Linux public-key output {path.name}",
+            max_bytes=MAX_PUBLIC_KEY_BYTES,
+            allow_empty=False,
+        )
+        os.replace(temp_path, path)
+        validate_regular_file(
+            path,
+            f"Linux public-key output {path.name}",
+            max_bytes=MAX_PUBLIC_KEY_BYTES,
+            allow_empty=False,
+        )
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
 def write_sha256_sidecar(path: Path) -> None:
-    path.with_name(f"{path.name}.sha256").write_text(
-        f"{sha256_file(path)}  {path.name}\n",
-        encoding="ascii",
-        newline="\n",
-    )
+    sidecar = path.with_name(f"{path.name}.sha256")
+    if sidecar.exists() or sidecar.is_symlink():
+        validate_regular_file(
+            sidecar,
+            f"SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=True,
+        )
+    text = f"{sha256_file(path)}  {path.name}\n"
+    temp_path = temporary_sibling_path(sidecar)
+    try:
+        temp_path.write_text(text, encoding="ascii", newline="\n")
+        temp_path.chmod(0o644)
+        validate_regular_file(
+            temp_path,
+            f"temporary SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=False,
+        )
+        os.replace(temp_path, sidecar)
+        validate_regular_file(
+            sidecar,
+            f"SHA-256 sidecar output {sidecar.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=False,
+        )
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def validate_regular_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+) -> int:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"missing {label}: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular file: {path.name}")
+    size = metadata.st_size
+    if not allow_empty and size == 0:
+        raise SystemExit(f"{label} must not be empty: {path.name}")
+    if size > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+    return size
+
+
+def temporary_sibling_path(path: Path) -> Path:
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        delete=False,
+    ) as handle:
+        return Path(handle.name)
 
 
 def sha256_file(path: Path) -> str:


### PR DESCRIPTION
## **User description**
Fixes #322

Summary:
- Reject unsafe existing Linux public-key release asset paths before GPG export work.
- Bound exported public-key bytes and reject private-key material before writing a release asset.
- Write the public-key asset and SHA-256 sidecar through bounded temporary files with atomic replacement.
- Add output-path regression coverage that runs before local gpg availability skips.

Validation:
- python -m py_compile scripts/export-linux-gpg-public-key.py scripts/check-linux-gpg-public-key-export.py
- python scripts/check-linux-gpg-public-key-export.py (GPG export subtest skipped locally because gpg is unavailable; new output preflights ran)
- python scripts/check-linux-release-signing.py (skipped locally because gpg is unavailable)
- python scripts/check-linux-repository-signing.py (skipped locally because gpg is unavailable)
- python scripts/check-rpm-package-signing.py (skipped locally because gpg/rpm tools are unavailable)
- python scripts/check-github-release-assets-published-regression.py
- python scripts/check-release-update-policy.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check


___

## **CodeAnt-AI Description**
Harden Linux public key export outputs and cover unsafe output cases

### What Changed
- The Linux public key export now checks the exported key before writing it, rejecting empty, oversized, non-public-key, or private-key content.
- Public key and checksum files are now written through temporary files and replaced atomically, with checks that block symlinks, directories, and oversized existing files.
- The regression check now runs output-safety checks up front and covers bad output paths before skipping when GPG is unavailable.

### Impact
`✅ Safer release asset publishing`
`✅ Fewer corrupted public-key downloads`
`✅ Fewer broken checksum files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
