### PR TITLE
Harden package-manager manifest files

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -8,6 +8,7 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
 import shutil
 import stat
 import subprocess
@@ -255,6 +256,52 @@ def expect_failure(description: str, action, expected: str) -> None:
             ) from exc
         return
     raise AssertionError(f"{description} unexpectedly passed")
+
+
+def run_generator_cli(dist: Path, output: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR_PATH),
+            str(dist),
+            "--output-dir",
+            str(output),
+            "--version",
+            VERSION,
+            "--repo",
+            "imthegoodboy/conU",
+            "--tag",
+            f"v{VERSION}",
+            *extra_args,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def expect_cli_failure(
+    description: str,
+    dist: Path,
+    output: Path,
+    expected: str,
+    *extra_args: str,
+) -> None:
+    failed = run_generator_cli(dist, output, *extra_args)
+    if failed.returncode == 0 or expected not in failed.stdout:
+        raise AssertionError(
+            f"{description} failed with {failed.stdout!r}, expected {expected!r}"
+        )
+
+
+def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:
+    try:
+        os.symlink(target, link, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError):
+        return False
+    return True
 
 
 def expect_failure_with_limit(
@@ -762,8 +809,116 @@ def main() -> int:
                 "imthegoodboy/conU",
                 f"v{VERSION}",
             ),
-            "release asset is larger than 1 bytes",
+            "release asset for macos-arm64 is too large",
         )
