### PR TITLE
Harden S3 publication metadata inputs

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -98,6 +98,55 @@ def main() -> int:
         )
         assert_failure("bad endpoint URL", bad_endpoint, "S3 endpoint URL must use HTTPS")
 
+        oversized_metadata = temp / "oversized-metadata-site"
+        shutil.copytree(site_dir, oversized_metadata)
+        (oversized_metadata / "repository.json").write_text(
+            '{"padding":"' + ("x" * (1024 * 1024 + 1)) + '"}\n',
+            encoding="ascii",
+            newline="\n",
+        )
+        oversized_result = run_publisher_raw(oversized_metadata, "--dry-run")
+        assert_failure("oversized metadata", oversized_result, "repository.json is larger")
+
+        bad_cache_control = temp / "bad-cache-control-site"
+        shutil.copytree(site_dir, bad_cache_control)
+        cache_policy_path = bad_cache_control / "cache-policy.json"
+        cache_policy = json.loads(cache_policy_path.read_text(encoding="ascii"))
+        cache_policy["rules"][0]["cacheControl"] = "public, max-age=300\nx-bad: 1"
+        cache_policy_path.write_text(
+            json.dumps(cache_policy, indent=2, sort_keys=True) + "\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        bad_cache_result = run_publisher_raw(bad_cache_control, "--dry-run")
+        assert_failure("bad Cache-Control", bad_cache_result, "Cache-Control")
+
+        symlink_metadata = temp / "symlink-metadata-site"
+        shutil.copytree(site_dir, symlink_metadata)
+        metadata_target = temp / "repository-target.json"
+        metadata_target.write_text(
+            (site_dir / "repository.json").read_text(encoding="ascii"),
+            encoding="ascii",
+            newline="\n",
+        )
+        metadata_link = symlink_metadata / "repository.json"
+        metadata_link.unlink()
+        if try_symlink(metadata_target, metadata_link):
+            symlink_result = run_publisher_raw(symlink_metadata, "--dry-run")
+            assert_failure(
+                "symlinked metadata",
+                symlink_result,
+                "repository.json must not be a symlink",
+            )
+
+        symlink_entry = temp / "symlink-entry-site"
+        shutil.copytree(site_dir, symlink_entry)
+        external_dir = temp / "external-dir"
+        external_dir.mkdir()
+        if try_symlink(external_dir, symlink_entry / "linked-dir", target_is_directory=True):
+            symlink_entry_result = run_publisher_raw(symlink_entry, "--dry-run")
+            assert_failure("symlinked site entry", symlink_entry_result, "site entry must not be a symlink")
+
     assert_workflow_wiring()
     print("Hosted Linux repository S3 publication regression checks passed")
     return 0
@@ -276,6 +325,14 @@ def assert_fake_aws_log(log: Path, expected_count: int) -> None:
 def assert_failure(description: str, result: subprocess.CompletedProcess[str], expected: str) -> None:
     if result.returncode == 0 or expected not in result.stdout:
         raise AssertionError(f"{description} failed with {result.stdout!r}, expected {expected!r}")
+
+
+def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:
+    try:
+        os.symlink(target, link, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError):
+        return False
+    return True
 
 
 def assert_workflow_wiring() -> None:

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -11,6 +11,7 @@ import mimetypes
 import os
 import re
 import shlex
+import stat
 import subprocess
 import sys
 import time
@@ -25,8 +26,10 @@ ENDPOINT_CHECKER = ROOT / "scripts" / "check-hosted-linux-repository-endpoint.py
 SITE_SCHEMA = "conu.hostedLinuxRepository.site.v1"
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
 MAX_FILES = 10000
+MAX_METADATA_BYTES = 1024 * 1024
 MAX_FILE_BYTES = 2 * 1024 * 1024 * 1024
 MAX_TOTAL_BYTES = 4 * 1024 * 1024 * 1024
+MAX_CACHE_CONTROL_BYTES = 256
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,253}[A-Za-z0-9]$")
 FORBIDDEN_SEGMENTS = {
@@ -326,12 +329,7 @@ def validate_base_url(raw: str) -> str:
 
 
 def read_json_file(path: Path, label: str) -> dict[str, Any]:
-    if not path.exists() or not path.is_file():
-        raise PublicationError(f"missing {label} in site directory")
-    try:
-        text = path.read_text(encoding="ascii")
-    except UnicodeDecodeError as exc:
-        raise PublicationError(f"{label} must be ASCII JSON") from exc
+    text = read_bounded_ascii_file(path, label, max_bytes=MAX_METADATA_BYTES)
     assert_no_forbidden_text(text, label)
     try:
         value = json.loads(text)
@@ -403,6 +401,7 @@ def parse_cache_rules(cache_policy: dict[str, Any]) -> list[dict[str, Any]]:
             raise PublicationError("cache-policy.json cache rule kind is missing")
         if not isinstance(cache_control, str) or not cache_control:
             raise PublicationError(f"cache-policy.json cache rule {kind} cacheControl is missing")
+        validate_cache_control_value(cache_control, f"cache-policy.json cache rule {kind}")
         if not isinstance(paths, list) or not paths:
             raise PublicationError(f"cache-policy.json cache rule {kind} paths are missing")
         clean_paths: list[str] = []
@@ -428,17 +427,17 @@ def collect_files(
     files: list[PublishFile] = []
     total_size = 0
     for path in sorted(site_dir.rglob("*")):
+        relative_path = relative_name(site_dir, path)
+        if path.is_symlink():
+            raise PublicationError(f"site entry must not be a symlink: {relative_path}")
         if path.is_dir():
             continue
-        if path.is_symlink():
-            raise PublicationError(f"site file must not be a symlink: {relative_name(site_dir, path)}")
-        if not path.is_file():
-            raise PublicationError(f"site entry must be a regular file: {relative_name(site_dir, path)}")
-        relative_path = relative_name(site_dir, path)
         validate_relative_path(relative_path)
-        size = path.stat().st_size
-        if size > MAX_FILE_BYTES:
-            raise PublicationError(f"site file is too large: {relative_path}")
+        size = validate_regular_file(
+            path,
+            f"site file {relative_path}",
+            max_bytes=MAX_FILE_BYTES,
+        )
         total_size += size
         if total_size > MAX_TOTAL_BYTES:
             raise PublicationError("site directory is too large to publish")
@@ -487,6 +486,47 @@ def assert_no_forbidden_text(text: str, label: str) -> None:
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
             raise PublicationError(f"{label} contains forbidden repository publication text: {forbidden}")
+
+
+def validate_cache_control_value(value: str, label: str) -> None:
+    if len(value) > MAX_CACHE_CONTROL_BYTES:
+        raise PublicationError(f"{label} Cache-Control is too long")
+    if value != value.strip():
+        raise PublicationError(f"{label} Cache-Control must not have leading or trailing whitespace")
+    for character in value:
+        codepoint = ord(character)
+        if codepoint < 32 or codepoint == 127 or codepoint > 126:
+            raise PublicationError(
+                f"{label} Cache-Control must be printable ASCII without control characters"
+            )
+
+
+def read_bounded_ascii_file(path: Path, label: str, *, max_bytes: int) -> str:
+    validate_regular_file(path, label, max_bytes=max_bytes)
+    with path.open("rb") as handle:
+        data = handle.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise PublicationError(f"{label} is larger than {max_bytes} bytes")
+    try:
+        return data.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise PublicationError(f"{label} must be ASCII") from exc
+
+
+def validate_regular_file(path: Path, label: str, *, max_bytes: int) -> int:
+    if path.is_symlink():
+        raise PublicationError(f"{label} must not be a symlink")
+    if not path.exists():
+        raise PublicationError(f"missing {label} in site directory")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise PublicationError(f"{label} could not be inspected") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise PublicationError(f"{label} must be a regular file")
+    if metadata.st_size > max_bytes:
+        raise PublicationError(f"{label} is larger than {max_bytes} bytes")
+    return metadata.st_size
 
 
 def cache_control_for_path(path: str, rules: list[dict[str, Any]]) -> str:


### PR DESCRIPTION
## **User description**
Fixes #324.\n\n## Summary\n- add bounded regular-file reads for hosted repository S3 publication metadata\n- reject symlinked site entries before publication planning\n- reject unsafe Cache-Control values before passing metadata to aws s3 cp\n- extend the S3 publication regression for oversized metadata, unsafe Cache-Control, and symlink cases when supported\n\n## Validation\n- python -m py_compile scripts/publish-hosted-linux-repository-s3.py scripts/check-hosted-linux-repository-s3-publication.py\n- python scripts/check-hosted-linux-repository-s3-publication.py\n- python scripts/check-hosted-linux-repository-endpoint-regression.py\n- python scripts/check-hosted-linux-repositories.py\n- python scripts/check-hosted-linux-repository-site.py\n- python scripts/check-hosted-linux-repository-pages.py\n- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check


___

## **CodeAnt-AI Description**
**Reject unsafe or oversized files before publishing hosted Linux repository metadata**

### What Changed
- Repository metadata files are now rejected if they are larger than 1 MB, not regular files, or symlinks
- Cache-Control values are now checked for control characters, newlines, and surrounding whitespace before publication
- Site content checks now stop symlinked entries anywhere in the repository tree, not just obvious file paths
- Regression coverage now includes oversized metadata, unsafe Cache-Control values, and symlinked files or directories

### Impact
`✅ Fewer failed S3 publications`
`✅ Safer metadata uploads`
`✅ Clearer rejection of unsafe site entries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
