### PR TITLE
Validate release prerelease flag before npm publication

### DIFF
--- a/scripts/check-github-release-assets-published-regression.py
+++ b/scripts/check-github-release-assets-published-regression.py
@@ -28,7 +28,13 @@ def load_module():
     return module
 
 
-def ready_payload(module) -> dict[str, object]:
+def ready_payload(
+    module,
+    *,
+    tag: str = TEST_TAG,
+    version: str = TEST_VERSION,
+    prerelease: bool = False,
+) -> dict[str, object]:
     assets = [
         {
             "name": name,
@@ -36,13 +42,13 @@ def ready_payload(module) -> dict[str, object]:
             "state": "uploaded",
             "browser_download_url": f"https://example.invalid/{SENSITIVE_SENTINEL}/{name}",
         }
-        for index, name in enumerate(module.expected_release_asset_names(TEST_VERSION))
+        for index, name in enumerate(module.expected_release_asset_names(version))
     ]
     return {
         "id": 12345,
-        "tag_name": TEST_TAG,
+        "tag_name": tag,
         "draft": False,
-        "prerelease": False,
+        "prerelease": prerelease,
         "assets": assets,
         "body": SENSITIVE_SENTINEL,
     }
@@ -127,6 +133,38 @@ def run_audit_tests(module) -> None:
         module.audit_release_assets("owner/repo", TEST_TAG, draft_payload),
         "release is still a draft",
     )
+
+    stable_prerelease_payload = ready_payload(module, prerelease=True)
+    assert_not_ready(
+        module.audit_release_assets("owner/repo", TEST_TAG, stable_prerelease_payload),
+        "stable tags",
+    )
+
+    prerelease_tag = "v0.1.0-rc.1"
+    prerelease_version = "0.1.0-rc.1"
+    prerelease_flag_payload = ready_payload(
+        module,
+        tag=prerelease_tag,
+        version=prerelease_version,
+        prerelease=False,
+    )
+    assert_not_ready(
+        module.audit_release_assets("owner/repo", prerelease_tag, prerelease_flag_payload),
+        "semver prerelease tags",
+    )
+    prerelease_ready_payload = ready_payload(
+        module,
+        tag=prerelease_tag,
+        version=prerelease_version,
+        prerelease=True,
+    )
+    prerelease_report = module.audit_release_assets(
+        "owner/repo",
+        prerelease_tag,
+        prerelease_ready_payload,
+    )
+    if not prerelease_report.ready:
+        raise AssertionError(f"expected prerelease report to pass, got {prerelease_report.issues!r}")
 
     mismatch_payload = ready_payload(module)
     mismatch_payload["tag_name"] = "v0.2.0"

--- a/scripts/check-github-release-assets-published.py
+++ b/scripts/check-github-release-assets-published.py
@@ -224,6 +224,7 @@ def audit_release_assets(
     actual_tag = release_tag_name(payload)
     required_assets = expected_release_asset_names(version)
     required_set = set(required_assets)
+    expected_prerelease = "-" in version
 
     assets_payload = payload.get("assets")
     if not isinstance(assets_payload, list):
@@ -263,6 +264,11 @@ def audit_release_assets(
         issues.append(f"release tag is {actual_tag}, expected {expected_tag}")
     if draft:
         issues.append("release is still a draft")
+    if prerelease != expected_prerelease:
+        if expected_prerelease:
+            issues.append("release prerelease flag must be true for semver prerelease tags")
+        else:
+            issues.append("release prerelease flag must be false for stable tags")
     if missing:
         issues.append(f"missing {len(missing)} required release asset(s)")
     if duplicates:


### PR DESCRIPTION
## **User description**
## Summary
- require the GitHub Release `prerelease` flag to match the semver tag shape before npm publication
- fail stable tags marked prerelease and semver prerelease tags marked stable
- extend the release asset publication regression fixture for both mismatch directions and a valid prerelease path

Closes #376.

## Validation
- python -m py_compile scripts/check-github-release-assets-published.py scripts/check-github-release-assets-published-regression.py
- python scripts/check-github-release-assets-published-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- git diff --check


___

## **CodeAnt-AI Description**
**Validate release prerelease status before publishing**

### What Changed
- Release checks now reject stable tags that are marked as prerelease, and prerelease tags that are not marked as prerelease.
- Existing release asset checks still pass when the tag shape and prerelease status match.
- Regression coverage now includes both mismatch cases and a valid prerelease release.

### Impact
`✅ Fewer bad release publications`
`✅ Clearer release readiness errors`
`✅ Safer prerelease tagging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
