### PR TITLE
Harden hosted repository generator files

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -7,6 +7,7 @@ import gzip
 import hashlib
 import io
 import importlib.util
+import os
 import shutil
 import stat
 import subprocess
@@ -62,6 +63,86 @@ def main() -> int:
             missing_signature,
             "missing detached signature",
         )
+
+        symlink_dist = temp / "symlink-dist"
+        if try_symlink(dist, symlink_dist, target_is_directory=True):
+            expect_failure_at_output(
+                "symlinked dist directory",
+                symlink_dist,
+                temp / "symlink-dist-output",
+                "release dist directory must not be a symlink",
+            )
+
+        symlink_asset = temp / "symlink-asset"
+        shutil.copytree(dist, symlink_asset)
+        asset_target = temp / "debian-package-target.deb"
+        shutil.copy2(symlink_asset / DEBIAN_PACKAGES[0], asset_target)
+        (symlink_asset / DEBIAN_PACKAGES[0]).unlink()
+        if try_symlink(asset_target, symlink_asset / DEBIAN_PACKAGES[0]):
+            expect_failure(
+                "symlinked package asset",
+                symlink_asset,
+                "signed Debian package must not be a symlink",
+            )
+
+        symlink_checksum = temp / "symlink-checksum"
+        shutil.copytree(dist, symlink_checksum)
+        checksum_target = temp / "debian-package-target.deb.sha256"
+        shutil.copy2(symlink_checksum / f"{DEBIAN_PACKAGES[0]}.sha256", checksum_target)
+        (symlink_checksum / f"{DEBIAN_PACKAGES[0]}.sha256").unlink()
+        if try_symlink(checksum_target, symlink_checksum / f"{DEBIAN_PACKAGES[0]}.sha256"):
+            expect_failure(
+                "symlinked package checksum",
+                symlink_checksum,
+                "SHA-256 sidecar for signed Debian package must not be a symlink",
+            )
+
+        symlink_signature = temp / "symlink-signature"
+        shutil.copytree(dist, symlink_signature)
+        signature_target = temp / "debian-package-target.deb.asc"
+        shutil.copy2(symlink_signature / f"{DEBIAN_PACKAGES[0]}.asc", signature_target)
+        (symlink_signature / f"{DEBIAN_PACKAGES[0]}.asc").unlink()
+        if try_symlink(signature_target, symlink_signature / f"{DEBIAN_PACKAGES[0]}.asc"):
+            expect_failure(
+                "symlinked package signature",
+                symlink_signature,
+                "detached signature for hosted repository asset must not be a symlink",
+            )
+
+        symlink_output_target = temp / "output-target"
+        symlink_output_target.mkdir()
+        symlink_output = temp / "symlink-output"
+        if try_symlink(symlink_output_target, symlink_output, target_is_directory=True):
+            expect_failure_at_output(
+                "symlinked output directory",
+                dist,
+                symlink_output,
+                "hosted repository output directory must not be a symlink",
+            )
+
+        symlink_output_file = temp / "symlink-output-file"
+        symlink_output_file.mkdir()
+        output_file_target = temp / "hosted-bundle-target.zip"
+        output_file_target.write_bytes(b"existing\n")
+        if try_symlink(output_file_target, symlink_output_file / HOSTED_BUNDLE):
+            expect_failure_at_output(
+                "symlinked output bundle",
+                dist,
+                symlink_output_file,
+                "hosted Linux repository bundle output must not be a symlink",
+            )
+
+        symlink_output_sidecar = temp / "symlink-output-sidecar"
+        symlink_output_sidecar.mkdir()
+        output_sidecar_target = temp / "hosted-bundle-target.zip.sha256"
+        output_sidecar_target.write_text("", encoding="ascii")
+        if try_symlink(output_sidecar_target, symlink_output_sidecar / f"{HOSTED_BUNDLE}.sha256"):
+            expect_failure_at_output(
+                "symlinked output checksum",
+                dist,
+                symlink_output_sidecar,
+                "hosted Linux repository bundle SHA-256 sidecar output must not be a symlink",
+            )
 
         missing_native_apt_signature = temp / "missing-native-apt-signature"
         shutil.copytree(dist, missing_native_apt_signature)
@@ -190,13 +271,17 @@ def run_generator(dist: Path, output: Path) -> str:
 
 
 def expect_failure(description: str, dist: Path, expected: str) -> None:
