### PR TITLE
Harden session and route metadata handling

### DIFF
--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -607,10 +607,13 @@ fn ensure_route_files(paths: &StatePaths) -> Result<(), RouteError> {
 }
 
 fn read_config(paths: &StatePaths) -> Result<HashMap<String, String>, RouteError> {
-    let contents = match fs::read_to_string(&paths.config) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(HashMap::new()),
-        Err(error) => return Err(RouteError::io("read route config", &paths.config, error)),
+    let contents = match state::read_optional_regular_state_file(
+        &paths.config,
+        "inspect route config",
+        "read route config",
+    )? {
+        Some(contents) => contents,
+        None => return Ok(HashMap::new()),
     };
     Ok(parse_key_values(&contents))
 }
@@ -626,12 +629,14 @@ fn relay_endpoint(config: &HashMap<String, String>) -> Result<String, RouteError
 }
 
 fn read_routes(paths: &StatePaths) -> Result<Vec<RouteRecord>, RouteError> {
-    if !paths.route_registry.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.route_registry,
+        "inspect route registry",
+        "read route registry",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.route_registry)
-        .map_err(|error| RouteError::io("read route registry", &paths.route_registry, error))?;
+    };
     parse_routes(&contents)
 }
 
@@ -694,8 +699,15 @@ fn write_routes(paths: &StatePaths, routes: &[RouteRecord]) -> Result<(), RouteE
         contents.push_str("payload_displayed = false\n");
     }
 
-    fs::write(&paths.route_registry, contents)
-        .map_err(|error| RouteError::io("write route registry", &paths.route_registry, error))
+    state::write_regular_state_file(
+        &paths.route_registry,
+        &contents,
+        "inspect route registry",
+        "create route registry",
+        "open route registry",
+        "write route registry",
+    )?;
+    Ok(())
 }
 
 fn append_probes(paths: &StatePaths, probes: &[RouteProbe]) -> Result<(), RouteError> {
@@ -705,22 +717,16 @@ fn append_probes(paths: &StatePaths, probes: &[RouteProbe]) -> Result<(), RouteE
 
     fs::create_dir_all(&paths.routes_dir)
         .map_err(|error| RouteError::io("create routes directory", &paths.routes_dir, error))?;
-    let new_file = !paths.route_probes.exists();
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&paths.route_probes)
-        .map_err(|error| RouteError::io("open route probes", &paths.route_probes, error))?;
-
-    if new_file {
-        writeln!(file, "# conU route probes\nversion = \"{}\"", ROUTE_VERSION)
-            .map_err(|error| RouteError::io("write route probes", &paths.route_probes, error))?;
-    }
+    let mut contents = state::read_optional_regular_state_file(
+        &paths.route_probes,
+        "inspect route probes",
+        "read route probes",
+    )?
+    .unwrap_or_else(|| format!("# conU route probes\nversion = \"{}\"\n", ROUTE_VERSION));
 
     for probe in probes {
-        writeln!(
-            file,
-            "\n[[probe]]\nprobe_id = \"{}\"\nroute_id = \"{}\"\npeer_node_id = \"{}\"\ntransport = \"{}\"\nendpoint = \"{}\"\noutcome = \"{}\"\nscore = {}\nlatency_ms = {}\ncandidate_source = \"{}\"\ncandidate_kind = \"{}\"\nrendezvous_state = \"{}\"\ncreated_at_unix = {}\npayload_displayed = false",
+        contents.push_str(&format!(
+            "\n[[probe]]\nprobe_id = \"{}\"\nroute_id = \"{}\"\npeer_node_id = \"{}\"\ntransport = \"{}\"\nendpoint = \"{}\"\noutcome = \"{}\"\nscore = {}\nlatency_ms = {}\ncandidate_source = \"{}\"\ncandidate_kind = \"{}\"\nrendezvous_state = \"{}\"\ncreated_at_unix = {}\npayload_displayed = false\n",
             escape_file_value(&probe.probe_id),
             escape_file_value(&probe.route_id),
             escape_file_value(&probe.peer_node_id),
@@ -733,20 +739,29 @@ fn append_probes(paths: &StatePaths, probes: &[RouteProbe]) -> Result<(), RouteE
             escape_file_value(&probe.candidate_kind),
             escape_file_value(&probe.rendezvous_state),
             probe.created_at_unix
-        )
-        .map_err(|error| RouteError::io("write route probe", &paths.route_probes, error))?;
+        ));
     }
 
