### PR TITLE
Fail release asset preflight on unexpected assets

### DIFF
--- a/scripts/check-github-release-assets-published-regression.py
+++ b/scripts/check-github-release-assets-published-regression.py
@@ -158,6 +158,15 @@ def run_audit_tests(module) -> None:
         "forbiddenAssets",
     )
 
+    unexpected_payload = ready_payload(module)
+    unexpected_payload["assets"].append(
+        {"name": "conu-0.1.0-extra-notes.txt", "size": 100, "state": "uploaded"}
+    )
+    assert_not_ready(
+        module.audit_release_assets("owner/repo", TEST_TAG, unexpected_payload),
+        "unexpectedAssets",
+    )
+
     assert_raises(lambda: module.validate_tag("0.1.0"), "must start with")
     assert_raises(lambda: module.validate_tag("vlatest"), "semver")
 

--- a/scripts/check-github-release-assets-published.py
+++ b/scripts/check-github-release-assets-published.py
@@ -271,6 +271,8 @@ def audit_release_assets(
         issues.append(f"found {len(invalid)} invalid release asset metadata issue(s)")
     if forbidden:
         issues.append(f"found {len(forbidden)} forbidden release asset name(s)")
+    if unexpected:
+        issues.append(f"found {len(unexpected)} unexpected release asset name(s)")
 
     return ReleaseAssetReadiness(
         repo=repo,
@@ -350,12 +352,9 @@ def load_release_json(path: Path) -> dict[str, Any]:
 
 def print_text_report(report: ReleaseAssetReadiness) -> None:
     if report.ready:
-        extra = ""
-        if report.unexpected_assets:
-            extra = f"; {len(report.unexpected_assets)} extra public asset(s) were also present"
         print(
             "GitHub Release asset publication preflight passed: "
-            f"{report.repo}@{report.tag} has {len(report.required_assets)} required asset(s){extra}"
+            f"{report.repo}@{report.tag} has {len(report.required_assets)} required asset(s)"
         )
         return
 
@@ -373,6 +372,8 @@ def print_text_report(report: ReleaseAssetReadiness) -> None:
         print(f"invalid: {issue}", file=sys.stderr)
     for issue in report.forbidden_assets:
         print(f"forbidden: {issue}", file=sys.stderr)
+    for name in report.unexpected_assets:
+        print(f"unexpected: {name}", file=sys.stderr)
 
 
 def default_tag() -> str:


### PR DESCRIPTION
## **User description**
## Summary
- make the GitHub Release asset publication preflight fail on unexpected public asset names
- print unexpected asset names in the metadata-only failure report
- add regression coverage for an unexpected non-forbidden asset name

Closes #372.

## Validation
- python -m py_compile scripts/check-github-release-assets-published.py scripts/check-github-release-assets-published-regression.py
- python scripts/check-github-release-assets-published-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- git diff --check


___

## **CodeAnt-AI Description**
**Fail release asset checks when extra public files are present**

### What Changed
- Release asset preflight now fails if a release includes unexpected public asset names
- The failure report now lists each unexpected asset name so the issue is easier to spot
- The success message no longer mentions extra assets when the release passes
- Regression coverage was added for an unexpected non-forbidden asset

### Impact
`✅ Fewer release uploads with stray public files`
`✅ Clearer release validation failures`
`✅ Safer release publishing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
