### PR TITLE
Use descriptor-bound hosted repository IO

### DIFF
--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -4,21 +4,25 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import gzip
 import hashlib
 import json
+import os
 import re
 import stat
 import sys
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+from typing import BinaryIO
 import xml.etree.ElementTree as ET
 
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 HASH_CHUNK_BYTES = 1024 * 1024
+MAX_PACKAGE_JSON_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
 MAX_SIGNATURE_BYTES = 1024 * 1024
 MAX_PUBLIC_KEY_BYTES = 1024 * 1024
@@ -37,6 +41,8 @@ RPM_ARCHES = {
     "linux-arm64": "aarch64",
 }
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
+OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+OPEN_BINARY = getattr(os, "O_BINARY", 0)
 
 
 @dataclass(frozen=True)
@@ -88,8 +94,15 @@ def parse_args() -> argparse.Namespace:
 
 def read_repo_version() -> str:
     package_json = Path(__file__).resolve().parents[1] / "packaging/npm/conu-cli/package.json"
-    with package_json.open("r", encoding="utf-8") as handle:
-        package = json.load(handle)
+    package_data = read_regular_file(
+        package_json,
+        "npm package metadata",
+        max_bytes=MAX_PACKAGE_JSON_BYTES,
+    )
+    try:
+        package = json.loads(package_data.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        raise SystemExit(f"{package_json} is not valid UTF-8") from exc
     version = package.get("version")
     if not isinstance(version, str) or not version:
         raise SystemExit(f"{package_json} does not contain a non-empty version")
@@ -177,7 +190,11 @@ def require_detached_signature(path: Path) -> Path:
         max_bytes=MAX_SIGNATURE_BYTES,
     )
     try:
-        signature_text = signature.read_text(encoding="ascii")
+        signature_text = read_ascii_file(
+            signature,
+            "detached signature for hosted repository asset",
+            max_bytes=MAX_SIGNATURE_BYTES,
+        )
     except UnicodeDecodeError as exc:
         raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}") from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
@@ -188,7 +205,7 @@ def require_detached_signature(path: Path) -> Path:
 def verify_public_key(path: Path) -> None:
     validate_regular_file(path, "Linux public key asset", max_bytes=MAX_PUBLIC_KEY_BYTES)
     try:
-        text = path.read_text(encoding="ascii")
+        text = read_ascii_file(path, "Linux public key asset", max_bytes=MAX_PUBLIC_KEY_BYTES)
     except UnicodeDecodeError as exc:
         raise SystemExit(f"Linux public key asset is not ASCII-armored: {path.name}") from exc
     if "BEGIN PGP PUBLIC KEY BLOCK" not in text:
@@ -363,28 +380,39 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
     members: dict[str, bytes] = {}
     total_uncompressed = 0
     try:
-        with zipfile.ZipFile(bundle) as archive:
-            infos = archive.infolist()
-            if len(infos) > MAX_ZIP_MEMBERS:
-                raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
-            for member in infos:
-                name = normalize_zip_path(member.filename)
-                if not validate_zip_member_for_read(bundle.name, member, name):
-                    continue
-                if name in members:
-                    raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
-                if name != "README.txt" and not (
-                    name in {"Packages", "Packages.gz", "Release", "InRelease", "Release.gpg"}
-                    or name.startswith("repodata/")
-                ):
-                    raise SystemExit(f"{bundle.name} contains unexpected zip member: {name}")
-                total_uncompressed += member.file_size
-                if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
-                    raise SystemExit(
-                        f"{bundle.name} uncompressed ZIP contents exceed "
-                        f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
-                    )
-                members[name] = archive.read(member)
+        archive_file, _size = open_regular_file(
+            bundle,
+            "hosted repository metadata bundle",
+            max_bytes=MAX_RELEASE_ASSET_BYTES,
+        )
+        with archive_file:
+            with zipfile.ZipFile(archive_file) as archive:
+                infos = archive.infolist()
+                if len(infos) > MAX_ZIP_MEMBERS:
+                    raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
+                for member in infos:
+                    name = normalize_zip_path(member.filename)
+                    if not validate_zip_member_for_read(bundle.name, member, name):
+                        continue
+                    if name in members:
+                        raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
+                    if name != "README.txt" and not (
+                        name in {"Packages", "Packages.gz", "Release", "InRelease", "Release.gpg"}
+                        or name.startswith("repodata/")
+                    ):
+                        raise SystemExit(f"{bundle.name} contains unexpected zip member: {name}")
+                    total_uncompressed += member.file_size
+                    if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
+                        raise SystemExit(
+                            f"{bundle.name} uncompressed ZIP contents exceed "
+                            f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                        )
+                    members[name] = archive.read(member)
+                validate_open_regular_file(
+                    archive_file,
+                    "hosted repository metadata bundle",
+                    max_bytes=MAX_RELEASE_ASSET_BYTES,
+                )
     except zipfile.BadZipFile as exc:
         raise SystemExit(f"{bundle.name} is not a readable zip archive") from exc
     return members
