### PR TITLE
Harden state write handle verification

### DIFF
--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::env;
 use std::fmt;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
@@ -644,11 +644,8 @@ pub(crate) fn write_regular_state_file(
         }
     }
 
-    regular_state_file_metadata(path, inspect_action)?;
-    let mut file = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .open(path)
+    let mut file = open_existing_regular_state_file_for_write(path, inspect_action, open_action)?;
+    file.set_len(0)
         .map_err(|error| StateError::io(open_action, path, error))?;
     file.write_all(contents.as_bytes())
         .map_err(|error| StateError::io(write_action, path, error))
@@ -669,10 +666,8 @@ pub(crate) fn rewrite_existing_regular_state_file(
         ));
     }
 
-    let mut file = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .open(path)
+    let mut file = open_existing_regular_state_file_for_write(path, inspect_action, open_action)?;
+    file.set_len(0)
         .map_err(|error| StateError::io(open_action, path, error))?;
     file.write_all(contents.as_bytes())
         .map_err(|error| StateError::io(write_action, path, error))
@@ -711,13 +706,94 @@ pub(crate) fn append_regular_state_file(
         }
     }
 
-    regular_state_file_metadata(path, inspect_action)?;
-    let mut file = OpenOptions::new()
+    let mut file = open_existing_regular_state_file_for_append(path, inspect_action, open_action)?;
+    file.write_all(contents.as_bytes())
+        .map_err(|error| StateError::io(write_action, path, error))
+}
+
+fn open_existing_regular_state_file_for_write(
+    path: &Path,
+    inspect_action: &'static str,
+    open_action: &'static str,
+) -> Result<File, StateError> {
+    let Some(metadata) = regular_state_file_metadata(path, inspect_action)? else {
+        return Err(StateError::io(
+            inspect_action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "state file path is missing"),
+        ));
+    };
+    let file = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|error| StateError::io(open_action, path, error))?;
+    validate_opened_regular_state_file(path, inspect_action, open_action, &metadata, &file)?;
+    Ok(file)
+}
+
+fn open_existing_regular_state_file_for_append(
+    path: &Path,
+    inspect_action: &'static str,
+    open_action: &'static str,
+) -> Result<File, StateError> {
+    let Some(metadata) = regular_state_file_metadata(path, inspect_action)? else {
+        return Err(StateError::io(
+            inspect_action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "state file path is missing"),
+        ));
+    };
+    let file = OpenOptions::new()
         .append(true)
         .open(path)
         .map_err(|error| StateError::io(open_action, path, error))?;
-    file.write_all(contents.as_bytes())
-        .map_err(|error| StateError::io(write_action, path, error))
+    validate_opened_regular_state_file(path, inspect_action, open_action, &metadata, &file)?;
+    Ok(file)
+}
+
+fn validate_opened_regular_state_file(
+    path: &Path,
+    inspect_action: &'static str,
+    open_action: &'static str,
+    expected_metadata: &fs::Metadata,
+    file: &File,
+) -> Result<(), StateError> {
+    let Some(path_metadata) = regular_state_file_metadata(path, inspect_action)? else {
+        return Err(StateError::io(
+            inspect_action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "state file path is missing"),
+        ));
+    };
+    if !state_file_write_target_matches(expected_metadata, &path_metadata) {
+        return Err(StateError::io(
+            inspect_action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "state file path changed while opening",
+            ),
+        ));
+    }
+
+    let opened_metadata = file
+        .metadata()
+        .map_err(|error| StateError::io(open_action, path, error))?;
+    if !opened_metadata.is_file()
+        || opened_metadata.len() > MAX_STATE_FILE_BYTES
+        || !state_file_write_target_matches(expected_metadata, &opened_metadata)
+    {
+        return Err(StateError::io(
+            open_action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "opened state file does not match inspected path",
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 fn state_file_exists(path: &Path, inspect_action: &'static str) -> Result<bool, StateError> {
@@ -762,8 +838,17 @@ fn state_file_metadata_matches(expected: &fs::Metadata, current: &fs::Metadata) 
     expected.len() == current.len() && state_file_identity_matches(expected, current)
 }
 
+fn state_file_write_target_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    state_file_stable_identity_matches(expected, current)
+}
+
 #[cfg(unix)]
 fn state_file_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    state_file_stable_identity_matches(expected, current)
+}
+
+#[cfg(unix)]
+fn state_file_stable_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
     use std::os::unix::fs::MetadataExt;
 
     expected.dev() == current.dev() && expected.ino() == current.ino()
@@ -773,15 +858,27 @@ fn state_file_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) 
 fn state_file_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
     use std::os::windows::fs::MetadataExt;
 
