### PR TITLE
Guard config file reads

### DIFF
--- a/crates/conu-core/src/direct_transport.rs
+++ b/crates/conu-core/src/direct_transport.rs
@@ -7,10 +7,9 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -189,14 +188,6 @@ pub enum DirectTransportError {
 }
 
 impl DirectTransportError {
-    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
-        Self::Io {
-            action,
-            path: path.to_path_buf(),
-            source,
-        }
-    }
-
     fn network(action: &'static str, error: impl fmt::Display) -> Self {
         Self::Network {
             action,
@@ -857,16 +848,13 @@ fn validate_delivery_ack(
 }
 
 fn read_config(paths: &StatePaths) -> Result<HashMap<String, String>, DirectTransportError> {
-    let contents = match fs::read_to_string(&paths.config) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(HashMap::new()),
-        Err(error) => {
-            return Err(DirectTransportError::io(
-                "read conU config",
-                &paths.config,
-                error,
-            ));
-        }
+    let contents = match state::read_optional_regular_state_file(
+        &paths.config,
+        "inspect direct transport config",
+        "read direct transport config",
+    )? {
+        Some(contents) => contents,
+        None => return Ok(HashMap::new()),
     };
     Ok(parse_key_values(&contents))
 }
@@ -1444,6 +1432,8 @@ fn current_unix_nanos() -> u128 {
 mod tests {
     use super::*;
     use crate::agents::AgentRegistration;
+    use std::fs;
+    use std::path::Path;
 
     #[test]
     fn direct_endpoint_validation_rejects_secret_bearing_values() {
@@ -1452,6 +1442,38 @@ mod tests {
         assert!(validate_direct_endpoint("quic://token@127.0.0.1:9443").is_err());
         assert!(validate_direct_endpoint("quic://127.0.0.1:9443/path").is_err());
         assert!(validate_direct_endpoint("quic://127.0.0.1:9443?token=value").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_config_read_rejects_symlink_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("direct-config-read-symlink");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let outside = init.paths.home.join("outside-config.toml");
+        fs::write(
+            &outside,
+            "version = \"1\"\ndirect_quic_endpoint = \"quic://127.0.0.1:9443\"\n",
+        )
+        .expect("outside config writes");
+        fs::remove_file(&init.paths.config).expect("config removes");
+        symlink(&outside, &init.paths.config).expect("config symlink creates");
+
+        let error = configured_direct_quic_endpoint_from_paths(&init.paths)
+            .expect_err("direct config symlink should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("inspect direct transport config")
+        );
+        assert!(
+            fs::symlink_metadata(&init.paths.config)
+                .expect("config symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -1484,18 +1484,13 @@ fn configured_relay_endpoint(paths: &StatePaths) -> Result<String, RelayDelivery
 }
 
 fn configured_default_relay(paths: &StatePaths) -> Result<Option<String>, RelayDeliveryError> {
-    let contents = match fs::read_to_string(&paths.config) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            return Ok(None);
-        }
-        Err(error) => {
-            return Err(RelayDeliveryError::io(
-                "read conU config",
-                &paths.config,
-                error,
-            ));
-        }
+    let contents = match state::read_optional_regular_state_file(
+        &paths.config,
+        "inspect relay config",
+        "read relay config",
+    )? {
+        Some(contents) => contents,
+        None => return Ok(None),
     };
     let values = parse_key_values(&contents);
     Ok(values
@@ -1505,16 +1500,13 @@ fn configured_default_relay(paths: &StatePaths) -> Result<Option<String>, RelayD
 }
 
 fn relay_auto_sync_enabled(paths: &StatePaths) -> Result<bool, RelayDeliveryError> {
-    let contents = match fs::read_to_string(&paths.config) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(true),
-        Err(error) => {
-            return Err(RelayDeliveryError::io(
-                "read conU config",
-                &paths.config,
-                error,
-            ));
-        }
+    let contents = match state::read_optional_regular_state_file(
+        &paths.config,
+        "inspect relay config",
+        "read relay config",
+    )? {
+        Some(contents) => contents,
+        None => return Ok(true),
     };
     let values = parse_key_values(&contents);
     let value = values
@@ -2233,6 +2225,34 @@ mod tests {
 
         assert!(should_sync);
         assert_eq!(endpoint, "wss://relay.example.com/conu");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relay_config_read_rejects_symlink_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("relay-config-read-symlink");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let outside = init.paths.home.join("outside-config.toml");
+        fs::write(
+            &outside,
+            "version = \"1\"\ndefault_relay = \"wss://relay.example.com/conu\"\nrelay_auto_sync = true\n",
+        )
+        .expect("outside config writes");
+        fs::remove_file(&init.paths.config).expect("config removes");
+        symlink(&outside, &init.paths.config).expect("config symlink creates");
+
+        let error = configured_relay_endpoint(&init.paths)
+            .expect_err("relay config symlink should fail closed");
+
+        assert!(error.to_string().contains("inspect relay config"));
+        assert!(
+            fs::symlink_metadata(&init.paths.config)
+                .expect("config symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/conu-core/src/trust.rs
+++ b/crates/conu-core/src/trust.rs
@@ -1065,12 +1065,13 @@ fn validate_direct_endpoint(value: String) -> Result<String, TrustError> {
 }
 
 fn configured_relay_endpoint(paths: &StatePaths) -> Result<String, TrustError> {
-    let contents = match fs::read_to_string(&paths.config) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            return Ok(DEFAULT_RELAY_ENDPOINT.to_string());
-        }
-        Err(error) => return Err(TrustError::io("read conU config", &paths.config, error)),
+    let contents = match state::read_optional_regular_state_file(
+        &paths.config,
+        "inspect trust config",
+        "read trust config",
+    )? {
+        Some(contents) => contents,
+        None => return Ok(DEFAULT_RELAY_ENDPOINT.to_string()),
     };
     let values = parse_key_values(&contents);
     let endpoint = values
@@ -1351,6 +1352,34 @@ mod tests {
 
         assert_eq!(peer.source, "manual_signed_peer_card");
         assert!(peer.direct_quic_endpoint.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn trust_config_read_rejects_symlink_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("trust-config-read-symlink");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let outside = init.paths.home.join("outside-config.toml");
+        fs::write(
+            &outside,
+            "version = \"1\"\ndefault_relay = \"wss://relay.example.com/conu\"\n",
+        )
+        .expect("outside config writes");
+        fs::remove_file(&init.paths.config).expect("config removes");
+        symlink(&outside, &init.paths.config).expect("config symlink creates");
+
+        let error = configured_relay_endpoint(&init.paths)
+            .expect_err("trust config symlink should fail closed");
+
+        assert!(error.to_string().contains("inspect trust config"));
+        assert!(
+            fs::symlink_metadata(&init.paths.config)
+                .expect("config symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes #446.\n\n## Summary\n- route direct, relay, and trust config reads through the regular state-file guard\n- preserve existing config parsing/default behavior while rejecting symlink/non-regular config files\n- add Unix regressions for direct, relay, and trust config symlink reads\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- python scripts/verify-release-versions.py\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n\nFocused local test attempt: cargo +stable-x86_64-pc-windows-gnu test -p conu-core --lib direct_config_read_rejects_symlink_without_reading_target -- --nocapture failed before tests because this workstation is missing dlltool.exe. Hosted CI should cover executable tests on Ubuntu/macOS/Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration file handling in direct transport, relay delivery, and trust modules now rejects symlinked files, requiring configuration to be stored in regular files.
  
* **Tests**
  * Added validation tests for configuration symlink handling across affected modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imthegoodboy/conU/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->