### PR TITLE
Harden core metadata file handling

### DIFF
--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -613,12 +613,14 @@ fn signed_agent_card_from_record(agent: &LocalAgentRecord) -> Result<SignedAgent
 }
 
 fn read_registry(paths: &StatePaths) -> Result<Vec<LocalAgentRecord>, AgentError> {
-    if !paths.agent_registry.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.agent_registry,
+        "inspect agent registry",
+        "read agent registry",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.agent_registry)
-        .map_err(|error| AgentError::io("read agent registry", &paths.agent_registry, error))?;
+    };
     parse_registry(&contents)
 }
 
@@ -675,8 +677,15 @@ fn write_registry(paths: &StatePaths, agents: &[LocalAgentRecord]) -> Result<(),
         }
     }
 
-    fs::write(&paths.agent_registry, contents)
-        .map_err(|error| AgentError::io("write agent registry", &paths.agent_registry, error))
+    state::write_regular_state_file(
+        &paths.agent_registry,
+        &contents,
+        "inspect agent registry",
+        "create agent registry",
+        "open agent registry",
+        "write agent registry",
+    )?;
+    Ok(())
 }
 
 fn parse_registry(contents: &str) -> Result<Vec<LocalAgentRecord>, AgentError> {

--- a/crates/conu-core/src/policy.rs
+++ b/crates/conu-core/src/policy.rs
@@ -6,9 +6,8 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+use std::io;
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::state::{self, StateError, StatePaths};
@@ -121,16 +120,6 @@ pub enum PolicyError {
     InvalidRecord {
         reason: String,
     },
-}
-
-impl PolicyError {
-    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
-        Self::Io {
-            action,
-            path: path.to_path_buf(),
-            source,
-        }
-    }
 }
 
 impl fmt::Display for PolicyError {
@@ -267,12 +256,14 @@ fn ensure_peer_is_trusted(paths: &StatePaths, peer_node_id: &str) -> Result<(), 
 }
 
 fn read_policies(paths: &StatePaths) -> Result<Vec<PeerPolicyRecord>, PolicyError> {
-    if !paths.policy_store.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.policy_store,
+        "inspect peer policy store",
+        "read peer policy store",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.policy_store)
-        .map_err(|error| PolicyError::io("read peer policy store", &paths.policy_store, error))?;
+    };
     let mut policies = Vec::new();
     let mut current = HashMap::new();
     let version_line = format!("version = \"{POLICY_VERSION}\"");
@@ -321,14 +312,15 @@ fn write_policies(paths: &StatePaths, policies: &[PeerPolicyRecord]) -> Result<(
         contents.push_str("payload_displayed = false\n");
     }
 
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(&paths.policy_store)
-        .map_err(|error| PolicyError::io("open peer policy store", &paths.policy_store, error))?;
-    file.write_all(contents.as_bytes())
-        .map_err(|error| PolicyError::io("write peer policy store", &paths.policy_store, error))
+    state::write_regular_state_file(
+        &paths.policy_store,
+        &contents,
+        "inspect peer policy store",
+        "create peer policy store",
+        "open peer policy store",
+        "write peer policy store",
+    )?;
+    Ok(())
 }
 
 fn policy_from_values(values: &HashMap<String, String>) -> Result<PeerPolicyRecord, PolicyError> {
@@ -419,6 +411,7 @@ mod tests {
     use super::*;
     use crate::trust;
     use std::env;
+    use std::fs;
     use std::process;
 
     #[test]

--- a/crates/conu-core/src/rooms.rs
+++ b/crates/conu-core/src/rooms.rs
@@ -865,12 +865,14 @@ fn room_topic_allows(
 }
 
 fn read_rooms(paths: &StatePaths) -> Result<Vec<RoomRecord>, RoomError> {
-    if !paths.room_registry.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.room_registry,
+        "inspect room registry",
+        "read room registry",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.room_registry)
-        .map_err(|error| RoomError::io("read room registry", &paths.room_registry, error))?;
+    };
     parse_rooms(&contents)
 }
 
@@ -923,8 +925,15 @@ fn write_rooms(paths: &StatePaths, rooms: &[RoomRecord]) -> Result<(), RoomError
         contents.push_str("payload_displayed = false\n");
     }
 
-    fs::write(&paths.room_registry, contents)
-        .map_err(|error| RoomError::io("write room registry", &paths.room_registry, error))
+    state::write_regular_state_file(
+        &paths.room_registry,
+        &contents,
+        "inspect room registry",
+        "create room registry",
+        "open room registry",
+        "write room registry",
+    )?;
+    Ok(())
 }
 
 fn append_event(paths: &StatePaths, event: RoomEvent) -> Result<(), RoomError> {
@@ -947,12 +956,14 @@ fn append_event_once(paths: &StatePaths, event: RoomEvent) -> Result<(), RoomErr
 }
 
 fn read_events(paths: &StatePaths) -> Result<Vec<RoomEvent>, RoomError> {
-    if !paths.room_events.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.room_events,
+        "inspect room events",
+        "read room events",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.room_events)
-        .map_err(|error| RoomError::io("read room events", &paths.room_events, error))?;
+    };
     parse_events(&contents)
 }
 
