### PR TITLE
Guard security state removals

### DIFF
--- a/crates/conu-core/src/security.rs
+++ b/crates/conu-core/src/security.rs
@@ -369,17 +369,13 @@ pub fn clear_relay_credential(
     home_override: Option<PathBuf>,
 ) -> Result<RelayCredentialStatus, SecurityError> {
     let paths = StatePaths::resolve(home_override)?;
-    delete_secret_references(&paths.relay_credential, "token")?;
-    match fs::remove_file(&paths.relay_credential) {
-        Ok(()) => {}
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(SecurityError::io(
-                "remove relay credential",
-                &paths.relay_credential,
-                error,
-            ));
-        }
+    if secret_file_exists(&paths.relay_credential)? {
+        delete_secret_references(&paths.relay_credential, "token")?;
+        remove_existing_secret_file(
+            &paths.relay_credential,
+            "inspect relay credential removal",
+            "remove relay credential",
+        )?;
     }
     relay_credential_status_from_paths(&paths)
 }
@@ -542,9 +538,11 @@ pub fn retire_unused_storage_keys_from_paths(
             continue;
         }
 
-        fs::remove_file(&archive_path).map_err(|error| {
-            SecurityError::io("remove unused archived storage key", &archive_path, error)
-        })?;
+        state::remove_existing_regular_state_file(
+            &archive_path,
+            "inspect archived storage key removal",
+            "remove unused archived storage key",
+        )?;
         report.retired_storage_keys += 1;
     }
 
@@ -583,9 +581,11 @@ pub fn retire_archived_identity_keys_from_paths(
             continue;
         }
 
-        fs::remove_file(&archive_path).map_err(|error| {
-            SecurityError::io("remove archived identity key", &archive_path, error)
-        })?;
+        state::remove_existing_regular_state_file(
+            &archive_path,
+            "inspect archived identity key removal",
+            "remove archived identity key",
+        )?;
         report.retired_identity_keys += 1;
     }
     report.old_key_decrypt_compatibility_retired = report.retired_identity_keys > 0;
@@ -2857,6 +2857,15 @@ fn ensure_replaceable_secret_file(path: &Path) -> Result<(), SecurityError> {
     ensure_regular_secret_file(path, "inspect replacement security file")
 }
 
