### PR TITLE
Harden request archive marker moves

### DIFF
--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -808,6 +808,7 @@ fn move_request(request_path: &Path, target_dir: &Path) -> Result<(), AgentError
             .file_name()
             .unwrap_or_else(|| std::ffi::OsStr::new("request.req")),
     );
+    ensure_ipc_archive_target_available(&target)?;
     fs::rename(request_path, &target)
         .map_err(|error| AgentError::io("move IPC request", request_path, error))
 }
@@ -825,10 +826,30 @@ fn reject_request(
             .unwrap_or_else(|| std::ffi::OsStr::new("request.req")),
     );
     let error_path = target.with_extension("error");
-    fs::write(&error_path, format!("{error}\n"))
-        .map_err(|error| AgentError::io("write IPC rejection reason", &error_path, error))?;
+    ensure_ipc_archive_target_available(&target)?;
+    write_new_file_with_action(
+        &error_path,
+        &format!("{error}\n"),
+        "create IPC rejection reason",
+        "write IPC rejection reason",
+    )?;
     fs::rename(request_path, &target)
         .map_err(|error| AgentError::io("move rejected IPC request", request_path, error))
+}
+
+fn ensure_ipc_archive_target_available(path: &Path) -> Result<(), AgentError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(AgentError::io(
+            "reserve IPC archive target",
+            path,
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "archive target already exists",
+            ),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(AgentError::io("inspect IPC archive target", path, error)),
+    }
 }
 
 fn render_registration_request(request_id: &str, registration: &AgentRegistration) -> String {
@@ -878,14 +899,23 @@ fn append_agent_log(paths: &StatePaths, event: &str, agent_id: &str) -> Result<(
 }
 
 fn write_new_file(path: &Path, contents: &str) -> Result<(), AgentError> {
+    write_new_file_with_action(path, contents, "create IPC request", "write IPC request")
+}
+
+fn write_new_file_with_action(
+    path: &Path,
+    contents: &str,
+    create_action: &'static str,
+    write_action: &'static str,
+) -> Result<(), AgentError> {
     let mut file = OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
-        .map_err(|error| AgentError::io("create IPC request", path, error))?;
+        .map_err(|error| AgentError::io(create_action, path, error))?;
 
     file.write_all(contents.as_bytes())
-        .map_err(|error| AgentError::io("write IPC request", path, error))
+        .map_err(|error| AgentError::io(write_action, path, error))
 }
 
 fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, AgentError> {
@@ -1184,6 +1214,81 @@ mod tests {
         assert!(rejected >= 1);
         assert!(error_text.contains("unsupported request type"));
         assert!(!error_text.contains("secret private message contents"));
+    }
+
+    #[test]
+    fn processed_request_archive_refuses_existing_marker() {
+        let home = test_home("processed-collision");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let registration = AgentRegistration::new("agent.codex", "Codex Desktop", "coding-agent")
+            .expect("valid registration");
+        let submission =
+            submit_registration(Some(home.clone()), registration).expect("request submits");
+        let target = init.paths.ipc_processed_dir.join(
+            submission
+                .request_path
+                .file_name()
+                .expect("request filename"),
+        );
+        fs::write(&target, "existing processed marker").expect("existing marker writes");
+
+        let error = process_gateway_requests(Some(home))
+            .expect_err("existing processed marker should fail closed");
+
+        assert!(error.to_string().contains("reserve IPC archive target"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("existing marker reads"),
+            "existing processed marker"
+        );
+        assert!(submission.request_path.exists());
+    }
+
+    #[test]
+    fn rejected_request_archive_refuses_existing_marker() {
+        let home = test_home("rejected-collision");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let bad = init.paths.ipc_inbox_dir.join("bad.req");
+        fs::write(&bad, "version = \"1\"\ntype = \"unsupported\"\n").expect("bad request writes");
+        let target = init.paths.ipc_rejected_dir.join("bad.req");
+        let error_path = init.paths.ipc_rejected_dir.join("bad.error");
+        fs::write(&target, "existing rejected marker").expect("existing marker writes");
+        fs::write(&error_path, "existing rejection reason").expect("existing error writes");
+
+        let error = process_gateway_requests(Some(home))
+            .expect_err("existing rejected marker should fail closed");
+
+        assert!(error.to_string().contains("reserve IPC archive target"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("existing marker reads"),
+            "existing rejected marker"
+        );
+        assert_eq!(
+            fs::read_to_string(&error_path).expect("existing error reads"),
+            "existing rejection reason"
+        );
+        assert!(bad.exists());
+    }
+
+    #[test]
+    fn rejected_request_reason_refuses_existing_file() {
+        let home = test_home("rejected-error-collision");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let bad = init.paths.ipc_inbox_dir.join("bad.req");
+        fs::write(&bad, "version = \"1\"\ntype = \"unsupported\"\n").expect("bad request writes");
+        let target = init.paths.ipc_rejected_dir.join("bad.req");
+        let error_path = init.paths.ipc_rejected_dir.join("bad.error");
+        fs::write(&error_path, "existing rejection reason").expect("existing error writes");
+
+        let error = process_gateway_requests(Some(home))
+            .expect_err("existing rejection reason should fail closed");
+
+        assert!(error.to_string().contains("create IPC rejection reason"));
+        assert_eq!(
+            fs::read_to_string(&error_path).expect("existing error reads"),
+            "existing rejection reason"
+        );
+        assert!(!target.exists());
+        assert!(bad.exists());
     }
 
     fn test_home(label: &str) -> PathBuf {

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -1427,8 +1427,28 @@ fn move_relay_request(
         .and_then(|value| value.to_str())
         .unwrap_or("relay-request");
     let target = target_dir.join(format!("{stem}.{extension}"));
+    ensure_relay_archive_target_available(&target)?;
     fs::rename(request_path, &target)
         .map_err(|error| RelayDeliveryError::io("move relay request marker", request_path, error))
+}
+
+fn ensure_relay_archive_target_available(path: &Path) -> Result<(), RelayDeliveryError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(RelayDeliveryError::io(
+            "reserve relay archive target",
+            path,
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "archive target already exists",
+            ),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(RelayDeliveryError::io(
+            "inspect relay archive target",
+            path,
+            error,
+        )),
+    }
 }
 
 fn relay_endpoint_for_sync(
@@ -2062,6 +2082,46 @@ mod tests {
         let error = read_relay_request(&path).expect_err("mismatched request fails");
 
         assert!(error.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn relay_sent_archive_refuses_existing_marker() {
+        let home = test_home("sent-archive-collision");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let request = init.paths.relay_outbox_dir.join("queued.relay");
+        let target = init.paths.relay_sent_dir.join("queued.sent");
+        fs::write(&request, "queued relay marker").expect("request writes");
+        fs::write(&target, "existing sent marker").expect("existing marker writes");
+
+        let error = move_relay_request(&init.paths.relay_sent_dir, &request, "sent")
+            .expect_err("existing sent marker should fail closed");
+
+        assert!(error.to_string().contains("reserve relay archive target"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("existing marker reads"),
+            "existing sent marker"
+        );
+        assert!(request.exists());
+    }
+
+    #[test]
+    fn relay_rejected_archive_refuses_existing_marker() {
+        let home = test_home("rejected-archive-collision");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let request = init.paths.relay_outbox_dir.join("bad.relay");
+        let target = init.paths.relay_rejected_dir.join("bad.rejected");
+        fs::write(&request, "bad relay marker").expect("request writes");
+        fs::write(&target, "existing rejected marker").expect("existing marker writes");
+
+        let error = move_relay_request(&init.paths.relay_rejected_dir, &request, "rejected")
+            .expect_err("existing rejected marker should fail closed");
+
+        assert!(error.to_string().contains("reserve relay archive target"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("existing marker reads"),
+            "existing rejected marker"
+        );
+        assert!(request.exists());
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- fail closed before moving agent IPC requests over existing processed/rejected archive markers
- write IPC rejection reason files with create-new semantics so existing reasons are preserved
- fail closed before moving relay outbox markers over existing sent/rejected archive markers
- add regressions that preserve existing archive markers and leave source requests intact on collision

Closes #408

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Local test execution was attempted but this workstation is missing both GNU dlltool.exe and MSVC link.exe, so the focused tests could not start locally. CI should execute them on hosted runners.

## Security review
- payload exposure risk: none; request bodies remain metadata-only and relay payload bytes remain opaque
- trust/permission risk: reduced; archival moves no longer overwrite existing processed/rejected/sent markers
- storage/logging risk: reduced; existing audit marker and rejection-reason files are preserved on collisions
- relay/network risk: reduced for local relay queue bookkeeping only; relay protocol behavior is unchanged


___

## **CodeAnt-AI Description**
**Prevent archived request markers from being overwritten on collision**

### What Changed
- Request archiving now stops instead of replacing an existing processed or rejected marker.
- Rejected IPC requests also keep any existing rejection note instead of overwriting it.
- Relay queue markers now fail the same way when a sent or rejected marker already exists.
- New checks leave the original request and any existing archive files untouched when a collision occurs.

### Impact
`✅ Preserved audit markers`
`✅ Fewer lost rejection notes`
`✅ Safer request archiving`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