+    expect_failure_at_output(description, dist, dist / "out", expected)
+
+
+def expect_failure_at_output(description: str, dist: Path, output: Path, expected: str) -> None:
     failed = subprocess.run(
         [
             sys.executable,
             str(GENERATOR),
             str(dist),
             "--output-dir",
-            str(dist / "out"),
+            str(output),
             "--version",
             VERSION,
         ],
@@ -241,6 +326,14 @@ def expect_action_failure(action, expected: str, label: str) -> None:
             return
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:
+    try:
+        os.symlink(target, link, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError):
+        return False
+    return True
 
 
 def write_signed_dist(dist: Path) -> None:

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 import shutil
 import stat
 import subprocess
@@ -158,6 +159,93 @@ def main() -> int:
             "missing detached signature",
         )
 
+        symlink_dist = temp / "symlink-dist"
+        if try_symlink(dist, symlink_dist, target_is_directory=True):
+            expect_failure_at_output(
+                "symlinked dist directory",
+                symlink_dist,
+                temp / "symlink-dist-output",
+                BASE_URL,
+                "release dist directory must not be a symlink",
+            )
+
+        symlink_bundle = temp / "symlink-bundle"
+        shutil.copytree(dist, symlink_bundle)
+        bundle_target = temp / "hosted-bundle-target.zip"
+        shutil.copy2(symlink_bundle / HOSTED_BUNDLE, bundle_target)
+        (symlink_bundle / HOSTED_BUNDLE).unlink()
+        if try_symlink(bundle_target, symlink_bundle / HOSTED_BUNDLE):
+            expect_failure(
+                "symlinked hosted bundle",
+                symlink_bundle,
+                BASE_URL,
+                "hosted Linux repository bundle must not be a symlink",
+            )
+
+        symlink_checksum = temp / "symlink-checksum"
+        shutil.copytree(dist, symlink_checksum)
+        checksum_target = temp / "hosted-bundle-target.zip.sha256"
+        shutil.copy2(symlink_checksum / f"{HOSTED_BUNDLE}.sha256", checksum_target)
+        (symlink_checksum / f"{HOSTED_BUNDLE}.sha256").unlink()
+        if try_symlink(checksum_target, symlink_checksum / f"{HOSTED_BUNDLE}.sha256"):
+            expect_failure(
+                "symlinked hosted bundle checksum",
+                symlink_checksum,
+                BASE_URL,
+                "SHA-256 sidecar for hosted Linux repository bundle must not be a symlink",
+            )
+
+        symlink_signature = temp / "symlink-signature"
+        shutil.copytree(dist, symlink_signature)
+        signature_target = temp / "hosted-bundle-target.zip.asc"
+        shutil.copy2(symlink_signature / f"{HOSTED_BUNDLE}.asc", signature_target)
+        (symlink_signature / f"{HOSTED_BUNDLE}.asc").unlink()
+        if try_symlink(signature_target, symlink_signature / f"{HOSTED_BUNDLE}.asc"):
+            expect_failure(
+                "symlinked hosted bundle signature",
+                symlink_signature,
+                BASE_URL,
+                "detached signature for hosted Linux repository site input must not be a symlink",
+            )
+
+        symlink_output_target = temp / "output-target"
+        symlink_output_target.mkdir()
+        symlink_output = temp / "symlink-output"
+        if try_symlink(symlink_output_target, symlink_output, target_is_directory=True):
+            expect_failure_at_output(
+                "symlinked output directory",
+                dist,
+                symlink_output,
+                BASE_URL,
+                "hosted repository site output directory must not be a symlink",
+            )
+
+        symlink_output_file = temp / "symlink-output-file"
+        symlink_output_file.mkdir()
+        output_file_target = temp / "site-target.zip"
+        output_file_target.write_bytes(b"existing\n")
+        if try_symlink(output_file_target, symlink_output_file / SITE_BUNDLE):
+            expect_failure_at_output(
+                "symlinked output site bundle",
+                dist,
+                symlink_output_file,
+                BASE_URL,
+                "hosted Linux repository site artifact output must not be a symlink",
+            )
+
+        symlink_output_sidecar = temp / "symlink-output-sidecar"
+        symlink_output_sidecar.mkdir()
+        output_sidecar_target = temp / "site-target.zip.sha256"
+        output_sidecar_target.write_text("", encoding="ascii")
+        if try_symlink(output_sidecar_target, symlink_output_sidecar / f"{SITE_BUNDLE}.sha256"):
+            expect_failure_at_output(
+                "symlinked output site checksum",
+                dist,
+                symlink_output_sidecar,
+                BASE_URL,
+                "hosted Linux repository site artifact SHA-256 sidecar output must not be a symlink",
+            )
+
         unsafe_bundle = temp / "unsafe-bundle"
         shutil.copytree(dist, unsafe_bundle)
         with zipfile.ZipFile(unsafe_bundle / HOSTED_BUNDLE, "w", compression=zipfile.ZIP_STORED) as archive:
