### PR TITLE
Harden Pages preparation inputs

### DIFF
--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 import shutil
 import stat
 import subprocess
@@ -115,6 +116,45 @@ def main() -> int:
             "missing detached signature",
         )
 
+        symlink_site = temp / "symlink-site"
+        shutil.copytree(dist, symlink_site)
+        site_target = temp / "site-target.zip"
+        shutil.copy2(site, site_target)
+        (symlink_site / SITE_BUNDLE).unlink()
+        if try_symlink(site_target, symlink_site / SITE_BUNDLE):
+            expect_failure(
+                "symlinked site ZIP",
+                symlink_site,
+                temp / "symlink-site-pages",
+                "site ZIP must not be a symlink",
+            )
+
+        symlink_checksum = temp / "symlink-checksum"
+        shutil.copytree(dist, symlink_checksum)
+        checksum_target = temp / "site-target.zip.sha256"
+        shutil.copy2(dist / f"{SITE_BUNDLE}.sha256", checksum_target)
+        (symlink_checksum / f"{SITE_BUNDLE}.sha256").unlink()
+        if try_symlink(checksum_target, symlink_checksum / f"{SITE_BUNDLE}.sha256"):
+            expect_failure(
+                "symlinked site checksum",
+                symlink_checksum / SITE_BUNDLE,
+                temp / "symlink-checksum-pages",
+                "SHA-256 sidecar for hosted Linux repository site must not be a symlink",
+            )
+
+        symlink_signature = temp / "symlink-signature"
+        shutil.copytree(dist, symlink_signature)
+        signature_target = temp / "site-target.zip.asc"
+        shutil.copy2(dist / f"{SITE_BUNDLE}.asc", signature_target)
+        (symlink_signature / f"{SITE_BUNDLE}.asc").unlink()
+        if try_symlink(signature_target, symlink_signature / f"{SITE_BUNDLE}.asc"):
+            expect_failure(
+                "symlinked site signature",
+                symlink_signature / SITE_BUNDLE,
+                temp / "symlink-signature-pages",
+                "detached signature for hosted Linux repository site must not be a symlink",
+            )
+
         unsafe = temp / "unsafe"
         shutil.copytree(dist, unsafe)
         rewrite_site_zip(unsafe / SITE_BUNDLE, {"../index.html": b"escape\n"})
@@ -222,6 +262,17 @@ def main() -> int:
             "must be empty",
         )
 
+        output_target = temp / "output-target"
+        output_target.mkdir()
+        output_link = temp / "output-link"
+        if try_symlink(output_target, output_link, target_is_directory=True):
+            expect_failure(
+                "symlinked output",
+                dist / SITE_BUNDLE,
+                output_link,
+                "Pages output directory must not be a symlink",
+            )
+
     print("Hosted Linux repository Pages regression checks passed")
     return 0
 
@@ -320,6 +371,14 @@ def expect_action_failure(action, expected: str, label: str) -> None:
             return
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:
+    try:
+        os.symlink(target, link, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError):
+        return False
+    return True
 
 
 def assert_pages_output(pages: Path, site: Path) -> None:

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -109,8 +109,9 @@ def main() -> int:
     version = version_from_site_name(site_zip.name)
     verify_sha256_sidecar(site_zip, "hosted Linux repository site")
     require_detached_signature(site_zip)
-    output_dir = args.output_dir.resolve()
+    output_dir = args.output_dir.expanduser()
     prepare_output_dir(output_dir)
+    output_dir = output_dir.resolve()
     members = read_site_members(site_zip)
     validate_site_members(site_zip.name, version, members)
     extract_members(output_dir, members)
@@ -139,25 +140,44 @@ def parse_args() -> argparse.Namespace:
 
 
 def find_site_zip(site: Path, version: str | None) -> Path:
-    path = site.resolve()
+    path = site.expanduser()
+    if path.is_symlink():
+        raise SystemExit(f"hosted Linux repository site input must not be a symlink: {site}")
     if path.is_file():
         if version is not None and f"conu-{version}-hosted-linux-repository-site.zip" != path.name:
             raise SystemExit(f"site ZIP {path.name} does not match requested version {version}")
         version_from_site_name(path.name)
+        validate_regular_file(
+            path,
+            "hosted Linux repository site ZIP",
+            max_bytes=MAX_SITE_ZIP_BYTES,
+        )
         return path
     if not path.exists() or not path.is_dir():
         raise SystemExit(f"hosted Linux repository site input does not exist: {site}")
     if version is not None:
         candidate = path / f"conu-{version}-hosted-linux-repository-site.zip"
-        if not candidate.exists() or not candidate.is_file():
-            raise SystemExit(f"missing hosted Linux repository site ZIP: {candidate.name}")
+        validate_regular_file(
+            candidate,
+            "hosted Linux repository site ZIP",
+            max_bytes=MAX_SITE_ZIP_BYTES,
+        )
         return candidate