-    expected.file_attributes() == current.file_attributes()
-        && expected.creation_time() == current.creation_time()
+    state_file_stable_identity_matches(expected, current)
         && expected.last_write_time() == current.last_write_time()
         && expected.file_size() == current.file_size()
+}
+
+#[cfg(windows)]
+fn state_file_stable_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    expected.file_attributes() == current.file_attributes()
+        && expected.creation_time() == current.creation_time()
 }
 
 #[cfg(not(any(unix, windows)))]
 fn state_file_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
     expected.modified().ok() == current.modified().ok()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn state_file_stable_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    state_file_identity_matches(expected, current)
 }
 
 fn regular_state_directory_metadata(
@@ -1118,6 +1215,83 @@ mod tests {
         let error = init_state(Some(home)).expect_err("file state directory should fail closed");
 
         assert!(error.to_string().contains("inspect state directory"));
+    }
+
+    #[test]
+    fn opened_state_write_guard_rejects_mismatched_handle() {
+        let home = test_home("opened-write-guard");
+        fs::create_dir_all(&home).expect("home creates");
+        let target = home.join("target.toml");
+        let replacement = home.join("replacement.toml");
+        fs::write(&target, "version = \"1\"\n").expect("target writes");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        fs::write(&replacement, "version = \"1\"\nchanged = true\n").expect("replacement writes");
+
+        let expected = regular_state_file_metadata(&target, "inspect state write target")
+            .expect("target metadata reads")
+            .expect("target exists");
+        let opened = OpenOptions::new()
+            .write(true)
+            .open(&replacement)
+            .expect("replacement opens");
+
+        let error = validate_opened_regular_state_file(
+            &target,
+            "inspect state write target",
+            "open state write target",
+            &expected,
+            &opened,
+        )
+        .expect_err("mismatched opened handle should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("opened state file does not match inspected path")
+        );
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            "version = \"1\"\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&replacement).expect("replacement reads"),
+            "version = \"1\"\nchanged = true\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_regular_state_file_rejects_symlink_without_truncating_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("write-state-symlink");
+        fs::create_dir_all(&home).expect("home creates");
+        let target = home.join("outside-state.toml");
+        let link = home.join("linked-state.toml");
+        fs::write(&target, "version = \"1\"\nsecret = \"kept\"\n").expect("outside writes");
+        symlink(&target, &link).expect("state symlink creates");
+
+        let error = write_regular_state_file(
+            &link,
+            "version = \"1\"\nsecret = \"changed\"\n",
+            "inspect symlinked state write",
+            "create symlinked state",
+            "open symlinked state",
+            "write symlinked state",
+        )
+        .expect_err("symlinked state write should fail closed");
+
+        assert!(error.to_string().contains("not a regular file"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("outside reads"),
+            "version = \"1\"\nsecret = \"kept\"\n"
+        );
+        assert!(
+            fs::symlink_metadata(&link)
+                .expect("state symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #528

Summary:
- verify opened state write/append handles against the inspected regular path before truncating or appending
- avoid pre-verification truncation on existing state files
- add regression coverage for mismatched opened handles and symlink write refusal

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- focused local cargo test was attempted but this workstation is missing dlltool.exe


___

## **CodeAnt-AI Description**
**Prevent state writes from touching the wrong file**

### What Changed
- State files are now checked again after opening so writes only proceed when the opened file still matches the file that was inspected
- Rewrite and append operations now fail before truncating or appending if the path changed, points to a symlink, or opens to a different file
- Added regression coverage for mismatched open handles and symlinked state files

### Impact
`✅ Fewer accidental state file overwrites`
`✅ Safer writes when paths change during updates`
`✅ Clearer failures for symlinked state files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
