### PR TITLE
Harden relay delivery queue directories

### DIFF
--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -1378,15 +1378,14 @@ fn ensure_relay_dirs(paths: &StatePaths) -> Result<(), RelayDeliveryError> {
         &paths.relay_rejected_dir,
         &paths.logs_dir,
     ] {
-        fs::create_dir_all(directory)
-            .map_err(|error| RelayDeliveryError::io("create relay directory", directory, error))?;
+        state::ensure_state_directory(directory)?;
     }
     Ok(())
 }
 
 fn pending_relay_requests(paths: &StatePaths) -> Result<Vec<PathBuf>, RelayDeliveryError> {
     let mut requests = Vec::new();
-    if !paths.relay_outbox_dir.exists() {
+    if !state::state_directory_exists(&paths.relay_outbox_dir, "inspect relay outbox")? {
         return Ok(requests);
     }
 
@@ -1422,9 +1421,7 @@ fn move_relay_request(
     request_path: &Path,
     extension: &str,
 ) -> Result<(), RelayDeliveryError> {
-    fs::create_dir_all(target_dir).map_err(|error| {
-        RelayDeliveryError::io("create relay marker directory", target_dir, error)
-    })?;
+    state::ensure_state_directory(target_dir)?;
     let stem = request_path
         .file_stem()
         .and_then(|value| value.to_str())
@@ -1670,7 +1667,7 @@ fn append_relay_log(
 }
 
 fn count_files_with_extension(path: &Path, extension: &str) -> Result<usize, RelayDeliveryError> {
-    if !path.exists() {
+    if !state::state_directory_exists(path, "inspect relay queue directory")? {
         return Ok(0);
     }
     let mut count = 0;
@@ -2106,6 +2103,119 @@ mod tests {
         assert!(
             fs::symlink_metadata(&path)
                 .expect("relay request symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relay_outbox_directory_symlink_is_rejected_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("relay-outbox-dir-symlink");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let outside = init.paths.home.join("outside-relay-outbox");
+        fs::create_dir_all(&outside).expect("outside outbox dir creates");
+        fs::write(
+            outside.join("outside.relay"),
+            "version = \"1\"\ntype = \"relay_message\"\npayload = \"secret private message contents\"\n",
+        )
+        .expect("outside relay request writes");
+        fs::remove_dir(&init.paths.relay_outbox_dir).expect("relay outbox removes");
+        symlink(&outside, &init.paths.relay_outbox_dir).expect("relay outbox symlink creates");
+
+        let error =
+            pending_relay_requests(&init.paths).expect_err("symlinked relay outbox fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("state directory path is not a directory")
+        );
+        assert_eq!(
+            fs::read_to_string(outside.join("outside.relay")).expect("outside relay request reads"),
+            "version = \"1\"\ntype = \"relay_message\"\npayload = \"secret private message contents\"\n"
+        );
+        assert!(
+            fs::symlink_metadata(&init.paths.relay_outbox_dir)
+                .expect("relay outbox link metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relay_archive_directory_symlink_is_rejected_without_moving_request() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("relay-archive-dir-symlink");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let request = init.paths.relay_outbox_dir.join("queued.relay");
+        fs::write(&request, "queued relay marker").expect("request writes");
+        let outside = init.paths.home.join("outside-relay-sent");
+        fs::create_dir_all(&outside).expect("outside sent dir creates");
+        fs::remove_dir(&init.paths.relay_sent_dir).expect("relay sent removes");
+        symlink(&outside, &init.paths.relay_sent_dir).expect("relay sent symlink creates");
+
+        let error = move_relay_request(&init.paths.relay_sent_dir, &request, "sent")
+            .expect_err("symlinked relay sent directory fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("state directory path is not a directory")
+        );
+        assert_eq!(
+            fs::read_dir(&outside).expect("outside sent reads").count(),
+            0
+        );
+        assert_eq!(
+            fs::read_to_string(&request).expect("request remains readable"),
+            "queued relay marker"
+        );
+        assert!(
+            fs::symlink_metadata(&init.paths.relay_sent_dir)
+                .expect("relay sent link metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relay_queue_count_rejects_symlinked_directory_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("relay-count-dir-symlink");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let outside = init.paths.home.join("outside-relay-rejected");
+        fs::create_dir_all(&outside).expect("outside rejected dir creates");
+        fs::write(
+            outside.join("outside.rejected"),
+            "payload = \"secret private message contents\"\n",
+        )
+        .expect("outside rejected marker writes");
+        fs::remove_dir(&init.paths.relay_rejected_dir).expect("relay rejected removes");
+        symlink(&outside, &init.paths.relay_rejected_dir).expect("relay rejected symlink creates");
+
+        let error = count_files_with_extension(&init.paths.relay_rejected_dir, "rejected")
+            .expect_err("symlinked relay rejected directory fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("state directory path is not a directory")
+        );
+        assert_eq!(
+            fs::read_to_string(outside.join("outside.rejected"))
+                .expect("outside rejected marker reads"),
+            "payload = \"secret private message contents\"\n"
+        );
+        assert!(
+            fs::symlink_metadata(&init.paths.relay_rejected_dir)
+                .expect("relay rejected link metadata")
                 .file_type()
                 .is_symlink()
         );


### PR DESCRIPTION
## **User description**
Closes #484\n\n## What changed\n- Reuse non-symlink state-directory validation for relay delivery queue directories.\n- Reject symlinked relay outbox before queue scans.\n- Reject symlinked relay sent/rejected directories before archive moves and queue counts.\n- Add Unix regressions for symlinked outbox, archive, and count paths.\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- python scripts/verify-release-versions.py\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n\nNote: the new symlink regressions are Unix-only and are covered by GitHub Ubuntu/macOS CI.


___

## **CodeAnt-AI Description**
**Reject symlinked relay queue directories before reading or moving files**

### What Changed
- Relay delivery now treats the outbox, sent, and rejected directories as unsafe if they are symlinks.
- Queue scans, message moves, and file counts stop instead of following a linked directory.
- Existing relay files outside the app’s own directories are no longer read or modified when a queue path is replaced with a symlink.

### Impact
`✅ Fewer relay file leaks`
`✅ Safer relay delivery handling`
`✅ Fewer accidental writes outside the relay folders`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
