### PR TITLE
Harden observability log directory handling

### DIFF
--- a/crates/conu-core/src/observability.rs
+++ b/crates/conu-core/src/observability.rs
@@ -8,7 +8,7 @@ use std::fs::{self, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 
-use crate::state::{StateError, StatePaths};
+use crate::state::{self, StateError, StatePaths};
 
 /// Default maximum active log size before rotation.
 pub const DEFAULT_LOG_ROTATE_MAX_BYTES: u64 = 1024 * 1024;
@@ -178,8 +178,8 @@ pub fn rotate_logs_from_paths(
     paths: &StatePaths,
     policy: LogRotationPolicy,
 ) -> Result<LogRotationReport, ObservabilityError> {
-    fs::create_dir_all(&paths.logs_dir)
-        .map_err(|error| ObservabilityError::io("create logs directory", &paths.logs_dir, error))?;
+    state::ensure_state_directory(&paths.home)?;
+    state::ensure_state_directory(&paths.logs_dir)?;
 
     let mut entries = Vec::new();
     for entry in fs::read_dir(&paths.logs_dir)
@@ -509,6 +509,66 @@ mod tests {
         );
         assert!(archive_dir.is_dir());
         assert!(!paths.logs_dir.join("conud.log.2").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn home_symlink_fails_before_creating_logs_directory() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("home-symlink");
+        let outside = test_home("home-symlink-target");
+        fs::create_dir_all(&outside).expect("outside directory creates");
+        symlink(&outside, &home).expect("home symlink creates");
+        let paths = StatePaths::from_home(home.clone());
+
+        let error = rotate_logs_from_paths(
+            &paths,
+            LogRotationPolicy::new(1, 2).expect("policy validates"),
+        )
+        .expect_err("home symlink should fail closed");
+
+        assert!(error.to_string().contains("inspect state directory"));
+        assert!(!outside.join("logs").exists());
+        assert!(
+            fs::symlink_metadata(&home)
+                .expect("home link metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn logs_directory_symlink_fails_before_rotating_target_logs() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("logs-dir-symlink");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = test_home("logs-dir-symlink-target");
+        fs::create_dir_all(&home).expect("home directory creates");
+        fs::create_dir_all(&outside).expect("outside directory creates");
+        fs::write(outside.join("conud.log"), "outside active log\n").expect("outside log writes");
+        symlink(&outside, &paths.logs_dir).expect("logs directory symlink creates");
+
+        let error = rotate_logs_from_paths(
+            &paths,
+            LogRotationPolicy::new(1, 2).expect("policy validates"),
+        )
+        .expect_err("logs directory symlink should fail closed");
+
+        assert!(error.to_string().contains("inspect state directory"));
+        assert_eq!(
+            fs::read_to_string(outside.join("conud.log")).expect("outside log reads"),
+            "outside active log\n"
+        );
+        assert!(!outside.join("conud.log.1").exists());
+        assert!(
+            fs::symlink_metadata(&paths.logs_dir)
+                .expect("logs link metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     fn test_home(name: &str) -> PathBuf {


### PR DESCRIPTION
## **User description**
## Summary
- require the conU state home and logs directory to be real state directories before log rotation scans or writes
- add Unix regressions for symlinked home/log directory paths so rotation fails closed without touching targets

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu test -p conu-core observability -- --nocapture (blocked locally: dlltool.exe missing)

Closes #498


___

## **CodeAnt-AI Description**
**Harden observability log directory handling**

### What Changed
- Log rotation now refuses to use a home or logs directory unless both are real state directories
- If either path is a symlink, rotation stops without creating or modifying files outside the expected state area
- Added coverage for symlinked home and logs directories to confirm rotation fails closed

### Impact
`✅ Safer log rotation`
`✅ Fewer accidental writes outside state directories`
`✅ Clearer failure behavior for misconfigured observability paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
