### PR TITLE
Harden message IPC marker writes

### DIFF
--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -221,6 +221,9 @@ pub fn process_message_requests_from_paths(
     };
 
     for request_path in pending_message_requests(paths)? {
+        ensure_message_ipc_marker_available(&processed_marker_path(paths, &request_path))?;
+        ensure_message_ipc_marker_available(&rejected_marker_path(paths, &request_path))?;
+
         match process_one_message_request(paths, &request_path) {
             Ok(delivery) => {
                 report.delivered += 1;
@@ -673,9 +676,7 @@ fn write_processed_marker(
             error,
         )
     })?;
-    let marker_path = paths
-        .message_ipc_processed_dir
-        .join(replace_extension(request_path, "meta"));
+    let marker_path = processed_marker_path(paths, request_path);
     let contents = format!(
         "version = \"{}\"\ntype = \"send_message\"\nrequest_id = \"{}\"\nenvelope_id = \"{}\"\nfrom_agent_id = \"{}\"\nto_agent_id = \"{}\"\nstatus = \"delivered_local\"\npayload_len = {}\npayload_displayed = false\n",
         REQUEST_VERSION,
@@ -686,9 +687,12 @@ fn write_processed_marker(
         delivery.payload_bytes
     );
 
-    fs::write(&marker_path, contents).map_err(|error| {
-        MessageError::io("write message IPC processed marker", &marker_path, error)
-    })
+    write_new_file_with_action(
+        &marker_path,
+        &contents,
+        "create message IPC processed marker",
+        "write message IPC processed marker",
+    )
 }
 
 fn reject_message_request(
@@ -703,13 +707,38 @@ fn reject_message_request(
             error,
         )
     })?;
-    let error_path = paths
-        .message_ipc_rejected_dir
-        .join(replace_extension(request_path, "error"));
-    fs::write(&error_path, format!("{error}\n")).map_err(|error| {
-        MessageError::io("write message IPC rejection reason", &error_path, error)
-    })?;
+    let error_path = rejected_marker_path(paths, request_path);
+    write_new_file_with_action(
+        &error_path,
+        &format!("{error}\n"),
+        "create message IPC rejection reason",
+        "write message IPC rejection reason",
+    )?;
     remove_file_if_exists(request_path)
