### PR TITLE
Harden relay metadata storage directories

### DIFF
--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -2573,7 +2573,7 @@ pub fn audit_relay_session_state_dir(
         contents_displayed: false,
     };
 
-    if !root.exists() {
+    if !relay_directory_exists(root, "inspect relay session state directory")? {
         return Ok(audit);
     }
 
@@ -2684,7 +2684,7 @@ pub fn audit_relay_accounting_dir(
         contents_displayed: false,
     };
 
-    if !root.exists() {
+    if !relay_directory_exists(root, "inspect relay accounting directory")? {
         return Ok(audit);
     }
 
@@ -2920,7 +2920,7 @@ pub fn audit_relay_abuse_dir(
         contents_displayed: false,
     };
 
-    if !root.exists() {
+    if !relay_directory_exists(root, "inspect relay abuse directory")? {
         return Ok(audit);
     }
 
@@ -6326,8 +6326,7 @@ impl RelayAccountingState {
             return Ok(state);
         };
 
-        fs::create_dir_all(root)
-            .map_err(|error| RelayError::io("create relay accounting directory", error))?;
+        ensure_relay_directory(root, "create relay accounting directory")?;
         for entry in fs::read_dir(root)
             .map_err(|error| RelayError::io("read relay accounting directory", error))?
         {
@@ -6506,8 +6505,7 @@ impl RelayAbuseState {
             return Ok(state);
         };
 
-        fs::create_dir_all(root)
-            .map_err(|error| RelayError::io("create relay abuse directory", error))?;
+        ensure_relay_directory(root, "create relay abuse directory")?;
         for entry in fs::read_dir(root)
             .map_err(|error| RelayError::io("read relay abuse directory", error))?
         {
@@ -7392,7 +7390,7 @@ fn purge_abuse_storage(storage: &RelayAbuseStorage) -> Result<(), RelayError> {
     let RelayAbuseStorage::FileBacked(root) = storage else {
         return Ok(());
     };
-    if !root.exists() {
+    if !relay_directory_exists(root, "inspect relay abuse directory")? {
         return Ok(());
     }
     for entry in
@@ -11513,6 +11511,64 @@ token_displayed = true\n",
                 .expect("session dir link metadata")
                 .file_type()
                 .is_symlink()
+        );
+
+        let session_audit_error = audit_relay_session_state_dir(&session_dir, None)
+            .expect_err("symlinked session audit directory fails closed");
+        assert!(session_audit_error.to_string().contains("not a directory"));
+
+        let accounting_outside = home.join("outside-accounting");
+        let accounting_dir = home.join("accounting");
+        fs::create_dir_all(&accounting_outside).expect("outside accounting dir creates");
+        symlink(&accounting_outside, &accounting_dir).expect("accounting dir symlink creates");
+        let accounting_storage = RelayAccountingStorage::file_backed(accounting_dir.clone())
+            .expect("accounting storage");
+
+        let accounting_load_error =
+            RelayAccountingState::load(&accounting_storage, RelayAccountingPolicy::default())
+                .expect_err("symlinked accounting load directory fails closed");
+        let accounting_audit_error = audit_relay_accounting_dir(&accounting_dir, None)
+            .expect_err("symlinked accounting audit directory fails closed");
+
+        assert!(
+            accounting_load_error
+                .to_string()
+                .contains("not a directory")
+        );
+        assert!(
+            accounting_audit_error
+                .to_string()
+                .contains("not a directory")
+        );
+        assert_eq!(
+            fs::read_dir(&accounting_outside)
+                .expect("outside accounting dir reads")
+                .count(),
+            0
+        );
+
+        let abuse_outside = home.join("outside-abuse");
+        let abuse_dir = home.join("abuse");
+        fs::create_dir_all(&abuse_outside).expect("outside abuse dir creates");
+        symlink(&abuse_outside, &abuse_dir).expect("abuse dir symlink creates");
+        let abuse_storage =
+            RelayAbuseStorage::file_backed(abuse_dir.clone()).expect("abuse storage");
+
+        let abuse_load_error = RelayAbuseState::load(&abuse_storage, RelayAbusePolicy::default())
+            .expect_err("symlinked abuse load directory fails closed");
+        let abuse_audit_error = audit_relay_abuse_dir(&abuse_dir, None)
+            .expect_err("symlinked abuse audit directory fails closed");
+        let abuse_purge_error =
+            purge_abuse_storage(&abuse_storage).expect_err("symlinked abuse purge fails closed");
+
+        assert!(abuse_load_error.to_string().contains("not a directory"));
+        assert!(abuse_audit_error.to_string().contains("not a directory"));
+        assert!(abuse_purge_error.to_string().contains("not a directory"));
+        assert_eq!(
+            fs::read_dir(&abuse_outside)
+                .expect("outside abuse dir reads")
+                .count(),
+            0
         );
     }
 


### PR DESCRIPTION
## **User description**
Closes #504.

## Summary
- reject symlinked relay session/accounting/abuse metadata root directories before audit scans
- use the relay directory guard for accounting and abuse state reloads
- fail closed before abuse purges can follow a symlinked root
- add Unix regressions proving symlinked roots are rejected without touching target directories

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-relay --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-relay --all-targets -- -D warnings


___

## **CodeAnt-AI Description**
**Reject symlinked relay metadata directories and fail closed**

### What Changed
- Relay session, accounting, and abuse directory checks now refuse symlinked paths instead of following them
- Loading accounting and abuse state now uses the same directory guard as audits, so a linked storage root is rejected before any file access
- Abuse cleanup now also stops when the storage root is not a real directory
- Added tests showing symlinked session, accounting, and abuse directories are rejected without touching the target location

### Impact
`✅ Safer relay metadata storage`
`✅ Fewer accidental writes through symlinked directories`
`✅ Clearer failure for invalid relay storage paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
