### PR TITLE
Harden release update backup restore

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -8203,9 +8203,35 @@ fn restore_update_backup(target_file: &Path, backup_file: &Path) -> Result<(), S
             backup_file.display()
         ));
     }
-    let copied = match fs::copy(backup_file, target_file) {
+    let mut backup = fs::File::open(backup_file).map_err(|error| {
+        format!(
+            "could not open release update backup file {}: {error}",
+            backup_file.display()
+        )
+    })?;
+    let mut target = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(target_file)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            return Err(format!(
+                "release update restore target already exists: {}",
+                target_file.display()
+            ));
+        }
+        Err(error) => {
+            return Err(format!(
+                "could not reserve release update restore target {}: {error}",
+                target_file.display()
+            ));
+        }
+    };
+    let copied = match io::copy(&mut backup, &mut target) {
         Ok(copied) => copied,
         Err(error) => {
+            drop(target);
             let _ = fs::remove_file(target_file);
             return Err(format!(
                 "could not restore release update backup {} to {}: {error}",
@@ -8214,6 +8240,7 @@ fn restore_update_backup(target_file: &Path, backup_file: &Path) -> Result<(), S
             ));
         }
     };
+    drop(target);
     if copied != metadata.len() {
         let _ = fs::remove_file(target_file);
         return Err(format!(
@@ -11349,6 +11376,55 @@ mod tests {
         assert_eq!(
             fs::read(&target_file).expect("target remains readable"),
             b"partial update target"
+        );
+    }
+
+    #[test]
+    fn update_apply_restore_backup_rejects_existing_target_without_overwrite() {
+        let home = temp_home("update-apply-existing-restore-target");
+        let install_dir = home.join("install-bin");
+        let backup_dir = install_dir.join(".conu-update-backups").join("restore");
+        fs::create_dir_all(&backup_dir).expect("backup dir creates");
+        let target_file = install_dir.join(update_binary_filename("conu"));
+        let backup_file = backup_dir.join(update_binary_filename("conu"));
+        fs::write(&target_file, b"unexpected restore target").expect("target writes");
+        fs::write(&backup_file, b"backup binary").expect("backup writes");
+
+        let error = restore_update_backup(&target_file, &backup_file)
+            .expect_err("existing restore target should fail closed");
+
+        assert!(error.contains("release update restore target already exists"));
+        assert_eq!(
+            fs::read(&target_file).expect("target remains readable"),
+            b"unexpected restore target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_apply_restore_backup_rejects_symlink_target_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = temp_home("update-apply-symlink-restore-target");
+        let install_dir = home.join("install-bin");
+        let backup_dir = install_dir.join(".conu-update-backups").join("restore");
+        fs::create_dir_all(&backup_dir).expect("backup dir creates");
+        let target_file = install_dir.join(update_binary_filename("conu"));
+        let backup_file = backup_dir.join(update_binary_filename("conu"));
+        let outside_target = home.join("outside-restore-target");
+        fs::write(&backup_file, b"backup binary").expect("backup writes");
+        symlink(&outside_target, &target_file).expect("restore target symlink creates");
+
+        let error = restore_update_backup(&target_file, &backup_file)
+            .expect_err("symlink restore target should fail closed");
+
+        assert!(error.contains("release update restore target already exists"));
+        assert!(!outside_target.exists());
+        assert!(
+            fs::symlink_metadata(&target_file)
+                .expect("restore symlink metadata")
+                .file_type()
+                .is_symlink()
         );
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- reserve release update rollback restore targets with create-new semantics before copying backup bytes
- fail closed when a stale, raced, or symlink restore target exists instead of overwriting through it
- add regressions for existing restore targets and Unix symlink restore targets

Closes #394

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- attempted cargo check -p conu-cli --lib, blocked locally because link.exe is missing
- attempted cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_apply_restore_backup_rejects_existing_target_without_overwrite --lib, blocked locally because dlltool.exe is missing

## Security Review
payload exposure risk: none; release update backup restore handles public binaries, not agent payloads.
trust/permission risk: none; no trust, auth, policy, or permission behavior changed.
storage/logging risk: reduced; rollback restore now fails closed on existing or symlink target paths and cleans partial restore files on copy failure.
relay/network risk: none; no relay or network behavior changed.
required fixes: none before CI.


___

## **CodeAnt-AI Description**
**Prevent update restore from overwriting an existing target**

### What Changed
- Update restore now refuses to write if the destination file already exists, instead of replacing it
- Restore also stops when the destination is a symlink, so it cannot write through a link to another location
- If copying fails, any partial restore file is removed so users are not left with a broken binary
- Added checks that cover existing targets and symlink targets

### Impact
`✅ Safer release rollbacks`
`✅ Fewer overwritten binaries during restore`
`✅ Fewer broken restore leftovers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
