### PR TITLE
Reject unusable direct QUIC peer endpoints

### DIFF
--- a/crates/conu-core/src/direct_transport.rs
+++ b/crates/conu-core/src/direct_transport.rs
@@ -317,6 +317,17 @@ pub fn configured_direct_quic_endpoint_from_paths(
     Ok(Some(endpoint))
 }
 
+/// Return the configured direct QUIC endpoint only if it is safe to advertise to peers.
+pub fn configured_direct_quic_advertised_endpoint_from_paths(
+    paths: &StatePaths,
+) -> Result<Option<String>, DirectTransportError> {
+    let Some(endpoint) = configured_direct_quic_endpoint_from_paths(paths)? else {
+        return Ok(None);
+    };
+    validate_direct_peer_endpoint(&endpoint)?;
+    Ok(Some(endpoint))
+}
+
 /// Probe a peer's direct QUIC endpoint and authenticate both peer-card keys.
 pub fn probe_direct_quic_from_paths(
     paths: &StatePaths,
@@ -326,7 +337,7 @@ pub fn probe_direct_quic_from_paths(
     timeout: Duration,
 ) -> Result<DirectProbeReport, DirectTransportError> {
     let peer = trusted_peer_with_key(paths, &peer.peer_node_id)?;
-    validate_direct_endpoint(endpoint)?;
+    validate_direct_peer_endpoint(endpoint)?;
     let probe_id = request_id("directprobe");
     let plaintext = format!(
         "direct-probe:{probe_id}:{local_node_id}:{}",
@@ -509,7 +520,7 @@ fn send_direct_envelope(
     peer: &TrustedPeer,
     local_node_id: &str,
 ) -> Result<HashMap<String, String>, DirectTransportError> {
-    validate_direct_endpoint(endpoint)?;
+    validate_direct_peer_endpoint(endpoint)?;
     let envelope_id = frame.envelope_id.to_string();
     let request = render_direct_frame(frame);
     let response = direct_client_round_trip(
@@ -895,7 +906,7 @@ fn direct_endpoint_for_peer(
         .ok_or_else(|| DirectTransportError::InvalidRequest {
             reason: "trusted peer does not have a direct QUIC endpoint".to_string(),
         })?;
-    validate_direct_endpoint(&endpoint)?;
+    validate_direct_peer_endpoint(&endpoint)?;
     Ok(endpoint)
 }
 
@@ -1176,6 +1187,7 @@ fn endpoint_to_socket_addr(
     usage: EndpointUse,
 ) -> Result<SocketAddr, DirectTransportError> {
     validate_direct_endpoint(endpoint)?;
+    let endpoint = endpoint.trim();
     let without_scheme = endpoint
         .strip_prefix("quic://")
         .or_else(|| endpoint.strip_prefix("udp://"))
@@ -1185,14 +1197,16 @@ fn endpoint_to_socket_addr(
     let mut addrs = without_scheme
         .to_socket_addrs()
         .map_err(|error| DirectTransportError::network("resolve direct QUIC endpoint", error))?;
-    addrs
+    let address = addrs
         .next()
         .ok_or_else(|| DirectTransportError::InvalidRequest {
             reason: match usage {
                 EndpointUse::Bind => "direct bind endpoint did not resolve".to_string(),
                 EndpointUse::Connect => "direct peer endpoint did not resolve".to_string(),
             },
-        })
+        })?;
+    validate_direct_socket_addr(address, usage)?;
+    Ok(address)
 }
 
 /// Validate that an endpoint cannot hide credentials, query strings, or spaces.
@@ -1213,6 +1227,28 @@ pub fn validate_direct_endpoint(endpoint: &str) -> Result<(), DirectTransportErr
             reason: "direct endpoint is invalid".to_string(),
         });
     }
+    let (host, port) = direct_endpoint_host_port(endpoint)?;
+    validate_direct_endpoint_host(host)?;
+    if !port.parse::<u16>().is_ok_and(|port| port > 0) {
+        return Err(DirectTransportError::InvalidRequest {
+            reason: "direct endpoint host or port is invalid".to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Validate an endpoint that will be advertised to or dialed as a peer endpoint.
+pub fn validate_direct_peer_endpoint(endpoint: &str) -> Result<(), DirectTransportError> {
+    validate_direct_endpoint(endpoint)?;
+    let (host, _) = direct_endpoint_host_port(endpoint)?;
+    if let Some(address) = direct_endpoint_ip_literal(host)? {
+        validate_direct_peer_ip(address)?;
+    }
+    Ok(())
+}
+
+fn direct_endpoint_host_port(endpoint: &str) -> Result<(&str, &str), DirectTransportError> {
+    let endpoint = endpoint.trim();
     let Some(without_scheme) = endpoint
         .strip_prefix("quic://")
         .or_else(|| endpoint.strip_prefix("udp://"))
@@ -1226,17 +1262,83 @@ pub fn validate_direct_endpoint(endpoint: &str) -> Result<(), DirectTransportErr
             reason: "direct endpoint path is not supported".to_string(),
         });
     }
-    let Some((host, port)) = without_scheme.rsplit_once(':') else {
-        return Err(DirectTransportError::InvalidRequest {
+    without_scheme
+        .rsplit_once(':')
+        .ok_or_else(|| DirectTransportError::InvalidRequest {
             reason: "direct endpoint must include host and port".to_string(),
+        })
+}
+
+fn validate_direct_endpoint_host(host: &str) -> Result<(), DirectTransportError> {
+    if host.trim().is_empty() {
+        return Err(DirectTransportError::InvalidRequest {
+            reason: "direct endpoint host or port is invalid".to_string(),
         });
-    };
-    if host.trim().is_empty() || !port.parse::<u16>().is_ok_and(|port| port > 0) {
+    }
+    if host.starts_with('[') || host.ends_with(']') {
+        if direct_endpoint_ip_literal(host)?.is_none() {
+            return Err(DirectTransportError::InvalidRequest {
+                reason: "direct endpoint host or port is invalid".to_string(),
+            });
+        }
+    } else if host.contains(':') {
         return Err(DirectTransportError::InvalidRequest {
             reason: "direct endpoint host or port is invalid".to_string(),
         });
     }
     Ok(())
+}
+
+fn direct_endpoint_ip_literal(host: &str) -> Result<Option<IpAddr>, DirectTransportError> {
+    let host = host.trim();
+    if let Some(inner) = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        let address =
+            inner
+                .parse::<IpAddr>()
+                .map_err(|_| DirectTransportError::InvalidRequest {
+                    reason: "direct endpoint host or port is invalid".to_string(),
+                })?;
+        return Ok(Some(address));
+    }
+    Ok(host.parse::<IpAddr>().ok())
+}
+
+fn validate_direct_socket_addr(
+    address: SocketAddr,
+    usage: EndpointUse,
+) -> Result<(), DirectTransportError> {
+    if matches!(usage, EndpointUse::Connect) {
+        validate_direct_peer_ip(address.ip())?;
+    } else if is_multicast_or_broadcast(address.ip()) {
+        return Err(DirectTransportError::InvalidRequest {
+            reason: "direct bind endpoint cannot use multicast or broadcast address".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_direct_peer_ip(address: IpAddr) -> Result<(), DirectTransportError> {
+    if address.is_unspecified() {
+        return Err(DirectTransportError::InvalidRequest {
+            reason: "direct peer endpoint cannot use an unspecified address".to_string(),
+        });
+    }
+    if is_multicast_or_broadcast(address) {
+        return Err(DirectTransportError::InvalidRequest {
+            reason: "direct peer endpoint cannot use multicast or broadcast address".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn is_multicast_or_broadcast(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => address.is_multicast() || address == Ipv4Addr::BROADCAST,
+        IpAddr::V6(address) => address.is_multicast(),
+    }
 }
 
 fn append_direct_log(
@@ -1460,9 +1562,39 @@ mod tests {
     fn direct_endpoint_validation_rejects_secret_bearing_values() {
         assert!(validate_direct_endpoint("quic://127.0.0.1:9443").is_ok());
         assert!(validate_direct_endpoint("udp://127.0.0.1:9443").is_ok());
+        assert!(validate_direct_endpoint("quic://[::1]:9443").is_ok());
+        assert!(validate_direct_endpoint("quic://::1:9443").is_err());
         assert!(validate_direct_endpoint("quic://token@127.0.0.1:9443").is_err());
         assert!(validate_direct_endpoint("quic://127.0.0.1:9443/path").is_err());
         assert!(validate_direct_endpoint("quic://127.0.0.1:9443?token=value").is_err());
+    }
+
+    #[test]
+    fn direct_peer_endpoint_validation_rejects_unusable_ip_literals() {
+        assert!(validate_direct_peer_endpoint("quic://127.0.0.1:9443").is_ok());
+        assert!(validate_direct_peer_endpoint("quic://[::1]:9443").is_ok());
+        assert!(validate_direct_peer_endpoint("quic://peer.example.com:9443").is_ok());
+        assert!(validate_direct_peer_endpoint("quic://0.0.0.0:9443").is_err());
+        assert!(validate_direct_peer_endpoint("quic://[::]:9443").is_err());
+        assert!(validate_direct_peer_endpoint("quic://224.0.0.1:9443").is_err());
+        assert!(validate_direct_peer_endpoint("quic://[ff02::1]:9443").is_err());
+        assert!(validate_direct_peer_endpoint("quic://255.255.255.255:9443").is_err());
+    }
+
+    #[test]
+    fn direct_advertised_endpoint_rejects_unspecified_bind_address() {
+        let home = test_home("direct-advertised-unspecified");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        fs::write(
+            &init.paths.config,
+            "version = \"1\"\ndirect_quic_endpoint = \"quic://0.0.0.0:9443\"\n",
+        )
+        .expect("config writes");
+
+        let error = configured_direct_quic_advertised_endpoint_from_paths(&init.paths)
+            .expect_err("unspecified advertised endpoint should fail closed");
+
+        assert!(error.to_string().contains("unspecified address"));
     }
 
     #[cfg(unix)]

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -1017,7 +1017,7 @@ fn validate_endpoint(value: String) -> Result<String, RouteError> {
 }
 
 fn valid_direct_endpoint(value: &str) -> bool {
-    direct_transport::validate_direct_endpoint(value).is_ok()
+    direct_transport::validate_direct_peer_endpoint(value).is_ok()
 }
 
 fn parse_bool(value: Option<&String>) -> Option<bool> {
@@ -1340,6 +1340,49 @@ mod tests {
             assert!(!contents.contains("BEGIN PRIVATE KEY"));
             assert!(!contents.contains("private message contents"));
         }
+    }
+
+    #[test]
+    fn unusable_direct_ip_literal_is_not_probed() {
+        let home = test_home("invalid-endpoint-unspecified");
+        let peer = trusted_peer(&home);
+        let config_key = format!("direct_quic_{}", config_key_suffix(&peer.peer_node_id));
+        fs::write(
+            StatePaths::from_home(home.clone()).config,
+            format!(
+                "version = \"1\"\ndefault_relay = \"ws://127.0.0.1:8787\"\nnat_profile = \"public\"\n{config_key} = \"quic://0.0.0.0:9443\"\n"
+            ),
+        )
+        .expect("config writes");
+
+        let report = sync_routes(Some(home.clone())).expect("routes sync");
+        let routes = list_routes(Some(home.clone())).expect("routes read");
+        let selected =
+            selected_route_for_peer(Some(home.clone()), &peer.peer_node_id).expect("route lookup");
+        let direct = routes
+            .iter()
+            .find(|route| route.peer_node_id == peer.peer_node_id && route.is_direct())
+            .expect("direct route recorded");
+        let paths = StatePaths::from_home(home);
+        let registry = fs::read_to_string(paths.route_registry).expect("routes read");
+        let probes = fs::read_to_string(paths.route_probes).expect("probes read");
+
+        assert_eq!(report.direct_attempts, 0);
+        assert_eq!(report.selected_relay, 1);
+        assert_eq!(
+            selected.expect("selected").transport,
+            RouteTransport::RelayWebSocket
+        );
+        assert_eq!(direct.endpoint, "quic://invalid");
+        assert!(!direct.direct_attempted);
+        assert_eq!(
+            direct.failure_reason.as_deref(),
+            Some("invalid_direct_quic_endpoint")
+        );
+        assert!(registry.contains("payload_displayed = false"));
+        assert!(probes.contains("payload_displayed = false"));
+        assert!(!registry.contains("0.0.0.0"));
+        assert!(!probes.contains("0.0.0.0"));
     }
 
     #[test]

--- a/crates/conu-core/src/trust.rs
+++ b/crates/conu-core/src/trust.rs
@@ -1166,7 +1166,7 @@ fn optional_direct_endpoint(value: Option<&String>) -> Result<Option<String>, Tr
 
 fn validate_direct_endpoint(value: String) -> Result<String, TrustError> {
     let value = value.trim().to_string();
-    direct_transport::validate_direct_endpoint(&value).map_err(|error| {
+    direct_transport::validate_direct_peer_endpoint(&value).map_err(|error| {
         TrustError::InvalidRequest {
             reason: error.to_string(),
         }
@@ -1193,11 +1193,11 @@ fn configured_relay_endpoint(paths: &StatePaths) -> Result<String, TrustError> {
 }
 
 fn configured_direct_quic_endpoint(paths: &StatePaths) -> Result<Option<String>, TrustError> {
-    direct_transport::configured_direct_quic_endpoint_from_paths(paths).map_err(|error| {
-        TrustError::InvalidRequest {
+    direct_transport::configured_direct_quic_advertised_endpoint_from_paths(paths).map_err(
+        |error| TrustError::InvalidRequest {
             reason: error.to_string(),
-        }
-    })
+        },
+    )
 }
 
 fn parse_key_values(contents: &str) -> HashMap<String, String> {
@@ -1500,6 +1500,26 @@ mod tests {
 
         assert_eq!(peer.source, "manual_signed_peer_card");
         assert!(peer.direct_quic_endpoint.is_none());
+    }
+
+    #[test]
+    fn peer_card_rejects_unusable_direct_endpoint_literal() {
+        let card = PeerCard {
+            node_id: "node_peer".to_string(),
+            display_name: "Peer".to_string(),
+            exchange_public_key_hex: "aa".to_string(),
+            relay_endpoint: "ws://127.0.0.1:8787".to_string(),
+            direct_quic_endpoint: Some("quic://0.0.0.0:9443".to_string()),
+            signing_public_key_hex: None,
+            signature_algorithm: None,
+            signature_key_id: None,
+            signature_hex: None,
+        };
+
+        let error = validate_peer_card(card)
+            .expect_err("unusable direct endpoint literal should fail closed");
+
+        assert!(error.to_string().contains("unspecified address"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #526.

Changes:
- Adds peer/advertised direct QUIC endpoint validation that rejects unspecified, multicast, and broadcast IP literals before route probing or peer-card import.
- Keeps local bind endpoint syntax validation separate from advertised/dialed peer endpoint validation.
- Prevents unusable direct IP literals from being stored as route candidates or probed, preserving payload-safe route/probe output.

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu test -p conu-core direct_peer_endpoint_validation_rejects_unusable_ip_literals --lib (blocked locally: dlltool.exe missing)


___

## **CodeAnt-AI Description**
**Reject unusable direct QUIC peer endpoints**

### What Changed
- Direct peer endpoints now reject unspecified, multicast, and broadcast IP addresses instead of treating them as valid targets.
- Direct endpoints that are only meant for local binding are kept separate from endpoints that may be advertised to or dialed by peers.
- Route syncing and peer-card import now skip unusable direct endpoints, so they are not probed or used as direct route candidates.
- Invalid direct endpoints now fail closed with clearer errors, including when an advertised endpoint uses `0.0.0.0`.

### Impact
`✅ Fewer failed direct connection attempts`
`✅ Safer peer endpoint sharing`
`✅ Fewer unusable routes stored or probed`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
