### PR TITLE
Harden package-manager submission files

### DIFF
--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -265,7 +265,7 @@ def main() -> int:
                     require_repository_metadata=True,
                     require_linux_signatures=True,
                 ),
-                "package-manager submission source directory must not be a symlink",
+                "must not be a symlink",
             )
 
         symlink_source = temp / "symlink-source"
@@ -284,7 +284,7 @@ def main() -> int:
                     require_repository_metadata=True,
                     require_linux_signatures=True,
                 ),
-                "package-manager submission source must not be a symlink",
+                "must not be a symlink",
             )
 
         symlink_checksum = temp / "symlink-checksum-source"
@@ -303,7 +303,7 @@ def main() -> int:
                     require_repository_metadata=True,
                     require_linux_signatures=True,
                 ),
-                "package-manager submission source must not be a symlink",
+                "must not be a symlink",
             )
 
         symlink_output_target = temp / "symlink-output-target"
@@ -320,7 +320,7 @@ def main() -> int:
                     require_repository_metadata=True,
                     require_linux_signatures=True,
                 ),
-                "package-manager submission output directory must not be a symlink",
+                "must not be a symlink",
             )
 
         bundle_name = preparer.submission_bundle_filename(VERSION)
@@ -339,7 +339,7 @@ def main() -> int:
                     require_repository_metadata=True,
                     require_linux_signatures=True,
                 ),
-                "package-manager submission bundle output must not be a symlink",
+                "must not be a symlink",
             )
 
         directory_output_bundle = temp / "directory-output-bundle"
@@ -355,7 +355,7 @@ def main() -> int:
                 require_repository_metadata=True,
                 require_linux_signatures=True,
             ),
-            "package-manager submission bundle output must be a regular file",
+            "must be a regular file",
         )
 
         symlink_output_sidecar = temp / "symlink-output-sidecar"
@@ -373,7 +373,7 @@ def main() -> int:
                     require_repository_metadata=True,
                     require_linux_signatures=True,
                 ),
-                "package-manager submission bundle SHA-256 sidecar output must not be a symlink",
+                "must not be a symlink",
             )
 
         directory_output_sidecar = temp / "directory-output-sidecar"
@@ -389,7 +389,7 @@ def main() -> int:
                 require_repository_metadata=True,
                 require_linux_signatures=True,
             ),