+fn remove_existing_secret_file(
+    path: &Path,
+    inspect_action: &'static str,
+    remove_action: &'static str,
+) -> Result<(), SecurityError> {
+    ensure_regular_secret_file(path, inspect_action)?;
+    fs::remove_file(path).map_err(|error| SecurityError::io(remove_action, path, error))
+}
+
 fn ensure_regular_secret_file(path: &Path, action: &'static str) -> Result<(), SecurityError> {
     let metadata =
         fs::symlink_metadata(path).map_err(|error| SecurityError::io(action, path, error))?;
@@ -3218,6 +3227,67 @@ mod tests {
         assert!(
             fs::symlink_metadata(&paths.relay_credential)
                 .expect("credential link metadata reads")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relay_credential_clear_rejects_symlink_without_deleting_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("relay-credential-clear-symlink");
+        let paths = StatePaths::from_home(home.clone());
+        fs::create_dir_all(&paths.security_dir).expect("security dir created");
+        let target = paths.security_dir.join("outside-relay-token-target");
+        let target_contents = "kind = \"relay_token\"\ncontents_displayed = false\n";
+        fs::write(&target, target_contents).expect("target writes");
+        symlink(&target, &paths.relay_credential).expect("credential symlink creates");
+
+        let error = clear_relay_credential(Some(home))
+            .expect_err("credential symlink clear should fail closed");
+
+        assert!(error.to_string().contains("not a regular file"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            target_contents
+        );
+        assert!(
+            fs::symlink_metadata(&paths.relay_credential)
+                .expect("credential link metadata reads")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secret_file_removal_rejects_symlink_without_deleting_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("remove-secret-symlink");
+        fs::create_dir_all(&home).expect("home directory created");
+        let target = home.join("outside-secret-target");
+        let link = home.join("secret.key");
+        fs::write(&target, "existing secret").expect("target writes");
+        symlink(&target, &link).expect("symlink creates");
+
+        let error = remove_existing_secret_file(
+            &link,
+            "inspect symlinked security removal",
+            "remove symlinked security file",
+        )
+        .expect_err("symlinked secret removal should fail closed");
+
+        assert!(error.to_string().contains("not a regular file"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            "existing secret"
+        );
+        assert!(
+            fs::symlink_metadata(&link)
+                .expect("secret link metadata reads")
                 .file_type()
                 .is_symlink()
         );

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -591,6 +591,22 @@ pub(crate) fn rewrite_existing_regular_state_file(
         .map_err(|error| StateError::io(write_action, path, error))
 }
 
+pub(crate) fn remove_existing_regular_state_file(
+    path: &Path,
+    inspect_action: &'static str,
+    remove_action: &'static str,
+) -> Result<(), StateError> {
+    if regular_state_file_metadata(path, inspect_action)?.is_none() {
+        return Err(StateError::io(
+            inspect_action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "state file path is missing"),
+        ));
+    }
+
+    fs::remove_file(path).map_err(|error| StateError::io(remove_action, path, error))
+}
+
 pub(crate) fn append_regular_state_file(
     path: &Path,
     contents: &str,
@@ -894,6 +910,39 @@ mod tests {
     }
 
     #[test]
+    fn remove_existing_regular_state_file_removes_regular_file() {
+        let home = test_home("remove-regular-state-file");
+        fs::create_dir_all(&home).expect("home creates");
+        let path = home.join("state.toml");
+        fs::write(&path, "version = \"1\"\n").expect("state file writes");
+
+        remove_existing_regular_state_file(&path, "inspect removable state", "remove state file")
+            .expect("regular state file removes");
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_existing_regular_state_file_rejects_missing_file() {
+        let home = test_home("remove-missing-state-file");
+        fs::create_dir_all(&home).expect("home creates");
+        let path = home.join("missing.toml");
+
+        let error = remove_existing_regular_state_file(
+            &path,
+            "inspect removable missing state",
+            "remove missing state file",
+        )
+        .expect_err("missing state file should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("inspect removable missing state")
+        );
+    }
+
+    #[test]
     fn init_rejects_directory_required_state_file() {
         let home = test_home("directory-config");
         let report = init_state(Some(home.clone())).expect("state initializes");
@@ -974,6 +1023,38 @@ mod tests {
         assert_eq!(
             fs::read_to_string(&outside).expect("outside reads"),
             outside_contents
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_existing_regular_state_file_rejects_symlink_without_deleting_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("remove-state-symlink");
+        fs::create_dir_all(&home).expect("home creates");
+        let target = home.join("outside-state.toml");
+        let link = home.join("linked-state.toml");
+        fs::write(&target, "version = \"1\"\n").expect("outside state writes");
+        symlink(&target, &link).expect("state symlink creates");
+
+        let error = remove_existing_regular_state_file(
+            &link,
+            "inspect symlinked state removal",
+            "remove symlinked state",
+        )
+        .expect_err("symlinked state file should fail closed");
+
+        assert!(error.to_string().contains("not a regular file"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("outside state reads"),
+            "version = \"1\"\n"
+        );
+        assert!(
+            fs::symlink_metadata(&link)
+                .expect("state symlink metadata")
+                .file_type()
+                .is_symlink()
         );
     }
 


### PR DESCRIPTION
## Summary
- add a checked helper for removing existing regular state files
- use checked removal for archived storage-key and identity-key retirement
- re-check relay credential files before clearing and add symlink deletion regressions

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `python scripts/verify-release-versions.py`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib`
- `cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`

Targeted `cargo test` was attempted locally, but this Windows workstation cannot link test binaries because `dlltool.exe` is missing. Hosted CI should cover executable tests on Ubuntu/macOS/Windows.

Closes #442