-    candidates = sorted(item for item in path.glob("conu-*-hosted-linux-repository-site.zip") if item.is_file())
+    candidates = sorted(
+        item
+        for item in path.glob("conu-*-hosted-linux-repository-site.zip")
+        if item.is_file() or item.is_symlink()
+    )
     if len(candidates) != 1:
         raise SystemExit(
             f"expected exactly one hosted Linux repository site ZIP in {path}, found {len(candidates)}"
         )
     version_from_site_name(candidates[0].name)
+    validate_regular_file(
+        candidates[0],
+        "hosted Linux repository site ZIP",
+        max_bytes=MAX_SITE_ZIP_BYTES,
+    )
     return candidates[0]
 
 
@@ -169,13 +189,13 @@ def version_from_site_name(name: str) -> str:
 
 
 def verify_sha256_sidecar(path: Path, label: str) -> str:
-    if path.stat().st_size > MAX_SITE_ZIP_BYTES:
-        raise SystemExit(f"{label} is too large for Pages deployment: {path.name}")
+    validate_regular_file(path, label, max_bytes=MAX_SITE_ZIP_BYTES)
     sidecar = path.with_name(f"{path.name}.sha256")
-    if not sidecar.exists() or not sidecar.is_file():
-        raise SystemExit(f"missing SHA-256 sidecar for {label}: {path.name}")
-    if sidecar.stat().st_size > MAX_CHECKSUM_BYTES:
-        raise SystemExit(f"SHA-256 sidecar is too large for {label}: {path.name}")
+    validate_regular_file(
+        sidecar,
+        f"SHA-256 sidecar for {label}",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
     try:
         checksum_text = sidecar.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -194,10 +214,11 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
 
 def require_detached_signature(path: Path) -> None:
     signature = path.with_name(f"{path.name}.asc")
-    if not signature.exists() or not signature.is_file():
-        raise SystemExit(f"missing detached signature for hosted Linux repository site: {signature.name}")
-    if signature.stat().st_size > MAX_SIGNATURE_BYTES:
-        raise SystemExit(f"detached signature is too large: {signature.name}")
+    validate_regular_file(
+        signature,
+        "detached signature for hosted Linux repository site",
+        max_bytes=MAX_SIGNATURE_BYTES,
+    )
     try:
         signature_text = signature.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -207,9 +228,29 @@ def require_detached_signature(path: Path) -> None:
 
 
 def prepare_output_dir(output_dir: Path) -> None:
+    if output_dir.is_symlink():
+        raise SystemExit(f"Pages output directory must not be a symlink: {output_dir}")
+    if output_dir.exists() and not output_dir.is_dir():
+        raise SystemExit(f"Pages output path must be a directory: {output_dir}")
     if output_dir.exists() and any(output_dir.iterdir()):
         raise SystemExit(f"Pages output directory must be empty: {output_dir}")
     output_dir.mkdir(parents=True, exist_ok=True)
+
+
+def validate_regular_file(path: Path, label: str, *, max_bytes: int) -> int:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    if not path.exists():
+        raise SystemExit(f"missing {label}: {path.name}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"{label} could not be inspected: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular file: {path.name}")
+    if metadata.st_size > max_bytes:
+        raise SystemExit(f"{label} is too large for Pages deployment: {path.name}")
+    return metadata.st_size
 
 
 def read_site_members(site_zip: Path) -> dict[str, bytes]:


### PR DESCRIPTION
## **User description**
Fixes #326.

Summary:
- Reject symlinked, missing, non-regular, or oversized hosted repository site ZIP inputs before checksum/signature reads or extraction.
- Reject symlinked SHA-256 sidecars, detached signatures, and Pages output directories.
- Add hosted Pages regression coverage for symlinked site ZIP, checksum, signature, and output paths.

Validation:
- python -m py_compile scripts/prepare-hosted-linux-repository-pages.py scripts/check-hosted-linux-repository-pages.py
- python scripts/check-hosted-linux-repository-pages.py
- python scripts/check-hosted-linux-repository-site.py
- python scripts/check-hosted-linux-repositories.py
- python scripts/check-hosted-linux-repository-endpoint-regression.py
- python scripts/check-hosted-linux-repository-s3-publication.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions


___

## **CodeAnt-AI Description**
**Reject unsafe Pages inputs before preparation**

### What Changed
- Pages preparation now refuses symlinked, missing, non-regular, or oversized site ZIP, checksum, and signature inputs before reading or extracting them
- The output directory is also rejected if it is a symlink or not a directory, and preparation still fails when the target folder is not empty
- Regression checks now cover symlinked site ZIP, checksum, signature, and output paths

### Impact
`✅ Safer Pages deployment inputs`
`✅ Fewer broken publish attempts`
`✅ Clearer failures for invalid artifact paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression testing for input validation in repository page preparation.

* **Bug Fixes**
  * Enhanced input validation and error handling for repository page generation scripts.
  * Improved robustness of file and directory checks during preparation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->