### PR TITLE
Reject private key blocks in package manifests

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -332,6 +332,8 @@ def assert_no_forbidden_text(text: str, label: str, temp: Path) -> None:
         "CONU_RELAY_TOKEN",
         "token_sha256_hex",
         "payloadHex",
+        "PRIVATE KEY BLOCK",
+        "BEGIN OPENSSH PRIVATE KEY",
         "BEGIN PRIVATE KEY",
     ]
     normalized = text.replace("\\", "/")
@@ -797,6 +799,16 @@ def main() -> int:
         rootless_dist.mkdir()
         hashes = write_dist(rootless_dist, rooted_windows=False)
         generate(generator, rootless_dist, rootless_out)
+
+        for literal in ("PRIVATE KEY BLOCK", "BEGIN OPENSSH PRIVATE KEY"):
+            expect_failure(
+                f"forbidden package-manager manifest literal {literal}",
+                lambda literal=literal: generator.assert_output_safe(
+                    f"public manifest text\n{literal}\n",
+                    rootless_dist,
+                ),
+                f"forbidden literal: {literal}",
+            )
 
         expect_failure_with_limit(
             generator,

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -1735,6 +1735,8 @@ def assert_output_safe(text: str, dist: Path) -> None:
         "CONU_RELAY_TOKEN",
         "CONU_WINDOWS_SIGN_CERT",
         "CONU_MACOS_DEVELOPER_ID",
+        "PRIVATE KEY BLOCK",
+        "BEGIN OPENSSH PRIVATE KEY",
         "BEGIN PRIVATE KEY",
         "BEGIN CERTIFICATE",
         "payload_ciphertext",


### PR DESCRIPTION
## **User description**
## Summary
- reject `PRIVATE KEY BLOCK` and OpenSSH private-key markers from generated package-manager public text
- extend package-manager manifest regression coverage for these forbidden literals
- keep package-manager output checks metadata-only and path-safe

Closes #374.

## Validation
- python -m py_compile scripts/generate-package-manager-manifests.py scripts/check-package-manager-manifests.py
- python scripts/check-package-manager-manifests.py
- python scripts/check-package-manager-submissions.py
- git diff --check


___

## **CodeAnt-AI Description**
**Block private key markers from appearing in package manifests**

### What Changed
- Package manifest text now rejects `PRIVATE KEY BLOCK` and `BEGIN OPENSSH PRIVATE KEY` in addition to existing private-key and token markers
- Manifest checks now fail when these forbidden private key strings appear in generated public output

### Impact
`✅ Fewer secret leaks in published manifests`
`✅ Safer package metadata generation`
`✅ Lower risk of exposing private key material`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
