### PR TITLE
Harden downloaded update metadata writes

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -9222,12 +9222,33 @@ fn write_downloaded_update_file(dir: &Path, name: &str, bytes: &[u8]) -> Result<
         )
     })?;
     let path = dir.join(name);
-    fs::write(&path, bytes).map_err(|error| {
-        format!(
+    let mut file = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            return Err(format!(
+                "downloaded release update policy file already exists: {}",
+                path.display()
+            ));
+        }
+        Err(error) => {
+            return Err(format!(
+                "could not reserve downloaded release update policy file {}: {error}",
+                path.display()
+            ));
+        }
+    };
+    if let Err(error) = file.write_all(bytes) {
+        drop(file);
+        let _ = fs::remove_file(&path);
+        return Err(format!(
             "could not write downloaded release update policy file {}: {error}",
             path.display()
-        )
-    })?;
+        ));
+    }
     Ok(path)
 }
 
@@ -10913,6 +10934,49 @@ mod tests {
         ]);
 
         assert_eq!(output.code, 2);
+    }
+
+    #[test]
+    fn update_downloaded_metadata_write_rejects_existing_file_without_overwrite() {
+        let download_dir = temp_home("update-downloaded-metadata-existing");
+        fs::create_dir_all(&download_dir).expect("download dir creates");
+        let filename = "conu-0.1.0-update-policy.json";
+        let existing = download_dir.join(filename);
+        fs::write(&existing, b"existing policy metadata").expect("existing metadata writes");
+
+        let error = write_downloaded_update_file(&download_dir, filename, b"new metadata")
+            .expect_err("existing downloaded metadata should fail closed");
+
+        assert!(error.contains("downloaded release update policy file already exists"));
+        assert_eq!(
+            fs::read(&existing).expect("existing metadata reads"),
+            b"existing policy metadata"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_downloaded_metadata_write_rejects_symlink_target_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let download_dir = temp_home("update-downloaded-metadata-symlink");
+        fs::create_dir_all(&download_dir).expect("download dir creates");
+        let filename = "conu-0.1.0-update-policy.json";
+        let target = download_dir.join(filename);
+        let outside_target = download_dir.join("outside-metadata-target");
+        symlink(&outside_target, &target).expect("metadata symlink creates");
+
+        let error = write_downloaded_update_file(&download_dir, filename, b"new metadata")
+            .expect_err("symlink downloaded metadata should fail closed");
+
+        assert!(error.contains("downloaded release update policy file already exists"));
+        assert!(!outside_target.exists());
+        assert!(
+            fs::symlink_metadata(&target)
+                .expect("metadata symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- reserve downloaded remote update metadata files with create-new semantics instead of truncating through fs::write
- clean up partial metadata files on write failure
- add regressions for existing metadata files and Unix symlink metadata targets

Closes #396

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- attempted cargo check -p conu-cli --lib, blocked locally because link.exe is missing
- attempted cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_downloaded_metadata_write_rejects_existing_file_without_overwrite --lib, blocked locally because dlltool.exe is missing

## Security Review
payload exposure risk: none; downloaded update metadata is public release policy/checksum/signature data, not agent payloads.
trust/permission risk: none; no trust, auth, policy, or permission behavior changed.
storage/logging risk: reduced; remote update metadata staging now fails closed on existing or symlink paths and removes partial files after write failures.
relay/network risk: none; no relay or network behavior changed.
required fixes: none before CI.


___

## **CodeAnt-AI Description**
**Prevent downloaded update metadata from overwriting existing files**

### What Changed
- Downloaded update metadata now fails if the target file already exists instead of replacing it
- Symlink targets are treated as existing files, so metadata cannot be written through a linked path
- If writing the metadata fails partway through, the partial file is removed
- Added regression coverage for existing files and Unix symlink targets

### Impact
`✅ No silent overwrite of existing update metadata`
`✅ Safer handling of symlinked download paths`
`✅ Fewer broken partial update files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