-            "package-manager submission bundle SHA-256 sidecar output must be a regular file",
+            "must be a regular file",
         )
 
         expect_failure_with_limit(

--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
+import shutil
 import stat
 import sys
 import tempfile
@@ -185,6 +187,14 @@ def expect_failure_with_limit(
         setattr(module, limit_name, original)
 
 
+def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:
+    try:
+        os.symlink(target, link, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError):
+        return False
+    return True
+
+
 def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
     data = bytearray(path.read_bytes())
     target = member_name.encode("utf-8")
@@ -242,6 +252,145 @@ def main() -> int:
         second = assert_bundle(preparer, generated, repeat_output)
         if first.read_bytes() != second.read_bytes():
             raise AssertionError("package-manager submission bundle was not deterministic")
+
+        symlink_dist = temp / "symlink-dist"
+        if try_symlink(generated, symlink_dist, target_is_directory=True):
+            expect_failure(
+                "symlinked submission source directory",
+                lambda: preparer.prepare_submission_bundle(
+                    symlink_dist,
+                    temp / "symlink-dist-out",
+                    VERSION,
+                    require_rpm_assets=True,
+                    require_repository_metadata=True,
+                    require_linux_signatures=True,
+                ),
+                "package-manager submission source directory must not be a symlink",
+            )
+
+        symlink_source = temp / "symlink-source"
+        shutil.copytree(generated, symlink_source)
+        source_target = temp / "symlink-source-target.deb"
+        shutil.copy2(symlink_source / DEBIAN_PACKAGES[0], source_target)
+        (symlink_source / DEBIAN_PACKAGES[0]).unlink()
+        if try_symlink(source_target, symlink_source / DEBIAN_PACKAGES[0]):
+            expect_failure(
+                "symlinked submission source",
+                lambda: preparer.prepare_submission_bundle(
+                    symlink_source,
+                    temp / "symlink-source-out",
+                    VERSION,
+                    require_rpm_assets=True,
+                    require_repository_metadata=True,
+                    require_linux_signatures=True,
+                ),
+                "package-manager submission source must not be a symlink",
+            )
+
+        symlink_checksum = temp / "symlink-checksum-source"
+        shutil.copytree(generated, symlink_checksum)
+        checksum_target = temp / "symlink-checksum-target.sha256"
+        shutil.copy2(symlink_checksum / f"{DEBIAN_PACKAGES[0]}.sha256", checksum_target)
+        (symlink_checksum / f"{DEBIAN_PACKAGES[0]}.sha256").unlink()
+        if try_symlink(checksum_target, symlink_checksum / f"{DEBIAN_PACKAGES[0]}.sha256"):
+            expect_failure(
+                "symlinked submission checksum source",
+                lambda: preparer.prepare_submission_bundle(
+                    symlink_checksum,
+                    temp / "symlink-checksum-source-out",
+                    VERSION,
+                    require_rpm_assets=True,
+                    require_repository_metadata=True,
+                    require_linux_signatures=True,
+                ),
+                "package-manager submission source must not be a symlink",
+            )
+
+        symlink_output_target = temp / "symlink-output-target"
+        symlink_output_target.mkdir()
+        symlink_output = temp / "symlink-output"
+        if try_symlink(symlink_output_target, symlink_output, target_is_directory=True):
+            expect_failure(
+                "symlinked submission output directory",
+                lambda: preparer.prepare_submission_bundle(
+                    generated,
+                    symlink_output,
+                    VERSION,
+                    require_rpm_assets=True,
+                    require_repository_metadata=True,
+                    require_linux_signatures=True,
+                ),
+                "package-manager submission output directory must not be a symlink",
+            )
+
+        bundle_name = preparer.submission_bundle_filename(VERSION)
+        symlink_output_bundle = temp / "symlink-output-bundle"
+        symlink_output_bundle.mkdir()
+        bundle_target = temp / "symlink-output-bundle-target.zip"
+        bundle_target.write_bytes(b"existing bundle\n")
+        if try_symlink(bundle_target, symlink_output_bundle / bundle_name):
+            expect_failure(
+                "symlinked submission output bundle",
+                lambda: preparer.prepare_submission_bundle(
+                    generated,
+                    symlink_output_bundle,
+                    VERSION,
+                    require_rpm_assets=True,
+                    require_repository_metadata=True,
+                    require_linux_signatures=True,
+                ),
+                "package-manager submission bundle output must not be a symlink",
+            )
+
+        directory_output_bundle = temp / "directory-output-bundle"
+        directory_output_bundle.mkdir()
+        (directory_output_bundle / bundle_name).mkdir()
+        expect_failure(
+            "directory submission output bundle",
+            lambda: preparer.prepare_submission_bundle(
+                generated,
+                directory_output_bundle,
+                VERSION,
+                require_rpm_assets=True,
+                require_repository_metadata=True,
+                require_linux_signatures=True,
+            ),
+            "package-manager submission bundle output must be a regular file",
+        )
+
+        symlink_output_sidecar = temp / "symlink-output-sidecar"
+        symlink_output_sidecar.mkdir()
+        sidecar_target = temp / "symlink-output-sidecar-target.sha256"
+        sidecar_target.write_text("", encoding="ascii")
+        if try_symlink(sidecar_target, symlink_output_sidecar / f"{bundle_name}.sha256"):
+            expect_failure(
+                "symlinked submission output checksum",
+                lambda: preparer.prepare_submission_bundle(
+                    generated,
+                    symlink_output_sidecar,
+                    VERSION,
+                    require_rpm_assets=True,
+                    require_repository_metadata=True,
+                    require_linux_signatures=True,
+                ),
+                "package-manager submission bundle SHA-256 sidecar output must not be a symlink",
+            )
+
+        directory_output_sidecar = temp / "directory-output-sidecar"
+        directory_output_sidecar.mkdir()
+        (directory_output_sidecar / f"{bundle_name}.sha256").mkdir()
+        expect_failure(
+            "directory submission output checksum",
+            lambda: preparer.prepare_submission_bundle(
+                generated,
+                directory_output_sidecar,
+                VERSION,
+                require_rpm_assets=True,
+                require_repository_metadata=True,
+                require_linux_signatures=True,
+            ),
+            "package-manager submission bundle SHA-256 sidecar output must be a regular file",
+        )
 
         expect_failure_with_limit(
             preparer,

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import hashlib
 import json
+import os
 import re
 import shutil
 import stat
@@ -13,7 +15,7 @@ import sys
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, BinaryIO
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
@@ -24,6 +26,8 @@ MAX_BINARY_BYTES = 512 * 1024 * 1024
 MAX_TOTAL_SOURCE_BYTES = 2 * 1024 * 1024 * 1024
 MAX_SUBMISSION_BUNDLE_BYTES = MAX_TOTAL_SOURCE_BYTES + MAX_TEXT_BYTES + (1024 * 1024)
 MAX_CHECKSUM_BYTES = 4096
+OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+OPEN_BINARY = getattr(os, "O_BINARY", 0)
 ZIP_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 DEBIAN_ARCHES = ("amd64", "arm64")
 RPM_ARCHES = ("x86_64", "aarch64")
@@ -306,21 +310,35 @@ def prepare_submission_bundle(
     assert_safe_text(readme, "README.txt", dist)
 
     bundle = output_dir / submission_bundle_filename(version)
-    validate_output_file(bundle, "package-manager submission bundle")
-    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_STORED) as archive:
-        write_zip_text(archive, "README.txt", readme)
-        for prepared in selected:
-            write_zip_file(archive, prepared.entry.archive_name, prepared.source, prepared.size)
+    with open_output_file(bundle, "package-manager submission bundle") as bundle_file:
+        with zipfile.ZipFile(bundle_file, "w", compression=zipfile.ZIP_STORED) as archive:
+            write_zip_text(archive, "README.txt", readme)
+            for prepared in selected:
+                write_zip_file(archive, prepared.entry.archive_name, prepared.source, prepared.size)
+        validate_open_regular_file(
+            bundle_file,
+            "package-manager submission bundle",
+            max_bytes=MAX_SUBMISSION_BUNDLE_BYTES,
+        )
+        checksum = sha256_open_file(bundle_file)
     validate_regular_file(
         bundle,
         "package-manager submission bundle",
         max_bytes=MAX_SUBMISSION_BUNDLE_BYTES,
     )
 
-    checksum = sha256_file(bundle)
     checksum_path = bundle.with_name(f"{bundle.name}.sha256")
-    validate_output_file(checksum_path, "package-manager submission bundle SHA-256 sidecar")
-    checksum_path.write_text(f"{checksum}  {bundle.name}\n", encoding="ascii", newline="\n")
+    with open_output_file(
+        checksum_path,
+        "package-manager submission bundle SHA-256 sidecar",
+    ) as checksum_file:
+        checksum_file.write(f"{checksum}  {bundle.name}\n".encode("ascii"))
+        checksum_file.flush()
+        validate_open_regular_file(
+            checksum_file,
+            "package-manager submission bundle SHA-256 sidecar",
+            max_bytes=MAX_CHECKSUM_BYTES,
+        )
     validate_regular_file(
         checksum_path,
         "package-manager submission bundle SHA-256 sidecar",
@@ -476,7 +494,12 @@ def validate_checksum_source(path: Path, dist: Path) -> None:
         non_regular_message=f"{path.name} target is not a regular file: {target_name}",
     )
     expected = match.group(1).lower()
-    actual = sha256_file(target)
+    actual = sha256_file(
+        target,
+        f"{path.name} target",
+        max_bytes=MAX_BINARY_BYTES,
+        display_name=target_name,
+    )
     if expected != actual:
         raise SystemExit(f"{path.name} SHA-256 mismatch for {target_name}")
 
@@ -558,19 +581,63 @@ def validate_regular_file(
     missing_message: str | None = None,
     non_regular_message: str | None = None,
 ) -> int:
+    handle, size = open_regular_file(
+        path,
+        label,
+        max_bytes=max_bytes,
+        display_name=display_name,
+        missing_message=missing_message,
+        non_regular_message=non_regular_message,
+    )
+    handle.close()
+    return size
+
+
+def open_regular_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    display_name: str | None = None,
+    missing_message: str | None = None,
+    non_regular_message: str | None = None,
+) -> tuple[BinaryIO, int]:
     display = display_name or path.name
     if path.is_symlink():
         raise SystemExit(f"{label} must not be a symlink: {display}")
     if not path.exists():
         raise SystemExit(missing_message or f"missing {label}: {display}")
+    flags = os.O_RDONLY | OPEN_BINARY | OPEN_NOFOLLOW
     try:
-        metadata = path.stat()
+        fd = os.open(path, flags)
     except OSError as exc:
-        raise SystemExit(f"{label} could not be inspected: {display}") from exc
+        if exc.errno == errno.ELOOP:
+            raise SystemExit(f"{label} must not be a symlink: {display}") from exc
+        if not path.exists():
+            raise SystemExit(missing_message or f"missing {label}: {display}") from exc
+        if not path.is_file():
+            raise SystemExit(
+                non_regular_message or f"{label} must be a regular file: {display}"
+            ) from exc
+        raise SystemExit(f"{label} could not be opened: {display}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(non_regular_message or f"{label} must be a regular file: {display}")
+        if metadata.st_size > max_bytes:
+            raise SystemExit(f"{label} is too large: {display}")
+        return os.fdopen(fd, "rb"), metadata.st_size
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def validate_open_regular_file(handle: BinaryIO, label: str, *, max_bytes: int) -> int:
+    metadata = os.fstat(handle.fileno())
     if not stat.S_ISREG(metadata.st_mode):
-        raise SystemExit(non_regular_message or f"{label} must be a regular file: {display}")
+        raise SystemExit(f"{label} must be a regular file")
     if metadata.st_size > max_bytes:
-        raise SystemExit(f"{label} is too large: {display}")
+        raise SystemExit(f"{label} is too large")
     return metadata.st_size
 
 
@@ -584,6 +651,27 @@ def validate_output_file(path: Path, label: str) -> None:
             raise SystemExit(f"{label} output could not be inspected: {path.name}") from exc
         if not stat.S_ISREG(metadata.st_mode):
             raise SystemExit(f"{label} output must be a regular file: {path.name}")
+
+
+def open_output_file(path: Path, label: str) -> BinaryIO:
+    validate_output_file(path, label)
+    flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC | OPEN_BINARY | OPEN_NOFOLLOW
+    try:
+        fd = os.open(path, flags, 0o644)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise SystemExit(f"{label} output must not be a symlink: {path.name}") from exc
+        if path.exists() and not path.is_file():
+            raise SystemExit(f"{label} output must be a regular file: {path.name}") from exc
+        raise SystemExit(f"{label} output could not be opened: {path.name}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} output must be a regular file: {path.name}")
+        return os.fdopen(fd, "w+b")
+    except BaseException:
+        os.close(fd)
+        raise
 
 
 def render_readme(version: str, entries: list[str]) -> str:
@@ -625,18 +713,48 @@ def write_zip_file(archive: zipfile.ZipFile, name: str, source: Path, size: int)
     info.compress_type = zipfile.ZIP_STORED
     info.external_attr = 0o644 << 16
     info.file_size = size
-    with archive.open(info, "w") as output, source.open("rb") as input_file:
-        shutil.copyfileobj(input_file, output, HASH_CHUNK_BYTES)
+    input_file, actual_size = open_regular_file(
+        source,
+        "package-manager submission source",
+        display_name=source.name,
+        max_bytes=MAX_BINARY_BYTES,
+    )
+    if actual_size != size:
+        input_file.close()
+        raise SystemExit(f"package-manager submission source changed while bundling: {source.name}")
+    with input_file:
+        with archive.open(info, "w") as output:
+            shutil.copyfileobj(input_file, output, HASH_CHUNK_BYTES)
 
 
-def sha256_file(path: Path) -> str:
+def sha256_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    display_name: str | None = None,
+) -> str:
+    handle, _size = open_regular_file(
+        path,
+        label,
+        max_bytes=max_bytes,
+        display_name=display_name,
+    )
+    with handle:
+        return sha256_open_file(handle)
+
+
+def sha256_open_file(handle: BinaryIO) -> str:
     digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while True:
-            chunk = handle.read(HASH_CHUNK_BYTES)
-            if not chunk:
-                break
-            digest.update(chunk)
+    if handle.writable():
+        handle.flush()
+    handle.seek(0)
+    while True:
+        chunk = handle.read(HASH_CHUNK_BYTES)
+        if not chunk:
+            break
+        digest.update(chunk)
+    handle.seek(0, os.SEEK_END)
     return digest.hexdigest()
 
 

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -22,6 +22,8 @@ HASH_CHUNK_BYTES = 1024 * 1024
 MAX_TEXT_BYTES = 2 * 1024 * 1024
 MAX_BINARY_BYTES = 512 * 1024 * 1024
 MAX_TOTAL_SOURCE_BYTES = 2 * 1024 * 1024 * 1024
+MAX_SUBMISSION_BUNDLE_BYTES = MAX_TOTAL_SOURCE_BYTES + MAX_TEXT_BYTES + (1024 * 1024)
+MAX_CHECKSUM_BYTES = 4096
 ZIP_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 DEBIAN_ARCHES = ("amd64", "arm64")
 RPM_ARCHES = ("x86_64", "aarch64")
@@ -81,12 +83,9 @@ class SubmissionBundleReport:
 
 def main() -> int:
     args = parse_args()
-    dist = args.dist.resolve()
-    output_dir = args.output_dir.resolve()
+    dist = args.dist.expanduser()
+    output_dir = args.output_dir.expanduser()
     version = validate_version(args.version or read_repo_version())
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"package-manager output directory does not exist: {dist}")
-
     report = prepare_submission_bundle(
         dist,
         output_dir,
@@ -274,6 +273,11 @@ def prepare_submission_bundle(
     require_repository_metadata: bool = False,
     require_linux_signatures: bool = False,
 ) -> SubmissionBundleReport:
+    validate_input_directory(dist, "package-manager submission source directory")
+    dist = dist.resolve()
+    prepare_output_directory(output_dir, "package-manager submission output directory")
+    output_dir = output_dir.resolve()
+
     entries = required_and_optional_entries(
         version,
         require_rpm_assets=require_rpm_assets,
@@ -284,12 +288,10 @@ def prepare_submission_bundle(
     total_source_bytes = 0
     for entry in entries:
         source = dist / entry.source_name
-        if not source.exists():
+        if not source.exists() and not source.is_symlink():
             if entry.required:
                 raise SystemExit(f"missing package-manager submission source: {entry.source_name}")
             continue
-        if not source.is_file():
-            raise SystemExit(f"package-manager submission source is not a file: {entry.source_name}")
         size = validate_entry_source(source, entry, dist)
         total_source_bytes += size
         if total_source_bytes > MAX_TOTAL_SOURCE_BYTES:
@@ -303,16 +305,27 @@ def prepare_submission_bundle(
     readme = render_readme(version, [prepared.entry.archive_name for prepared in selected])
     assert_safe_text(readme, "README.txt", dist)
 
-    output_dir.mkdir(parents=True, exist_ok=True)
     bundle = output_dir / submission_bundle_filename(version)
+    validate_output_file(bundle, "package-manager submission bundle")
     with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_STORED) as archive:
         write_zip_text(archive, "README.txt", readme)
         for prepared in selected:
             write_zip_file(archive, prepared.entry.archive_name, prepared.source, prepared.size)
+    validate_regular_file(
+        bundle,
+        "package-manager submission bundle",
+        max_bytes=MAX_SUBMISSION_BUNDLE_BYTES,
+    )
 
     checksum = sha256_file(bundle)
     checksum_path = bundle.with_name(f"{bundle.name}.sha256")
+    validate_output_file(checksum_path, "package-manager submission bundle SHA-256 sidecar")
     checksum_path.write_text(f"{checksum}  {bundle.name}\n", encoding="ascii", newline="\n")
+    validate_regular_file(
+        checksum_path,
+        "package-manager submission bundle SHA-256 sidecar",
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
     entries_written = ("README.txt", *(prepared.entry.archive_name for prepared in selected))
     return SubmissionBundleReport(
         version=version,
@@ -324,11 +337,16 @@ def prepare_submission_bundle(
 
 
 def validate_entry_source(source: Path, entry: BundleEntry, dist: Path) -> int:
-    size = source.stat().st_size
+    size = validate_regular_file(
+        source,
+        "package-manager submission source",
+        display_name=entry.source_name,
+        max_bytes=MAX_BINARY_BYTES,
+        missing_message=f"missing package-manager submission source: {entry.source_name}",
+        non_regular_message=f"package-manager submission source is not a file: {entry.source_name}",
+    )
     if size <= 0:
         raise SystemExit(f"package-manager submission source is empty: {entry.source_name}")
-    if size > MAX_BINARY_BYTES:
-        raise SystemExit(f"package-manager submission source is too large: {entry.source_name}")
     if entry.kind == "checksum":
         validate_checksum_source(source, dist)
     elif entry.kind == "signature":
@@ -449,8 +467,14 @@ def validate_checksum_source(path: Path, dist: Path) -> None:
     if target_name != expected_target:
         raise SystemExit(f"{path.name} names wrong target: {target_name}")
     target = dist / target_name
-    if not target.exists() or not target.is_file():
-        raise SystemExit(f"{path.name} target is missing: {target_name}")
+    validate_regular_file(
+        target,
+        f"{path.name} target",
+        display_name=target_name,
+        max_bytes=MAX_BINARY_BYTES,
+        missing_message=f"{path.name} target is missing: {target_name}",
+        non_regular_message=f"{path.name} target is not a regular file: {target_name}",
+    )
     expected = match.group(1).lower()
     actual = sha256_file(target)
     if expected != actual:
@@ -460,8 +484,14 @@ def validate_checksum_source(path: Path, dist: Path) -> None:
 def validate_signature_source(source: Path, label: str, dist: Path) -> None:
     target_name = source.name[: -len(".asc")]
     target = dist / target_name
-    if not target.exists() or not target.is_file():
-        raise SystemExit(f"{label} signed target is missing: {target_name}")
+    validate_regular_file(
+        target,
+        f"{label} signed target",
+        display_name=target_name,
+        max_bytes=MAX_BINARY_BYTES,
+        missing_message=f"{label} signed target is missing: {target_name}",
+        non_regular_message=f"{label} signed target is not a regular file: {target_name}",
+    )
     text = read_ascii_text(source, label)
     if "BEGIN PGP SIGNATURE" not in text or "END PGP SIGNATURE" not in text:
         raise SystemExit(f"{label} is not an armored detached PGP signature")
@@ -502,6 +532,58 @@ def normalize_archive_path(raw_name: str) -> str:
     if path.is_absolute() or ".." in parts or not parts:
         raise SystemExit(f"unsafe package-manager submission archive path: {raw_name}")
     return "/".join(parts)
+
+
+def validate_input_directory(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+
+
+def prepare_output_directory(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if path.exists() and not path.is_dir():
+        raise SystemExit(f"{label} must be a directory: {path}")
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def validate_regular_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    display_name: str | None = None,
+    missing_message: str | None = None,
+    non_regular_message: str | None = None,
+) -> int:
+    display = display_name or path.name
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {display}")
+    if not path.exists():
+        raise SystemExit(missing_message or f"missing {label}: {display}")
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise SystemExit(f"{label} could not be inspected: {display}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SystemExit(non_regular_message or f"{label} must be a regular file: {display}")
+    if metadata.st_size > max_bytes:
+        raise SystemExit(f"{label} is too large: {display}")
+    return metadata.st_size
+
+
+def validate_output_file(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise SystemExit(f"{label} output must not be a symlink: {path.name}")
+    if path.exists():
+        try:
+            metadata = path.stat()
+        except OSError as exc:
+            raise SystemExit(f"{label} output could not be inspected: {path.name}") from exc
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} output must be a regular file: {path.name}")
 
 
 def render_readme(version: str, entries: list[str]) -> str:


### PR DESCRIPTION
## **User description**
## Summary
- reject symlinked package-manager submission source/output directories before resolving paths
- require submission source files, checksum/signature targets, generated ZIPs, and generated checksum sidecars to be regular files
- add regressions for source/output symlink and non-regular file boundaries

## Validation
- python -m py_compile scripts\\prepare-package-manager-submissions.py scripts\\check-package-manager-submissions.py
- python scripts\\check-package-manager-submissions.py
- python scripts\\check-package-manager-manifests.py
- python scripts\\check-release-artifact-verifier.py
- python scripts\\check-hosted-linux-repositories.py
- python scripts\\check-hosted-linux-repository-site.py
- python scripts\\check-linux-release-signing.py (skipped: gpg unavailable)
- python scripts\\check-github-release-assets-published-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Fixes #334


___

## **CodeAnt-AI Description**
**Harden package-manager submission bundle checks against symlinks and non-file outputs**

### What Changed
- Submission inputs are now rejected if the source folder itself is a symlink, or if any required source file, checksum file, or signature file is a symlink or not a regular file
- Output now refuses to write the bundle or its SHA-256 sidecar through symlinks, and fails when an existing output path is not a regular file
- The bundle and checksum sidecar are now checked for size limits after creation, and the validation suite adds regressions for symlink and directory boundaries

### Impact
`✅ Safer package submission files`
`✅ Fewer broken bundle exports`
`✅ Clearer failures for invalid output paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for symlink handling in package manager submissions.

* **Bug Fixes**
  * Enhanced submission bundle validation with size limits and filesystem safety checks.
  * Improved symlink detection and rejection to prevent invalid submissions.
  * Strengthened input/output directory and file validation with clearer error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->