### PR TITLE
Harden runtime stop request detection

### DIFF
--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -143,7 +143,7 @@ impl RuntimeLease {
 
     /// True when the CLI has requested a graceful shutdown.
     pub fn stop_requested(&self) -> bool {
-        self.paths.runtime_stop_request.exists()
+        runtime_control_path_present(&self.paths.runtime_stop_request)
     }
 
     /// Process local IPC, route/session mirrors, and one bounded relay pump.
@@ -926,6 +926,13 @@ fn clear_runtime_files(paths: &StatePaths) -> Result<(), RuntimeError> {
     remove_file_if_exists(&paths.runtime_stop_request)
 }
 
+fn runtime_control_path_present(path: &Path) -> bool {
+    match fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(error) => error.kind() != io::ErrorKind::NotFound,
+    }
+}
+
 fn remove_file_if_exists(path: &Path) -> Result<(), RuntimeError> {
     match fs::remove_file(path) {
         Ok(()) => Ok(()),
@@ -1035,6 +1042,27 @@ mod tests {
         assert!(report.requested);
         assert!(request.contains("requested_at_unix"));
         assert!(!request.contains("private message contents"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stop_requested_treats_dangling_symlink_as_present() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("stop-request-dangling-symlink");
+        let lease = acquire_runtime(Some(home.clone())).expect("runtime starts");
+        let paths = StatePaths::from_home(home);
+        let missing_target = paths.runtime_dir.join("missing-stop-target");
+        symlink(&missing_target, &paths.runtime_stop_request)
+            .expect("dangling stop request symlink creates");
+
+        assert!(lease.stop_requested());
+        assert!(
+            fs::symlink_metadata(&paths.runtime_stop_request)
+                .expect("stop request symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #510.\n\n## Summary\n- replace Path::exists() stop-request polling with symlink-aware metadata presence checks\n- treat malformed/unknown stop-request inspection errors as present so the daemon fails toward stopping instead of ignoring control state\n- add a Unix regression test for dangling stop-request symlinks\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu test -p conu-core stop_requested_treats_dangling_symlink_as_present --lib (blocked locally: missing dlltool.exe)


___

## **CodeAnt-AI Description**
**Treat stop-request symlinks as an active shutdown request**

### What Changed
- The runtime now treats any existing stop-request path as present, even when it is a broken or unreadable symlink
- This prevents the daemon from ignoring a shutdown request because the control file cannot be resolved
- Added a regression test to cover a dangling stop-request symlink on Unix

### Impact
`✅ Fewer missed shutdown requests`
`✅ More reliable graceful stops`
`✅ Safer control-file handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
