### PR TITLE
Harden local secret file symlink handling

### DIFF
--- a/crates/conu-core/src/security.rs
+++ b/crates/conu-core/src/security.rs
@@ -2732,20 +2732,52 @@ fn required(
 }
 
 fn write_new_secret_file(path: &Path, contents: &str) -> Result<bool, SecurityError> {
-    let created = write_new_file(path, contents)?;
-    set_sensitive_file_permissions(path)?;
-    Ok(created)
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut file) => {
+            set_sensitive_file_permissions(&file, path)?;
+            file.write_all(contents.as_bytes())
+                .map_err(|error| SecurityError::io("write security file", path, error))?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            ensure_existing_secret_file(path)?;
+            Ok(false)
+        }
+        Err(error) => Err(SecurityError::io("create security file", path, error)),
+    }
 }
 
 fn replace_secret_file(path: &Path, contents: &str) -> Result<(), SecurityError> {
+    ensure_replaceable_secret_file(path)?;
     let mut file = OpenOptions::new()
         .write(true)
-        .truncate(true)
         .open(path)
         .map_err(|error| SecurityError::io("open replacement security file", path, error))?;
+    set_sensitive_file_permissions(&file, path)?;
+    file.set_len(0)
+        .map_err(|error| SecurityError::io("truncate replacement security file", path, error))?;
     file.write_all(contents.as_bytes())
-        .map_err(|error| SecurityError::io("write replacement security file", path, error))?;
-    set_sensitive_file_permissions(path)
+        .map_err(|error| SecurityError::io("write replacement security file", path, error))
+}
+
+fn ensure_existing_secret_file(path: &Path) -> Result<(), SecurityError> {
+    ensure_regular_secret_file(path, "inspect existing security file")
+}
+
+fn ensure_replaceable_secret_file(path: &Path) -> Result<(), SecurityError> {
+    ensure_regular_secret_file(path, "inspect replacement security file")
+}
+
+fn ensure_regular_secret_file(path: &Path, action: &'static str) -> Result<(), SecurityError> {
+    let metadata =
+        fs::symlink_metadata(path).map_err(|error| SecurityError::io(action, path, error))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(SecurityError::InvalidKey {
+            path: path.to_path_buf(),
+            reason: "security file path is not a regular file".to_string(),
+        });
+    }
+    Ok(())
 }
 
 fn write_new_file(path: &Path, contents: &str) -> Result<bool, SecurityError> {
@@ -2761,16 +2793,16 @@ fn write_new_file(path: &Path, contents: &str) -> Result<bool, SecurityError> {
 }
 
 #[cfg(unix)]
-fn set_sensitive_file_permissions(path: &Path) -> Result<(), SecurityError> {
+fn set_sensitive_file_permissions(file: &fs::File, path: &Path) -> Result<(), SecurityError> {
     use std::os::unix::fs::PermissionsExt;
 
     let permissions = fs::Permissions::from_mode(0o600);
-    fs::set_permissions(path, permissions)
+    file.set_permissions(permissions)
         .map_err(|error| SecurityError::io("set security file permissions", path, error))
 }
 
 #[cfg(not(unix))]
-fn set_sensitive_file_permissions(_path: &Path) -> Result<(), SecurityError> {
+fn set_sensitive_file_permissions(_file: &fs::File, _path: &Path) -> Result<(), SecurityError> {
     Ok(())
 }
 
@@ -2969,6 +3001,60 @@ mod tests {
             assert!(!report.secrets_os_protected);
         }
         assert!(!signing.contains("private message contents"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn new_secret_file_rejects_existing_symlink_without_touching_target() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let home = test_home("new-secret-symlink");
+        fs::create_dir_all(&home).expect("home directory created");
+        let target = home.join("outside-secret-target");
+        let link = home.join("secret.key");
+        fs::write(&target, "existing secret").expect("target writes");
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644))
+            .expect("target permissions set");
+        symlink(&target, &link).expect("symlink creates");
+
+        let error = write_new_secret_file(&link, "new secret")
+            .expect_err("existing symlink should fail closed");
+
+        assert!(error.to_string().contains("not a regular file"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            "existing secret"
+        );
+        assert_eq!(
+            fs::metadata(&target)
+                .expect("target metadata reads")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacement_secret_file_rejects_symlink_without_truncating_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("replace-secret-symlink");
+        fs::create_dir_all(&home).expect("home directory created");
+        let target = home.join("outside-secret-target");
+        let link = home.join("secret.key");
+        fs::write(&target, "existing secret").expect("target writes");
+        symlink(&target, &link).expect("symlink creates");
+
+        let error =
+            replace_secret_file(&link, "new secret").expect_err("symlink replacement fails closed");
+
+        assert!(error.to_string().contains("not a regular file"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            "existing secret"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #416.

## Summary
- reject existing symlink/non-file paths when creating or replacing local secret files
- set Unix secret-file permissions through the opened file handle instead of chmodding by path
- add Unix regressions proving symlink targets are not chmodded or truncated

## Security review
- payload exposure risk: unchanged; no payload contents are logged or displayed
- trust/permission risk: reduced for local identity, storage-key, and relay credential maintenance because secret paths no longer follow symlink/non-file indirections
- storage/logging risk: reduced; replacement now rejects symlink/non-file targets before truncating and permission setting is handle-bound
- relay/network risk: none; local secret storage only
- required fixes: none before CI

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Focused local Rust test execution was attempted with cargo +stable-x86_64-pc-windows-gnu test -p conu-core secret_file --lib, but this workstation is missing dlltool.exe, so the binary did not link before test execution. Hosted CI should run the Unix symlink regressions on Linux/macOS.


___

## **CodeAnt-AI Description**
**Harden local secret file handling against symlink targets**

### What Changed
- Creating or replacing a local secret file now refuses paths that are symlinks or not regular files
- Existing secret files are no longer touched through the path before this check, so linked target files are not overwritten or truncated
- File permissions are now applied to the opened secret file directly

### Impact
`✅ Safer secret file updates`
`✅ Fewer accidental secret overwrites`
`✅ Less risk of changing files outside the intended secret path`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
