### PR TITLE
Harden message delivery receipt writes

### DIFF
--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -561,8 +561,18 @@ fn deliver_envelope_with_status_and_stream(
     status: &str,
     stream_id: Option<String>,
 ) -> Result<InboxEntry, MessageError> {
-    let now = current_unix_seconds();
     let receipt_id = request_id("rcpt");
+    deliver_envelope_with_status_stream_and_receipt(paths, envelope, status, stream_id, receipt_id)
+}
+
+fn deliver_envelope_with_status_stream_and_receipt(
+    paths: &StatePaths,
+    envelope: Envelope,
+    status: &str,
+    stream_id: Option<String>,
+    receipt_id: String,
+) -> Result<InboxEntry, MessageError> {
+    let now = current_unix_seconds();
     let inbox_dir = paths.message_inbox_dir.join(envelope.to.as_str());
     fs::create_dir_all(&inbox_dir)
         .map_err(|error| MessageError::io("create agent message inbox", &inbox_dir, error))?;
@@ -584,6 +594,13 @@ fn deliver_envelope_with_status_and_stream(
         delivered_at_unix: now,
         payload_bytes: envelope.payload.len(),
     };
+    let envelope_path = inbox_dir.join(format!("{}.env", entry.envelope_id));
+    let receipt_path = paths
+        .message_receipts_dir
+        .join(format!("{}.receipt", entry.receipt_id));
+    ensure_message_delivery_file_available(&envelope_path)?;
+    ensure_message_delivery_file_available(&receipt_path)?;
+
     let encrypted = security::encrypt_for_storage_from_paths(
         paths,
         envelope.payload.as_bytes(),
@@ -594,7 +611,6 @@ fn deliver_envelope_with_status_and_stream(
             entry.stream_id.as_deref(),
         ),
     )?;
-    let envelope_path = inbox_dir.join(format!("{}.env", entry.envelope_id));
     write_new_file(
         &envelope_path,
         &render_envelope_file(&entry, envelope.kind, &encrypted),
@@ -611,10 +627,10 @@ fn deliver_envelope_with_status_and_stream(
         delivered_at_unix: now,
         payload_bytes: entry.payload_bytes,
     };
-    let receipt_path = paths
-        .message_receipts_dir
-        .join(format!("{}.receipt", receipt.receipt_id));
-    write_new_file(&receipt_path, &render_receipt(&receipt))?;
+    if let Err(error) = write_new_file(&receipt_path, &render_receipt(&receipt)) {
+        let _ = fs::remove_file(&envelope_path);
+        return Err(error);
+    }
     append_message_log(paths, &entry, status)?;
 
     Ok(entry)
@@ -738,6 +754,22 @@ fn ensure_message_ipc_marker_available(path: &Path) -> Result<(), MessageError> 
         )),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(MessageError::io("inspect message IPC marker", path, error)),
+    }
+}
+
+fn ensure_message_delivery_file_available(path: &Path) -> Result<(), MessageError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(MessageError::io(
+            "reserve message delivery file",
+            path,
+            io::Error::new(io::ErrorKind::AlreadyExists, "delivery file already exists"),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(MessageError::io(
+            "inspect message delivery file",
+            path,
+            error,
+        )),
     }
 }
 
@@ -1431,6 +1463,48 @@ mod tests {
         assert!(replacement.contains("recipient is not a registered local agent"));
         assert!(!replacement.contains("secret private message contents"));
         assert!(!submission.request_path.exists());
+    }
+
+    #[test]
+    fn delivery_receipt_collision_fails_before_writing_envelope() {
+        let home = test_home("receipt-collision");
+        register_agent(&home, "agent.sender");
+        register_agent(&home, "agent.receiver");
+        let paths = StatePaths::from_home(home);
+        fs::create_dir_all(&paths.message_receipts_dir).expect("receipt dir creates");
+        let receipt_id = "rcpt.collision".to_string();
+        let receipt_path = paths.message_receipts_dir.join("rcpt.collision.receipt");
+        fs::write(&receipt_path, "existing receipt marker").expect("existing receipt writes");
+        let envelope = Envelope::new(
+            "env.receipt.collision",
+            AgentId::new("agent.sender").expect("sender id"),
+            AgentId::new("agent.receiver").expect("receiver id"),
+            EnvelopeKind::Message,
+            OpaquePayload::from_bytes(b"secret private message contents".to_vec()),
+        )
+        .expect("envelope creates");
+
+        let error = deliver_envelope_with_status_stream_and_receipt(
+            &paths,
+            envelope,
+            "delivered_local",
+            None,
+            receipt_id,
+        )
+        .expect_err("existing receipt should fail before envelope write");
+
+        assert!(error.to_string().contains("reserve message delivery file"));
+        assert_eq!(
+            fs::read_to_string(&receipt_path).expect("existing receipt reads"),
+            "existing receipt marker"
+        );
+        assert!(
+            !paths
+                .message_inbox_dir
+                .join("agent.receiver")
+                .join("env.receipt.collision.env")
+                .exists()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- preflight local message delivery envelope and receipt output paths before writing encrypted inbox state
- clean up a newly written envelope if receipt creation still fails after envelope creation
- add a regression proving an existing receipt marker prevents encrypted inbox envelope creation

Closes #414

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Focused Rust tests were attempted locally, but this workstation is missing GNU dlltool.exe, so test execution could not start. Hosted PR CI should run tests on Ubuntu, macOS, and Windows.

## Security review
- payload exposure risk: reduced; receipt collisions now fail before encrypted payload-bearing inbox files are written
- trust/permission risk: unchanged; sender/recipient and policy checks are not modified
- storage/logging risk: reduced; delivery no longer leaves envelope-only partial state on receipt collision, and best-effort cleanup covers late receipt write failures
- relay/network risk: none; local message delivery storage only
- required fixes: none before CI


___

## **CodeAnt-AI Description**
**Prevent duplicate message delivery files from being written when a receipt already exists**

### What Changed
- Delivery now checks for an existing message file and receipt before writing anything
- If receipt creation fails after the message file is written, the message file is removed so no partial delivery is left behind
- Added a test that shows an existing receipt blocks the encrypted inbox file from being created

### Impact
`✅ Fewer duplicate delivery records`
`✅ No partial message files after receipt errors`
`✅ Clearer failure when a receipt already exists`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
