### PR TITLE
Harden release update file creation

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -7771,13 +7771,28 @@ fn write_update_staged_binary<R: Read>(
     archive_name: &str,
     binary_name: &str,
 ) -> Result<(), String> {
-    let mut file = fs::File::create(path).map_err(|error| {
-        format!("could not stage {binary_name} from release update archive {archive_name}: {error}")
-    })?;
-    let copied = io::copy(reader, &mut file).map_err(|error| {
-        format!("could not read {binary_name} from release update archive {archive_name}: {error}")
-    })?;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| {
+            format!(
+                "could not stage {binary_name} from release update archive {archive_name}: {error}"
+            )
+        })?;
+    let copied = match io::copy(reader, &mut file) {
+        Ok(copied) => copied,
+        Err(error) => {
+            drop(file);
+            let _ = fs::remove_file(path);
+            return Err(format!(
+                "could not read {binary_name} from release update archive {archive_name}: {error}"
+            ));
+        }
+    };
+    drop(file);
     if copied != expected_bytes {
+        let _ = fs::remove_file(path);
         return Err(format!(
             "release update archive {binary_name} size changed while staging"
         ));
@@ -8260,12 +8275,33 @@ fn write_update_output_file(
             path.display()
         ));
     }
-    fs::write(&path, bytes).map_err(|error| {
-        format!(
+    let mut file = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            return Err(format!(
+                "release update artifact {label} output already exists: {}",
+                path.display()
+            ));
+        }
+        Err(error) => {
+            return Err(format!(
+                "could not reserve release update artifact {label} {}: {error}",
+                path.display()
+            ));
+        }
+    };
+    if let Err(error) = file.write_all(bytes) {
+        drop(file);
+        let _ = fs::remove_file(&path);
+        return Err(format!(
             "could not write release update artifact {label} {}: {error}",
             path.display()
-        )
-    })?;
+        ));
+    }
     Ok(path)
 }
 
@@ -10963,6 +10999,24 @@ mod tests {
     }
 
     #[test]
+    fn update_download_output_write_rejects_existing_file_without_overwrite() {
+        let output_dir = temp_home("update-download-existing-output");
+        fs::create_dir_all(&output_dir).expect("output dir creates");
+        let filename = "conu-0.1.0-linux-x64.tar.gz";
+        let existing = output_dir.join(filename);
+        fs::write(&existing, b"existing public archive").expect("existing output writes");
+
+        let error = write_update_output_file(&output_dir, filename, b"new archive", "archive")
+            .expect_err("existing output should fail closed");
+
+        assert!(error.contains("output already exists"));
+        assert_eq!(
+            fs::read(&existing).expect("existing output reads"),
+            b"existing public archive"
+        );
+    }
+
+    #[test]
     fn update_download_requires_output_dir() {
         let output = run([
             "update",
@@ -11120,6 +11174,30 @@ mod tests {
         assert_eq!(
             fs::read(&stale).expect("stale temp target reads"),
             b"stale temp target"
+        );
+    }
+
+    #[test]
+    fn update_apply_staged_binary_rejects_existing_path_without_overwrite() {
+        let home = temp_home("update-apply-existing-staged");
+        fs::create_dir_all(&home).expect("staging dir creates");
+        let staged = home.join(update_binary_filename("conu"));
+        fs::write(&staged, b"existing staged binary").expect("existing staged file writes");
+        let mut reader = &b"new staged binary"[..];
+
+        let error = write_update_staged_binary(
+            &staged,
+            &mut reader,
+            b"new staged binary".len() as u64,
+            "conu-0.1.0-linux-x64.tar.gz",
+            "conu",
+        )
+        .expect_err("existing staged path should fail closed");
+
+        assert!(error.contains("could not stage conu"));
+        assert_eq!(
+            fs::read(&staged).expect("existing staged file reads"),
+            b"existing staged binary"
         );
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- reserve release update staged binary files with create-new semantics instead of truncating existing files
- reserve release update download output files with create-new semantics after preflight checks
- add regressions proving existing staged/output files are not overwritten

Closes #390

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- attempted cargo check -p conu-cli --lib, blocked locally because link.exe is missing
- attempted cargo test -p conu-cli update_apply_staged_binary_rejects_existing_path_without_overwrite --lib, blocked locally because link.exe is missing
- attempted cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_apply_staged_binary_rejects_existing_path_without_overwrite --lib, blocked locally because dlltool.exe is missing

## Security Review
payload exposure risk: none; this only changes release update file creation and test fixture bytes are not user payloads.
trust/permission risk: none; no trust, auth, policy, or permission paths changed.
storage/logging risk: reduced; stale or raced release update files now fail closed instead of being truncated, and partial write failures clean up the reserved path.
relay/network risk: none; no relay or network behavior changed.
required fixes: none before CI.


___

## **CodeAnt-AI Description**
**Prevent release update files from overwriting existing files**

### What Changed
- Release update staging now fails if the target file already exists instead of replacing it
- Downloaded update files now reserve their output path first, then clean up if writing fails
- New checks keep any pre-existing staged or downloaded file unchanged when an update is rejected

### Impact
`✅ Fewer overwritten update files`
`✅ Safer update downloads`
`✅ Preserved existing binaries and archives`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
