### PR TITLE
Harden update download output paths

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -8507,12 +8507,7 @@ fn set_update_binary_file_permissions(_file: &fs::File, _path: &Path) -> Result<
 }
 
 fn ensure_update_output_files_available(dir: &Path, names: &[&str]) -> Result<(), String> {
-    fs::create_dir_all(dir).map_err(|error| {
-        format!(
-            "could not create release update artifact output directory {}: {error}",
-            dir.display()
-        )
-    })?;
+    ensure_update_output_directory(dir)?;
     let mut seen = HashSet::new();
     for name in names {
         validate_public_asset_name(name, "downloaded update asset")?;
@@ -8522,14 +8517,72 @@ fn ensure_update_output_files_available(dir: &Path, names: &[&str]) -> Result<()
             ));
         }
         let path = dir.join(name);
-        if path.exists() {
-            return Err(format!(
-                "release update artifact output already exists: {}",
-                path.display()
-            ));
-        }
+        ensure_update_output_path_available(&path, None)?;
     }
     Ok(())
+}
+
+fn ensure_update_output_directory(dir: &Path) -> Result<(), String> {
+    if update_output_directory_exists(dir)? {
+        return Ok(());
+    }
+    fs::create_dir_all(dir).map_err(|error| {
+        format!(
+            "could not create release update artifact output directory {}: {error}",
+            dir.display()
+        )
+    })?;
+    if update_output_directory_exists(dir)? {
+        return Ok(());
+    }
+    Err(format!(
+        "could not create release update artifact output directory {}: directory was not created",
+        dir.display()
+    ))
+}
+
+fn update_output_directory_exists(dir: &Path) -> Result<bool, String> {
+    match fs::symlink_metadata(dir) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() || !metadata.is_dir() {
+                return Err(format!(
+                    "release update artifact output directory is not a directory: {}",
+                    dir.display()
+                ));
+            }
+            Ok(true)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!(
+            "could not inspect release update artifact output directory {}: {error}",
+            dir.display()
+        )),
+    }
+}
+
+fn ensure_update_output_path_available(path: &Path, label: Option<&str>) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(update_output_exists_message(path, label)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "could not inspect release update artifact output {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn update_output_exists_message(path: &Path, label: Option<&str>) -> String {
+    match label {
+        Some(label) => format!(
+            "release update artifact {label} output already exists: {}",
+            path.display()
+        ),
+        None => format!(
+            "release update artifact output already exists: {}",
+            path.display()
+        ),
+    }
 }
 
 fn write_update_output_file(
@@ -8539,19 +8592,9 @@ fn write_update_output_file(
     label: &str,
 ) -> Result<PathBuf, String> {
     validate_public_asset_name(name, "downloaded update asset")?;
-    fs::create_dir_all(dir).map_err(|error| {
-        format!(
-            "could not create release update artifact output directory {}: {error}",
-            dir.display()
-        )
-    })?;
+    ensure_update_output_directory(dir)?;
     let path = dir.join(name);
-    if path.exists() {
-        return Err(format!(
-            "release update artifact {label} output already exists: {}",
-            path.display()
-        ));
-    }
+    ensure_update_output_path_available(&path, Some(label))?;
     let mut file = match fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -11515,6 +11558,68 @@ mod tests {
         assert_eq!(
             fs::read(&existing).expect("existing output reads"),
             b"existing public archive"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_download_output_write_rejects_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let output_dir = temp_home("update-download-output-symlink");
+        fs::create_dir_all(&output_dir).expect("output dir creates");
+        let filename = "conu-0.1.0-linux-x64.tar.gz";
+        let outside = output_dir.join("outside-archive");
+        let output = output_dir.join(filename);
+        fs::write(&outside, b"existing outside archive").expect("outside writes");
+        symlink(&outside, &output).expect("output symlink creates");
+
+        let error = write_update_output_file(&output_dir, filename, b"new archive", "archive")
+            .expect_err("symlink output should fail closed");
+
+        assert!(error.contains("output already exists"));
+        assert_eq!(
+            fs::read(&outside).expect("outside reads"),
+            b"existing outside archive"
+        );
+        assert!(
+            fs::symlink_metadata(&output)
+                .expect("output symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_download_output_write_rejects_symlinked_output_directory() {
+        use std::os::unix::fs::symlink;
+
+        let home = temp_home("update-download-output-dir-symlink");
+        fs::create_dir_all(&home).expect("home creates");
+        let outside = home.join("outside");
+        fs::create_dir_all(&outside).expect("outside dir creates");
+        let output_dir = home.join("output");
+        symlink(&outside, &output_dir).expect("output dir symlink creates");
+
+        let error = write_update_output_file(
+            &output_dir,
+            "conu-0.1.0-linux-x64.tar.gz",
+            b"new archive",
+            "archive",
+        )
+        .expect_err("symlinked output directory should fail closed");
+
+        assert!(error.contains("output directory is not a directory"));
+        assert_eq!(
+            fs::read_dir(&outside).expect("outside dir reads").count(),
+            0
+        );
+        assert!(
+            fs::symlink_metadata(&output_dir)
+                .expect("output dir symlink metadata")
+                .file_type()
+                .is_symlink()
         );
     }
 


### PR DESCRIPTION
## **User description**
Closes #512.\n\n## Summary\n- reject symlinked release update download output directories before writing artifacts\n- replace output Path::exists() checks with symlink-aware metadata checks for artifact and sidecar paths\n- add Unix regression tests for symlinked output files and symlinked output directories\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-cli --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-cli --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_download_output_write_rejects --lib (blocked locally: missing dlltool.exe)


___

## **CodeAnt-AI Description**
**Block update downloads from writing through symlinks**

### What Changed
- Update downloads now refuse to write into a symlinked output folder
- Existing output files are checked in a way that also catches symlinks, so downloads fail instead of overwriting or following them
- Added tests for symlinked files and symlinked output folders to confirm nothing is written in these cases

### Impact
`✅ Safer update downloads`
`✅ Fewer accidental overwrites`
`✅ Lower risk of writing release files to the wrong place`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced artifact output handling with improved filesystem validation and clearer error messages for existing paths and invalid directories.

* **Tests**
  * Added unit tests to verify robust handling of symlinks and invalid output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->