### PR TITLE
Harden core log append handling

### DIFF
--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -888,23 +888,24 @@ fn render_presence_request(request_id: &str, heartbeat: &PresenceHeartbeat) -> S
 }
 
 fn append_agent_log(paths: &StatePaths, event: &str, agent_id: &str) -> Result<(), AgentError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| AgentError::io("create log directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let log_path = paths.logs_dir.join("agents.log");
-    let mut file = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(&log_path)
-        .map_err(|error| AgentError::io("open agent log", &log_path, error))?;
-
-    writeln!(
-        file,
+    let line = format!(
         "time={} event={} agent={} payload=not_observed",
         current_unix_seconds(),
         event,
         sanitize_log_value(agent_id)
-    )
-    .map_err(|error| AgentError::io("write agent log", &log_path, error))
+    );
+
+    state::append_regular_state_file(
+        &log_path,
+        &(line + "\n"),
+        "inspect agent log",
+        "create agent log",
+        "open agent log",
+        "write agent log",
+    )?;
+    Ok(())
 }
 
 fn write_new_file(path: &Path, contents: &str) -> Result<(), AgentError> {

--- a/crates/conu-core/src/direct_transport.rs
+++ b/crates/conu-core/src/direct_transport.rs
@@ -7,8 +7,8 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::fs;
+use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process;
@@ -1237,25 +1237,26 @@ fn append_direct_log(
     peer_node_id: &str,
     bytes: usize,
 ) -> Result<(), DirectTransportError> {
-    fs::create_dir_all(&paths.logs_dir).map_err(|error| {
-        DirectTransportError::io("create log directory", &paths.logs_dir, error)
-    })?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let log_path = paths.logs_dir.join("direct.log");
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .map_err(|error| DirectTransportError::io("open direct log", &log_path, error))?;
-    writeln!(
-        file,
+    let line = format!(
         "time={} event={} peer={} envelope={} bytes={} payload=not_observed",
         current_unix_seconds(),
         sanitize_log_value(event),
         sanitize_log_value(peer_node_id),
         sanitize_log_value(envelope_id),
         bytes
-    )
-    .map_err(|error| DirectTransportError::io("write direct log", &log_path, error))
+    );
+
+    state::append_regular_state_file(
+        &log_path,
+        &(line + "\n"),
+        "inspect direct log",
+        "create direct log",
+        "open direct log",
+        "write direct log",
+    )?;
+    Ok(())
 }
 
 fn direct_probe_aad(probe_id: &str, from_node_id: &str, to_node_id: &str) -> Vec<u8> {

--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -977,22 +977,15 @@ fn append_message_log(
     entry: &InboxEntry,
     status: &str,
 ) -> Result<(), MessageError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| MessageError::io("create log directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let log_path = paths.logs_dir.join("messages.log");
-    let mut file = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(&log_path)
-        .map_err(|error| MessageError::io("open message log", &log_path, error))?;
     let stream_field = entry
         .stream_id
         .as_deref()
         .map(|stream_id| format!(" stream={}", sanitize_log_value(stream_id)))
         .unwrap_or_default();
 
-    writeln!(
-        file,
+    let line = format!(
         "time={} event=envelope_delivered status={} envelope={} kind={}{} from={} to={} bytes={} payload=not_observed",
         current_unix_seconds(),
         sanitize_log_value(status),
@@ -1002,8 +995,17 @@ fn append_message_log(
         sanitize_log_value(&entry.from_agent_id),
         sanitize_log_value(&entry.to_agent_id),
         entry.payload_bytes
-    )
-    .map_err(|error| MessageError::io("write message log", &log_path, error))
+    );
+
+    state::append_regular_state_file(
+        &log_path,
+        &(line + "\n"),
+        "inspect message log",
+        "create message log",
+        "open message log",
+        "write message log",
+    )?;
+    Ok(())
 }
 
 fn write_new_file(path: &Path, contents: &str) -> Result<(), MessageError> {

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -1651,25 +1651,27 @@ fn append_relay_log(
     peer_node_id: &str,
     payload_bytes: usize,
 ) -> Result<(), RelayDeliveryError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| RelayDeliveryError::io("create log directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let path = paths.logs_dir.join("relay-delivery.log");
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .map_err(|error| RelayDeliveryError::io("open relay delivery log", &path, error))?;
 
-    writeln!(
-        file,
+    let line = format!(
         "time={} event={} envelope={} peer={} bytes={} payload=not_observed",
         current_unix_seconds(),
         sanitize_log_value(event),
         sanitize_log_value(envelope_id),
         sanitize_log_value(peer_node_id),
         payload_bytes
-    )
-    .map_err(|error| RelayDeliveryError::io("write relay delivery log", &path, error))
+    );
+
+    state::append_regular_state_file(
+        &path,
+        &(line + "\n"),
+        "inspect relay delivery log",
+        "create relay delivery log",
+        "open relay delivery log",
+        "write relay delivery log",
+    )?;
+    Ok(())
 }
 
 fn count_files_with_extension(path: &Path, extension: &str) -> Result<usize, RelayDeliveryError> {

--- a/crates/conu-core/src/rooms.rs
+++ b/crates/conu-core/src/rooms.rs
@@ -7,9 +7,9 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::hash::{Hash, Hasher};
-use std::io::{self, Write};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1370,17 +1370,10 @@ fn append_room_log(
     agent_id: Option<&str>,
     payload_bytes: usize,
 ) -> Result<(), RoomError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| RoomError::io("create logs directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let path = paths.logs_dir.join("rooms.log");
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .map_err(|error| RoomError::io("open room log", &path, error))?;
 
-    writeln!(
-        file,
+    let line = format!(
         "time={} event={} room={} agent={} bytes={} payload=not_observed",
         current_unix_seconds(),
         event,
@@ -1389,8 +1382,17 @@ fn append_room_log(
             .map(sanitize_log_value)
             .unwrap_or_else(|| "none".to_string()),
         payload_bytes
-    )
-    .map_err(|error| RoomError::io("write room log", &path, error))
+    );
+
+    state::append_regular_state_file(
+        &path,
+        &(line + "\n"),
+        "inspect room log",
+        "create room log",
+        "open room log",
+        "write room log",
+    )?;
+    Ok(())
 }
 
 fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, RoomError> {

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -7,9 +7,9 @@
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::hash::{Hash, Hasher};
-use std::io::{self, Write};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -600,10 +600,9 @@ fn report_from_routes(routes: &[RouteRecord], probes_recorded: usize) -> RouteSy
 }
 
 fn ensure_route_files(paths: &StatePaths) -> Result<(), RouteError> {
-    fs::create_dir_all(&paths.routes_dir)
-        .map_err(|error| RouteError::io("create routes directory", &paths.routes_dir, error))?;
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| RouteError::io("create logs directory", &paths.logs_dir, error))
+    state::ensure_state_directory(&paths.routes_dir)?;
+    state::ensure_state_directory(&paths.logs_dir)?;
+    Ok(())
 }
 
 fn read_config(paths: &StatePaths) -> Result<HashMap<String, String>, RouteError> {
@@ -766,18 +765,11 @@ fn read_probes(paths: &StatePaths) -> Result<Vec<RouteProbe>, RouteError> {
 }
 
 fn append_route_log(paths: &StatePaths, routes: &[RouteRecord]) -> Result<(), RouteError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| RouteError::io("create logs directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let log_path = paths.logs_dir.join("routes.log");
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .map_err(|error| RouteError::io("open route log", &log_path, error))?;
     let report = report_from_routes(routes, 0);
 
-    writeln!(
-        file,
+    let line = format!(
         "event=route_sync peers={} candidates={} selected_direct={} selected_relay={} relay_fallbacks={} nat_traversal_unavailable={} payload=not_observed",
         report.peers,
         report.candidates,
@@ -785,8 +777,17 @@ fn append_route_log(paths: &StatePaths, routes: &[RouteRecord]) -> Result<(), Ro
         report.selected_relay,
         report.relay_fallbacks,
         report.nat_traversal_unavailable
-    )
-    .map_err(|error| RouteError::io("write route log", &log_path, error))
+    );
+
+    state::append_regular_state_file(
+        &log_path,
+        &(line + "\n"),
+        "inspect route log",
+        "create route log",
+        "open route log",
+        "write route log",
+    )?;
+    Ok(())
 }
 
 fn parse_routes(contents: &str) -> Result<Vec<RouteRecord>, RouteError> {

--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -776,24 +776,25 @@ fn append_log(
     pid: u32,
     node_id: &str,
 ) -> Result<(), RuntimeError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| RuntimeError::io("create log directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let log_path = paths.logs_dir.join("conud.log");
-    let mut file = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(&log_path)
-        .map_err(|error| RuntimeError::io("open runtime log", &log_path, error))?;
-
-    writeln!(
-        file,
+    let line = format!(
         "time={} event={} pid={} node={} payload=not_observed",
         current_unix_seconds(),
         event,
         pid,
         sanitize_log_value(node_id)
-    )
-    .map_err(|error| RuntimeError::io("write runtime log", &log_path, error))
+    );
+
+    state::append_regular_state_file(
+        &log_path,
+        &(line + "\n"),
+        "inspect runtime log",
+        "create runtime log",
+        "open runtime log",
+        "write runtime log",
+    )?;
+    Ok(())
 }
 
 fn runtime_is_stale(status: &RuntimeStatus) -> bool {

--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -6,9 +6,8 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+use std::io;
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use conu_protocol::AgentCapabilities;
@@ -113,16 +112,6 @@ pub enum SessionError {
     InvalidRecord {
         reason: String,
     },
-}
-
-impl SessionError {
-    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
-        Self::Io {
-            action,
-            path: path.to_path_buf(),
-            source,
-        }
-    }
 }
 
 impl fmt::Display for SessionError {
@@ -446,13 +435,10 @@ fn report_from_sessions(sessions: &[RemoteSession], remote_agents: usize) -> Ses
 }
 
 fn ensure_session_files(paths: &StatePaths) -> Result<(), SessionError> {
-    fs::create_dir_all(&paths.sessions_dir).map_err(|error| {
-        SessionError::io("create sessions directory", &paths.sessions_dir, error)
-    })?;
-    fs::create_dir_all(&paths.agents_dir)
-        .map_err(|error| SessionError::io("create agents directory", &paths.agents_dir, error))?;
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| SessionError::io("create logs directory", &paths.logs_dir, error))
+    state::ensure_state_directory(&paths.sessions_dir)?;
+    state::ensure_state_directory(&paths.agents_dir)?;
+    state::ensure_state_directory(&paths.logs_dir)?;
+    Ok(())
 }
 
 fn local_node_id(paths: &StatePaths) -> Result<String, SessionError> {
@@ -832,25 +818,27 @@ fn append_session_log(
     sessions: &[RemoteSession],
     remote_agents: usize,
 ) -> Result<(), SessionError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| SessionError::io("create logs directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let path = paths.logs_dir.join("sessions.log");
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .map_err(|error| SessionError::io("open session log", &path, error))?;
     let report = report_from_sessions(sessions, remote_agents);
-    writeln!(
-        file,
+    let line = format!(
         "event=session_sync sessions={} connected={} reconnecting={} offline={} remote_agents={} payload=not_observed",
         report.sessions_synced,
         report.connected,
         report.reconnecting,
         report.offline,
         report.remote_agents_synced
-    )
-    .map_err(|error| SessionError::io("write session log", &path, error))
+    );
+
+    state::append_regular_state_file(
+        &path,
+        &(line + "\n"),
+        "inspect session log",
+        "create session log",
+        "open session log",
+        "write session log",
+    )?;
+    Ok(())
 }
 
 fn parse_key_values(contents: &str) -> HashMap<String, String> {
@@ -1015,6 +1003,8 @@ mod tests {
     use crate::security;
     use crate::trust;
     use std::env;
+    use std::fs;
+    use std::path::{Path, PathBuf};
     use std::process;
 
     #[test]

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -411,7 +411,7 @@ fn create_layout(paths: &StatePaths) -> Result<(), StateError> {
     Ok(())
 }
 
-fn ensure_state_directory(path: &Path) -> Result<(), StateError> {
+pub(crate) fn ensure_state_directory(path: &Path) -> Result<(), StateError> {
     if regular_state_directory_metadata(path, "inspect state directory")?.is_some() {
         return Ok(());
     }
@@ -561,6 +561,32 @@ pub(crate) fn write_regular_state_file(
     let mut file = OpenOptions::new()
         .write(true)
         .truncate(true)
+        .open(path)
+        .map_err(|error| StateError::io(open_action, path, error))?;
+    file.write_all(contents.as_bytes())
+        .map_err(|error| StateError::io(write_action, path, error))
+}
+
+pub(crate) fn append_regular_state_file(
+    path: &Path,
+    contents: &str,
+    inspect_action: &'static str,
+    create_action: &'static str,
+    open_action: &'static str,
+    write_action: &'static str,
+) -> Result<(), StateError> {
+    if regular_state_file_metadata(path, inspect_action)?.is_none() {
+        match write_new_file_with_actions(path, contents, create_action, write_action) {
+            Ok(()) => return Ok(()),
+            Err(StateError::Io { source, .. }) if source.kind() == io::ErrorKind::AlreadyExists => {
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    regular_state_file_metadata(path, inspect_action)?;
+    let mut file = OpenOptions::new()
+        .append(true)
         .open(path)
         .map_err(|error| StateError::io(open_action, path, error))?;
     file.write_all(contents.as_bytes())

--- a/crates/conu-core/src/streams.rs
+++ b/crates/conu-core/src/streams.rs
@@ -6,9 +6,9 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::hash::{Hash, Hasher};
-use std::io::{self, Write};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -693,17 +693,10 @@ fn append_stream_log(
     stream: &StreamRecord,
     payload_bytes: usize,
 ) -> Result<(), StreamError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| StreamError::io("create logs directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.logs_dir)?;
     let path = paths.logs_dir.join("streams.log");
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .map_err(|error| StreamError::io("open stream log", &path, error))?;
 
-    writeln!(
-        file,
+    let line = format!(
         "event={} stream={} from={} to={} route={} bytes={} chunks={} state={} payload=not_observed",
         event,
         stream.stream_id,
@@ -713,8 +706,17 @@ fn append_stream_log(
         payload_bytes,
         stream.chunks_written,
         stream.state.as_str()
-    )
-    .map_err(|error| StreamError::io("write stream log", &path, error))
+    );
+
+    state::append_regular_state_file(
+        &path,
+        &(line + "\n"),
+        "inspect stream log",
+        "create stream log",
+        "open stream log",
+        "write stream log",
+    )?;
+    Ok(())
 }
 
 fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, StreamError> {
@@ -889,6 +891,36 @@ mod tests {
         assert!(
             fs::symlink_metadata(&paths.stream_registry)
                 .expect("stream registry metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_log_rejects_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("log-symlink");
+        register_agent(&home, "agent.a");
+        register_agent(&home, "agent.b");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = home.with_extension("outside-stream-log");
+        let outside_contents = "outside stream log\n";
+        fs::write(&outside, outside_contents).expect("outside log writes");
+        symlink(&outside, paths.logs_dir.join("streams.log")).expect("stream log symlink creates");
+
+        let error = open_stream(Some(home), "agent.a", "agent.b", "message")
+            .expect_err("symlinked stream log fails closed");
+
+        assert!(error.to_string().contains("inspect stream log"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside log reads"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(paths.logs_dir.join("streams.log"))
+                .expect("stream log metadata")
                 .file_type()
                 .is_symlink()
         );


### PR DESCRIPTION
## **User description**
## Summary
- add a shared guarded append helper for conU-owned state files
- route core metadata log appends through regular-file inspection before create/open/write
- add a Unix regression for symlinked stream logs failing closed without writing outside state

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --lib -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu test -p conu-core stream_log_rejects_symlink_without_writing_target (blocked locally: dlltool.exe missing on this workstation)

Closes #432


___

## **CodeAnt-AI Description**
**Reject symlinked state logs and append only to regular files**

### What Changed
- Log appends now check that the target is a regular file before writing, instead of following symlinks or other unsafe paths
- If a log file does not exist, it is created safely first and then written to
- This protection now applies to message, route, agent, room, session, relay, runtime, direct transport, and stream logs
- A new Unix test confirms a symlinked stream log fails closed without changing the linked file

### Impact
`✅ Fewer log-writing security issues`
`✅ Safer state file updates`
`✅ Prevents writes through symlinked logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