+
+        symlink_dist = temp / "symlink-dist"
+        if try_symlink(rootless_dist, symlink_dist, target_is_directory=True):
+            expect_cli_failure(
+                "symlinked release dist directory",
+                symlink_dist,
+                temp / "symlink-dist-out",
+                "release dist directory must not be a symlink",
+            )
+
+        symlink_asset = temp / "symlink-asset"
+        shutil.copytree(rootless_dist, symlink_asset)
+        asset_target = temp / "symlink-asset-target.zip"
+        shutil.copy2(symlink_asset / TARGETS["windows-x64"], asset_target)
+        (symlink_asset / TARGETS["windows-x64"]).unlink()
+        if try_symlink(asset_target, symlink_asset / TARGETS["windows-x64"]):
+            expect_cli_failure(
+                "symlinked release asset",
+                symlink_asset,
+                temp / "symlink-asset-out",
+                "release asset for windows-x64 must not be a symlink",
+            )
+
+        symlink_checksum = temp / "symlink-checksum"
+        shutil.copytree(rootless_dist, symlink_checksum)
+        checksum_target = temp / "symlink-checksum-target.sha256"
+        shutil.copy2(symlink_checksum / f"{TARGETS['macos-arm64']}.sha256", checksum_target)
+        (symlink_checksum / f"{TARGETS['macos-arm64']}.sha256").unlink()
+        if try_symlink(checksum_target, symlink_checksum / f"{TARGETS['macos-arm64']}.sha256"):
+            expect_cli_failure(
+                "symlinked release checksum",
+                symlink_checksum,
+                temp / "symlink-checksum-out",
+                "checksum file for package-manager asset must not be a symlink",
+            )
+
+        symlink_output_target = temp / "symlink-output-target"
+        symlink_output_target.mkdir()
+        symlink_output = temp / "symlink-output"
+        if try_symlink(symlink_output_target, symlink_output, target_is_directory=True):
+            expect_cli_failure(
+                "symlinked output directory",
+                rootless_dist,
+                symlink_output,
+                "package-manager output directory must not be a symlink",
+            )
+
+        symlink_output_file = temp / "symlink-output-file"
+        symlink_output_file.mkdir()
+        output_file_target = temp / "symlink-output-file-target.rb"
+        output_file_target.write_text("# target\n", encoding="ascii", newline="\n")
+        if try_symlink(output_file_target, symlink_output_file / HOMEBREW_FILENAME):
+            expect_cli_failure(
+                "symlinked Homebrew output",
+                rootless_dist,
+                symlink_output_file,
+                "Homebrew formula output must not be a symlink",
+            )
+
+        symlink_chocolatey = temp / "symlink-chocolatey"
+        symlink_chocolatey.mkdir()
+        chocolatey_target = temp / "symlink-chocolatey-target.nupkg"
+        chocolatey_target.write_bytes(b"target\n")
+        if try_symlink(chocolatey_target, symlink_chocolatey / CHOCOLATEY_FILENAME):
+            expect_cli_failure(
+                "symlinked Chocolatey output",
+                rootless_dist,
+                symlink_chocolatey,
+                "Chocolatey package output must not be a symlink",
+            )
+
+        symlink_sidecar = temp / "symlink-sidecar"
+        symlink_sidecar.mkdir()
+        sidecar_target = temp / "symlink-sidecar-target.sha256"
+        sidecar_target.write_text(f"{'0' * 64}  target\n", encoding="ascii", newline="\n")
+        if try_symlink(sidecar_target, symlink_sidecar / f"{DEBIAN_AMD64_FILENAME}.sha256"):
+            expect_cli_failure(
+                "symlinked generated sidecar",
+                rootless_dist,
+                symlink_sidecar,
+                "package-manager output SHA-256 sidecar output must not be a symlink",
+            )
+
+        symlink_existing_rpm = temp / "symlink-existing-rpm"
+        symlink_existing_rpm.mkdir()
+        rpm_target = temp / "symlink-existing-rpm-target.rpm"
+        rpm_target.write_bytes(b"rpm target\n")
+        if try_symlink(rpm_target, symlink_existing_rpm / RPM_X64_FILENAME):
+            expect_failure(
+                "symlinked existing RPM package",
+                lambda: generator.existing_rpm_package_paths(VERSION, symlink_existing_rpm),
+                "generated RPM package must not be a symlink",
+            )
+
+        symlink_existing_rpm_sidecar = temp / "symlink-existing-rpm-sidecar"
+        symlink_existing_rpm_sidecar.mkdir()
+        rpm_package = symlink_existing_rpm_sidecar / RPM_X64_FILENAME
+        rpm_package.write_bytes(b"rpm package\n")
+        write_checksum(rpm_package)
+        rpm_sidecar_target = temp / "symlink-existing-rpm-sidecar-target.sha256"
+        shutil.copy2(rpm_package.with_name(f"{rpm_package.name}.sha256"), rpm_sidecar_target)
+        rpm_package.with_name(f"{rpm_package.name}.sha256").unlink()
+        if try_symlink(rpm_sidecar_target, rpm_package.with_name(f"{rpm_package.name}.sha256")):
+            expect_failure(
+                "symlinked existing RPM sidecar",
+                lambda: generator.existing_rpm_package_paths(VERSION, symlink_existing_rpm_sidecar),
+                "SHA-256 sidecar for generated RPM package must not be a symlink",
+            )
 
         expect_failure_with_limit(
             generator,

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -51,6 +51,7 @@ MAX_RELEASE_MEMBER_BYTES = 512_000_000
 MAX_RELEASE_MEMBER_COUNT = 10_000
 MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 MAX_PACKAGE_BINARY_BYTES = MAX_RELEASE_MEMBER_BYTES
+MAX_GENERATED_OUTPUT_BYTES = MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES
 
 
 @dataclass
@@ -96,12 +97,16 @@ class RpmRepositoryMetadata:
 
 def main() -> int:
     args = parse_args()
-    dist = args.dist.resolve()
+    dist = args.dist.expanduser()
+    validate_input_directory(dist, "release dist directory")
+    dist = dist.resolve()
     version = args.version or read_repo_version()
     validate_version(version)
     repo = validate_repo(args.repo)
     tag = validate_tag(args.tag or f"v{version}")
-    output_dir = args.output_dir.resolve()
+    output_dir = args.output_dir.expanduser()
+    prepare_output_directory(output_dir, "package-manager output directory")
+    output_dir = output_dir.resolve()
 
     assets = load_release_assets(dist, version, repo, tag)
     windows_extract_dir = detect_windows_extract_dir(dist / assets["windows-x64"].filename, version)
@@ -110,7 +115,6 @@ def main() -> int:
         for target in DEBIAN_ARCHES
     }
 
