### PR TITLE
Harden core state directory handling

### DIFF
--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -372,8 +372,10 @@ impl NodeIdentity {
 }
 
 fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
+    fs::create_dir_all(&paths.home)
+        .map_err(|error| StateError::io("create state directory", &paths.home, error))?;
+
     for directory in [
-        &paths.home,
         &paths.agents_dir,
         &paths.runtime_dir,
         &paths.ipc_dir,
@@ -403,11 +405,34 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
         &paths.security_dir,
         &paths.storage_key_archive_dir,
     ] {
-        fs::create_dir_all(directory)
-            .map_err(|error| StateError::io("create state directory", directory, error))?;
+        ensure_state_directory(directory)?;
     }
 
     Ok(())
+}
+
+fn ensure_state_directory(path: &Path) -> Result<(), StateError> {
+    if regular_state_directory_metadata(path, "inspect state directory")?.is_some() {
+        return Ok(());
+    }
+
+    match fs::create_dir(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            match regular_state_directory_metadata(path, "inspect state directory")? {
+                Some(_) => Ok(()),
+                None => Err(StateError::io(
+                    "inspect state directory",
+                    path,
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "state directory disappeared after create collision",
+                    ),
+                )),
+            }
+        }
+        Err(error) => Err(StateError::io("create state directory", path, error)),
+    }
 }
 
 fn write_if_missing(
@@ -512,6 +537,30 @@ fn regular_state_file_metadata(
                     io::Error::new(
                         io::ErrorKind::InvalidInput,
                         "state file path is not a regular file",
+                    ),
+                ));
+            }
+            Ok(Some(metadata))
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(StateError::io(action, path, error)),
+    }
+}
+
+fn regular_state_directory_metadata(
+    path: &Path,
+    action: &'static str,
+) -> Result<Option<fs::Metadata>, StateError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() || !file_type.is_dir() {
+                return Err(StateError::io(
+                    action,
+                    path,
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "state directory path is not a directory",
                     ),
                 ));
             }
@@ -758,6 +807,18 @@ mod tests {
         assert!(error.to_string().contains("inspect config file"));
     }
 
+    #[test]
+    fn init_rejects_file_instead_of_state_directory() {
+        let home = test_home("file-logs-dir");
+        let report = init_state(Some(home.clone())).expect("state initializes");
+        fs::remove_dir(&report.paths.logs_dir).expect("logs dir removes");
+        fs::write(&report.paths.logs_dir, "not a directory").expect("logs file writes");
+
+        let error = init_state(Some(home)).expect_err("file state directory should fail closed");
+
+        assert!(error.to_string().contains("inspect state directory"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn init_rejects_symlinked_node_identity_without_reading_target() {
@@ -841,6 +902,30 @@ mod tests {
         assert!(
             fs::symlink_metadata(&report.paths.config)
                 .expect("config symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn init_rejects_symlinked_state_directory_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("messages-dir-symlink");
+        let report = init_state(Some(home.clone())).expect("state initializes");
+        let outside = home.join("outside-messages");
+        fs::create_dir_all(&outside).expect("outside directory creates");
+        fs::remove_dir_all(&report.paths.messages_dir).expect("messages dir removes");
+        symlink(&outside, &report.paths.messages_dir).expect("messages dir symlink creates");
+
+        let error = init_state(Some(home)).expect_err("state dir symlink should fail closed");
+
+        assert!(error.to_string().contains("inspect state directory"));
+        assert!(!outside.join(MESSAGE_INBOX_DIR).exists());
+        assert!(
+            fs::symlink_metadata(&report.paths.messages_dir)
+                .expect("messages dir symlink metadata")
                 .file_type()
                 .is_symlink()
         );


### PR DESCRIPTION
## **User description**
Closes #426.

## Summary
- reject symlink/non-directory conU-owned state subdirectories before reusing them during init
- create missing state subdirectories one level at a time after parent directories have been checked
- keep `CONU_HOME` creation behavior intact while hardening conU-owned child directories
- add regressions for file-backed state directory paths and Unix symlinked state directories

## Security review
- payload exposure risk: unchanged; no payload fields are read, logged, or displayed
- trust/permission risk: unchanged; this only hardens local state directory handling
- storage/logging risk: reduced; conU-owned state subdirectories no longer silently follow symlink or non-directory paths
- relay/network risk: none; local state layout handling only
- required fixes: none before CI

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Focused local Rust test execution was attempted with `cargo +stable-x86_64-pc-windows-gnu test -p conu-core state --lib`, but this workstation is missing `dlltool.exe`, so the binary did not link before test execution. Hosted CI should execute the state directory regressions on Linux/macOS/Windows.


___

## **CodeAnt-AI Description**
**State setup now rejects files and symlinks in state directories**

### What Changed
- State setup now checks existing state folders before using them, instead of following files or symlinks
- Missing state folders are still created when needed, but only after the parent state folder is confirmed safe
- Added coverage for cases where a state folder is replaced with a file or a symlink, so setup fails closed instead of writing through it

### Impact
`✅ Fewer unsafe state writes`
`✅ Safer app startup after tampered local storage`
`✅ Clearer failures when state folders are replaced`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
