### PR TITLE
Harden relay token output paths

### DIFF
--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -3130,8 +3130,16 @@ pub fn write_issued_relay_token_file(
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
     {
-        fs::create_dir_all(parent)
-            .map_err(|error| RelayError::io("create issued relay token directory", error))?;
+        ensure_relay_directory(parent, "create issued relay token directory")?;
+    }
+    if regular_relay_file_exists(path, "inspect issued relay token file")? {
+        return Err(RelayError::io(
+            "create issued relay token file",
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "issued relay token file already exists",
+            ),
+        ));
     }
 
     let mut options = OpenOptions::new();
@@ -3155,8 +3163,7 @@ fn write_credential_manifest_records(
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
     {
-        fs::create_dir_all(parent)
-            .map_err(|error| RelayError::io("create relay credential file directory", error))?;
+        ensure_relay_directory(parent, "create relay credential file directory")?;
     }
     let _existing_target_is_regular =
         regular_relay_file_exists(path, "inspect relay credential file replacement")?;
@@ -3712,8 +3719,7 @@ fn write_hosted_tenant_manifest(
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
     {
-        fs::create_dir_all(parent)
-            .map_err(|error| RelayError::io("create hosted tenant file directory", error))?;
+        ensure_relay_directory(parent, "create hosted tenant file directory")?;
     }
     let _existing_target_is_regular =
         regular_relay_file_exists(path, "inspect hosted tenant file replacement")?;
@@ -8099,6 +8105,86 @@ mod tests {
                 .contains("create issued relay token file")
         );
         assert!(!credential.manifest_entry().contains(credential.token()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn issued_relay_token_file_rejects_symlink_without_replacing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("issued-relay-token-symlink");
+        fs::create_dir_all(&home).expect("home creates");
+        let token_path = home.join("node.issue.token");
+        let target_path = home.join("outside-token.txt");
+        let target_contents = "existing relay token\n";
+        fs::write(&target_path, target_contents).expect("target token writes");
+        symlink(&target_path, &token_path).expect("token symlink creates");
+        let credential = issue_relay_credential_from_token_bytes(
+            "node.issue",
+            &[12_u8; ISSUED_RELAY_TOKEN_BYTES],
+            None,
+            1_000,
+        )
+        .expect("credential issues");
+
+        let error = write_issued_relay_token_file(&credential, &token_path)
+            .expect_err("symlinked token output should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("inspect issued relay token file")
+        );
+        assert_eq!(
+            fs::read_to_string(&target_path).expect("target token reads"),
+            target_contents
+        );
+        assert!(
+            fs::symlink_metadata(&token_path)
+                .expect("token symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn issued_relay_token_file_rejects_symlinked_output_directory() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("issued-relay-token-dir-symlink");
+        fs::create_dir_all(&home).expect("home creates");
+        let outside = home.join("outside");
+        fs::create_dir_all(&outside).expect("outside dir creates");
+        let token_dir = home.join("tokens");
+        symlink(&outside, &token_dir).expect("token dir symlink creates");
+        let token_path = token_dir.join("node.issue.token");
+        let credential = issue_relay_credential_from_token_bytes(
+            "node.issue",
+            &[14_u8; ISSUED_RELAY_TOKEN_BYTES],
+            None,
+            1_000,
+        )
+        .expect("credential issues");
+
+        let error = write_issued_relay_token_file(&credential, &token_path)
+            .expect_err("symlinked token output directory should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("create issued relay token directory")
+        );
+        assert_eq!(
+            fs::read_dir(&outside).expect("outside dir reads").count(),
+            0
+        );
+        assert!(
+            fs::symlink_metadata(&token_dir)
+                .expect("token dir symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/conu-relay/src/main.rs
+++ b/crates/conu-relay/src/main.rs
@@ -3758,17 +3758,46 @@ fn read_bounded_stdin_token<R: Read>(mut reader: R, label: &'static str) -> Resu
 }
 
 fn ensure_token_out_available(path: &Path) -> Result<(), String> {
-    if path.exists() {
-        return Err("token output file already exists".to_string());
+    match fs::symlink_metadata(path) {
+        Ok(_) => return Err("token output file already exists".to_string()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("inspect issued relay token file: {error}")),
     }
     if let Some(parent) = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
     {
-        fs::create_dir_all(parent)
-            .map_err(|error| format!("create issued relay token directory: {error}"))?;
+        ensure_token_out_directory(parent)?;
     }
     Ok(())
+}
+
+fn ensure_token_out_directory(path: &Path) -> Result<(), String> {
+    if token_out_directory_exists(path)? {
+        return Ok(());
+    }
+    fs::create_dir_all(path)
+        .map_err(|error| format!("create issued relay token directory: {error}"))?;
+    if token_out_directory_exists(path)? {
+        return Ok(());
+    }
+    Err("inspect issued relay token directory: directory was not created".to_string())
+}
+
+fn token_out_directory_exists(path: &Path) -> Result<bool, String> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() || !metadata.is_dir() {
+                return Err(
+                    "create issued relay token directory: path is not a directory".to_string(),
+                );
+            }
+            Ok(true)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!("inspect issued relay token directory: {error}")),
+    }
 }
 
 fn send_admin_request(relay: &str, request: RelayAdminRequest) -> Result<RelayAdminResult, String> {
@@ -13398,6 +13427,63 @@ mod tests {
         contents.push_str(&"a".repeat((MAX_RELAY_CLI_FILE_BYTES + 1) as usize));
         fs::write(&path, contents).expect("write oversized file");
         path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn token_out_preflight_rejects_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let token_path = unique_temp_path("token-out-dangling-link", "node.token");
+        fs::create_dir_all(token_path.parent().expect("token link parent"))
+            .expect("create token link parent");
+        let missing_target = token_path
+            .parent()
+            .expect("token link parent")
+            .join("missing-token-target");
+        symlink(&missing_target, &token_path).expect("create dangling token symlink");
+
+        let error = ensure_token_out_available(&token_path)
+            .expect_err("dangling symlink token output should fail closed");
+
+        assert!(error.contains("token output file already exists"));
+        assert!(
+            fs::symlink_metadata(&token_path)
+                .expect("token symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn token_out_preflight_rejects_symlinked_output_directory() {
+        use std::os::unix::fs::symlink;
+
+        let outside = unique_temp_path("token-out-dir-target", "outside");
+        fs::create_dir_all(&outside).expect("create outside token dir");
+        let token_dir = unique_temp_path("token-out-dir-link", "tokens");
+        fs::create_dir_all(token_dir.parent().expect("token dir link parent"))
+            .expect("create token dir link parent");
+        symlink(&outside, &token_dir).expect("create token dir symlink");
+        let token_path = token_dir.join("node.token");
+
+        let error = ensure_token_out_available(&token_path)
+            .expect_err("symlinked token output directory should fail closed");
+
+        assert!(error.contains("create issued relay token directory"));
+        assert_eq!(
+            fs::read_dir(&outside)
+                .expect("outside token dir reads")
+                .count(),
+            0
+        );
+        assert!(
+            fs::symlink_metadata(&token_dir)
+                .expect("token dir symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #506.\n\n## Summary\n- reject symlinked or already-existing issued relay token output files before writing raw tokens\n- reuse guarded relay directory creation for token, credential manifest, and hosted tenant manifest parents\n- add token-output symlink regression coverage for write and admin preflight paths\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-relay --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-relay --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu test -p conu-relay issued_relay_token_file --lib (blocked locally: missing dlltool.exe)


___

## **CodeAnt-AI Description**
**Prevent relay token files from being written through symlinks**

### What Changed
- Relay token output now refuses to write if the target file already exists or is a symlink
- Token output directories are now checked before creation so symlinked directories are rejected instead of used
- The same guarded directory handling now applies to relay credential and hosted tenant files
- Added regression coverage for symlinked token files, symlinked output directories, and dangling links

### Impact
`✅ Safer token output paths`
`✅ Fewer accidental overwrites`
`✅ Stronger protection against symlink-based file writes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay token file security to prevent unauthorized symlink attacks
  * Added explicit error handling when attempting to overwrite existing token files
  * Enhanced directory safety validation for file operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->