-    output_dir.mkdir(parents=True, exist_ok=True)
     homebrew = render_homebrew_formula(version, repo, assets)
     scoop = render_scoop_manifest(version, repo, assets["windows-x64"], windows_extract_dir)
     winget = render_winget_manifest(version, repo, assets["windows-x64"], windows_extract_dir)
@@ -150,9 +154,9 @@ def main() -> int:
         dist,
     )
 
-    (output_dir / "conu.rb").write_text(homebrew, encoding="ascii", newline="\n")
-    (output_dir / "conu.json").write_text(scoop, encoding="ascii", newline="\n")
-    (output_dir / "imthegoodboy.conU.yaml").write_text(winget, encoding="ascii", newline="\n")
+    write_text_output(output_dir / "conu.rb", "Homebrew formula", homebrew)
+    write_text_output(output_dir / "conu.json", "Scoop manifest", scoop)
+    write_text_output(output_dir / "imthegoodboy.conU.yaml", "WinGet manifest", winget)
     write_chocolatey_package(
         output_dir / chocolatey_filename(version),
         chocolatey_nuspec,
@@ -161,14 +165,18 @@ def main() -> int:
     )
     for package in debian_packages:
         package_path = output_dir / package.filename
-        package_path.write_bytes(package.content)
+        write_bytes_output(package_path, "generated Debian package", package.content)
         write_sha256_sidecar(package_path, package.sha256)
     if apt_repository_metadata is not None:
         metadata_path = output_dir / apt_repository_metadata.filename
-        metadata_path.write_bytes(apt_repository_metadata.content)
+        write_bytes_output(
+            metadata_path,
+            "generated APT repository metadata",
+            apt_repository_metadata.content,
+        )
         write_sha256_sidecar(metadata_path, apt_repository_metadata.sha256)
     rpm_spec_path = output_dir / "conu.spec"
-    rpm_spec_path.write_text(rpm_spec, encoding="ascii", newline="\n")
+    write_text_output(rpm_spec_path, "RPM spec", rpm_spec)
     rpm_package_paths: tuple[Path, ...] = ()
     if args.build_rpm_packages:
         rpm_package_paths = build_rpm_packages(version, dist, rpm_spec_path, output_dir)
@@ -178,7 +186,11 @@ def main() -> int:
         rpm_repository_metadata = build_rpm_repository_metadata(version, rpm_package_paths)
         assert_output_safe(rpm_repository_metadata.metadata_text, dist)
         metadata_path = output_dir / rpm_repository_metadata.filename
-        metadata_path.write_bytes(rpm_repository_metadata.content)
+        write_bytes_output(
+            metadata_path,
+            "generated RPM repository metadata",
+            rpm_repository_metadata.content,
+        )
         write_sha256_sidecar(metadata_path, rpm_repository_metadata.sha256)
     print(
         "generated package-manager manifests: "
@@ -347,15 +359,16 @@ def load_release_assets(
     repo: str,
     tag: str,
 ) -> dict[str, ReleaseAsset]:
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"release dist directory does not exist: {dist}")
+    validate_input_directory(dist, "release dist directory")
 
     assets: dict[str, ReleaseAsset] = {}
     for target, filename in expected_filenames(version).items():
         archive = dist / filename