@@ -467,13 +495,19 @@ native RPM signatures from the release signing key.
 
 
 def write_zip_members(path: Path, members: dict[str, bytes]) -> None:
-    validate_output_file(path, "hosted Linux repository bundle")
-    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
-        for name in sorted(members):
-            info = zipfile.ZipInfo(name, ZIP_SOURCE_TIMESTAMP)
-            info.compress_type = zipfile.ZIP_STORED
-            info.external_attr = 0o644 << 16
-            archive.writestr(info, members[name])
+    with open_output_file(path, "hosted Linux repository bundle") as bundle_file:
+        with zipfile.ZipFile(bundle_file, "w", compression=zipfile.ZIP_STORED) as archive:
+            for name in sorted(members):
+                info = zipfile.ZipInfo(name, ZIP_SOURCE_TIMESTAMP)
+                info.compress_type = zipfile.ZIP_STORED
+                info.external_attr = 0o644 << 16
+                archive.writestr(info, members[name])
+        validate_open_regular_file(
+            bundle_file,
+            "hosted Linux repository bundle",
+            max_bytes=MAX_HOSTED_BUNDLE_BYTES,
+        )
+    validate_regular_file(path, "hosted Linux repository bundle", max_bytes=MAX_HOSTED_BUNDLE_BYTES)
 
 
 def verify_sha256_sidecar(path: Path, label: str) -> str:
@@ -485,7 +519,11 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
         max_bytes=MAX_CHECKSUM_BYTES,
     )
     try:
-        checksum_text = sidecar.read_text(encoding="ascii")
+        checksum_text = read_ascii_file(
+            sidecar,
+            f"SHA-256 sidecar for {label}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+        )
     except UnicodeDecodeError as exc:
         raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
@@ -496,7 +534,7 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
             f"SHA-256 sidecar for {label} {path.name} names wrong file: {match.group(2)}"
         )
     expected = match.group(1).lower()
-    actual = sha256_file(path)
+    actual = sha256_file(path, label, max_bytes=MAX_RELEASE_ASSET_BYTES)
     if expected != actual:
         raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
     return expected
@@ -505,11 +543,11 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
 def write_sha256_sidecar(path: Path) -> None:
     validate_regular_file(path, "hosted Linux repository bundle", max_bytes=MAX_HOSTED_BUNDLE_BYTES)
     sidecar = path.with_name(f"{path.name}.sha256")
-    validate_output_file(sidecar, "hosted Linux repository bundle SHA-256 sidecar")
-    sidecar.write_text(
+    write_text_output(
+        sidecar,
+        "hosted Linux repository bundle SHA-256 sidecar",
         f"{sha256_file(path)}  {path.name}\n",
-        encoding="ascii",
-        newline="\n",
+        max_bytes=MAX_CHECKSUM_BYTES,
     )
     validate_regular_file(
         sidecar,
@@ -534,18 +572,45 @@ def prepare_output_directory(path: Path, label: str) -> None:
 
 
 def validate_regular_file(path: Path, label: str, *, max_bytes: int) -> int:
+    handle, size = open_regular_file(path, label, max_bytes=max_bytes)
+    handle.close()
+    return size
+
+
+def open_regular_file(path: Path, label: str, *, max_bytes: int) -> tuple[BinaryIO, int]:
     if path.is_symlink():
         raise SystemExit(f"{label} must not be a symlink: {path.name}")
     if not path.exists():
         raise SystemExit(f"missing {label}: {path.name}")
+    flags = os.O_RDONLY | OPEN_BINARY | OPEN_NOFOLLOW
     try:
-        metadata = path.stat()
+        fd = os.open(path, flags)
     except OSError as exc:
-        raise SystemExit(f"{label} could not be inspected: {path.name}") from exc
+        if exc.errno == errno.ELOOP:
+            raise SystemExit(f"{label} must not be a symlink: {path.name}") from exc
+        if not path.exists():
+            raise SystemExit(f"missing {label}: {path.name}") from exc
+        if not path.is_file():
+            raise SystemExit(f"{label} must be a regular file: {path.name}") from exc
+        raise SystemExit(f"{label} could not be opened: {path.name}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} must be a regular file: {path.name}")
+        if metadata.st_size > max_bytes:
+            raise SystemExit(f"{label} is too large: {path.name}")
+        return os.fdopen(fd, "rb"), metadata.st_size
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def validate_open_regular_file(handle: BinaryIO, label: str, *, max_bytes: int) -> int:
+    metadata = os.fstat(handle.fileno())
     if not stat.S_ISREG(metadata.st_mode):
-        raise SystemExit(f"{label} must be a regular file: {path.name}")
+        raise SystemExit(f"{label} must be a regular file")
     if metadata.st_size > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name}")
+        raise SystemExit(f"{label} is too large")
     return metadata.st_size
 
 
@@ -561,19 +626,78 @@ def validate_output_file(path: Path, label: str) -> None:
             raise SystemExit(f"{label} output must be a regular file: {path.name}")
 
 
-def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
+def open_output_file(path: Path, label: str) -> BinaryIO:
+    validate_output_file(path, label)
+    flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC | OPEN_BINARY | OPEN_NOFOLLOW
+    try:
+        fd = os.open(path, flags, 0o644)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise SystemExit(f"{label} output must not be a symlink: {path.name}") from exc
+        if path.exists() and not path.is_file():
+            raise SystemExit(f"{label} output must be a regular file: {path.name}") from exc
+        raise SystemExit(f"{label} output could not be opened: {path.name}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} output must be a regular file: {path.name}")
+        return os.fdopen(fd, "w+b")
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def write_text_output(path: Path, label: str, text: str, *, max_bytes: int) -> None:
+    data = text.encode("ascii")
+    if len(data) > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name}")
+    with open_output_file(path, label) as handle:
+        handle.write(data)
+        handle.flush()
+        validate_open_regular_file(handle, label, max_bytes=max_bytes)
     validate_regular_file(path, label, max_bytes=max_bytes)
