### PR TITLE
Stabilize direct QUIC listener tests

### DIFF
--- a/crates/conu-core/src/direct_transport.rs
+++ b/crates/conu-core/src/direct_transport.rs
@@ -38,6 +38,10 @@ const DIRECT_VERSION: &str = "1";
 const DEFAULT_DIRECT_TIMEOUT_MS: u64 = 700;
 const MAX_DIRECT_FRAME_BYTES: usize = 80 * 1024;
 const MAX_DIRECT_PAYLOAD_BYTES: usize = 64 * 1024;
+
+#[cfg(test)]
+pub(crate) static DIRECT_QUIC_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// A completed direct QUIC route probe.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectProbeReport {
@@ -1504,6 +1508,7 @@ mod tests {
 
     #[test]
     fn direct_quic_probe_authenticates_trusted_peer() {
+        let _direct_guard = DIRECT_QUIC_TEST_LOCK.lock().expect("direct quic test lock");
         let alice_home = test_home("probe-alice");
         let bob_home = test_home("probe-bob");
         let bob_endpoint = free_loopback_endpoint();
@@ -1557,6 +1562,7 @@ mod tests {
 
     #[test]
     fn direct_stream_chunk_delivers_to_peer_inbox_without_payload_logs() {
+        let _direct_guard = DIRECT_QUIC_TEST_LOCK.lock().expect("direct quic test lock");
         let alice_home = test_home("stream-alice");
         let bob_home = test_home("stream-bob");
         let bob_endpoint = free_loopback_endpoint();
@@ -1624,6 +1630,7 @@ mod tests {
 
     #[test]
     fn direct_message_delivers_to_peer_inbox_without_payload_logs() {
+        let _direct_guard = DIRECT_QUIC_TEST_LOCK.lock().expect("direct quic test lock");
         let alice_home = test_home("message-alice");
         let bob_home = test_home("message-bob");
         let bob_endpoint = free_loopback_endpoint();

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -1344,6 +1344,9 @@ mod tests {
 
     #[test]
     fn sync_selects_direct_when_authenticated_quic_probe_succeeds() {
+        let _direct_guard = crate::direct_transport::DIRECT_QUIC_TEST_LOCK
+            .lock()
+            .expect("direct quic test lock");
         let alice_home = test_home("direct-selected-alice");
         let bob_home = test_home("direct-selected-bob");
         let bob_endpoint = free_loopback_endpoint();


### PR DESCRIPTION
## **User description**
Closes #508.\n\n## Summary\n- add a test-only direct QUIC listener mutex shared by core route/direct transport tests\n- hold the lock around tests that reserve a loopback port and start a QUIC listener\n- avoid parallel test port reuse that failed macOS main CI with Address already in use\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu test -p conu-core routes::tests::sync_selects_direct_when_authenticated_quic_probe_succeeds --lib (blocked locally: missing dlltool.exe)


___

## **CodeAnt-AI Description**
**Stabilize direct QUIC tests that use a loopback listener**

### What Changed
- Direct QUIC tests that start a local listener now run one at a time to avoid port reuse conflicts
- The affected probe, stream, message, and route-selection tests share the same test-only lock
- This prevents intermittent “address already in use” failures on shared CI and local test runs

### Impact
`✅ Fewer flaky QUIC test failures`
`✅ Fewer port conflicts in CI`
`✅ More reliable direct route test runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