@@ -240,13 +328,23 @@ def run_generator(dist: Path, output: Path, base_url: str) -> str:
 
 
 def expect_failure(description: str, dist: Path, base_url: str, expected: str) -> None:
+    expect_failure_at_output(description, dist, dist / "out", base_url, expected)
+
+
+def expect_failure_at_output(
+    description: str,
+    dist: Path,
+    output: Path,
+    base_url: str,
+    expected: str,
+) -> None:
     failed = subprocess.run(
         [
             sys.executable,
             str(SITE_GENERATOR),
             str(dist),
             "--output-dir",
-            str(dist / "out"),
+            str(output),
             "--version",
             VERSION,
             "--base-url",
@@ -293,6 +391,14 @@ def expect_action_failure(action, expected: str, label: str) -> None:
             return
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:
+    try:
+        os.symlink(target, link, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError):
+        return False
+    return True
 
 
 def assert_site_bundle(site: Path, hosted_bundle: Path) -> None:

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -22,6 +22,8 @@ HASH_CHUNK_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
 MAX_SIGNATURE_BYTES = 1024 * 1024
 MAX_PUBLIC_KEY_BYTES = 1024 * 1024
+MAX_RELEASE_ASSET_BYTES = 2 * 1024 * 1024 * 1024
+MAX_HOSTED_BUNDLE_BYTES = 6 * 1024 * 1024 * 1024
 MAX_ZIP_MEMBER_BYTES = 512_000_000
 MAX_ZIP_MEMBERS = 10_000
 MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
@@ -50,15 +52,21 @@ class HostedLinuxAssets:
 def main() -> int:
     args = parse_args()
     version = validate_version(args.version or read_repo_version())
-    dist = args.dist.resolve()
-    output_dir = args.output_dir.resolve()
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"release dist directory does not exist: {dist}")
-    output_dir.mkdir(parents=True, exist_ok=True)
+    dist = args.dist.expanduser()
+    output_dir = args.output_dir.expanduser()
+    validate_input_directory(dist, "release dist directory")
+    prepare_output_directory(output_dir, "hosted repository output directory")
+    dist = dist.resolve()
+    output_dir = output_dir.resolve()
 
     assets = collect_assets(dist, version)
     members = build_hosted_repository_members(assets)
     output = output_dir / hosted_repository_bundle_filename(version)
+    validate_output_file(output, "hosted Linux repository bundle")
+    validate_output_file(
+        output.with_name(f"{output.name}.sha256"),
+        "hosted Linux repository bundle SHA-256 sidecar",
+    )
     write_zip_members(output, members)
     write_sha256_sidecar(output)
     print(f"generated hosted Linux repositories: {output.name}, {output.name}.sha256")
@@ -155,19 +163,19 @@ def collect_assets(dist: Path, version: str) -> HostedLinuxAssets:
     )
 
 
-def required_asset(path: Path, label: str) -> Path:
-    if not path.exists() or not path.is_file():
-        raise SystemExit(f"missing {label}: {path.name}")
+def required_asset(path: Path, label: str, *, max_bytes: int = MAX_RELEASE_ASSET_BYTES) -> Path:
+    validate_regular_file(path, label, max_bytes=max_bytes)
     verify_sha256_sidecar(path, label)
     return path
 
 
 def require_detached_signature(path: Path) -> Path:
     signature = path.with_name(f"{path.name}.asc")
