### PR TITLE
Harden log rotation file handling

### DIFF
--- a/crates/conu-core/src/observability.rs
+++ b/crates/conu-core/src/observability.rs
@@ -193,11 +193,9 @@ pub fn rotate_logs_from_paths(
             continue;
         }
 
-        let metadata = fs::metadata(&path)
-            .map_err(|error| ObservabilityError::io("read log metadata", &path, error))?;
-        if !metadata.is_file() {
+        let Some(metadata) = active_log_metadata(&path)? else {
             continue;
-        }
+        };
 
         let size_bytes = metadata.len();
         let archives_removed = if size_bytes > policy.max_bytes {
@@ -228,10 +226,11 @@ pub fn rotate_logs_from_paths(
 }
 
 fn rotate_one_log(path: &Path, keep_archives: usize) -> Result<usize, ObservabilityError> {
+    ensure_regular_log_file(path, "inspect active log before rotation")?;
     let mut removed = 0;
     for index in (1..=keep_archives).rev() {
         let source = archive_path(path, index);
-        if !source.exists() {
+        if regular_log_metadata(&source, "inspect log archive")?.is_none() {
             continue;
         }
         if index == keep_archives {
@@ -241,12 +240,14 @@ fn rotate_one_log(path: &Path, keep_archives: usize) -> Result<usize, Observabil
             removed += 1;
         } else {
             let target = archive_path(path, index + 1);
+            ensure_log_archive_target_available(&target)?;
             fs::rename(&source, &target)
                 .map_err(|error| ObservabilityError::io("shift log archive", &source, error))?;
         }
     }
 
     let first_archive = archive_path(path, 1);
+    ensure_log_archive_target_available(&first_archive)?;
     fs::rename(path, &first_archive)
         .map_err(|error| ObservabilityError::io("rotate active log", path, error))?;
     OpenOptions::new()
@@ -256,6 +257,72 @@ fn rotate_one_log(path: &Path, keep_archives: usize) -> Result<usize, Observabil
         .map_err(|error| ObservabilityError::io("create fresh active log", path, error))?;
 
     Ok(removed)
+}
+
+fn regular_log_metadata(
+    path: &Path,
+    action: &'static str,
+) -> Result<Option<fs::Metadata>, ObservabilityError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(ObservabilityError::io(
+                    action,
+                    path,
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "log path is not a regular file",
+                    ),
+                ));
+            }
+            Ok(Some(metadata))
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(ObservabilityError::io(action, path, error)),
+    }
+}
+
+fn active_log_metadata(path: &Path) -> Result<Option<fs::Metadata>, ObservabilityError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Ok(None);
+            }
+            Ok(Some(metadata))
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(ObservabilityError::io("read log metadata", path, error)),
+    }
+}
+
+fn ensure_regular_log_file(path: &Path, action: &'static str) -> Result<(), ObservabilityError> {
+    match regular_log_metadata(path, action)? {
+        Some(_) => Ok(()),
+        None => Err(ObservabilityError::io(
+            action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "log path does not exist"),
+        )),
+    }
+}
+
+fn ensure_log_archive_target_available(path: &Path) -> Result<(), ObservabilityError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(ObservabilityError::io(
+            "reserve log archive target",
+            path,
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "log archive target already exists",
+            ),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(ObservabilityError::io(
+            "inspect log archive target",
+            path,
+            error,
+        )),
+    }
 }
 
 fn is_active_log_file(path: &Path) -> bool {
@@ -344,6 +411,104 @@ mod tests {
             fs::read_to_string(paths.logs_dir.join("conud.log.2")).expect("archive two reads"),
             "archive one\n"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skips_symlinked_active_log_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("active-symlink");
+        let paths = StatePaths::from_home(home.clone());
+        fs::create_dir_all(&paths.logs_dir).expect("logs directory");
+        let outside = home.join("outside.log");
+        let link = paths.logs_dir.join("conud.log");
+        fs::write(&outside, "outside payload-safe log\n").expect("outside log writes");
+        symlink(&outside, &link).expect("active log symlink creates");
+
+        let report = rotate_logs_from_paths(
+            &paths,
+            LogRotationPolicy::new(1, 2).expect("policy validates"),
+        )
+        .expect("logs rotate");
+
+        assert_eq!(report.files_scanned, 0);
+        assert_eq!(report.files_rotated, 0);
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside log reads"),
+            "outside payload-safe log\n"
+        );
+        assert!(
+            fs::symlink_metadata(&link)
+                .expect("active link metadata")
+                .file_type()
+                .is_symlink()
+        );
+        assert!(!paths.logs_dir.join("conud.log.1").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn archive_symlink_fails_before_rotating_active_log() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("archive-symlink");
+        let paths = StatePaths::from_home(home.clone());
+        fs::create_dir_all(&paths.logs_dir).expect("logs directory");
+        let active = paths.logs_dir.join("conud.log");
+        let outside = home.join("outside-archive");
+        let archive_link = paths.logs_dir.join("conud.log.1");
+        fs::write(&active, "active active\n").expect("active writes");
+        fs::write(&outside, "outside archive\n").expect("outside archive writes");
+        symlink(&outside, &archive_link).expect("archive symlink creates");
+
+        let error = rotate_logs_from_paths(
+            &paths,
+            LogRotationPolicy::new(4, 2).expect("policy validates"),
+        )
+        .expect_err("archive symlink should fail closed");
+
+        assert!(error.to_string().contains("inspect log archive"));
+        assert_eq!(
+            fs::read_to_string(&active).expect("active reads"),
+            "active active\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside reads"),
+            "outside archive\n"
+        );
+        assert!(
+            fs::symlink_metadata(&archive_link)
+                .expect("archive link metadata")
+                .file_type()
+                .is_symlink()
+        );
+        assert!(!paths.logs_dir.join("conud.log.2").exists());
+    }
+
+    #[test]
+    fn archive_directory_fails_before_rotating_active_log() {
+        let home = test_home("archive-directory");
+        let paths = StatePaths::from_home(home);
+        fs::create_dir_all(&paths.logs_dir).expect("logs directory");
+        let active = paths.logs_dir.join("conud.log");
+        let archive_dir = paths.logs_dir.join("conud.log.1");
+        fs::write(&active, "active active\n").expect("active writes");
+        fs::create_dir_all(&archive_dir).expect("archive directory creates");
+
+        let error = rotate_logs_from_paths(
+            &paths,
+            LogRotationPolicy::new(4, 2).expect("policy validates"),
+        )
+        .expect_err("archive directory should fail closed");
+
+        assert!(error.to_string().contains("inspect log archive"));
+        assert_eq!(
+            fs::read_to_string(&active).expect("active reads"),
+            "active active\n"
+        );
+        assert!(archive_dir.is_dir());
+        assert!(!paths.logs_dir.join("conud.log.2").exists());
     }
 
     fn test_home(name: &str) -> PathBuf {


### PR DESCRIPTION
## **User description**
Closes #418.

## Summary
- scan active .log files with symlink_metadata so symlinked/non-regular active log entries are not followed
- validate active logs again before rotation and validate archive source slots as regular files
- reserve archive targets before rename to avoid clobbering unexpected files or symlinks
- add regressions for symlinked active logs, symlinked archives, and directory archives

## Security review
- payload exposure risk: unchanged; log contents are still not read or reported by rotation output
- trust/permission risk: unchanged
- storage/logging risk: reduced; rotation no longer follows symlinked active logs and fails closed before moving active logs when archive slots are symlinks or directories
- relay/network risk: none; local observability maintenance only
- required fixes: none before CI

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Focused local Rust test execution was attempted with cargo +stable-x86_64-pc-windows-gnu test -p conu-core observability --lib, but this workstation is missing dlltool.exe, so the binary did not link before test execution. Hosted CI should run the observability regressions on Linux/macOS/Windows.


___

## **CodeAnt-AI Description**
**Stop log rotation from following symlinks or overwriting unexpected files**

### What Changed
- Active `.log` files are skipped if they are symlinks or not regular files, so rotation no longer touches linked logs outside the logs folder.
- Before rotating, the code now checks that the active log is still a regular file and that archive slots are regular files or empty.
- Rotation now refuses to write over an existing archive path if it is already a file, symlink, or directory.
- Added checks for symlinked active logs, symlinked archives, and archive directories to keep rotation from modifying the wrong files.

### Impact
`✅ Safer log rotation`
`✅ Fewer accidental file overwrites`
`✅ No rotation of symlinked logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
