### PR TITLE
Guard final release update install targets

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -7897,16 +7897,9 @@ fn plan_staged_update_binaries(
                 target_file.display()
             ));
         }
-        if let Ok(metadata) = fs::symlink_metadata(&target_file) {
-            if metadata.file_type().is_symlink() || !metadata.is_file() {
-                return Err(format!(
-                    "release update install target is not a regular file: {}",
-                    target_file.display()
-                ));
-            }
-        }
+        let target_exists = inspect_update_install_target(&target_file)?;
         let backup_file = backup_dir.and_then(|dir| {
-            if target_file.exists() {
+            if target_exists {
                 Some(dir.join(&filename))
             } else {
                 None
@@ -7977,18 +7970,10 @@ fn install_staged_update_binaries(
             .iter()
             .find(|report| report.target_file == *target_file)
             .and_then(|report| report.backup_file.clone());
-        if target_file.exists() {
-            if let Err(error) = fs::remove_file(target_file) {
-                let recovery_errors = rollback_update_install(&installed).err();
-                cleanup_update_temp_targets(&temp_targets);
-                return Err(with_update_recovery_error(
-                    format!(
-                        "could not replace release update binary {}: {error}",
-                        target_file.display()
-                    ),
-                    recovery_errors,
-                ));
-            }
+        if let Err(error) = remove_existing_update_install_target(target_file) {
+            let recovery_errors = rollback_update_install(&installed).err();
+            cleanup_update_temp_targets(&temp_targets);
+            return Err(with_update_recovery_error(error, recovery_errors));
         }
         if let Err(error) = fs::rename(temp_target, target_file) {
             let mut recovery_errors = Vec::new();
@@ -8013,6 +7998,37 @@ fn install_staged_update_binaries(
     }
 
     Ok(reports)
+}
+
+fn inspect_update_install_target(target_file: &Path) -> Result<bool, String> {
+    match fs::symlink_metadata(target_file) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(format!(
+                    "release update install target is not a regular file: {}",
+                    target_file.display()
+                ));
+            }
+            Ok(true)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!(
+            "could not inspect release update install target {}: {error}",
+            target_file.display()
+        )),
+    }
+}
+
+fn remove_existing_update_install_target(target_file: &Path) -> Result<(), String> {
+    if !inspect_update_install_target(target_file)? {
+        return Ok(());
+    }
+    fs::remove_file(target_file).map_err(|error| {
+        format!(
+            "could not replace release update binary {}: {error}",
+            target_file.display()
+        )
+    })
 }
 
 fn with_update_recovery_error(error: String, recovery_error: Option<String>) -> String {
@@ -11436,6 +11452,45 @@ mod tests {
         assert_eq!(
             fs::read(&staged).expect("existing staged file reads"),
             b"existing staged binary"
+        );
+    }
+
+    #[test]
+    fn update_apply_final_replacement_rejects_directory_target() {
+        let home = temp_home("update-apply-final-directory-target");
+        let install_dir = home.join("install-bin");
+        let target_file = install_dir.join(update_binary_filename("conu"));
+        fs::create_dir_all(&target_file).expect("directory target creates");
+
+        let error = remove_existing_update_install_target(&target_file)
+            .expect_err("directory final install target should fail closed");
+
+        assert!(error.contains("release update install target is not a regular file"));
+        assert!(target_file.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_apply_final_replacement_rejects_symlink_target_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = temp_home("update-apply-final-symlink-target");
+        let install_dir = home.join("install-bin");
+        fs::create_dir_all(&install_dir).expect("install dir creates");
+        let target_file = install_dir.join(update_binary_filename("conu"));
+        let outside_target = home.join("outside-final-target");
+        symlink(&outside_target, &target_file).expect("target symlink creates");
+
+        let error = remove_existing_update_install_target(&target_file)
+            .expect_err("symlink final install target should fail closed");
+
+        assert!(error.contains("release update install target is not a regular file"));
+        assert!(!outside_target.exists());
+        assert!(
+            fs::symlink_metadata(&target_file)
+                .expect("target symlink metadata")
+                .file_type()
+                .is_symlink()
         );
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- replace final release update target existence checks with symlink_metadata-backed inspection
- reject symlink and non-regular install targets immediately before final replacement
- reuse the same target inspection for backup planning so metadata errors fail closed
- add regressions for directory and Unix symlink final replacement targets

Closes #400.

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-cli --lib
- attempted cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_apply_final_replacement_rejects_directory_target --lib; stopped before tests because dlltool.exe is not installed on this workstation

## Security review
payload exposure risk: low; final replacement errors report target paths and categories only, not archive or payload contents.
trust/permission risk: low; the confirmed update path now revalidates install targets at the final replacement boundary and fails closed on symlinks/non-regular files.
storage/logging risk: low; no new persistent state or log contents are added, and cleanup/rollback behavior is preserved.
relay/network risk: none; this is local CLI update apply storage handling only.
required fixes: none known.


___

## **CodeAnt-AI Description**
**Reject unsafe update targets right before replacement**

### What Changed
- Final update installation now rechecks each destination before replacing it, and fails if the target is a symlink or anything other than a normal file
- Existing targets are removed only after that check, so the updater no longer overwrites unexpected directory or link targets
- Added coverage for directory targets and Unix symlink targets to confirm they are refused

### Impact
`✅ Safer release updates`
`✅ Fewer accidental overwrites during install`
`✅ Clearer update failures for invalid target paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
