### PR TITLE
Harden hosted S3 publication IO

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -254,7 +254,7 @@ def write_fake_aws(temp: Path) -> Path:
     fake_py.write_text(
         "\n".join(
             [
-                "import json, os, pathlib, sys",
+                "import json, os, sys",
                 "args = sys.argv[1:]",
                 "if 's3' not in args or 'cp' not in args:",
                 "    print('expected s3 cp command', file=sys.stderr)",
@@ -263,14 +263,22 @@ def write_fake_aws(temp: Path) -> Path:
                 "    print('missing cache metadata', file=sys.stderr)",
                 "    sys.exit(3)",
                 "cp_index = args.index('cp')",
-                "source = pathlib.Path(args[cp_index + 1])",
+                "source = args[cp_index + 1]",
                 "target = args[cp_index + 2]",
-                "if not source.is_file() or not target.startswith('s3://conu-packages-fixture/public/conu/'):",
+                "if source != '-' or not target.startswith('s3://conu-packages-fixture/public/conu/'):",
                 "    print('bad source or target', file=sys.stderr)",
                 "    sys.exit(4)",
+                "if '--expected-size' not in args:",
+                "    print('missing expected upload size', file=sys.stderr)",
+                "    sys.exit(5)",
+                "body = sys.stdin.buffer.read()",
+                "expected_size = int(args[args.index('--expected-size') + 1])",
+                "if len(body) != expected_size:",
+                "    print('stdin size did not match expected upload size', file=sys.stderr)",
+                "    sys.exit(6)",
                 "log = os.environ['CONU_FAKE_AWS_LOG']",
                 "with open(log, 'a', encoding='utf-8') as handle:",
-                "    handle.write(json.dumps(args, sort_keys=True) + '\\n')",
+                "    handle.write(json.dumps({'args': args, 'stdinBytes': len(body)}, sort_keys=True) + '\\n')",
             ]
         )
         + "\n",
@@ -302,13 +310,20 @@ def assert_fake_aws_log(log: Path, expected_count: int) -> None:
     if len(rows) != expected_count:
         raise AssertionError(f"fake AWS saw {len(rows)} uploads, expected {expected_count}")
     targets = set()
-    for args in rows:
+    for row in rows:
+        args = row["args"]
         if args.count("s3") != 1 or args.count("cp") != 1:
             raise AssertionError(f"unexpected AWS command args: {args!r}")
+        source = args[args.index("cp") + 1]
+        if source != "-":
+            raise AssertionError(f"upload source was not stdin: {args!r}")
         target = args[args.index("cp") + 2]
         if target in targets:
             raise AssertionError(f"duplicate S3 target: {target}")
         targets.add(target)
+        expected_size = int(args[args.index("--expected-size") + 1])
+        if row["stdinBytes"] != expected_size:
+            raise AssertionError(f"upload body size did not match --expected-size: {args!r}")
         cache_control = args[args.index("--cache-control") + 1]
         if cache_control not in {
             "no-cache",

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import fnmatch
 import importlib.util
 import json
@@ -17,7 +18,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 from urllib.parse import urlparse, urlunparse
 
 
@@ -32,6 +33,8 @@ MAX_TOTAL_BYTES = 4 * 1024 * 1024 * 1024
 MAX_CACHE_CONTROL_BYTES = 256
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,253}[A-Za-z0-9]$")
+OPEN_BINARY = getattr(os, "O_BINARY", 0)
+OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 FORBIDDEN_SEGMENTS = {
     ".conu",
     ".git",
@@ -445,7 +448,10 @@ def collect_files(
             raise PublicationError("site directory has too many files to publish")
         if is_text_member(relative_path):
             try:
-                assert_no_forbidden_text(path.read_text(encoding="utf-8"), relative_path)
+                assert_no_forbidden_text(
+                    read_text_file(path, relative_path, max_bytes=MAX_FILE_BYTES),
+                    relative_path,
+                )
             except UnicodeDecodeError as exc:
                 raise PublicationError(f"{relative_path} must be UTF-8 text") from exc
         cache_control = cache_control_for_path(f"/{relative_path}", rules)
@@ -502,26 +508,62 @@ def validate_cache_control_value(value: str, label: str) -> None:
 
 
 def read_bounded_ascii_file(path: Path, label: str, *, max_bytes: int) -> str:
-    validate_regular_file(path, label, max_bytes=max_bytes)
-    with path.open("rb") as handle:
-        data = handle.read(max_bytes + 1)
-    if len(data) > max_bytes:
-        raise PublicationError(f"{label} is larger than {max_bytes} bytes")
+    data = read_regular_file(path, label, max_bytes=max_bytes)
     try:
         return data.decode("ascii")
     except UnicodeDecodeError as exc:
         raise PublicationError(f"{label} must be ASCII") from exc
 
 
+def read_text_file(path: Path, label: str, *, max_bytes: int) -> str:
+    data = read_regular_file(path, label, max_bytes=max_bytes)
+    return data.decode("utf-8")
+
+
+def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
+    handle, _size = open_regular_file(path, label, max_bytes=max_bytes)
+    with handle:
+        data = handle.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise PublicationError(f"{label} is larger than {max_bytes} bytes")
+    return data
+
+
 def validate_regular_file(path: Path, label: str, *, max_bytes: int) -> int:
+    handle, size = open_regular_file(path, label, max_bytes=max_bytes)
+    handle.close()
+    return size
+
+
+def open_regular_file(path: Path, label: str, *, max_bytes: int) -> tuple[BinaryIO, int]:
     if path.is_symlink():
-        raise PublicationError(f"{label} must not be a symlink")
+        raise PublicationError(f"{label} must not be a symlink: {path.name}")
     if not path.exists():
         raise PublicationError(f"missing {label} in site directory")
     try:
-        metadata = path.stat()
+        fd = os.open(path, os.O_RDONLY | OPEN_BINARY | OPEN_NOFOLLOW)
     except OSError as exc:
-        raise PublicationError(f"{label} could not be inspected") from exc
+        if exc.errno == errno.ELOOP:
+            raise PublicationError(f"{label} must not be a symlink: {path.name}") from exc
+        if not path.exists():
+            raise PublicationError(f"missing {label} in site directory") from exc
+        if not path.is_file():
+            raise PublicationError(f"{label} must be a regular file") from exc
+        raise PublicationError(f"{label} could not be opened") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise PublicationError(f"{label} must be a regular file")
+        if metadata.st_size > max_bytes:
+            raise PublicationError(f"{label} is larger than {max_bytes} bytes")
+        return os.fdopen(fd, "rb"), metadata.st_size
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def validate_open_regular_file(handle: BinaryIO, label: str, *, max_bytes: int) -> int:
+    metadata = os.fstat(handle.fileno())
     if not stat.S_ISREG(metadata.st_mode):
         raise PublicationError(f"{label} must be a regular file")
     if metadata.st_size > max_bytes:
@@ -568,20 +610,37 @@ def publish_plan(plan: PublishPlan, args: argparse.Namespace) -> None:
     if args.region.strip():
         global_args.extend(["--region", args.region.strip()])
     for file in plan.files:
-        command = [
-            *aws_command,
-            *global_args,
-            "s3",
-            "cp",
-            str(file.path),
-            file.s3_uri,
-            "--cache-control",
-            file.cache_control,
-            "--content-type",
-            file.content_type,
-            "--only-show-errors",
-        ]
-        subprocess.run(command, check=True)
+        label = f"site file {file.relative_path}"
+        handle, size = open_regular_file(file.path, label, max_bytes=MAX_FILE_BYTES)
+        with handle:
+            if size != file.size:
+                raise PublicationError(f"{label} changed after publication planning")
+            if is_text_member(file.relative_path):
+                try:
+                    assert_no_forbidden_text(
+                        handle.read(MAX_FILE_BYTES + 1).decode("utf-8"),
+                        file.relative_path,
+                    )
+                except UnicodeDecodeError as exc:
+                    raise PublicationError(f"{file.relative_path} must be UTF-8 text") from exc
+                validate_open_regular_file(handle, label, max_bytes=MAX_FILE_BYTES)
+                handle.seek(0)
+            command = [
+                *aws_command,
+                *global_args,
+                "s3",
+                "cp",
+                "-",
+                file.s3_uri,
+                "--cache-control",
+                file.cache_control,
+                "--content-type",
+                file.content_type,
+                "--expected-size",
+                str(file.size),
+                "--only-show-errors",
+            ]
+            subprocess.run(command, stdin=handle, check=True)
 
 
 def parse_aws_cli(raw: str) -> list[str]:


### PR DESCRIPTION
## **User description**
Closes #344.\n\n## Summary\n- use descriptor-bound regular-file opens for hosted S3 publication reads\n- stream confirmed AWS uploads from the validated descriptor via stdin instead of passing a mutable path\n- update the S3 publication regression to assert stdin uploads and expected byte counts\n\n## Validation\n- python -m py_compile scripts\\publish-hosted-linux-repository-s3.py scripts\\check-hosted-linux-repository-s3-publication.py\n- python scripts\\check-hosted-linux-repository-s3-publication.py\n- python scripts\\check-hosted-linux-repository-pages.py\n- python scripts\\check-hosted-linux-repository-site.py\n- python scripts\\check-hosted-linux-repositories.py\n- python scripts\\check-package-manager-manifests.py\n- python scripts\\check-package-manager-submissions.py\n- python scripts\\check-github-release-assets-published-regression.py\n- python scripts\\check-release-artifact-verifier.py\n- git diff --check\n- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions


___

## **CodeAnt-AI Description**
**Publish hosted S3 files through checked file handles**

### What Changed
- Hosted S3 uploads now read file content from a checked file handle instead of sending a path directly
- Uploads verify the file size at publish time, so changes after planning are rejected
- File checks now block symlinks and other non-regular files more reliably before upload
- The regression test now confirms uploads use stdin and that the sent bytes match the expected size

### Impact
`✅ Safer hosted repository publication`
`✅ Fewer broken S3 uploads`
`✅ Earlier detection of changed or unsafe files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced S3 upload security by preventing symlink vulnerabilities during file operations.
  * Strengthened data integrity validation to verify uploaded content size matches expectations.
  * Improved file handling with safer, bounded file reading mechanisms.
  * Added comprehensive validation checks during repository publication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->