### PR TITLE
Harden release update input file reads

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -9277,7 +9277,7 @@ fn read_limited_file(path: &Path, max_bytes: u64, label: &str) -> Result<Vec<u8>
     let mut file =
         fs::File::open(path).map_err(|error| format!("{label} file could not be read: {error}"))?;
     let path_metadata = update_input_file_metadata(path, label)?;
-    if path_metadata.len() != metadata.len() {
+    if !update_input_file_metadata_matches(&metadata, &path_metadata) {
         return Err(format!(
             "{label} file changed while opening: {}",
             path.display()
@@ -9295,7 +9295,7 @@ fn read_limited_file(path: &Path, max_bytes: u64, label: &str) -> Result<Vec<u8>
     if opened_metadata.len() > max_bytes {
         return Err(format!("{label} file is too large: {}", path.display()));
     }
-    if opened_metadata.len() != path_metadata.len() {
+    if !update_input_file_metadata_matches(&metadata, &opened_metadata) {
         return Err(format!(
             "{label} file changed while opening: {}",
             path.display()
@@ -9311,13 +9311,51 @@ fn read_limited_file(path: &Path, max_bytes: u64, label: &str) -> Result<Vec<u8>
     if read as u64 > max_bytes || bytes.len() as u64 > max_bytes {
         return Err(format!("{label} file is too large: {}", path.display()));
     }
-    if bytes.len() as u64 != opened_metadata.len() {
+    let final_path_metadata = update_input_file_metadata(path, label)?;
+    if !update_input_file_metadata_matches(&metadata, &final_path_metadata) {
+        return Err(format!(
+            "{label} file changed while reading: {}",
+            path.display()
+        ));
+    }
+    let final_opened_metadata = file
+        .metadata()
+        .map_err(|error| format!("{label} file metadata could not be read: {error}"))?;
+    if !update_input_file_metadata_matches(&metadata, &final_opened_metadata)
+        || bytes.len() as u64 != final_opened_metadata.len()
+    {
         return Err(format!(
             "{label} file changed while reading: {}",
             path.display()
         ));
     }
     Ok(bytes)
+}
+
+fn update_input_file_metadata_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    expected.len() == current.len() && update_input_file_identity_matches(expected, current)
+}
+
+#[cfg(unix)]
+fn update_input_file_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    expected.dev() == current.dev() && expected.ino() == current.ino()
+}
+
+#[cfg(windows)]
+fn update_input_file_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    expected.file_attributes() == current.file_attributes()
+        && expected.creation_time() == current.creation_time()
+        && expected.last_write_time() == current.last_write_time()
+        && expected.file_size() == current.file_size()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn update_input_file_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    expected.modified().ok() == current.modified().ok()
 }
 
 fn verify_update_sha256_sidecar(
@@ -10996,6 +11034,7 @@ mod tests {
         let home = temp_home("update-check-symlink-policy");
         let target = home.join("outside-policy-target");
         let policy = home.join("conu-0.1.0-update-policy.json");
+        fs::create_dir_all(&home).expect("home creates");
         fs::write(&target, b"private message contents").expect("target writes");
         symlink(&target, &policy).expect("policy symlink creates");
 

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -9252,20 +9252,72 @@ fn write_downloaded_update_file(dir: &Path, name: &str, bytes: &[u8]) -> Result<
     Ok(path)
 }
 
-fn read_limited_file(path: &Path, max_bytes: u64, label: &str) -> Result<Vec<u8>, String> {
-    let metadata = fs::metadata(path).map_err(|error| {
+fn update_input_file_metadata(path: &Path, label: &str) -> Result<fs::Metadata, String> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
         format!(
             "{label} file is not readable at {}: {error}",
             path.display()
         )
     })?;
-    if !metadata.is_file() {
-        return Err(format!("{label} path is not a file: {}", path.display()));
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(format!(
+            "{label} path is not a regular file: {}",
+            path.display()
+        ));
     }
+    Ok(metadata)
+}
+
+fn read_limited_file(path: &Path, max_bytes: u64, label: &str) -> Result<Vec<u8>, String> {
+    let metadata = update_input_file_metadata(path, label)?;
     if metadata.len() > max_bytes {
         return Err(format!("{label} file is too large: {}", path.display()));
     }
-    fs::read(path).map_err(|error| format!("{label} file could not be read: {error}"))
+
+    let mut file =
+        fs::File::open(path).map_err(|error| format!("{label} file could not be read: {error}"))?;
+    let path_metadata = update_input_file_metadata(path, label)?;
+    if path_metadata.len() != metadata.len() {
+        return Err(format!(
+            "{label} file changed while opening: {}",
+            path.display()
+        ));
+    }
+    let opened_metadata = file
+        .metadata()
+        .map_err(|error| format!("{label} file metadata could not be read: {error}"))?;
+    if !opened_metadata.is_file() {
+        return Err(format!(
+            "{label} path is not a regular file: {}",
+            path.display()
+        ));
+    }
+    if opened_metadata.len() > max_bytes {
+        return Err(format!("{label} file is too large: {}", path.display()));
+    }
+    if opened_metadata.len() != path_metadata.len() {
+        return Err(format!(
+            "{label} file changed while opening: {}",
+            path.display()
+        ));
+    }
+
+    let mut bytes = Vec::new();
+    let limit = max_bytes.saturating_add(1);
+    let read = std::io::Read::by_ref(&mut file)
+        .take(limit)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("{label} file could not be read: {error}"))?;
+    if read as u64 > max_bytes || bytes.len() as u64 > max_bytes {
+        return Err(format!("{label} file is too large: {}", path.display()));
+    }
+    if bytes.len() as u64 != opened_metadata.len() {
+        return Err(format!(
+            "{label} file changed while reading: {}",
+            path.display()
+        ));
+    }
+    Ok(bytes)
 }
 
 fn verify_update_sha256_sidecar(
@@ -10934,6 +10986,35 @@ mod tests {
         ]);
 
         assert_eq!(output.code, 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_check_rejects_symlinked_policy_file_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = temp_home("update-check-symlink-policy");
+        let target = home.join("outside-policy-target");
+        let policy = home.join("conu-0.1.0-update-policy.json");
+        fs::write(&target, b"private message contents").expect("target writes");
+        symlink(&target, &policy).expect("policy symlink creates");
+
+        let output = run([
+            "update",
+            "check",
+            "--policy-file",
+            policy.to_str().expect("policy path"),
+        ]);
+
+        assert_eq!(output.code, 1);
+        assert!(output.stderr.contains("path is not a regular file"));
+        assert!(!output.stderr.contains("private message contents"));
+        assert!(
+            fs::symlink_metadata(&policy)
+                .expect("policy symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- reject symlink and non-regular local release update input files before reading
- replace whole-file fs::read with a bounded file-handle read that fails if the file changes while opening or reading
- add a Unix regression for symlinked policy files that verifies the target contents are not displayed

Closes #398.

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-cli --lib
- attempted cargo check -p conu-cli --lib and targeted cargo test on default MSVC toolchain; both stopped before this crate because link.exe is not installed
- attempted cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_check_rejects_symlinked_policy_file_without_reading_target --lib; stopped because dlltool.exe is not installed

## Security review
payload exposure risk: low; the change avoids reading symlink targets and the regression checks that target contents are not printed.
trust/permission risk: low; update policy/artifact inputs now fail closed on symlinks and non-regular files.
storage/logging risk: low; errors report paths and categories only, not file contents, signatures, keys, tokens, or payloads.
relay/network risk: none; this is local CLI update file handling only.
required fixes: none known.


___

## **CodeAnt-AI Description**
**Reject symlinked release update files and stop reading files that change while opening**

### What Changed
- Release update input files are now refused unless they are regular files, so symlinks and other non-regular paths fail before any contents are read
- Update file reads now check that the file stays the same while opening and reading, and fail if it changes or grows past the allowed size
- Added a regression test that confirms a symlinked policy file is rejected without exposing the target file’s contents

### Impact
`✅ Fewer symlink-based file leaks`
`✅ Safer update checks`
`✅ Clearer release file errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
