### PR TITLE
Reject private key armor in submissions

### DIFF
--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -552,6 +552,39 @@ def main() -> int:
             "forbidden literal",
         )
 
+        private_key_public_asset = temp / "private-key-public-asset"
+        manifest_check.generate(
+            generator,
+            dist,
+            private_key_public_asset,
+            build_apt_repository_metadata=True,
+        )
+        write_signed_release_extras(private_key_public_asset)
+        public_key = private_key_public_asset / "conu-linux-gpg-key.asc"
+        public_key.write_text(
+            "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"
+            "fixture\n"
+            "-----END PGP PUBLIC KEY BLOCK-----\n"
+            "-----BEGIN PGP PRIVATE KEY BLOCK-----\n"
+            "fixture\n"
+            "-----END PGP PRIVATE KEY BLOCK-----\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        write_sha256(public_key)
+        expect_failure(
+            "private key material in public-key asset",
+            lambda: preparer.prepare_submission_bundle(
+                private_key_public_asset,
+                temp / "private-key-public-asset-out",
+                VERSION,
+                require_rpm_assets=True,
+                require_repository_metadata=True,
+                require_linux_signatures=True,
+            ),
+            "private key material",
+        )
+
         no_optional = temp / "no-optional"
         manifest_check.generate(generator, dist, no_optional)
         preparer.prepare_submission_bundle(no_optional, temp / "no-optional-out", VERSION)

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -525,6 +525,8 @@ def validate_public_key_source(source: Path, label: str) -> None:
     text = read_ascii_text(source, label)
     if "BEGIN PGP PUBLIC KEY BLOCK" not in text or "END PGP PUBLIC KEY BLOCK" not in text:
         raise SystemExit(f"{label} is not an armored PGP public key")
+    if "PRIVATE KEY BLOCK" in text:
+        raise SystemExit(f"{label} contains private key material")
     assert_safe_text(text, label, Path())
 
 


### PR DESCRIPTION
## **User description**
## Summary
- reject private key armor in package-manager submission public-key assets
- add a regression that injects `BEGIN PGP PRIVATE KEY BLOCK` into `conu-linux-gpg-key.asc`

## Validation
- `python -m py_compile scripts/prepare-package-manager-submissions.py scripts/check-package-manager-submissions.py`
- `python scripts/check-package-manager-submissions.py`
- `git diff --check`

Closes #364


___

## **CodeAnt-AI Description**
**Reject package submission public keys that contain private key material**

### What Changed
- Submission checks now fail if a public-key file includes any private key block, even when the file also contains a valid public key
- Added a regression test that covers a mixed public/private key file in the package submission assets

### Impact
`✅ Safer package submissions`
`✅ Fewer secret key leaks in uploaded assets`
`✅ Clearer validation errors for bad key files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
