### PR TITLE
Harden update apply backup preflight

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -7951,28 +7951,9 @@ fn install_staged_update_binaries(
         temp_targets.push((report.target_file.clone(), temp_target));
     }
 
-    for report in &reports {
-        if report.target_file.exists() {
-            let Some(backup_file) = report.backup_file.as_ref() else {
-                cleanup_update_temp_targets(&temp_targets);
-                return Err("release update backup path was not prepared".to_string());
-            };
-            if backup_file.exists() {
-                cleanup_update_temp_targets(&temp_targets);
-                return Err(format!(
-                    "release update backup target already exists: {}",
-                    backup_file.display()
-                ));
-            }
-            if let Err(error) = fs::copy(&report.target_file, backup_file) {
-                cleanup_update_temp_targets(&temp_targets);
-                let _ = fs::remove_file(backup_file);
-                return Err(format!(
-                    "could not back up release update binary {}: {error}",
-                    report.target_file.display()
-                ));
-            }
-        }
+    if let Err(error) = back_up_existing_update_binaries(&reports) {
+        cleanup_update_temp_targets(&temp_targets);
+        return Err(error);
     }
 
     let mut installed = Vec::new();
@@ -8006,6 +7987,57 @@ fn install_staged_update_binaries(
     }
 
     Ok(reports)
+}
+
+fn back_up_existing_update_binaries(reports: &[UpdateApplyBinaryReport]) -> Result<(), String> {
+    for report in reports {
+        let metadata = match fs::symlink_metadata(&report.target_file) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(format!(
+                    "could not inspect release update install target {}: {error}",
+                    report.target_file.display()
+                ));
+            }
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(format!(
+                "release update install target is not a regular file: {}",
+                report.target_file.display()
+            ));
+        }
+        let Some(backup_file) = report.backup_file.as_ref() else {
+            return Err(format!(
+                "release update backup path was not prepared for {}",
+                report.target_file.display()
+            ));
+        };
+        if backup_file.exists() {
+            return Err(format!(
+                "release update backup target already exists: {}",
+                backup_file.display()
+            ));
+        }
+        let copied = match fs::copy(&report.target_file, backup_file) {
+            Ok(copied) => copied,
+            Err(error) => {
+                let _ = fs::remove_file(backup_file);
+                return Err(format!(
+                    "could not back up release update binary {}: {error}",
+                    report.target_file.display()
+                ));
+            }
+        };
+        if copied != metadata.len() {
+            let _ = fs::remove_file(backup_file);
+            return Err(format!(
+                "release update install target changed while backing up {}",
+                report.target_file.display()
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn create_update_temp_install_target(
@@ -11028,6 +11060,36 @@ mod tests {
         assert_eq!(
             fs::read(&stale).expect("stale temp target reads"),
             b"stale temp target"
+        );
+    }
+
+    #[test]
+    fn update_apply_backup_rejects_unplanned_existing_target() {
+        let home = temp_home("update-apply-backup-unplanned-target");
+        let install_dir = home.join("install-bin");
+        fs::create_dir_all(&install_dir).expect("install dir creates");
+        let filename = update_binary_filename("conu");
+        let target_file = install_dir.join(&filename);
+        fs::write(&target_file, b"late existing target").expect("target writes");
+        let source_dir = home.join("staged");
+        fs::create_dir_all(&source_dir).expect("source dir creates");
+        let source_file = source_dir.join(&filename);
+        fs::write(&source_file, b"new conu binary").expect("source binary writes");
+        let report = UpdateApplyBinaryReport {
+            name: "conu".to_string(),
+            source_file,
+            target_file: target_file.clone(),
+            backup_file: None,
+            bytes: b"new conu binary".len() as u64,
+        };
+
+        let error = back_up_existing_update_binaries(&[report])
+            .expect_err("unplanned target should fail closed");
+
+        assert!(error.contains("release update backup path was not prepared"));
+        assert_eq!(
+            fs::read(&target_file).expect("target remains readable"),
+            b"late existing target"
         );
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- revalidate release update install targets immediately before backup/replacement
- fail closed when an existing target has no prepared backup path
- reject non-regular targets at backup time and verify backup copy byte counts
- add regression coverage for an unplanned existing target appearing before replacement

Closes #386.

## Security review
- payload exposure risk: none; no payload/log/telemetry output added
- trust/permission risk: none; release update install behavior only
- storage/logging risk: improved; prevents replacing an unplanned target without backup
- relay/network risk: none
- required fixes: none

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `python scripts/verify-release-versions.py`
- `cargo test -p conu-cli update_apply_backup_rejects_unplanned_existing_target --lib` attempted locally but blocked by missing Windows MSVC `link.exe`
- `cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_apply_backup_rejects_unplanned_existing_target --lib` attempted locally but blocked by missing `dlltool.exe`


___

## **CodeAnt-AI Description**
**Harden update installs when an existing target needs backup**

### What Changed
- Update installs now stop before replacement if an existing target does not have a prepared backup path
- Existing targets are checked before backup and are rejected when they are not regular files, such as symlinks
- Backup copies are verified to match the original file size, and failed backups are cleaned up
- Added coverage for an unexpected existing target appearing during update install

### Impact
`✅ Fewer update installs that replace the wrong file`
`✅ Safer handling of unexpected files in install folders`
`✅ Clearer failures when backup preparation is missing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
