### PR TITLE
Harden repository signing IO

### DIFF
--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -274,6 +274,11 @@ def run_source_file_preflights(signer) -> None:
                 "must not be a symlink",
                 "repository signing symlink source",
             )
+            expect_action_failure(
+                lambda: signer.sha256_file(linked_source),
+                "must not be a symlink",
+                "repository signing symlink hash source",
+            )
 
         symlink_sidecar = temp / "symlink-sidecar"
         symlink_sidecar.mkdir()

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import errno
 import hashlib
 import os
 import re
@@ -16,6 +17,7 @@ import tempfile
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+from typing import BinaryIO
 
 from linux_gpg_common import (
     add_fingerprint_env_argument,
@@ -37,6 +39,8 @@ HASH_CHUNK_BYTES = 1024 * 1024
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 APT_METADATA_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-apt-repository-metadata\.zip$")
 RPM_METADATA_RE = re.compile(r"^conu-[0-9A-Za-z.+_~-]+-rpm-repository-metadata\.zip$")
+OPEN_BINARY = getattr(os, "O_BINARY", 0)
+OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 
 @dataclass
@@ -278,24 +282,37 @@ def sign_rpm_bundle(
 def read_zip_members(bundle: Path) -> dict[str, bytes]:
     members: dict[str, bytes] = {}
     total_uncompressed = 0
+    bundle_file, _size = open_regular_file(
+        bundle,
+        f"repository metadata bundle {bundle.name}",
+        max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+        allow_empty=False,
+    )
     try:
-        with zipfile.ZipFile(bundle) as archive:
-            infos = archive.infolist()
-            if len(infos) > MAX_ZIP_MEMBERS:
-                raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
-            for member in infos:
-                name = normalize_zip_path(member.filename)
-                if not validate_zip_member_for_read(bundle.name, member, name):
-                    continue
-                if name in members:
-                    raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
-                total_uncompressed += member.file_size
-                if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
-                    raise SystemExit(
-                        f"{bundle.name} uncompressed ZIP contents exceed "
-                        f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
-                    )
-                members[name] = archive.read(member)
+        with bundle_file:
+            with zipfile.ZipFile(bundle_file) as archive:
+                infos = archive.infolist()
+                if len(infos) > MAX_ZIP_MEMBERS:
+                    raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
+                for member in infos:
+                    name = normalize_zip_path(member.filename)
+                    if not validate_zip_member_for_read(bundle.name, member, name):
+                        continue
+                    if name in members:
+                        raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
+                    total_uncompressed += member.file_size
+                    if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
+                        raise SystemExit(
+                            f"{bundle.name} uncompressed ZIP contents exceed "
+                            f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                        )
+                    members[name] = archive.read(member)
+            validate_open_regular_file(
+                bundle_file,
+                f"repository metadata bundle {bundle.name}",
+                max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+                allow_empty=False,
+            )
     except zipfile.BadZipFile as exc:
         raise SystemExit(f"{bundle.name} is not a readable zip archive") from exc
     return members
@@ -381,14 +398,14 @@ def write_deterministic_zip_bytes(archive: zipfile.ZipFile, name: str, data: byt
 
 def verify_sha256_sidecar(path: Path, label: str) -> None:
     sidecar = path.with_name(f"{path.name}.sha256")
-    validate_regular_file(
-        sidecar,
-        f"SHA-256 sidecar for {label} {path.name}",
-        max_bytes=MAX_CHECKSUM_BYTES,
-        allow_empty=False,
-    )
     try:
-        checksum_text = sidecar.read_text(encoding="ascii")
+        checksum_text = read_text_file(
+            sidecar,
+            f"SHA-256 sidecar for {label} {path.name}",
+            max_bytes=MAX_CHECKSUM_BYTES,
+            allow_empty=False,
+            encoding="ascii",
+        )
     except UnicodeDecodeError as exc:
         raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
@@ -398,7 +415,11 @@ def verify_sha256_sidecar(path: Path, label: str) -> None:
         raise SystemExit(
             f"SHA-256 sidecar for {label} {path.name} names wrong file: {match.group(2)}"
         )
-    if match.group(1).lower() != sha256_file(path):
+    if match.group(1).lower() != sha256_file(
+        path,
+        f"{label} {path.name}",
+        max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+    ):
         raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
 
 
@@ -411,7 +432,12 @@ def write_sha256_sidecar(path: Path) -> None:
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=True,
         )
-    text = f"{sha256_file(path)}  {path.name}\n"
+    digest = sha256_file(
+        path,
+        f"repository metadata bundle {path.name}",
+        max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+    )
+    text = f"{digest}  {path.name}\n"
     temp_path = temporary_sibling_path(sidecar)
     try:
         temp_path.write_text(text, encoding="ascii", newline="\n")
@@ -452,13 +478,12 @@ def validate_repository_metadata_bundle(
 
 
 def read_generated_signature(path: Path, label: str) -> bytes:
-    validate_regular_file(
+    return read_binary_file(
         path,
         label,
         max_bytes=MAX_GENERATED_SIGNATURE_BYTES,
         allow_empty=False,
     )
-    return path.read_bytes()
 
 
 def validate_regular_file(
@@ -468,20 +493,105 @@ def validate_regular_file(
     max_bytes: int,
     allow_empty: bool,
 ) -> int:
+    handle, size = open_regular_file(
+        path,
+        label,
+        max_bytes=max_bytes,
+        allow_empty=allow_empty,
+    )
+    handle.close()
+    return size
+
+
+def open_regular_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+) -> tuple[BinaryIO, int]:
     if path.is_symlink():
         raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    if not path.exists():
+        raise SystemExit(f"missing {label}: {path.name}")
+    flags = os.O_RDONLY | OPEN_BINARY | OPEN_NOFOLLOW
     try:
-        metadata = path.stat()
+        fd = os.open(path, flags)
     except OSError as exc:
-        raise SystemExit(f"missing {label}: {path.name}") from exc
+        if exc.errno == errno.ELOOP:
+            raise SystemExit(f"{label} must not be a symlink: {path.name}") from exc
+        if not path.exists():
+            raise SystemExit(f"missing {label}: {path.name}") from exc
+        if not path.is_file():
+            raise SystemExit(f"{label} must be a regular file: {path.name}") from exc
+        raise SystemExit(f"{label} could not be opened: {path.name}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} must be a regular file: {path.name}")
+        size = metadata.st_size
+        if not allow_empty and size == 0:
+            raise SystemExit(f"{label} must not be empty: {path.name}")
+        if size > max_bytes:
+            raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+        return os.fdopen(fd, "rb"), size
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def validate_open_regular_file(
+    handle: BinaryIO,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+) -> int:
+    metadata = os.fstat(handle.fileno())
     if not stat.S_ISREG(metadata.st_mode):
-        raise SystemExit(f"{label} must be a regular file: {path.name}")
+        raise SystemExit(f"{label} must be a regular file")
     size = metadata.st_size
     if not allow_empty and size == 0:
-        raise SystemExit(f"{label} must not be empty: {path.name}")
+        raise SystemExit(f"{label} must not be empty")
     if size > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+        raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
     return size
+
+
+def read_binary_file(path: Path, label: str, *, max_bytes: int, allow_empty: bool) -> bytes:
+    handle, _size = open_regular_file(
+        path,
+        label,
+        max_bytes=max_bytes,
+        allow_empty=allow_empty,
+    )
+    with handle:
+        data = handle.read(max_bytes + 1)
+        if len(data) > max_bytes:
+            raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+        validate_open_regular_file(
+            handle,
+            label,
+            max_bytes=max_bytes,
+            allow_empty=allow_empty,
+        )
+    return data
+
+
+def read_text_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+    encoding: str,
+) -> str:
+    return read_binary_file(
+        path,
+        label,
+        max_bytes=max_bytes,
+        allow_empty=allow_empty,
+    ).decode(encoding)
 
 
 def temporary_sibling_path(path: Path) -> Path:
@@ -494,14 +604,52 @@ def temporary_sibling_path(path: Path) -> Path:
         return Path(handle.name)
 
 
-def sha256_file(path: Path) -> str:
+def sha256_file(
+    path: Path,
+    label: str = "repository metadata bundle",
+    *,
+    max_bytes: int = MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+    allow_empty: bool = False,
+) -> str:
+    handle, _size = open_regular_file(
+        path,
+        label,
+        max_bytes=max_bytes,
+        allow_empty=allow_empty,
+    )
+    with handle:
+        return sha256_open_file(
+            handle,
+            label,
+            max_bytes=max_bytes,
+            allow_empty=allow_empty,
+        )
+
+
+def sha256_open_file(
+    handle: BinaryIO,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+) -> str:
     digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while True:
-            chunk = handle.read(HASH_CHUNK_BYTES)
-            if not chunk:
-                break
-            digest.update(chunk)
+    handle.seek(0)
+    total = 0
+    while True:
+        chunk = handle.read(HASH_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
+        digest.update(chunk)
+    validate_open_regular_file(
+        handle,
+        label,
+        max_bytes=max_bytes,
+        allow_empty=allow_empty,
+    )
     return digest.hexdigest()
 
 


### PR DESCRIPTION
## **User description**
## Summary
- open repository metadata ZIP bundles through validated descriptors before reading members
- read checksum sidecars, generated signatures, and bundle hashes through descriptor-bound helpers
- keep APT/RPM signing behavior and existing ZIP/member policy unchanged
- add a regression check for symlink rejection in direct bundle hashing

Closes #352.

## Validation
- python -m py_compile scripts\sign-linux-repository-metadata.py scripts\check-linux-repository-signing.py
- python scripts\check-linux-repository-signing.py (skipped locally: gpg unavailable after source/ZIP preflights)
- python scripts\check-linux-release-signing.py (skipped locally: gpg unavailable)
- python scripts\check-rpm-package-signing.py (native RPM/GPG portion skipped locally: gpg, rpmbuild, rpmsign or rpm, rpmkeys or rpm unavailable)
- python scripts\check-package-manager-manifests.py
- python scripts\check-package-manager-submissions.py
- python scripts\check-release-update-policy.py
- python scripts\check-github-release-assets-published-regression.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions


___

## **CodeAnt-AI Description**
**Harden repository signing inputs and sidecar checks**

### What Changed
- Repository metadata ZIP files are now opened through stricter file checks before signing or hashing, which blocks symlink tricks and non-regular files.
- SHA-256 sidecars and generated signatures are read through the same stricter checks, so invalid or tampered files are rejected earlier.
- ZIP bundle reading now verifies the bundle stays a valid regular file while it is being processed.
- Added a regression check that rejects symlinked repository metadata when hashing directly.

### Impact
`✅ Fewer repository signing failures from unsafe file links`
`✅ Safer validation of published metadata bundles`
`✅ Lower risk of signing or hashing the wrong file`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