+}
+
+fn processed_marker_path(paths: &StatePaths, request_path: &Path) -> PathBuf {
+    paths
+        .message_ipc_processed_dir
+        .join(replace_extension(request_path, "meta"))
+}
+
+fn rejected_marker_path(paths: &StatePaths, request_path: &Path) -> PathBuf {
+    paths
+        .message_ipc_rejected_dir
+        .join(replace_extension(request_path, "error"))
+}
+
+fn ensure_message_ipc_marker_available(path: &Path) -> Result<(), MessageError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(MessageError::io(
+            "reserve message IPC marker",
+            path,
+            io::Error::new(io::ErrorKind::AlreadyExists, "marker already exists"),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(MessageError::io("inspect message IPC marker", path, error)),
+    }
 }
 
 fn read_inbox_entry(path: &Path) -> Result<InboxEntry, MessageError> {
@@ -946,14 +975,23 @@ fn append_message_log(
 }
 
 fn write_new_file(path: &Path, contents: &str) -> Result<(), MessageError> {
+    write_new_file_with_action(path, contents, "create message file", "write message file")
+}
+
+fn write_new_file_with_action(
+    path: &Path,
+    contents: &str,
+    create_action: &'static str,
+    write_action: &'static str,
+) -> Result<(), MessageError> {
     let mut file = OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
-        .map_err(|error| MessageError::io("create message file", path, error))?;
+        .map_err(|error| MessageError::io(create_action, path, error))?;
 
     file.write_all(contents.as_bytes())
-        .map_err(|error| MessageError::io("write message file", path, error))
+        .map_err(|error| MessageError::io(write_action, path, error))
 }
 
 fn remove_file_if_exists(path: &Path) -> Result<(), MessageError> {
@@ -1323,6 +1361,76 @@ mod tests {
                 .count(),
             0
         );
+    }
+
+    #[test]
+    fn processed_message_marker_collision_fails_before_delivery() {
+        let home = test_home("processed-marker-collision");
+        register_agent(&home, "agent.sender");
+        register_agent(&home, "agent.receiver");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("message valid");
+        let submission =
+            submit_local_message(Some(home.clone()), message).expect("message submits");
+        let paths = StatePaths::from_home(home.clone());
+        let marker_path = processed_marker_path(&paths, &submission.request_path);
+        fs::write(&marker_path, "existing processed marker").expect("existing marker writes");
+
+        let error = process_message_requests(Some(home.clone()))
+            .expect_err("existing processed marker should fail closed");
+
+        assert!(error.to_string().contains("reserve message IPC marker"));
+        assert_eq!(
+            fs::read_to_string(&marker_path).expect("existing marker reads"),
+            "existing processed marker"
+        );
+        assert!(submission.request_path.exists());
+        assert!(
+            list_agent_inbox(Some(home), "agent.receiver")
+                .expect("inbox reads")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn rejected_message_marker_collision_fails_before_processing() {
+        let home = test_home("rejected-marker-collision");
+        register_agent(&home, "agent.sender");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"secret private message contents".to_vec()),
+        )
+        .expect("message valid");
+        let submission =
+            submit_local_message(Some(home.clone()), message).expect("message submits");
+        let paths = StatePaths::from_home(home.clone());
+        let marker_path = rejected_marker_path(&paths, &submission.request_path);
+        fs::write(&marker_path, "existing rejection reason").expect("existing marker writes");
+
+        let error = process_message_requests(Some(home.clone()))
+            .expect_err("existing rejection marker should fail closed");
+
+        assert!(error.to_string().contains("reserve message IPC marker"));
+        assert_eq!(
+            fs::read_to_string(&marker_path).expect("existing marker reads"),
+            "existing rejection reason"
+        );
+        assert!(submission.request_path.exists());
+
+        fs::remove_file(&marker_path).expect("existing marker removes");
+        let report = process_message_requests(Some(home.clone()))
+            .expect("request processes after collision is cleared");
+        let replacement = fs::read_to_string(&marker_path).expect("new rejection reason reads");
+
+        assert_eq!(report.rejected, 1);
+        assert!(replacement.contains("recipient is not a registered local agent"));
+        assert!(!replacement.contains("secret private message contents"));
+        assert!(!submission.request_path.exists());
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- preflight local message IPC processed/rejected marker paths before processing pending requests
- write message processed and rejected markers with create-new semantics
- add regressions that preserve existing markers, keep requests intact, and prevent delivery before processed-marker collisions

Closes #410

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Focused Rust tests were attempted locally, but this workstation is missing GNU dlltool.exe, so test execution could not start. Hosted PR CI should run tests on Ubuntu, macOS, and Windows.

## Security review
- payload exposure risk: none; payload fixtures remain asserted absent from marker/error surfaces
- trust/permission risk: unchanged; local sender/recipient validation still owns delivery authorization
- storage/logging risk: reduced; existing processed/rejected message IPC markers are preserved and source requests remain intact on collisions
- relay/network risk: none; local message IPC only
- required fixes: none before CI


___

## **CodeAnt-AI Description**
**Prevent message processing from overwriting existing marker files**

### What Changed
- Message requests now stop before delivery or rejection if the matching marker file already exists
- Processed and rejected markers are written only as new files, so existing marker contents are preserved
- If a collision is found, the original request stays in place and no message is delivered or rejected until the conflict is removed

### Impact
`✅ Preserved message records`
`✅ Fewer lost or overwritten IPC markers`
`✅ Safer message delivery after file collisions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
