### PR TITLE
Harden local stream storage directory handling

### DIFF
--- a/crates/conu-core/src/streams.rs
+++ b/crates/conu-core/src/streams.rs
@@ -6,10 +6,9 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use conu_protocol::OpaquePayload;
@@ -115,16 +114,6 @@ pub enum StreamError {
     InvalidRequest {
         reason: String,
     },
-}
-
-impl StreamError {
-    fn io(action: &'static str, path: &Path, source: io::Error) -> Self {
-        Self::Io {
-            action,
-            path: path.to_path_buf(),
-            source,
-        }
-    }
 }
 
 impl fmt::Display for StreamError {
@@ -456,6 +445,9 @@ fn remote_peer_for_stream_target(
 }
 
 fn read_streams(paths: &StatePaths) -> Result<Vec<StreamRecord>, StreamError> {
+    if !state::state_directory_exists(&paths.streams_dir, "inspect streams directory")? {
+        return Ok(Vec::new());
+    }
     let Some(contents) = state::read_optional_regular_state_file(
         &paths.stream_registry,
         "inspect stream registry",
@@ -468,8 +460,7 @@ fn read_streams(paths: &StatePaths) -> Result<Vec<StreamRecord>, StreamError> {
 }
 
 fn write_streams(paths: &StatePaths, streams: &[StreamRecord]) -> Result<(), StreamError> {
-    fs::create_dir_all(&paths.streams_dir)
-        .map_err(|error| StreamError::io("create streams directory", &paths.streams_dir, error))?;
+    ensure_streams_directory(paths)?;
     let mut sorted = streams.to_vec();
     sorted.sort_by(|left, right| left.stream_id.cmp(&right.stream_id));
     let mut contents = format!("# conU stream registry\nversion = \"{}\"\n", STREAM_VERSION);
@@ -517,14 +508,16 @@ fn write_streams(paths: &StatePaths, streams: &[StreamRecord]) -> Result<(), Str
 }
 
 fn append_event(paths: &StatePaths, event: StreamEvent) -> Result<(), StreamError> {
-    fs::create_dir_all(&paths.streams_dir)
-        .map_err(|error| StreamError::io("create streams directory", &paths.streams_dir, error))?;
+    ensure_streams_directory(paths)?;
     let mut events = read_events(paths)?;
     events.push(event);
     write_events(paths, &events)
 }
 
 fn read_events(paths: &StatePaths) -> Result<Vec<StreamEvent>, StreamError> {
+    if !state::state_directory_exists(&paths.streams_dir, "inspect streams directory")? {
+        return Ok(Vec::new());
+    }
     let Some(contents) = state::read_optional_regular_state_file(
         &paths.stream_events,
         "inspect stream events",
@@ -537,6 +530,7 @@ fn read_events(paths: &StatePaths) -> Result<Vec<StreamEvent>, StreamError> {
 }
 
 fn write_events(paths: &StatePaths, events: &[StreamEvent]) -> Result<(), StreamError> {
+    ensure_streams_directory(paths)?;
     let mut contents = format!(
         "# conU stream event bus\nversion = \"{}\"\n",
         STREAM_VERSION
@@ -581,6 +575,11 @@ fn write_events(paths: &StatePaths, events: &[StreamEvent]) -> Result<(), Stream
         "open stream events",
         "write stream events",
     )?;
+    Ok(())
+}
+
+fn ensure_streams_directory(paths: &StatePaths) -> Result<(), StreamError> {
+    state::ensure_state_directory(&paths.streams_dir)?;
     Ok(())
 }
 
@@ -819,6 +818,8 @@ mod tests {
     use crate::agents::{AgentRegistration, process_gateway_requests, submit_registration};
     use crate::trust;
     use std::env;
+    use std::fs;
+    use std::path::Path;
     use std::process;
 
     #[test]
@@ -894,6 +895,75 @@ mod tests {
                 .file_type()
                 .is_symlink()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_directory_symlink_is_rejected_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("streams-dir-write-symlink");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let paths = init.paths;
+        let outside = home.with_extension("outside-streams-dir-write");
+        fs::remove_dir_all(&paths.streams_dir).expect("streams dir removes");
+        fs::create_dir_all(&outside).expect("outside streams dir creates");
+        symlink(&outside, &paths.streams_dir).expect("streams dir symlink creates");
+
+        let error = write_streams(&paths, &[test_stream_record()])
+            .expect_err("symlinked streams directory fails closed");
+
+        assert!(error.to_string().contains("state directory"));
+        assert!(!outside.join("registry.toml").exists());
+        assert!(
+            fs::symlink_metadata(&paths.streams_dir)
+                .expect("streams dir metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_listing_rejects_symlinked_stream_directory_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("streams-dir-list-symlink");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let paths = init.paths;
+        let outside = home.with_extension("outside-streams-dir-list");
+        fs::remove_dir_all(&paths.streams_dir).expect("streams dir removes");
+        fs::create_dir_all(&outside).expect("outside streams dir creates");
+        fs::write(
+            outside.join("registry.toml"),
+            test_stream_registry_contents(),
+        )
+        .expect("outside registry writes");
+        symlink(&outside, &paths.streams_dir).expect("streams dir symlink creates");
+
+        let error = list_streams(Some(home)).expect_err("symlinked streams directory fails closed");
+
+        assert!(error.to_string().contains("inspect streams directory"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_event_listing_rejects_symlinked_stream_directory_without_reading_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("streams-dir-events-symlink");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let paths = init.paths;
+        let outside = home.with_extension("outside-streams-dir-events");
+        fs::remove_dir_all(&paths.streams_dir).expect("streams dir removes");
+        fs::create_dir_all(&outside).expect("outside streams dir creates");
+        fs::write(outside.join("events.toml"), test_stream_events_contents())
+            .expect("outside events write");
+        symlink(&outside, &paths.streams_dir).expect("streams dir symlink creates");
+
+        let error = list_events(Some(home)).expect_err("symlinked streams directory fails closed");
+
+        assert!(error.to_string().contains("inspect streams directory"));
     }
 
     #[cfg(unix)]
@@ -1075,5 +1145,32 @@ mod tests {
         ));
         let _ = fs::remove_dir_all(&path);
         path
+    }
+
+    #[cfg(unix)]
+    fn test_stream_record() -> StreamRecord {
+        StreamRecord {
+            stream_id: "stream.outside".to_string(),
+            from_agent_id: "agent.outside.a".to_string(),
+            to_agent_id: "agent.outside.b".to_string(),
+            kind: "message".to_string(),
+            state: StreamState::Open,
+            route: "local".to_string(),
+            chunks_written: 0,
+            bytes_written: 0,
+            backpressure_window: DEFAULT_BACKPRESSURE_WINDOW,
+            opened_at_unix: 1,
+            updated_at_unix: 1,
+        }
+    }
+
+    #[cfg(unix)]
+    fn test_stream_registry_contents() -> &'static str {
+        "# conU stream registry\nversion = \"1\"\n\n[[stream]]\nstream_id = \"stream.outside\"\nfrom_agent_id = \"agent.outside.a\"\nto_agent_id = \"agent.outside.b\"\nkind = \"message\"\nstate = \"open\"\nroute = \"local\"\nchunks_written = 0\nbytes_written = 0\nbackpressure_window = 65536\nopened_at_unix = 1\nupdated_at_unix = 1\npayload_displayed = false\n"
+    }
+
+    #[cfg(unix)]
+    fn test_stream_events_contents() -> &'static str {
+        "# conU stream event bus\nversion = \"1\"\n\n[[event]]\nevent_id = \"event.outside\"\nstream_id = \"stream.outside\"\nevent_type = \"chunk\"\nfrom_agent_id = \"agent.outside.a\"\nto_agent_id = \"agent.outside.b\"\nroute = \"local\"\npayload_bytes = 10\ncreated_at_unix = 1\npayload_displayed = false\n"
     }
 }


### PR DESCRIPTION
## **User description**
## Summary
- reject symlinked streams directories before stream registry or event reads
- use the shared non-symlink state directory guard before stream metadata writes
- add Unix regressions for stream directory read/write fail-closed behavior

Closes #488

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts/verify-release-versions.py
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript
- python scripts/check-github-workflow-permissions.py

Note: local Rust test execution on this Windows workstation remains limited by the missing dlltool.exe linker dependency; CI should run the Unix-only symlink regressions on Ubuntu/macOS.


___

## **CodeAnt-AI Description**
**Reject unsafe local stream directories before reading or writing stream data**

### What Changed
- Stream lists and event logs now fail closed when the local streams folder is missing or replaced with a symlink
- Writing stream records or events now checks the streams folder first, so data is not written into a linked outside directory
- Added Unix tests to confirm symlinked stream directories are blocked without touching the target location

### Impact
`✅ Fewer accidental writes outside the app data folder`
`✅ Safer stream history reads`
`✅ Clearer failures for tampered local storage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream directory validation and error handling for read/write operations.
  * Enhanced robustness when stream directories are absent or misconfigured.

* **Tests**
  * Extended test coverage for stream operations and symlinked directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->