### PR TITLE
Guard request queue reads

### DIFF
--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -429,8 +429,11 @@ fn process_one_request(
     node_id: &str,
     request_path: &Path,
 ) -> Result<ProcessedRequest, AgentError> {
-    let contents = fs::read_to_string(request_path)
-        .map_err(|error| AgentError::io("read IPC request", request_path, error))?;
+    let contents = state::read_required_regular_state_file(
+        request_path,
+        "inspect IPC request",
+        "read IPC request",
+    )?;
     let values = parse_key_values(&contents);
 
     if value_or_empty(&values, "version") != REQUEST_VERSION {
@@ -1224,6 +1227,38 @@ mod tests {
         assert!(rejected >= 1);
         assert!(error_text.contains("unsupported request type"));
         assert!(!error_text.contains("secret private message contents"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_request_is_rejected_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("request-read-symlink");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let outside = init.paths.home.join("outside-agent-request.req");
+        let outside_contents = "version = \"1\"\ntype = \"register_agent\"\nrequest_id = \"outside\"\nagent_id = \"agent.outside\"\ndisplay_name = \"Outside\"\nkind = \"test\"\n";
+        fs::write(&outside, outside_contents).expect("outside request writes");
+        let request = init.paths.ipc_inbox_dir.join("linked.req");
+        symlink(&outside, &request).expect("request symlink creates");
+
+        let report = process_gateway_requests(Some(home.clone())).expect("requests process");
+        let rejected_request = init.paths.ipc_rejected_dir.join("linked.req");
+        let error_text = fs::read_to_string(init.paths.ipc_rejected_dir.join("linked.error"))
+            .expect("rejection reason reads");
+
+        assert_eq!(report.rejected, 1);
+        assert!(error_text.contains("inspect IPC request"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside request reads"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(&rejected_request)
+                .expect("rejected request symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -414,8 +414,11 @@ fn process_one_message_request(
     paths: &StatePaths,
     request_path: &Path,
 ) -> Result<InboxEntry, MessageError> {
-    let contents = fs::read_to_string(request_path)
-        .map_err(|error| MessageError::io("read message IPC request", request_path, error))?;
+    let contents = state::read_required_regular_state_file(
+        request_path,
+        "inspect message IPC request",
+        "read message IPC request",
+    )?;
     let values = parse_key_values(&contents);
 
     if value_or_empty(&values, "version") != REQUEST_VERSION {
@@ -1395,6 +1398,33 @@ mod tests {
                 .count(),
             0
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_message_request_is_rejected_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("message-request-read-symlink");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let outside = init.paths.home.join("outside-message-request.msg");
+        let outside_contents = "version = \"1\"\ntype = \"send_message\"\npayload = \"secret private message contents\"\n";
+        fs::write(&outside, outside_contents).expect("outside request writes");
+        let request = init.paths.message_ipc_inbox_dir.join("linked.msg");
+        symlink(&outside, &request).expect("message request symlink creates");
+
+        let report = process_message_requests(Some(home.clone())).expect("message processes");
+        let error_path = init.paths.message_ipc_rejected_dir.join("linked.error");
+        let error_text = fs::read_to_string(error_path).expect("rejection reason reads");
+
+        assert_eq!(report.rejected, 1);
+        assert!(error_text.contains("inspect message IPC request"));
+        assert!(!error_text.contains("secret private message contents"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside request reads"),
+            outside_contents
+        );
+        assert!(!request.exists());
     }
 
     #[test]

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -1232,8 +1232,11 @@ impl RelayRequest {
 }
 
 fn read_relay_request(path: &Path) -> Result<RelayRequest, RelayDeliveryError> {
-    let contents = fs::read_to_string(path)
-        .map_err(|error| RelayDeliveryError::io("read relay outbox request", path, error))?;
+    let contents = state::read_required_regular_state_file(
+        path,
+        "inspect relay outbox request",
+        "read relay outbox request",
+    )?;
     let values = parse_key_values(&contents);
 
     if value_or_empty(&values, "version") != RELAY_REQUEST_VERSION {
@@ -2076,6 +2079,36 @@ mod tests {
         let error = read_relay_request(&path).expect_err("mismatched request fails");
 
         assert!(error.to_string().contains("does not match"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relay_request_read_rejects_symlink_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("relay-request-read-symlink");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        fs::create_dir_all(&init.paths.relay_outbox_dir).expect("relay outbox");
+        let outside = init.paths.home.join("outside-relay-request.relay");
+        let outside_contents = "version = \"1\"\ntype = \"relay_message\"\nkind = \"message\"\nrequest_id = \"relayreq.1\"\nenvelope_id = \"env.1\"\nfrom_node_id = \"node.a\"\nto_node_id = \"node.b\"\nfrom_agent_id = \"agent.a\"\nto_agent_id = \"agent.b\"\npayload_len = 0\npayload_cipher = \"xchacha20poly1305\"\npayload_key_id = \"key.1\"\nsender_exchange_public_key_hex = \"aa\"\npayload_nonce_hex = \"bb\"\npayload_ciphertext_hex = \"cc\"\n";
+        fs::write(&outside, outside_contents).expect("outside request writes");
+        let path = init.paths.relay_outbox_dir.join("linked.relay");
+        symlink(&outside, &path).expect("relay request symlink creates");
+
+        let error =
+            read_relay_request(&path).expect_err("relay request symlink should fail closed");
+
+        assert!(error.to_string().contains("inspect relay outbox request"));
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside request reads"),
+            outside_contents
+        );
+        assert!(
+            fs::symlink_metadata(&path)
+                .expect("relay request symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -540,6 +540,22 @@ pub(crate) fn read_optional_regular_state_file(
     read_existing_state_file(path, inspect_action, read_action).map(Some)
 }
 
+pub(crate) fn read_required_regular_state_file(
+    path: &Path,
+    inspect_action: &'static str,
+    read_action: &'static str,
+) -> Result<String, StateError> {
+    if regular_state_file_metadata(path, inspect_action)?.is_none() {
+        return Err(StateError::io(
+            inspect_action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "state file path is missing"),
+        ));
+    }
+
+    read_existing_state_file(path, inspect_action, read_action)
+}
+
 pub(crate) fn write_regular_state_file(
     path: &Path,
     contents: &str,


### PR DESCRIPTION
Closes #448.\n\n## Summary\n- add a required regular-state-file read helper\n- route agent IPC, message IPC, and relay outbox request parsing through the regular-file guard\n- add Unix regressions proving symlinked request entries fail closed without reading outside targets\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- python scripts/verify-release-versions.py\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --lib\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n\nFocused local test attempt: cargo +stable-x86_64-pc-windows-gnu test -p conu-core --lib symlinked_request_is_rejected_without_reading_target -- --nocapture failed before tests because this workstation is missing dlltool.exe. Hosted CI should cover executable tests on Ubuntu/macOS/Windows.