### PR TITLE
Reject private key armor in hosted site signatures

### DIFF
--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -116,6 +116,25 @@ def main() -> int:
             "missing detached signature",
         )
 
+        private_key_signature = temp / "private-key-signature"
+        shutil.copytree(dist, private_key_signature)
+        (private_key_signature / f"{SITE_BUNDLE}.asc").write_text(
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "fixture\n"
+            "-----END PGP SIGNATURE-----\n"
+            "-----BEGIN PGP PRIVATE KEY BLOCK-----\n"
+            "fixture\n"
+            "-----END PGP PRIVATE KEY BLOCK-----\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_failure(
+            "private key site signature",
+            private_key_signature / SITE_BUNDLE,
+            temp / "private-key-signature-pages",
+            "private key material",
+        )
+
         symlink_site = temp / "symlink-site"
         shutil.copytree(dist, symlink_site)
         site_target = temp / "site-target.zip"

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -159,6 +159,25 @@ def main() -> int:
             "missing detached signature",
         )
 
+        private_key_signature = temp / "private-key-signature"
+        shutil.copytree(dist, private_key_signature)
+        (private_key_signature / f"{HOSTED_BUNDLE}.asc").write_text(
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "fixture\n"
+            "-----END PGP SIGNATURE-----\n"
+            "-----BEGIN PGP PRIVATE KEY BLOCK-----\n"
+            "fixture\n"
+            "-----END PGP PRIVATE KEY BLOCK-----\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_failure(
+            "private key hosted bundle signature",
+            private_key_signature,
+            BASE_URL,
+            "private key material",
+        )
+
         symlink_dist = temp / "symlink-dist"
         if try_symlink(dist, symlink_dist, target_is_directory=True):
             expect_failure_at_output(

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -225,6 +225,8 @@ def require_detached_signature(path: Path) -> Path:
         raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}") from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
         raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}")
+    if "PRIVATE KEY BLOCK" in signature_text:
+        raise SystemExit(f"detached signature contains private key material: {signature.name}")
     return signature
 
 

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -238,6 +238,8 @@ def require_detached_signature(path: Path) -> None:
         raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}") from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
         raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}")
+    if "PRIVATE KEY BLOCK" in signature_text:
+        raise SystemExit(f"detached signature contains private key material: {signature.name}")
 
 
 def prepare_output_dir(output_dir: Path) -> None:


### PR DESCRIPTION
## **User description**
## Summary
- reject private-key armor in hosted Linux repository site input bundle signatures
- reject private-key armor in hosted Linux repository Pages site ZIP signatures
- add focused regressions for both public signature sidecar paths

## Validation
- `python -m py_compile scripts/generate-hosted-linux-repository-site.py scripts/prepare-hosted-linux-repository-pages.py scripts/check-hosted-linux-repository-site.py scripts/check-hosted-linux-repository-pages.py`
- `python scripts/check-hosted-linux-repository-site.py`
- `python scripts/check-hosted-linux-repository-pages.py`
- `python scripts/check-hosted-linux-repositories.py`
- `git diff --check`

Closes #368


___

## **CodeAnt-AI Description**
Reject signature files that include private key material

### What Changed
- Hosted repository site and Pages publishing now reject detached signatures that contain a private key block
- Existing signature checks still allow normal ASCII-armored signature files
- Added regression checks for both hosted site bundle signatures and Pages site ZIP signatures

### Impact
`✅ Safer signature validation`
`✅ Fewer invalid release uploads`
`✅ Clearer failure messages for malformed signatures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