-    if not signature.exists() or not signature.is_file():
-        raise SystemExit(f"missing detached signature for hosted repository asset: {path.name}.asc")
-    if signature.stat().st_size > MAX_SIGNATURE_BYTES:
-        raise SystemExit(f"detached signature is too large: {signature.name}")
+    validate_regular_file(
+        signature,
+        "detached signature for hosted repository asset",
+        max_bytes=MAX_SIGNATURE_BYTES,
+    )
     try:
         signature_text = signature.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -178,8 +186,7 @@ def require_detached_signature(path: Path) -> Path:
 
 
 def verify_public_key(path: Path) -> None:
-    if path.stat().st_size > MAX_PUBLIC_KEY_BYTES:
-        raise SystemExit(f"Linux public key asset is too large: {path.name}")
+    validate_regular_file(path, "Linux public key asset", max_bytes=MAX_PUBLIC_KEY_BYTES)
     try:
         text = path.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -200,15 +207,27 @@ def build_hosted_repository_members(assets: HostedLinuxAssets) -> dict[str, byte
 
     members: dict[str, bytes] = {
         "README.txt": render_root_readme(assets.version).encode("ascii"),
-        PUBLIC_KEY_NAME: assets.public_key.read_bytes(),
-        f"{PUBLIC_KEY_NAME}.sha256": assets.public_key.with_name(
-            f"{PUBLIC_KEY_NAME}.sha256"
-        ).read_bytes(),
+        PUBLIC_KEY_NAME: read_regular_file(
+            assets.public_key,
+            "Linux GPG public key",
+            max_bytes=MAX_PUBLIC_KEY_BYTES,
+        ),
+        f"{PUBLIC_KEY_NAME}.sha256": read_regular_file(
+            assets.public_key.with_name(f"{PUBLIC_KEY_NAME}.sha256"),
+            "SHA-256 sidecar for Linux GPG public key",
+            max_bytes=MAX_CHECKSUM_BYTES,
+        ),
         "apt/README.txt": render_apt_readme(assets.version, debian_names).encode("ascii"),
-        f"apt/{PUBLIC_KEY_NAME}": assets.public_key.read_bytes(),
-        f"apt/{PUBLIC_KEY_NAME}.sha256": assets.public_key.with_name(
-            f"{PUBLIC_KEY_NAME}.sha256"
-        ).read_bytes(),
+        f"apt/{PUBLIC_KEY_NAME}": read_regular_file(
+            assets.public_key,
+            "Linux GPG public key",
+            max_bytes=MAX_PUBLIC_KEY_BYTES,
+        ),
+        f"apt/{PUBLIC_KEY_NAME}.sha256": read_regular_file(
+            assets.public_key.with_name(f"{PUBLIC_KEY_NAME}.sha256"),
+            "SHA-256 sidecar for Linux GPG public key",
+            max_bytes=MAX_CHECKSUM_BYTES,
+        ),
     }
     for name in ("Packages", "Packages.gz", "Release", "InRelease", "Release.gpg"):
         members[f"apt/{name}"] = apt_metadata[name]
@@ -216,10 +235,16 @@ def build_hosted_repository_members(assets: HostedLinuxAssets) -> dict[str, byte
         add_asset_triplet(members, "apt", package)
 
     members["rpm/README.txt"] = render_rpm_readme(assets.version, rpm_names).encode("ascii")
-    members[f"rpm/{PUBLIC_KEY_NAME}"] = assets.public_key.read_bytes()
-    members[f"rpm/{PUBLIC_KEY_NAME}.sha256"] = assets.public_key.with_name(
-        f"{PUBLIC_KEY_NAME}.sha256"
-    ).read_bytes()
+    members[f"rpm/{PUBLIC_KEY_NAME}"] = read_regular_file(
+        assets.public_key,
+        "Linux GPG public key",
+        max_bytes=MAX_PUBLIC_KEY_BYTES,
+    )
+    members[f"rpm/{PUBLIC_KEY_NAME}.sha256"] = read_regular_file(
+        assets.public_key.with_name(f"{PUBLIC_KEY_NAME}.sha256"),
+        "SHA-256 sidecar for Linux GPG public key",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
     for package in assets.rpm_packages:
         add_asset_triplet(members, "rpm", package)
     for name in sorted(rpm_metadata):
@@ -231,9 +256,21 @@ def build_hosted_repository_members(assets: HostedLinuxAssets) -> dict[str, byte
 
 
 def add_asset_triplet(members: dict[str, bytes], prefix: str, asset: Path) -> None:
-    members[f"{prefix}/{asset.name}"] = asset.read_bytes()
-    members[f"{prefix}/{asset.name}.sha256"] = asset.with_name(f"{asset.name}.sha256").read_bytes()
-    members[f"{prefix}/{asset.name}.asc"] = asset.with_name(f"{asset.name}.asc").read_bytes()
+    members[f"{prefix}/{asset.name}"] = read_regular_file(
+        asset,
+        f"{prefix} hosted repository asset",
+        max_bytes=MAX_RELEASE_ASSET_BYTES,
+    )
+    members[f"{prefix}/{asset.name}.sha256"] = read_regular_file(
+        asset.with_name(f"{asset.name}.sha256"),
+        f"SHA-256 sidecar for {prefix} hosted repository asset",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
+    members[f"{prefix}/{asset.name}.asc"] = read_regular_file(
+        asset.with_name(f"{asset.name}.asc"),
+        f"detached signature for {prefix} hosted repository asset",
+        max_bytes=MAX_SIGNATURE_BYTES,
+    )
 
 
 def validate_apt_metadata(
@@ -430,6 +467,7 @@ native RPM signatures from the release signing key.
 
 
 def write_zip_members(path: Path, members: dict[str, bytes]) -> None:
+    validate_output_file(path, "hosted Linux repository bundle")
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
         for name in sorted(members):
             info = zipfile.ZipInfo(name, ZIP_SOURCE_TIMESTAMP)
@@ -439,11 +477,13 @@ def write_zip_members(path: Path, members: dict[str, bytes]) -> None:
 
 
 def verify_sha256_sidecar(path: Path, label: str) -> str:
+    validate_regular_file(path, label, max_bytes=MAX_RELEASE_ASSET_BYTES)
     sidecar = path.with_name(f"{path.name}.sha256")
-    if not sidecar.exists() or not sidecar.is_file():
-        raise SystemExit(f"missing SHA-256 sidecar for {label}: {path.name}")
-    if sidecar.stat().st_size > MAX_CHECKSUM_BYTES:
-        raise SystemExit(f"SHA-256 sidecar is too large for {label}: {path.name}")
+    validate_regular_file(
+        sidecar,
+        f"SHA-256 sidecar for {label}",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
     try:
         checksum_text = sidecar.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -463,11 +503,67 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
 
 
 def write_sha256_sidecar(path: Path) -> None:
-    path.with_name(f"{path.name}.sha256").write_text(
+    validate_regular_file(path, "hosted Linux repository bundle", max_bytes=MAX_HOSTED_BUNDLE_BYTES)
+    sidecar = path.with_name(f"{path.name}.sha256")
+    validate_output_file(sidecar, "hosted Linux repository bundle SHA-256 sidecar")
+    sidecar.write_text(
         f"{sha256_file(path)}  {path.name}\n",
         encoding="ascii",
         newline="\n",
     )
+    validate_regular_file(
+        sidecar,
+        "hosted Linux repository bundle SHA-256 sidecar",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
+
+
+def validate_input_directory(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+
+
+def prepare_output_directory(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if path.exists() and not path.is_dir():
+        raise SystemExit(f"{label} must be a directory: {path}")
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def validate_regular_file(path: Path, label: str, *, max_bytes: int) -> int:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    if not path.exists():
+        raise SystemExit(f"missing {label}: {path.name}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"{label} could not be inspected: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular file: {path.name}")
+    if metadata.st_size > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name}")
+    return metadata.st_size
+
+
+def validate_output_file(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} output must not be a symlink: {path.name}")
+    if path.exists():
+        try:
+            metadata = path.stat()
+        except OSError as exc:
+            raise SystemExit(f"{label} output could not be inspected: {path.name}") from exc
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} output must be a regular file: {path.name}")
+
+
+def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
+    validate_regular_file(path, label, max_bytes=max_bytes)
+    return path.read_bytes()
 
 
 def sha256_file(path: Path) -> str:

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -20,6 +20,7 @@ SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?
 HASH_CHUNK_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
 MAX_SIGNATURE_BYTES = 1024 * 1024
+MAX_HOSTED_BUNDLE_BYTES = 4 * 1024 * 1024 * 1024
 MAX_ZIP_MEMBER_BYTES = 512_000_000
 MAX_ZIP_MEMBERS = 10_000
 MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
@@ -94,11 +95,12 @@ def main() -> int:
     args = parse_args()
     version = validate_version(args.version or read_repo_version())
     base_url = validate_base_url(args.base_url or os.environ.get("CONU_LINUX_REPOSITORY_BASE_URL", ""))
-    dist = args.dist.resolve()
-    output_dir = args.output_dir.resolve()
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"release dist directory does not exist: {dist}")
-    output_dir.mkdir(parents=True, exist_ok=True)
+    dist = args.dist.expanduser()
+    output_dir = args.output_dir.expanduser()
+    validate_input_directory(dist, "release dist directory")
+    prepare_output_directory(output_dir, "hosted repository site output directory")
+    dist = dist.resolve()
+    output_dir = output_dir.resolve()
 
     bundle = required_asset(
         dist / hosted_repository_bundle_filename(version),
@@ -116,6 +118,11 @@ def main() -> int:
         bundle_members=bundle_members,
     )
     output = output_dir / hosted_repository_site_filename(version)
+    validate_output_file(output, "hosted Linux repository site artifact")
+    validate_output_file(
+        output.with_name(f"{output.name}.sha256"),
+        "hosted Linux repository site artifact SHA-256 sidecar",
+    )
     write_zip_members(output, site_members)
     write_sha256_sidecar(output)
     print(f"generated hosted Linux repository site: {output.name}, {output.name}.sha256")
@@ -183,19 +190,19 @@ def hosted_repository_site_filename(version: str) -> str:
     return f"conu-{version}-hosted-linux-repository-site.zip"
 
 
-def required_asset(path: Path, label: str) -> Path:
-    if not path.exists() or not path.is_file():
-        raise SystemExit(f"missing {label}: {path.name}")
+def required_asset(path: Path, label: str, *, max_bytes: int = MAX_HOSTED_BUNDLE_BYTES) -> Path:
+    validate_regular_file(path, label, max_bytes=max_bytes)
     verify_sha256_sidecar(path, label)
     return path
 
 
 def require_detached_signature(path: Path) -> Path:
     signature = path.with_name(f"{path.name}.asc")
-    if not signature.exists() or not signature.is_file():
-        raise SystemExit(f"missing detached signature for hosted Linux repository site input: {signature.name}")
-    if signature.stat().st_size > MAX_SIGNATURE_BYTES:
-        raise SystemExit(f"detached signature is too large: {signature.name}")
+    validate_regular_file(
+        signature,
+        "detached signature for hosted Linux repository site input",
+        max_bytes=MAX_SIGNATURE_BYTES,
+    )
     try:
         signature_text = signature.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -325,9 +332,21 @@ def build_site_members(
     members["install/README.txt"] = render_install_readme(version, base_url).encode("ascii")
     members["install/conu.list"] = render_apt_source(base_url).encode("ascii")
     members["install/conu.repo"] = render_yum_repo(base_url).encode("ascii")
-    members[f"downloads/{bundle.name}"] = bundle.read_bytes()
-    members[f"downloads/{bundle.name}.sha256"] = bundle.with_name(f"{bundle.name}.sha256").read_bytes()
-    members[f"downloads/{bundle.name}.asc"] = signature.read_bytes()
+    members[f"downloads/{bundle.name}"] = read_regular_file(
+        bundle,
+        "hosted Linux repository bundle",
+        max_bytes=MAX_HOSTED_BUNDLE_BYTES,
+    )
+    members[f"downloads/{bundle.name}.sha256"] = read_regular_file(
+        bundle.with_name(f"{bundle.name}.sha256"),
+        "SHA-256 sidecar for hosted Linux repository bundle",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
+    members[f"downloads/{bundle.name}.asc"] = read_regular_file(
+        signature,
+        "detached signature for hosted Linux repository bundle",
+        max_bytes=MAX_SIGNATURE_BYTES,
+    )
     for name, data in members.items():
         if is_text_member(name):
             assert_no_forbidden_text(data, name)
@@ -515,11 +534,13 @@ def render_headers_file() -> str:
 
 
 def verify_sha256_sidecar(path: Path, label: str) -> str:
+    validate_regular_file(path, label, max_bytes=MAX_HOSTED_BUNDLE_BYTES)
     sidecar = path.with_name(f"{path.name}.sha256")
-    if not sidecar.exists() or not sidecar.is_file():
-        raise SystemExit(f"missing SHA-256 sidecar for {label}: {path.name}")
-    if sidecar.stat().st_size > MAX_CHECKSUM_BYTES:
-        raise SystemExit(f"SHA-256 sidecar is too large for {label}: {path.name}")
+    validate_regular_file(
+        sidecar,
+        f"SHA-256 sidecar for {label}",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
     try:
         checksum_text = sidecar.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -539,10 +560,18 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
 
 
 def write_sha256_sidecar(path: Path) -> None:
-    path.with_name(f"{path.name}.sha256").write_text(
+    validate_regular_file(path, "hosted Linux repository site artifact", max_bytes=MAX_HOSTED_BUNDLE_BYTES)
+    sidecar = path.with_name(f"{path.name}.sha256")
+    validate_output_file(sidecar, "hosted Linux repository site artifact SHA-256 sidecar")
+    sidecar.write_text(
         f"{sha256_file(path)}  {path.name}\n",
         encoding="ascii",
         newline="\n",
+    )
+    validate_regular_file(
+        sidecar,
+        "hosted Linux repository site artifact SHA-256 sidecar",
+        max_bytes=MAX_CHECKSUM_BYTES,
     )
 
 
@@ -558,6 +587,7 @@ def sha256_file(path: Path) -> str:
 
 
 def write_zip_members(path: Path, members: dict[str, bytes]) -> None:
+    validate_output_file(path, "hosted Linux repository site artifact")
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
         for name in sorted(members):
             info = zipfile.ZipInfo(name, ZIP_SOURCE_TIMESTAMP)
@@ -578,6 +608,54 @@ def assert_no_forbidden_text(data: bytes, label: str) -> None:
 
 def is_text_member(name: str) -> bool:
     return name == "_headers" or name.endswith((".txt", ".json", ".html", ".list", ".repo", ".asc", ".sha256"))
+
+
+def validate_input_directory(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+
+
+def prepare_output_directory(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if path.exists() and not path.is_dir():
+        raise SystemExit(f"{label} must be a directory: {path}")
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def validate_regular_file(path: Path, label: str, *, max_bytes: int) -> int:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    if not path.exists():
+        raise SystemExit(f"missing {label}: {path.name}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"{label} could not be inspected: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular file: {path.name}")
+    if metadata.st_size > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name}")
+    return metadata.st_size
+
+
+def validate_output_file(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} output must not be a symlink: {path.name}")
+    if path.exists():
+        try:
+            metadata = path.stat()
+        except OSError as exc:
+            raise SystemExit(f"{label} output could not be inspected: {path.name}") from exc
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} output must be a regular file: {path.name}")
+
+
+def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
+    validate_regular_file(path, label, max_bytes=max_bytes)
+    return path.read_bytes()
 
 
 def html_escape(value: str) -> str:


### PR DESCRIPTION
## **User description**
Fixes #328.

Summary:
- Reject symlinked release dist/output directories before hosted repository bundle or site generation.
- Reject symlinked, non-regular, missing, or oversized hosted repository source assets, checksum sidecars, and detached signatures before reads.
- Reject symlinked/non-regular output ZIP and checksum sidecar paths before writing generated hosted artifacts.
- Add regression coverage for symlinked inputs and outputs in hosted repository bundle and site generation.

Validation:
- python -m py_compile scripts/generate-hosted-linux-repositories.py scripts/generate-hosted-linux-repository-site.py scripts/check-hosted-linux-repositories.py scripts/check-hosted-linux-repository-site.py
- python scripts/check-hosted-linux-repositories.py
- python scripts/check-hosted-linux-repository-site.py
- python scripts/check-hosted-linux-repository-pages.py
- python scripts/check-hosted-linux-repository-endpoint-regression.py
- python scripts/check-hosted-linux-repository-s3-publication.py
- python scripts/check-package-manager-manifests.py
- python scripts/check-package-manager-submissions.py
- powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check


___

## **CodeAnt-AI Description**
**Reject symlinked or invalid files when building hosted repository outputs**

### What Changed
- Hosted repository generation now refuses symlinked input directories, release assets, signatures, checksum files, and output paths.
- The generators also reject missing, non-regular, or oversized files before reading or writing them, with clearer error messages.
- Regression checks now cover symlinked inputs and outputs for both the hosted repository bundle and the hosted site artifact.

### Impact
`✅ Safer repository publishing`
`✅ Fewer broken hosted build runs`
`✅ Clearer file validation errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
