### PR TITLE
Harden release secret env file permissions

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -63,12 +63,18 @@ def restore_env(original: dict[str, str | None]) -> None:
             os.environ[name] = value
 
 
+def secure_write_text(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    if os.name == "posix":
+        path.chmod(0o600)
+
+
 def write_required_env_file(path: Path, module, value: str) -> None:
     lines = ["# local release secrets for regression"]
     for index, name in enumerate(module.REQUIRED_RELEASE_SECRETS):
         prefix = "export " if index == 0 else ""
         lines.append(f"{prefix}{name}={value}")
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    secure_write_text(path, "\n".join(lines) + "\n")
 
 
 def run_env_template_tests(module) -> None:
@@ -153,14 +159,26 @@ def run_env_file_tests(module) -> None:
         )
 
         oversized = temp_path / "oversized.env"
-        oversized.write_text(
+        secure_write_text(
+            oversized,
             "NPM_TOKEN=" + ("x" * module.MAX_ENV_FILE_BYTES) + "\n",
-            encoding="utf-8",
         )
         assert_raises(
             lambda: module.load_env_file_values(oversized, module.REQUIRED_RELEASE_SECRETS),
             "too large",
         )
+
+        if os.name == "posix":
+            permissive = temp_path / "permissive.env"
+            secure_write_text(permissive, "NPM_TOKEN=value\n")
+            permissive.chmod(0o644)
+            assert_raises(
+                lambda: module.load_env_file_values(
+                    permissive,
+                    module.REQUIRED_RELEASE_SECRETS,
+                ),
+                "permissions",
+            )
 
         symlink_target = temp_path / "real.env"
         symlink_link = temp_path / "linked.env"
@@ -175,21 +193,21 @@ def run_env_file_tests(module) -> None:
             )
 
         malformed = temp_path / "malformed.env"
-        malformed.write_text(f"{SENSITIVE_SENTINEL}\n", encoding="utf-8")
+        secure_write_text(malformed, f"{SENSITIVE_SENTINEL}\n")
         assert_raises(
             lambda: module.load_env_file_values(malformed, module.REQUIRED_RELEASE_SECRETS),
             "line 1",
         )
 
         unsupported = temp_path / "unsupported.env"
-        unsupported.write_text("UNRELATED_SECRET=value\n", encoding="utf-8")
+        secure_write_text(unsupported, "UNRELATED_SECRET=value\n")
         assert_raises(
             lambda: module.load_env_file_values(unsupported, module.REQUIRED_RELEASE_SECRETS),
             "unsupported key",
         )
 
         duplicate = temp_path / "duplicate.env"
-        duplicate.write_text("NPM_TOKEN=one\nNPM_TOKEN=two\n", encoding="utf-8")
+        secure_write_text(duplicate, "NPM_TOKEN=one\nNPM_TOKEN=two\n")
         assert_raises(
             lambda: module.load_env_file_values(duplicate, module.REQUIRED_RELEASE_SECRETS),
             "duplicates key",
@@ -456,7 +474,7 @@ def run_env_file_main_tests(module) -> None:
                     for name in module.REQUIRED_RELEASE_SECRETS
                     if name != missing_name
                 ]
-                partial_env_file.write_text("\n".join(partial_lines) + "\n", encoding="utf-8")
+                secure_write_text(partial_env_file, "\n".join(partial_lines) + "\n")
                 exit_code, rendered = call_main(
                     [
                         "set-github-release-secrets.py",

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -19,6 +19,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 MAX_ENV_FILE_BYTES = 128 * 1024
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+POSIX_ENV_FILE_FORBIDDEN_MODE = stat.S_IRWXG | stat.S_IRWXO
 
 
 def render_env_template(names: tuple[str, ...]) -> str:
@@ -127,6 +128,7 @@ def open_env_file(path: Path) -> tuple[BinaryIO, int]:
         metadata = os.fstat(fd)
         if not stat.S_ISREG(metadata.st_mode):
             raise ValueError(f"env file is not a regular file: {path}")
+        validate_env_file_permissions(metadata.st_mode, path)
         size = metadata.st_size
         if size > MAX_ENV_FILE_BYTES:
             raise ValueError(f"env file is too large: {path}")
@@ -140,10 +142,21 @@ def validate_open_env_file(handle: BinaryIO, path: Path) -> int:
     metadata = os.fstat(handle.fileno())
     if not stat.S_ISREG(metadata.st_mode):
         raise ValueError(f"env file is not a regular file: {path}")
+    validate_env_file_permissions(metadata.st_mode, path)
     size = metadata.st_size
     if size > MAX_ENV_FILE_BYTES:
         raise ValueError(f"env file is too large: {path}")
     return size
+
+
+def validate_env_file_permissions(mode: int, path: Path) -> None:
+    if os.name != "posix":
+        return
+    if mode & POSIX_ENV_FILE_FORBIDDEN_MODE:
+        raise ValueError(
+            "env file permissions must not allow group or other access: "
+            f"{path}"
+        )
 
 
 def missing_required_values(values: Mapping[str, str], names: tuple[str, ...]) -> tuple[str, ...]:


### PR DESCRIPTION
## **User description**
## Summary
- reject POSIX release-secret env files with group/other access before parsing values
- re-check permissions on the open file descriptor after reading
- keep Windows behavior compatible and add regression coverage for permissive env-file modes

Closes #360

## Validation
- python -m py_compile scripts/set-github-release-secrets.py scripts/set-github-release-secrets-regression.py
- python scripts/set-github-release-secrets-regression.py
- python scripts/check-github-release-secret-readiness-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

## Security review
- payload exposure risk: none; parser still reports names/errors only and never prints secret values
- trust/permission risk: improved for local release-secret handling by rejecting group/other readable/writable/executable env files on POSIX
- storage/logging risk: improved for filled `.env.release` handling; no new persistent storage or logs
- relay/network risk: none
- required fixes: none known


___

## **CodeAnt-AI Description**
**Reject release secret files that are readable by group or others**

### What Changed
- Release secret env files on POSIX now fail validation if group or other access is allowed
- The permission check is applied both when opening the file and when reading from an already-open file
- Regression coverage now includes permissive env files and keeps Windows behavior unchanged

### Impact
`✅ Safer local secret handling`
`✅ Fewer accidental secret exposures`
`✅ Clearer failures for insecure env files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment files with overly permissive access permissions (readable by group or others on POSIX systems) are now rejected with a clear error message.

* **Tests**
  * Enhanced regression test coverage for environment file permission validation scenarios, including permissive permission rejection cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->