-        if not archive.exists() or not archive.is_file():
-            raise SystemExit(f"missing required release asset for {target}: {filename}")
-        validate_release_asset_size(archive)
+        validate_regular_file(
+            archive,
+            f"release asset for {target}",
+            max_bytes=MAX_RELEASE_ARCHIVE_BYTES,
+        )
         sha256 = read_verified_checksum(archive)
         url = f"https://github.com/{repo}/releases/download/{tag}/{filename}"
         assets[target] = ReleaseAsset(
@@ -368,19 +381,25 @@ def load_release_assets(
 
 
 def validate_release_asset_size(archive: Path) -> None:
-    size = archive.stat().st_size
-    if size > MAX_RELEASE_ARCHIVE_BYTES:
-        raise SystemExit(
-            f"release asset is larger than {MAX_RELEASE_ARCHIVE_BYTES} bytes: {archive.name}"
-        )
+    validate_regular_file(
+        archive,
+        "release asset",
+        max_bytes=MAX_RELEASE_ARCHIVE_BYTES,
+    )
 
 
 def read_verified_checksum(archive: Path) -> str:
+    validate_regular_file(
+        archive,
+        "package-manager release asset",
+        max_bytes=MAX_RELEASE_ARCHIVE_BYTES,
+    )
     checksum_path = archive.with_name(f"{archive.name}.sha256")
-    if not checksum_path.exists() or not checksum_path.is_file():
-        raise SystemExit(f"missing checksum file for package-manager asset: {archive.name}")
-    if checksum_path.stat().st_size > MAX_CHECKSUM_BYTES:
-        raise SystemExit(f"checksum file is too large for package-manager asset: {archive.name}")
+    validate_regular_file(
+        checksum_path,
+        "checksum file for package-manager asset",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
     try:
         checksum_text = checksum_path.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -400,6 +419,61 @@ def read_verified_checksum(archive: Path) -> str:
     return expected
 
 
+def validate_input_directory(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+
+
+def prepare_output_directory(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if path.exists() and not path.is_dir():
+        raise SystemExit(f"{label} must be a directory: {path}")
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def validate_regular_file(path: Path, label: str, *, max_bytes: int) -> int:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    if not path.exists():
+        raise SystemExit(f"missing {label}: {path.name}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"{label} could not be inspected: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(f"{label} must be a regular file: {path.name}")
+    if metadata.st_size > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name}")
+    return metadata.st_size
+
+
+def validate_output_file(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} output must not be a symlink: {path.name}")
+    if path.exists():
+        try:
+            metadata = path.stat()
+        except OSError as exc:
+            raise SystemExit(f"{label} output could not be inspected: {path.name}") from exc
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} output must be a regular file: {path.name}")
+
+
+def write_text_output(path: Path, label: str, text: str) -> None:
+    validate_output_file(path, label)
+    path.write_text(text, encoding="ascii", newline="\n")
+    validate_regular_file(path, label, max_bytes=MAX_GENERATED_OUTPUT_BYTES)
+
+
+def write_bytes_output(path: Path, label: str, data: bytes) -> None:
+    validate_output_file(path, label)
+    path.write_bytes(data)
+    validate_regular_file(path, label, max_bytes=MAX_GENERATED_OUTPUT_BYTES)
+
+
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -412,6 +486,11 @@ def sha256_file(path: Path) -> str:
 
 
 def detect_windows_extract_dir(archive: Path, version: str) -> str | None:
+    validate_regular_file(
+        archive,
+        "Windows package-manager release asset",
+        max_bytes=MAX_RELEASE_ARCHIVE_BYTES,
+    )
     root = f"conu-{version}-windows-x64"
     rootless_bins = {f"bin/{binary}.exe" for binary in EXPECTED_BINARIES}
     state = ArchiveScanState(paths=set())
@@ -561,6 +640,11 @@ def update_release_root_style(
 
 
 def extract_linux_binaries(archive: Path, version: str, target: str) -> dict[str, bytes]:
+    validate_regular_file(
+        archive,
+        "Linux package-manager release asset",
+        max_bytes=MAX_RELEASE_ARCHIVE_BYTES,
+    )
     root = f"conu-{version}-{target}"
     rootless_bins = {f"bin/{binary}" for binary in EXPECTED_BINARIES}
     state = ArchiveScanState(paths=set())
@@ -895,6 +979,7 @@ def write_chocolatey_package(
     install_script: str,
     uninstall_script: str,
 ) -> None:
+    validate_output_file(path, "Chocolatey package")
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as package:
         write_deterministic_zip_text(package, "conu.nuspec", nuspec)
         write_deterministic_zip_text(package, "tools/chocolateyInstall.ps1", install_script)
@@ -903,6 +988,7 @@ def write_chocolatey_package(
             "tools/chocolateyUninstall.ps1",
             uninstall_script,
         )
+    validate_regular_file(path, "Chocolatey package", max_bytes=MAX_GENERATED_OUTPUT_BYTES)
 
 
 def build_debian_package(
@@ -1182,10 +1268,18 @@ def build_ar_archive(members: list[tuple[str, bytes]]) -> bytes:
 
 
 def write_sha256_sidecar(path: Path, digest: str) -> None:
-    path.with_name(f"{path.name}.sha256").write_text(
+    validate_regular_file(path, "package-manager output", max_bytes=MAX_GENERATED_OUTPUT_BYTES)
+    sidecar = path.with_name(f"{path.name}.sha256")
+    validate_output_file(sidecar, "package-manager output SHA-256 sidecar")
+    sidecar.write_text(
         f"{digest}  {path.name}\n",
         encoding="ascii",
         newline="\n",
+    )
+    validate_regular_file(
+        sidecar,
+        "package-manager output SHA-256 sidecar",
+        max_bytes=MAX_CHECKSUM_BYTES,
     )
 
 
@@ -1197,13 +1291,13 @@ def existing_rpm_package_paths(version: str, output_dir: Path) -> tuple[Path, ..
 
 
 def verify_sha256_sidecar(path: Path, label: str) -> str:
-    if not path.exists() or not path.is_file():
-        raise SystemExit(f"missing {label}: {path.name}")
+    validate_regular_file(path, label, max_bytes=MAX_GENERATED_OUTPUT_BYTES)
     sidecar = path.with_name(f"{path.name}.sha256")
-    if not sidecar.exists() or not sidecar.is_file():
-        raise SystemExit(f"missing SHA-256 sidecar for {label}: {path.name}")
-    if sidecar.stat().st_size > MAX_CHECKSUM_BYTES:
-        raise SystemExit(f"SHA-256 sidecar is too large for {label}: {path.name}")
+    validate_regular_file(
+        sidecar,
+        f"SHA-256 sidecar for {label}",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
     try:
         checksum_text = sidecar.read_text(encoding="ascii")
     except UnicodeDecodeError as exc:
@@ -1272,7 +1366,13 @@ def build_rpm_packages(
                     f"{packages[0].name!r}; expected {expected_name!r}"
                 )
             output_path = output_dir / expected_name
+            validate_output_file(output_path, "generated RPM package")
             shutil.copy2(packages[0], output_path)
+            validate_regular_file(
+                output_path,
+                "generated RPM package",
+                max_bytes=MAX_GENERATED_OUTPUT_BYTES,
+            )
             write_sha256_sidecar(output_path, sha256_file(output_path))
             outputs.append(output_path)
     return tuple(outputs)


### PR DESCRIPTION
## **User description**
## Summary
- harden package-manager manifest generation file boundaries for dist/output roots, release archives, checksum sidecars, generated artifacts, and output SHA-256 sidecars
- reject symlinked or non-regular package-manager inputs/outputs before reading or writing release/package artifacts
- add focused regression coverage for symlinked dist, asset, checksum, output, sidecar, and existing RPM package boundaries

## Validation
- python -m py_compile scripts/generate-package-manager-manifests.py scripts/check-package-manager-manifests.py
- python scripts/check-package-manager-manifests.py
- python scripts/check-package-manager-submissions.py
- python scripts/check-hosted-linux-repositories.py
- python scripts/check-hosted-linux-repository-site.py
- python scripts/check-release-artifact-verifier.py
- python scripts/check-release-artifact-smoke-preflight.py
- python scripts/check-npm-launcher-local-smoke-preflight.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Fixes #330


___

## **CodeAnt-AI Description**
**Block symlinked package-manager inputs and outputs**

### What Changed
- The manifest generator now rejects symlinked release folders, release archives, checksum files, and output files before reading or writing them
- Generated manifests, packages, and SHA-256 sidecar files are now checked after writing so unsafe or incomplete outputs are caught immediately
- Existing RPM package checks now also refuse symlinked package files and checksum sidecars
- Regression checks were expanded to cover symlinked inputs and outputs across release assets, generated packages, and checksum files

### Impact
`✅ Safer manifest generation`
`✅ Fewer broken release artifacts`
`✅ Reduced risk of writing through symlinks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
