### PR TITLE
Reject secret files in release archives

### DIFF
--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -303,7 +303,7 @@ def main() -> int:
         expect_failure(
             "forbidden state path",
             lambda: verify_archive(verifier, forbidden),
-            "forbidden state path",
+            "forbidden release archive path",
         )
 
         forbidden_dir = root / "conu-0.1.0-forbidden-dir.zip"
@@ -311,7 +311,26 @@ def main() -> int:
         expect_failure(
             "forbidden state directory",
             lambda: verify_archive(verifier, forbidden_dir),
-            "forbidden state path",
+            "forbidden release archive path",
+        )
+
+        forbidden_env = root / "conu-0.1.0-forbidden-env.zip"
+        write_zip(forbidden_env, {f"{archive_prefix(forbidden_env)}/docs/.env.release": b"secret"})
+        expect_failure(
+            "forbidden env file",
+            lambda: verify_archive(verifier, forbidden_env),
+            "forbidden release archive path",
+        )
+
+        forbidden_secret_suffix = root / "conu-0.1.0-forbidden-secret-suffix.zip"
+        write_zip(
+            forbidden_secret_suffix,
+            {f"{archive_prefix(forbidden_secret_suffix)}/docs/signing.p12": b"secret"},
+        )
+        expect_failure(
+            "forbidden secret suffix",
+            lambda: verify_archive(verifier, forbidden_secret_suffix),
+            "forbidden release archive path",
         )
 
         wrong_root = root / "conu-0.1.0-wrong-root.zip"

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -43,10 +43,14 @@ FORBIDDEN_PARTS = {
     "vendor",
 }
 FORBIDDEN_NAMES = {
+    ".env",
+    ".env.local",
+    ".npmrc",
     "node.toml",
     "runtime.toml",
     "trust.toml",
 }
+FORBIDDEN_SUFFIXES = (".key", ".pem", ".p12", ".pfx", ".token")
 REQUIRED_BINARIES = {"conu", "conud", "conu-relay", "conu-mcp"}
 REQUIRED_PACKAGING_FILES = {
     "packaging/README.md",
@@ -513,10 +517,8 @@ def verify_members(archive: Path, members: ArchiveMembers) -> None:
         )
 
     for path in sorted(paths):
-        member_path = PurePosixPath(path)
-        parts = set(member_path.parts)
-        if parts & FORBIDDEN_PARTS or member_path.name in FORBIDDEN_NAMES:
-            raise SystemExit(f"{archive.name} contains forbidden state path: {path}")
+        if is_forbidden_release_path(path):
+            raise SystemExit(f"{archive.name} contains forbidden release archive path: {path}")
 
 
 def required_binary_paths(paths: set[str]) -> set[str]:
@@ -524,6 +526,18 @@ def required_binary_paths(paths: set[str]) -> set[str]:
     if windows_bins <= paths:
         return windows_bins
     return {f"bin/{binary}" for binary in REQUIRED_BINARIES}
+
+
+def is_forbidden_release_path(path: str) -> bool:
+    member_path = PurePosixPath(path)
+    lower_parts = {part.lower() for part in member_path.parts}
+    if lower_parts & FORBIDDEN_PARTS:
+        return True
+
+    name = member_path.name.lower()
+    if name in FORBIDDEN_NAMES or name.startswith(".env."):
+        return True
+    return name.endswith(FORBIDDEN_SUFFIXES)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## **User description**
## Summary
- reject `.env`, `.env.*`, `.npmrc`, and key/cert/token-looking files in release archive members
- make the release archive verifier use case-insensitive forbidden path checks
- add regression fixtures for env files and signing material inside archives

Closes #362

## Validation
- python -m py_compile scripts/verify-release-artifacts.py scripts/check-release-artifact-verifier.py
- python scripts/check-release-artifact-verifier.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

## Security review
- payload exposure risk: reduced; archives now reject local env/secret-looking members before publication
- trust/permission risk: unchanged
- storage/logging risk: reduced for release artifacts; verifier reports member paths only and never prints file contents
- relay/network risk: none
- required fixes: none known


___

## **CodeAnt-AI Description**
**Block secret and credential files from release archives**

### What Changed
- Release archives now reject common secret files like `.env`, `.env.*`, `.npmrc`, and files ending in secret-like extensions such as `.key`, `.pem`, `.p12`, `.pfx`, and `.token`
- Archive checks now catch these paths even when folder or file names use different letter case
- Added regression checks for hidden env files and signing files inside archive contents

### Impact
`✅ Fewer secret files shipped in release builds`
`✅ Lower risk of exposing credentials in published archives`
`✅ Clearer release validation failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