@@ -990,17 +1001,26 @@ fn write_events(paths: &StatePaths, events: &[RoomEvent]) -> Result<(), RoomErro
         contents.push_str("payload_displayed = false\n");
     }
 
-    fs::write(&paths.room_events, contents)
-        .map_err(|error| RoomError::io("write room events", &paths.room_events, error))
+    state::write_regular_state_file(
+        &paths.room_events,
+        &contents,
+        "inspect room events",
+        "create room events",
+        "open room events",
+        "write room events",
+    )?;
+    Ok(())
 }
 
 fn read_topic_policies(paths: &StatePaths) -> Result<Vec<RoomTopicPolicyRecord>, RoomError> {
-    if !paths.room_policy.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.room_policy,
+        "inspect room topic policy",
+        "read room topic policy",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.room_policy)
-        .map_err(|error| RoomError::io("read room topic policy", &paths.room_policy, error))?;
+    };
     parse_topic_policies(&contents)
 }
 
@@ -1039,8 +1059,15 @@ fn write_topic_policies(
         contents.push_str("payload_displayed = false\n");
     }
 
-    fs::write(&paths.room_policy, contents)
-        .map_err(|error| RoomError::io("write room topic policy", &paths.room_policy, error))
+    state::write_regular_state_file(
+        &paths.room_policy,
+        &contents,
+        "inspect room topic policy",
+        "create room topic policy",
+        "open room topic policy",
+        "write room topic policy",
+    )?;
+    Ok(())
 }
 
 fn parse_rooms(contents: &str) -> Result<Vec<RoomRecord>, RoomError> {
@@ -1725,6 +1752,35 @@ mod tests {
 
         assert!(error.to_string().contains("not allowed to publish"));
         assert!(!error.to_string().contains("private message contents"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn room_registry_rejects_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("registry-symlink");
+        register_agent(&home, "agent.codex");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = home.with_extension("outside-room-registry");
+        let outside_contents = "outside room registry\n";
+        fs::write(&outside, outside_contents).expect("outside registry writes");
+        symlink(&outside, &paths.room_registry).expect("room registry symlink creates");
+
+        let error = create_room(Some(home), "room.dev", "Dev Room", "agent.codex")
+            .expect_err("symlinked room registry fails closed");
+
+        assert!(error.to_string().contains("inspect room registry"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside registry reads"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(&paths.room_registry)
+                .expect("room registry metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -464,14 +464,23 @@ fn write_if_missing(
 }
 
 fn write_new_file(path: &Path, contents: &str) -> Result<(), StateError> {
+    write_new_file_with_actions(path, contents, "create state file", "write state file")
+}
+
+fn write_new_file_with_actions(
+    path: &Path,
+    contents: &str,
+    create_action: &'static str,
+    write_action: &'static str,
+) -> Result<(), StateError> {
     let mut file = OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
-        .map_err(|error| StateError::io("create state file", path, error))?;
+        .map_err(|error| StateError::io(create_action, path, error))?;
 
     file.write_all(contents.as_bytes())
-        .map_err(|error| StateError::io("write state file", path, error))
+        .map_err(|error| StateError::io(write_action, path, error))
 }
 
 fn read_node_identity(path: &Path) -> Result<NodeIdentity, StateError> {
@@ -517,6 +526,45 @@ fn read_existing_state_file(
     file.read_to_string(&mut contents)
         .map_err(|error| StateError::io(read_action, path, error))?;
     Ok(contents)
+}
+
+pub(crate) fn read_optional_regular_state_file(
+    path: &Path,
+    inspect_action: &'static str,
+    read_action: &'static str,
+) -> Result<Option<String>, StateError> {
+    if regular_state_file_metadata(path, inspect_action)?.is_none() {
+        return Ok(None);
+    }
+
+    read_existing_state_file(path, inspect_action, read_action).map(Some)
+}
+
+pub(crate) fn write_regular_state_file(
+    path: &Path,
+    contents: &str,
+    inspect_action: &'static str,
+    create_action: &'static str,
+    open_action: &'static str,
+    write_action: &'static str,
+) -> Result<(), StateError> {
+    if regular_state_file_metadata(path, inspect_action)?.is_none() {
+        match write_new_file_with_actions(path, contents, create_action, write_action) {
+            Ok(()) => return Ok(()),
+            Err(StateError::Io { source, .. }) if source.kind() == io::ErrorKind::AlreadyExists => {
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    regular_state_file_metadata(path, inspect_action)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|error| StateError::io(open_action, path, error))?;
+    file.write_all(contents.as_bytes())
+        .map_err(|error| StateError::io(write_action, path, error))
 }
 
 fn state_file_exists(path: &Path, inspect_action: &'static str) -> Result<bool, StateError> {

--- a/crates/conu-core/src/streams.rs
+++ b/crates/conu-core/src/streams.rs
@@ -456,12 +456,14 @@ fn remote_peer_for_stream_target(
 }
 
 fn read_streams(paths: &StatePaths) -> Result<Vec<StreamRecord>, StreamError> {
-    if !paths.stream_registry.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.stream_registry,
+        "inspect stream registry",
+        "read stream registry",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.stream_registry)
-        .map_err(|error| StreamError::io("read stream registry", &paths.stream_registry, error))?;
+    };
     parse_streams(&contents)
 }
 
@@ -503,8 +505,15 @@ fn write_streams(paths: &StatePaths, streams: &[StreamRecord]) -> Result<(), Str
         contents.push_str("payload_displayed = false\n");
     }
 
-    fs::write(&paths.stream_registry, contents)
-        .map_err(|error| StreamError::io("write stream registry", &paths.stream_registry, error))
+    state::write_regular_state_file(
+        &paths.stream_registry,
+        &contents,
+        "inspect stream registry",
+        "create stream registry",
+        "open stream registry",
+        "write stream registry",
+    )?;
+    Ok(())
 }
 
 fn append_event(paths: &StatePaths, event: StreamEvent) -> Result<(), StreamError> {
@@ -516,12 +525,14 @@ fn append_event(paths: &StatePaths, event: StreamEvent) -> Result<(), StreamErro
 }
 
 fn read_events(paths: &StatePaths) -> Result<Vec<StreamEvent>, StreamError> {
-    if !paths.stream_events.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.stream_events,
+        "inspect stream events",
+        "read stream events",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.stream_events)
-        .map_err(|error| StreamError::io("read stream events", &paths.stream_events, error))?;
+    };
     parse_events(&contents)
 }
 
@@ -562,8 +573,15 @@ fn write_events(paths: &StatePaths, events: &[StreamEvent]) -> Result<(), Stream
         contents.push_str("payload_displayed = false\n");
     }
 
-    fs::write(&paths.stream_events, contents)
-        .map_err(|error| StreamError::io("write stream events", &paths.stream_events, error))
+    state::write_regular_state_file(
+        &paths.stream_events,
+        &contents,
+        "inspect stream events",
+        "create stream events",
+        "open stream events",
+        "write stream events",
+    )?;
+    Ok(())
 }
 
 fn parse_streams(contents: &str) -> Result<Vec<StreamRecord>, StreamError> {
@@ -844,6 +862,36 @@ mod tests {
         .expect_err("oversized chunk fails");
 
         assert!(error.to_string().contains("backpressure"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_registry_rejects_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("registry-symlink");
+        register_agent(&home, "agent.a");
+        register_agent(&home, "agent.b");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = home.with_extension("outside-stream-registry");
+        let outside_contents = "outside stream registry\n";
+        fs::write(&outside, outside_contents).expect("outside registry writes");
+        symlink(&outside, &paths.stream_registry).expect("stream registry symlink creates");
+
+        let error = open_stream(Some(home), "agent.a", "agent.b", "message")
+            .expect_err("symlinked stream registry fails closed");
+
+        assert!(error.to_string().contains("inspect stream registry"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside registry reads"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(&paths.stream_registry)
+                .expect("stream registry metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #428.

## Summary
- add shared guarded regular-file read/write helpers for conU state metadata files
- use the helpers for local agent registry, peer policy store, stream registry/events, and room registry/events/topic policy
- add Unix regressions for stream and room registry symlink replacements to prove redirected state files are rejected without writing the outside target

## Security review
- payload exposure risk: unchanged; no payload bytes are read, logged, or displayed by this change
- trust/permission risk: unchanged; existing peer, agent, stream, and room permission checks remain in place
- storage/logging risk: reduced; core metadata files now reject symlink/non-regular replacements before read/write reuse
- relay/network risk: none; local metadata file handling only
- required fixes: none before CI

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Focused local Rust test execution was attempted with `cargo +stable-x86_64-pc-windows-gnu test -p conu-core symlink_without_writing_target --lib`, but this workstation is missing `dlltool.exe`, so the binary did not link before test execution. Hosted CI should execute the new Unix symlink regressions on Linux/macOS and the existing Windows suite on Windows.


___

## **CodeAnt-AI Description**
**Reject symlinked state files before reading or writing them**

### What Changed
- Core metadata files now refuse to follow symlinks or other non-regular files before they are read or updated.
- Agent registries, peer policy stores, stream registries and events, room registries and events, and room topic policies now use the same guarded file handling.
- If a registry file is replaced with a symlink, the related action fails without writing to the symlink target.
- Added checks that prove symlinked stream and room registry files are rejected while the outside file stays unchanged.

### Impact
`✅ Safer metadata updates`
`✅ Fewer accidental writes to the wrong file`
`✅ Clearer failures when state files are tampered with`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