-    return path.read_bytes()
 
 
-def sha256_file(path: Path) -> str:
+def read_ascii_file(path: Path, label: str, *, max_bytes: int) -> str:
+    data = read_regular_file(path, label, max_bytes=max_bytes)
+    return data.decode("ascii")
+
+
+def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
+    handle, _size = open_regular_file(path, label, max_bytes=max_bytes)
+    with handle:
+        data = handle.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise SystemExit(f"{label} is too large: {path.name}")
+    return data
+
+
+def sha256_file(
+    path: Path,
+    label: str = "hosted Linux repository file",
+    *,
+    max_bytes: int = MAX_HOSTED_BUNDLE_BYTES,
+) -> str:
+    handle, _size = open_regular_file(path, label, max_bytes=max_bytes)
+    with handle:
+        return sha256_open_file(handle, label, max_bytes=max_bytes)
+
+
+def sha256_open_file(handle: BinaryIO, label: str, *, max_bytes: int) -> str:
     digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while True:
-            chunk = handle.read(HASH_CHUNK_BYTES)
-            if not chunk:
-                break
-            digest.update(chunk)
+    if handle.writable():
+        handle.flush()
+    handle.seek(0)
+    total = 0
+    while True:
+        chunk = handle.read(HASH_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise SystemExit(f"{label} is too large")
+        digest.update(chunk)
+    handle.seek(0, os.SEEK_END)
     return digest.hexdigest()
 
 


### PR DESCRIPTION
## **User description**
## Summary
- harden hosted Linux repository bundle generation with descriptor-bound regular-file opens
- write hosted bundle ZIPs and SHA-256 sidecars through validated output descriptors
- keep checksum, signature, public-key, and metadata ZIP reads bound to validated handles

Fixes #338

## Validation
- python -m py_compile scripts\\generate-hosted-linux-repositories.py scripts\\check-hosted-linux-repositories.py
- python scripts\\check-hosted-linux-repositories.py
- python scripts\\check-hosted-linux-repository-site.py
- python scripts\\check-hosted-linux-repository-pages.py
- python scripts\\check-hosted-linux-repository-s3-publication.py
- python scripts\\check-package-manager-manifests.py
- python scripts\\check-package-manager-submissions.py
- python scripts\\check-github-release-assets-published-regression.py
- python scripts\\check-release-artifact-verifier.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Note: production-readiness wrapper passed with expected local skips for unavailable gpg/openssl/rpm signing tools.


___

## **CodeAnt-AI Description**
**Harden hosted Linux repository bundle generation against unsafe file paths**

### What Changed
- Repository inputs and outputs are now opened only after confirming they are regular files, not symlinks or other file types.
- Bundle reads and checksum checks now fail earlier with clearer errors when files are missing, oversized, or not valid text.
- The generated bundle and its SHA-256 sidecar are written through the same safer file checks, reducing the chance of publishing a bad or tampered artifact.
- Reading the npm package version, signatures, public key, and ZIP contents now uses the same stricter file handling.

### Impact
`✅ Safer repository publishing`
`✅ Fewer invalid bundle uploads`
`✅ Clearer errors for bad release assets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal file handling and validation mechanisms with improved error handling and security constraints for repository operations.

* **Chores**
  * Improved robustness of file I/O utilities with centralized safety checks and size enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->