### PR TITLE
Harden release update backup restore reads

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -8342,24 +8342,34 @@ fn rollback_update_install(installed: &[(PathBuf, Option<PathBuf>)]) -> Result<(
 }
 
 fn restore_update_backup(target_file: &Path, backup_file: &Path) -> Result<(), String> {
-    let metadata = fs::symlink_metadata(backup_file).map_err(|error| {
-        format!(
-            "could not inspect release update backup file {}: {error}",
-            backup_file.display()
-        )
-    })?;
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
-        return Err(format!(
-            "release update backup file is not a regular file: {}",
-            backup_file.display()
-        ));
-    }
+    let metadata = update_backup_file_metadata(backup_file)?;
     let mut backup = fs::File::open(backup_file).map_err(|error| {
         format!(
             "could not open release update backup file {}: {error}",
             backup_file.display()
         )
     })?;
+    let opened_path_metadata = update_backup_file_metadata(backup_file)?;
+    if !update_input_file_metadata_matches(&metadata, &opened_path_metadata) {
+        return Err(format!(
+            "release update backup changed while opening {}",
+            backup_file.display()
+        ));
+    }
+    let opened_metadata = backup.metadata().map_err(|error| {
+        format!(
+            "could not inspect opened release update backup file {}: {error}",
+            backup_file.display()
+        )
+    })?;
+    if !opened_metadata.is_file()
+        || !update_input_file_metadata_matches(&metadata, &opened_metadata)
+    {
+        return Err(format!(
+            "release update backup changed while opening {}",
+            backup_file.display()
+        ));
+    }
     let mut target = match fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -8391,6 +8401,41 @@ fn restore_update_backup(target_file: &Path, backup_file: &Path) -> Result<(), S
             ));
         }
     };
+    let final_path_metadata = match update_backup_file_metadata(backup_file) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            drop(target);
+            let _ = fs::remove_file(target_file);
+            return Err(error);
+        }
+    };
+    if !update_input_file_metadata_matches(&metadata, &final_path_metadata) {
+        drop(target);
+        let _ = fs::remove_file(target_file);
+        return Err(format!(
+            "release update backup changed while restoring {}",
+            backup_file.display()
+        ));
+    }
+    let final_opened_metadata = match backup.metadata() {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            drop(target);
+            let _ = fs::remove_file(target_file);
+            return Err(format!(
+                "could not inspect opened release update backup file {}: {error}",
+                backup_file.display()
+            ));
+        }
+    };
+    if !update_input_file_metadata_matches(&metadata, &final_opened_metadata) {
+        drop(target);
+        let _ = fs::remove_file(target_file);
+        return Err(format!(
+            "release update backup changed while restoring {}",
+            backup_file.display()
+        ));
+    }
     if copied != metadata.len() {
         drop(target);
         let _ = fs::remove_file(target_file);
@@ -8406,6 +8451,22 @@ fn restore_update_backup(target_file: &Path, backup_file: &Path) -> Result<(), S
     }
     drop(target);
     Ok(())
+}
+
+fn update_backup_file_metadata(backup_file: &Path) -> Result<fs::Metadata, String> {
+    let metadata = fs::symlink_metadata(backup_file).map_err(|error| {
+        format!(
+            "could not inspect release update backup file {}: {error}",
+            backup_file.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(format!(
+            "release update backup file is not a regular file: {}",
+            backup_file.display()
+        ));
+    }
+    Ok(metadata)
 }
 
 fn cleanup_update_temp_targets(temp_targets: &[(PathBuf, PathBuf)]) {
@@ -11947,6 +12008,56 @@ mod tests {
         assert_eq!(
             fs::read(&target_file).expect("target remains readable"),
             b"partial update target"
+        );
+    }
+
+    #[test]
+    fn update_apply_restore_backup_rejects_directory_backup_without_writing_target() {
+        let home = temp_home("update-apply-directory-restore-backup");
+        let install_dir = home.join("install-bin");
+        let backup_dir = install_dir.join(".conu-update-backups").join("restore");
+        fs::create_dir_all(&backup_dir).expect("backup dir creates");
+        let target_file = install_dir.join(update_binary_filename("conu"));
+        let backup_file = backup_dir.join(update_binary_filename("conu"));
+        fs::create_dir_all(&backup_file).expect("directory backup creates");
+
+        let error = restore_update_backup(&target_file, &backup_file)
+            .expect_err("directory backup should fail closed");
+
+        assert!(error.contains("release update backup file is not a regular file"));
+        assert!(!target_file.exists());
+        assert!(backup_file.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_apply_restore_backup_rejects_symlink_backup_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = temp_home("update-apply-symlink-restore-backup");
+        let install_dir = home.join("install-bin");
+        let backup_dir = install_dir.join(".conu-update-backups").join("restore");
+        fs::create_dir_all(&backup_dir).expect("backup dir creates");
+        let target_file = install_dir.join(update_binary_filename("conu"));
+        let backup_file = backup_dir.join(update_binary_filename("conu"));
+        let outside_backup = home.join("outside-restore-backup");
+        fs::write(&outside_backup, b"backup binary").expect("outside backup writes");
+        symlink(&outside_backup, &backup_file).expect("backup symlink creates");
+
+        let error = restore_update_backup(&target_file, &backup_file)
+            .expect_err("symlink backup should fail closed");
+
+        assert!(error.contains("release update backup file is not a regular file"));
+        assert!(!target_file.exists());
+        assert_eq!(
+            fs::read(&outside_backup).expect("outside backup reads"),
+            b"backup binary"
+        );
+        assert!(
+            fs::symlink_metadata(&backup_file)
+                .expect("backup symlink metadata")
+                .file_type()
+                .is_symlink()
         );
     }
 


### PR DESCRIPTION
## **User description**
Closes #406

## Summary
- revalidates release update backup file metadata before open, after open, and after restore copy
- removes partial restore targets when post-copy backup validation fails
- adds regressions for directory and Unix symlink backup restore sources

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-cli --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-cli --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_apply_restore_backup --lib (blocked locally: dlltool.exe missing)

## Security review
payload exposure risk: none; backup binary bytes remain opaque and are not printed
trust/permission risk: reduced; backup restore reads now verify the opened backup handle still matches the inspected regular file
storage/logging risk: reduced; partial restore targets are removed on validation failures and errors remain metadata-only
relay/network risk: none; local release update filesystem path only
required fixes: none before CI


___

## **CodeAnt-AI Description**
**Harden release update backup restores against file changes during restore**

### What Changed
- Restore now rechecks the backup file before, during, and after copying it so a changed file is rejected instead of being restored
- Partial restore targets are removed when restore validation or copying fails
- Backup restore now rejects directories and symlinks without creating a target file
- Added tests for directory and symlink backups failing safely

### Impact
`✅ Fewer unsafe release restores`
`✅ No partial update files left behind after restore failures`
`✅ Safer handling of replaced backup files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
