### PR TITLE
Validate npm public package metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
         run: python scripts/check-npm-launcher-local-smoke-preflight.py
       - name: Verify npm package contents
         run: python scripts/verify-npm-package-contents.py
+      - name: npm package public metadata regression
+        run: python scripts/verify-npm-package-contents-regression.py
       - name: npm publish preflight
         run: python scripts/check-npm-publish-preflight.py
       - name: npm publish preflight regression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,8 @@ jobs:
         run: python scripts/check-npm-launcher-local-smoke-preflight.py
       - name: Verify npm package contents
         run: python scripts/verify-npm-package-contents.py
+      - name: npm package public metadata regression
+        run: python scripts/verify-npm-package-contents-regression.py
       - name: npm publish preflight
         run: python scripts/check-npm-publish-preflight.py
       - name: npm publish preflight regression
@@ -731,6 +733,8 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Verify npm package contents
         run: python scripts/verify-npm-package-contents.py
+      - name: npm package public metadata regression
+        run: python scripts/verify-npm-package-contents-regression.py
       - name: GitHub Release asset publication preflight
         env:
           GH_TOKEN: ${{ github.token }}

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -8488,19 +8488,30 @@ struct UpdateDownloadDir {
 
 impl UpdateDownloadDir {
     fn create() -> Result<Self, String> {
+        let temp_root = env::temp_dir();
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_nanos())
             .unwrap_or_default();
-        let path =
-            env::temp_dir().join(format!("conu-update-check-{}-{nonce}", std::process::id()));
-        fs::create_dir_all(&path).map_err(|error| {
-            format!(
-                "could not create temporary update check directory {}: {error}",
-                path.display()
-            )
-        })?;
-        Ok(Self { path })
+
+        for attempt in 0..1024 {
+            let path = temp_root.join(format!(
+                "conu-update-check-{}-{nonce}-{attempt}",
+                std::process::id()
+            ));
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    return Err(format!(
+                        "could not create temporary update check directory {}: {error}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+
+        Err("could not create unique temporary update check directory".to_string())
     }
 
     fn path(&self) -> &Path {

--- a/scripts/verify-npm-package-contents-regression.py
+++ b/scripts/verify-npm-package-contents-regression.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Regression checks for npm package content and public metadata validation."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify-npm-package-contents.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("verify_npm_package_contents", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load npm package content verifier")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_raises(func, pattern: str) -> None:
+    try:
+        func()
+    except ValueError as exc:
+        if pattern not in str(exc):
+            raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
+        return
+    raise AssertionError(f"expected ValueError containing {pattern!r}")
+
+
+def manifest_for(rule) -> dict[str, object]:
+    repo = Path(__file__).resolve().parents[1]
+    return json.loads((repo / rule.directory / "package.json").read_text(encoding="utf-8"))
+
+
+def rule_by_name(module, name: str):
+    for rule in module.PACKAGES:
+        if rule.name == name:
+            return rule
+    raise AssertionError(f"missing package rule {name}")
+
+
+def run_public_metadata_tests(module) -> None:
+    cli_rule = rule_by_name(module, "@conu/cli")
+    cli_manifest = manifest_for(cli_rule)
+    module.validate_manifest_public_surface(cli_rule, cli_manifest)
+
+    broken_bin = copy.deepcopy(cli_manifest)
+    broken_bin["bin"]["conu"] = "bin/missing.js"
+    assert_raises(
+        lambda: module.validate_manifest_public_surface(cli_rule, broken_bin),
+        "bin must match",
+    )
+
+    broken_files = copy.deepcopy(cli_manifest)
+    broken_files["files"].append("dist/")
+    assert_raises(
+        lambda: module.validate_manifest_public_surface(cli_rule, broken_files),
+        "files changed",
+    )
+
+    duplicate_files = copy.deepcopy(cli_manifest)
+    duplicate_files["files"].append("bin/")
+    assert_raises(
+        lambda: module.validate_manifest_public_surface(cli_rule, duplicate_files),
+        "duplicate entries",
+    )
+
+    broken_postinstall = copy.deepcopy(cli_manifest)
+    broken_postinstall["scripts"]["postinstall"] = "node scripts/other.js"
+    assert_raises(
+        lambda: module.validate_manifest_public_surface(cli_rule, broken_postinstall),
+        "scripts.postinstall",
+    )
+
+    sdk_rule = rule_by_name(module, "@conu/sdk")
+    sdk_manifest = manifest_for(sdk_rule)
+    module.validate_manifest_public_surface(sdk_rule, sdk_manifest)
+
+    broken_exports = copy.deepcopy(sdk_manifest)
+    broken_exports["exports"]["."]["default"] = "./src/missing.js"
+    assert_raises(
+        lambda: module.validate_manifest_public_surface(sdk_rule, broken_exports),
+        "exports must match",
+    )
+
+    broken_engine = copy.deepcopy(sdk_manifest)
+    broken_engine["engines"]["node"] = ">=18"
+    assert_raises(
+        lambda: module.validate_manifest_public_surface(sdk_rule, broken_engine),
+        "engines.node",
+    )
+
+
+def main() -> int:
+    module = load_module()
+    run_public_metadata_tests(module)
+    print("npm package content regression checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-npm-package-contents.py
+++ b/scripts/verify-npm-package-contents.py
@@ -52,12 +52,26 @@ class PackageRule:
     name: str
     directory: Path
     allowed_files: frozenset[str]
+    package_files: frozenset[str]
+    bin_entries: dict[str, str] | None = None
+    manifest_values: dict[str, Any] | None = None
+    script_entries: dict[str, str] | None = None
+    engines: dict[str, str] | None = None
 
 
 PACKAGES = (
     PackageRule(
         name="@conu/cli",
         directory=Path("packaging/npm/conu-cli"),
+        package_files=frozenset({"bin/", "lib/", "scripts/", "README.md"}),
+        bin_entries={
+            "conu": "bin/conu.js",
+            "conud": "bin/conud.js",
+            "conu-relay": "bin/conu-relay.js",
+            "conu-mcp": "bin/conu-mcp.js",
+        },
+        script_entries={"postinstall": "node scripts/install.js"},
+        engines={"node": ">=22 <23 || >=24 <25"},
         allowed_files=frozenset(
             {
                 "README.md",
@@ -89,6 +103,32 @@ PACKAGES = (
     PackageRule(
         name="@conu/sdk",
         directory=Path("sdk/typescript"),
+        package_files=frozenset({"src", "README.md"}),
+        manifest_values={
+            "type": "module",
+            "main": "./src/index.js",
+            "types": "./src/index.d.ts",
+            "browser": "./src/browser.js",
+            "exports": {
+                ".": {
+                    "browser": {
+                        "types": "./src/browser.d.ts",
+                        "default": "./src/browser.js",
+                    },
+                    "node": {
+                        "types": "./src/index.d.ts",
+                        "default": "./src/index.js",
+                    },
+                    "types": "./src/index.d.ts",
+                    "default": "./src/index.js",
+                },
+                "./browser": {
+                    "types": "./src/browser.d.ts",
+                    "default": "./src/browser.js",
+                },
+            },
+        },
+        engines={"node": ">=22 <23 || >=24 <25"},
         allowed_files=frozenset(
             {
                 "README.md",
@@ -179,6 +219,80 @@ def validate_size(field: str, value: Any, limit: int, context: str) -> None:
         raise ValueError(f"{context} reported {field} above {limit} bytes")
 
 
+def validate_manifest_string_set(
+    value: Any,
+    expected: frozenset[str],
+    *,
+    field: str,
+    context: Path,
+) -> None:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise ValueError(f"{context} {field} must be a non-empty string list")
+    actual = frozenset(value)
+    if len(actual) != len(value):
+        raise ValueError(f"{context} {field} must not contain duplicate entries")
+    if actual != expected:
+        details: list[str] = []
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if extra:
+            details.append("unexpected " + ", ".join(extra))
+        raise ValueError(f"{context} {field} changed: {'; '.join(details)}")
+
+
+def validate_manifest_mapping(
+    value: Any,
+    expected: dict[str, str],
+    *,
+    field: str,
+    context: Path,
+) -> None:
+    if value != expected:
+        raise ValueError(f"{context} {field} must match expected public metadata")
+
+
+def validate_manifest_public_surface(rule: PackageRule, manifest: dict[str, Any]) -> None:
+    context = rule.directory / "package.json"
+    validate_manifest_string_set(
+        manifest.get("files"),
+        rule.package_files,
+        field="files",
+        context=context,
+    )
+
+    if rule.bin_entries is not None:
+        validate_manifest_mapping(
+            manifest.get("bin"),
+            rule.bin_entries,
+            field="bin",
+            context=context,
+        )
+
+    for field, expected in (rule.manifest_values or {}).items():
+        if manifest.get(field) != expected:
+            raise ValueError(f"{context} {field} must match expected public metadata")
+
+    scripts = manifest.get("scripts")
+    if rule.script_entries is not None:
+        if not isinstance(scripts, dict):
+            raise ValueError(f"{context} scripts must contain required public commands")
+        for name, expected in rule.script_entries.items():
+            if scripts.get(name) != expected:
+                raise ValueError(f"{context} scripts.{name} must be {expected!r}")
+
+    engines = manifest.get("engines")
+    if rule.engines is not None:
+        if not isinstance(engines, dict):
+            raise ValueError(f"{context} engines must contain required runtime ranges")
+        for name, expected in rule.engines.items():
+            if engines.get(name) != expected:
+                raise ValueError(f"{context} engines.{name} must be {expected!r}")
+
+
 def validate_package(repo: Path, npm: str, rule: PackageRule) -> int:
     package_dir = repo / rule.directory
     manifest = load_json(package_dir / "package.json")
@@ -187,6 +301,7 @@ def validate_package(repo: Path, npm: str, rule: PackageRule) -> int:
     version = manifest.get("version")
     if not isinstance(version, str) or not version:
         raise ValueError(f"{rule.directory}/package.json must contain a non-empty version")
+    validate_manifest_public_surface(rule, manifest)
 
     report = run_npm_pack(npm, package_dir)
     if report.get("name") != rule.name:


### PR DESCRIPTION
## **User description**
## Summary
- require @conu/cli package metadata to keep the expected bin shims, files list, postinstall command, and Node engine range
- require @conu/sdk package metadata to keep the expected module entrypoints, exports map, files list, and Node engine range
- add the metadata regression to CI and release package gates

## Validation
- python -m py_compile scripts/verify-npm-package-contents.py scripts/verify-npm-package-contents-regression.py
- python scripts/verify-npm-package-contents-regression.py
- python scripts/verify-npm-package-contents.py
- python scripts/check-npm-publish-preflight.py
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript
- python scripts/verify-release-versions.py
- git diff --check

Closes #380


___

## **CodeAnt-AI Description**
**Validate npm package public metadata and catch regressions**

### What Changed
- The npm CLI package now must keep its published file list, command entries, install script, and Node version range exactly as expected.
- The TypeScript SDK package now must keep its published file list, entry points, export map, and Node version range exactly as expected.
- New regression checks fail CI and release runs if these public metadata fields change.

### Impact
`✅ Safer npm releases`
`✅ Fewer broken package installs`
`✅ Clearer package metadata checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated regression checks to validate npm package metadata and contents during CI/CD pipelines, ensuring consistent and correct package structure on each release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->