+    state::write_regular_state_file(
+        &paths.route_probes,
+        &contents,
+        "inspect route probes",
+        "create route probes",
+        "open route probes",
+        "write route probes",
+    )?;
     Ok(())
 }
 
 fn read_probes(paths: &StatePaths) -> Result<Vec<RouteProbe>, RouteError> {
-    if !paths.route_probes.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.route_probes,
+        "inspect route probes",
+        "read route probes",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.route_probes)
-        .map_err(|error| RouteError::io("read route probes", &paths.route_probes, error))?;
+    };
     parse_probes(&contents)
 }
 
@@ -1394,6 +1409,62 @@ mod tests {
         assert!(!log.contains("private message contents"));
         assert!(!probes.contains("private message contents"));
         assert!(!log.contains("Review this code"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn route_registry_rejects_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("route-registry-symlink");
+        trusted_peer(&home);
+        let paths = StatePaths::from_home(home.clone());
+        let outside = home.with_extension("outside-route-registry");
+        let outside_contents = "outside route registry\n";
+        fs::write(&outside, outside_contents).expect("outside registry writes");
+        symlink(&outside, &paths.route_registry).expect("route registry symlink creates");
+
+        let error = sync_routes(Some(home)).expect_err("symlinked route registry fails closed");
+
+        assert!(error.to_string().contains("inspect route registry"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside registry reads"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(&paths.route_registry)
+                .expect("route registry metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn route_probes_rejects_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("route-probes-symlink");
+        trusted_peer(&home);
+        let paths = StatePaths::from_home(home.clone());
+        let outside = home.with_extension("outside-route-probes");
+        let outside_contents = "outside route probes\n";
+        fs::write(&outside, outside_contents).expect("outside probes write");
+        symlink(&outside, &paths.route_probes).expect("route probes symlink creates");
+
+        let error = sync_routes(Some(home)).expect_err("symlinked route probes fail closed");
+
+        assert!(error.to_string().contains("inspect route probes"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside probes read"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(&paths.route_probes)
+                .expect("route probes metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -465,13 +465,14 @@ fn local_node_id(paths: &StatePaths) -> Result<String, SessionError> {
 }
 
 fn read_sessions(paths: &StatePaths) -> Result<Vec<RemoteSession>, SessionError> {
-    if !paths.session_registry.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.session_registry,
+        "inspect session registry",
+        "read session registry",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.session_registry).map_err(|error| {
-        SessionError::io("read session registry", &paths.session_registry, error)
-    })?;
+    };
     parse_sessions(&contents)
 }
 
@@ -515,22 +516,26 @@ fn write_sessions(paths: &StatePaths, sessions: &[RemoteSession]) -> Result<(), 
         contents.push_str("payload_displayed = false\n");
     }
 
-    fs::write(&paths.session_registry, contents)
-        .map_err(|error| SessionError::io("write session registry", &paths.session_registry, error))
+    state::write_regular_state_file(
+        &paths.session_registry,
+        &contents,
+        "inspect session registry",
+        "create session registry",
+        "open session registry",
+        "write session registry",
+    )?;
+    Ok(())
 }
 
 fn read_remote_agents(paths: &StatePaths) -> Result<Vec<RemoteAgentRecord>, SessionError> {
-    if !paths.remote_agent_registry.exists() {
+    let Some(contents) = state::read_optional_regular_state_file(
+        &paths.remote_agent_registry,
+        "inspect remote agent registry",
+        "read remote agent registry",
+    )?
+    else {
         return Ok(Vec::new());
-    }
-
-    let contents = fs::read_to_string(&paths.remote_agent_registry).map_err(|error| {
-        SessionError::io(
-            "read remote agent registry",
-            &paths.remote_agent_registry,
-            error,
-        )
-    })?;
+    };
     parse_remote_agents(&contents)
 }
 
@@ -598,13 +603,15 @@ fn write_remote_agents(
         contents.push_str("payload_displayed = false\n");
     }
 
-    fs::write(&paths.remote_agent_registry, contents).map_err(|error| {
-        SessionError::io(
-            "write remote agent registry",
-            &paths.remote_agent_registry,
-            error,
-        )
-    })
+    state::write_regular_state_file(
+        &paths.remote_agent_registry,
+        &contents,
+        "inspect remote agent registry",
+        "create remote agent registry",
+        "open remote agent registry",
+        "write remote agent registry",
+    )?;
+    Ok(())
 }
 
 fn parse_sessions(contents: &str) -> Result<Vec<RemoteSession>, SessionError> {
@@ -803,12 +810,13 @@ fn signed_agent_card_from_remote_record(
 }
 
 fn relay_endpoint(paths: &StatePaths) -> Result<String, SessionError> {
-    let contents = match fs::read_to_string(&paths.config) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            return Ok(DEFAULT_RELAY_ENDPOINT.to_string());
-        }
-        Err(error) => return Err(SessionError::io("read relay config", &paths.config, error)),
+    let contents = match state::read_optional_regular_state_file(
+        &paths.config,
+        "inspect relay config",
+        "read relay config",
+    )? {
+        Some(contents) => contents,
+        None => return Ok(DEFAULT_RELAY_ENDPOINT.to_string()),
     };
     let values = parse_key_values(&contents);
     let endpoint = values
@@ -1059,6 +1067,69 @@ mod tests {
         assert!(log.contains("payload=not_observed"));
         assert!(!log.contains("private message contents"));
         assert!(!log.contains("Review this code"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn session_registry_rejects_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("session-registry-symlink");
+        state::init_state(Some(home.clone())).expect("state initializes");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        trust::join_pairing_code(Some(home.clone()), &invite.code).expect("joins");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = home.with_extension("outside-session-registry");
+        let outside_contents = "outside session registry\n";
+        fs::write(&outside, outside_contents).expect("outside registry writes");
+        symlink(&outside, &paths.session_registry).expect("session registry symlink creates");
+
+        let error =
+            sync_remote_sessions(Some(home)).expect_err("symlinked session registry fails closed");
+
+        assert!(error.to_string().contains("inspect session registry"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside registry reads"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(&paths.session_registry)
+                .expect("session registry metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_agent_registry_rejects_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("remote-agent-registry-symlink");
+        state::init_state(Some(home.clone())).expect("state initializes");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        trust::join_pairing_code(Some(home.clone()), &invite.code).expect("joins");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = home.with_extension("outside-remote-agent-registry");
+        let outside_contents = "outside remote agent registry\n";
+        fs::write(&outside, outside_contents).expect("outside registry writes");
+        symlink(&outside, &paths.remote_agent_registry)
+            .expect("remote agent registry symlink creates");
+
+        let error = sync_remote_sessions(Some(home))
+            .expect_err("symlinked remote agent registry fails closed");
+
+        assert!(error.to_string().contains("inspect remote agent registry"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside registry reads"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(&paths.remote_agent_registry)
+                .expect("remote agent registry metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #430.

## Summary
- route session/remote-agent registries through guarded regular-file reads/writes
- route route registry and probe history through guarded regular-file reads/writes
- reject symlink/non-regular route and session config files before routing metadata reads reuse them
- add Unix regressions proving session registry, remote-agent mirror, route registry, and route probe symlinks fail closed without writing redirected targets

## Security review
- payload exposure risk: unchanged; the changed files remain metadata-only and do not read, log, or display payload bytes
- trust/permission risk: unchanged; existing trust, peer policy, route, and signed agent-card checks remain in place
- storage/logging risk: reduced; session and route metadata files now reject symlink/non-regular replacements before read/write reuse
- relay/network risk: unchanged; this is local metadata file handling, not relay protocol behavior
- required fixes: none before CI

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Focused local Rust test execution was attempted with `cargo +stable-x86_64-pc-windows-gnu test -p conu-core symlink_without_writing_target --lib`, but this workstation is missing `dlltool.exe`, so the binary did not link before test execution. Hosted CI should execute the new Unix symlink regressions on Linux/macOS and the existing Windows suite on Windows.


___

## **CodeAnt-AI Description**
**Reject symlinked session and route metadata files**

### What Changed
- Session, remote agent, route, probe, and relay config files now fail closed when they are replaced with symlinks or other non-regular files
- Reading these files now returns empty state or the default relay endpoint only when the file is missing, not when it is unsafe
- Writing session, remote agent, route, and probe data now avoids following redirected targets
- Added Unix regression tests showing symlinked metadata files do not overwrite files outside the app state directory

### Impact
`✅ Fewer metadata overwrite attacks`
`✅ Safer session and route sync`
`✅ Clearer failure when state files are tampered with`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
