### PR TITLE
Reject private key armor in update policy signatures

### DIFF
--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -134,6 +134,26 @@ def main() -> int:
             "missing detached signature",
         )
 
+        private_key_signature = temp / "private-key-signature"
+        shutil.copytree(dist, private_key_signature)
+        (
+            private_key_signature / f"conu-{VERSION}-linux-x64.tar.gz.asc"
+        ).write_text(
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "fixture\n"
+            "-----END PGP SIGNATURE-----\n"
+            "-----BEGIN PGP PRIVATE KEY BLOCK-----\n"
+            "fixture\n"
+            "-----END PGP PRIVATE KEY BLOCK-----\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_failure(
+            "private key Linux archive signature",
+            private_key_signature,
+            "private key material",
+        )
+
         bad_checksum_name = temp / "bad-checksum-name"
         shutil.copytree(dist, bad_checksum_name)
         archive = bad_checksum_name / f"conu-{VERSION}-windows-x64.zip"

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -517,6 +517,8 @@ def require_detached_signature(path: Path, source_budget: SourceBudget) -> None:
         raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}") from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
         raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}")
+    if "PRIVATE KEY BLOCK" in signature_text:
+        raise SystemExit(f"detached signature contains private key material: {signature.name}")
 
 
 def asset_url(release_base_url: str, filename: str) -> str:


### PR DESCRIPTION
## **User description**
## Summary
- reject private-key armor in release update policy detached signature sidecars
- add a regression that mutates a required Linux archive `.asc` sidecar

## Validation
- `python -m py_compile scripts/generate-release-update-policy.py scripts/check-release-update-policy.py`
- `python scripts/check-release-update-policy.py`
- `python scripts/check-release-update-download-gate.py`
- `git diff --check`

Closes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced signature validation to detect and reject release artifacts when detached signatures contain private key material.

* **Tests**
  * Added regression test to verify the system properly rejects Linux archive signature files that incorrectly include private key blocks alongside signature data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Reject private key material in release signature files**

### What Changed
- Release update policy checks now fail when a detached signature file includes private key blocks
- Added a regression test that replaces a Linux archive signature with a file containing private key material and expects validation to reject it

### Impact
`✅ Safer release signature checks`
`✅ Fewer accidental private key leaks in published assets`
`✅ Clearer validation failures for malformed signatures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
