### PR TITLE
Harden update apply backup source reads

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -8289,6 +8289,11 @@ fn back_up_existing_update_binaries(reports: &[UpdateApplyBinaryReport]) -> Resu
                 report.target_file.display()
             )
         })?;
+        ensure_update_install_target_unchanged_while_backing_up(
+            &report.target_file,
+            &metadata,
+            &source_file,
+        )?;
         let mut backup = match fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -8320,6 +8325,14 @@ fn back_up_existing_update_binaries(reports: &[UpdateApplyBinaryReport]) -> Resu
             }
         };
         drop(backup);
+        if let Err(error) = ensure_update_install_target_unchanged_while_backing_up(
+            &report.target_file,
+            &metadata,
+            &source_file,
+        ) {
+            remove_update_backup_file_if_safe(backup_file);
+            return Err(error);
+        }
         if copied != metadata.len() {
             remove_update_backup_file_if_safe(backup_file);
             return Err(format!(
@@ -8327,6 +8340,49 @@ fn back_up_existing_update_binaries(reports: &[UpdateApplyBinaryReport]) -> Resu
                 report.target_file.display()
             ));
         }
+    }
+    Ok(())
+}
+
+fn ensure_update_install_target_unchanged_while_backing_up(
+    target_file: &Path,
+    expected: &fs::Metadata,
+    source_file: &fs::File,
+) -> Result<(), String> {
+    ensure_update_install_file_parent(target_file)?;
+    let path_metadata = match fs::symlink_metadata(target_file) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return Err(format!(
+                "could not inspect release update install target {}: {error}",
+                target_file.display()
+            ));
+        }
+    };
+    if path_metadata.file_type().is_symlink() || !path_metadata.is_file() {
+        return Err(format!(
+            "release update install target is not a regular file: {}",
+            target_file.display()
+        ));
+    }
+    if !update_input_file_metadata_matches(expected, &path_metadata) {
+        return Err(format!(
+            "release update install target changed while backing up {}",
+            target_file.display()
+        ));
+    }
+    let opened_metadata = source_file.metadata().map_err(|error| {
+        format!(
+            "could not inspect opened release update install target {}: {error}",
+            target_file.display()
+        )
+    })?;
+    if !opened_metadata.is_file() || !update_input_file_metadata_matches(expected, &opened_metadata)
+    {
+        return Err(format!(
+            "release update install target changed while backing up {}",
+            target_file.display()
+        ));
     }
     Ok(())
 }
@@ -12666,6 +12722,67 @@ mod tests {
                 .expect("backup root symlink metadata")
                 .file_type()
                 .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_apply_backup_detects_source_replacement_after_open() {
+        let home = temp_home("update-apply-backup-source-open-swap");
+        let install_dir = home.join("install-bin");
+        fs::create_dir_all(&install_dir).expect("install dir creates");
+        let target_file = install_dir.join(update_binary_filename("conu"));
+        let replacement = install_dir.join("replacement-conu");
+        fs::write(&target_file, b"current binary").expect("target writes");
+        fs::write(&replacement, b"changed binary").expect("replacement writes");
+        let metadata = fs::symlink_metadata(&target_file).expect("target metadata");
+        let source_file = fs::File::open(&target_file).expect("target opens");
+        fs::rename(&replacement, &target_file).expect("target swaps");
+
+        let error = ensure_update_install_target_unchanged_while_backing_up(
+            &target_file,
+            &metadata,
+            &source_file,
+        )
+        .expect_err("swapped backup source should fail closed");
+
+        assert!(error.contains("release update install target changed while backing up"));
+        assert_eq!(
+            fs::read(&target_file).expect("replacement target reads"),
+            b"changed binary"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_apply_backup_detects_source_replacement_before_open() {
+        let home = temp_home("update-apply-backup-source-before-open-swap");
+        let install_dir = home.join("install-bin");
+        fs::create_dir_all(&install_dir).expect("install dir creates");
+        let filename = update_binary_filename("conu");
+        let target_file = install_dir.join(&filename);
+        let replacement = install_dir.join("replacement-conu");
+        let backup_dir = install_dir.join(".conu-update-backups").join("source-swap");
+        fs::create_dir_all(&backup_dir).expect("backup dir creates");
+        let backup_file = backup_dir.join(&filename);
+        fs::write(&target_file, b"current binary").expect("target writes");
+        let metadata = fs::symlink_metadata(&target_file).expect("target metadata");
+        fs::write(&replacement, b"changed binary").expect("replacement writes");
+        fs::rename(&replacement, &target_file).expect("target swaps");
+        let source_file = fs::File::open(&target_file).expect("target opens");
+
+        let error = ensure_update_install_target_unchanged_while_backing_up(
+            &target_file,
+            &metadata,
+            &source_file,
+        )
+        .expect_err("pre-open swapped backup source should fail closed");
+
+        assert!(error.contains("release update install target changed while backing up"));
+        assert!(!backup_file.exists());
+        assert_eq!(
+            fs::read(&target_file).expect("replacement target reads"),
+            b"changed binary"
         );
     }
 


### PR DESCRIPTION
## **User description**
Closes #522.

## Summary
- verify update-apply backup source path metadata still matches the opened install target before and after copying
- fail closed when an install target is replaced during backup preparation
- add Unix regressions for source replacement before and after opening

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-cli --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-cli --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_apply_backup_detects_source_replacement --lib (blocked locally: dlltool.exe missing)


___

## **CodeAnt-AI Description**
**Stop update backups from copying a replaced binary**

### What Changed
- Update backup now checks that the target file is still the same regular file before and after reading it
- If the install target is replaced during backup preparation, the backup is aborted and any partial backup is removed
- Added regression tests for source replacement before opening the file and after it is opened

### Impact
`✅ Fewer corrupted update backups`
`✅ Safer app updates when files change during install`
`✅ Clearer failure when the update target is replaced`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
