### PR TITLE
Harden runtime control write handle verification

### DIFF
--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process;
@@ -791,10 +791,8 @@ fn write_runtime_control_file(
 ) -> Result<(), RuntimeError> {
     match regular_runtime_control_metadata(path, inspect_action)? {
         Some(_) => {
-            let mut file = OpenOptions::new()
-                .write(true)
-                .open(path)
-                .map_err(|error| RuntimeError::io(open_action, path, error))?;
+            let mut file =
+                open_existing_runtime_control_for_write(path, inspect_action, open_action)?;
             file.set_len(0)
                 .map_err(|error| RuntimeError::io(truncate_action, path, error))?;
             file.write_all(contents.as_bytes())
@@ -810,6 +808,71 @@ fn write_runtime_control_file(
                 .map_err(|error| RuntimeError::io(write_action, path, error))
         }
     }
+}
+
+fn open_existing_runtime_control_for_write(
+    path: &Path,
+    inspect_action: &'static str,
+    open_action: &'static str,
+) -> Result<File, RuntimeError> {
+    let Some(metadata) = regular_runtime_control_metadata(path, inspect_action)? else {
+        return Err(RuntimeError::io(
+            inspect_action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "runtime control path is missing"),
+        ));
+    };
+    let file = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|error| RuntimeError::io(open_action, path, error))?;
+    validate_opened_runtime_control(path, inspect_action, open_action, &metadata, &file)?;
+    Ok(file)
+}
+
+fn validate_opened_runtime_control(
+    path: &Path,
+    inspect_action: &'static str,
+    open_action: &'static str,
+    expected_metadata: &fs::Metadata,
+    file: &File,
+) -> Result<(), RuntimeError> {
+    let Some(path_metadata) = regular_runtime_control_metadata(path, inspect_action)? else {
+        return Err(RuntimeError::io(
+            inspect_action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "runtime control path is missing"),
+        ));
+    };
+    if !runtime_control_write_target_matches(expected_metadata, &path_metadata) {
+        return Err(RuntimeError::io(
+            inspect_action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "runtime control path changed while opening",
+            ),
+        ));
+    }
+
+    let opened_metadata = file
+        .metadata()
+        .map_err(|error| RuntimeError::io(open_action, path, error))?;
+    if !opened_metadata.is_file()
+        || opened_metadata.len() > MAX_RUNTIME_CONTROL_FILE_BYTES
+        || !runtime_control_write_target_matches(expected_metadata, &opened_metadata)
+    {
+        return Err(RuntimeError::io(
+            open_action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "opened runtime control file does not match inspected path",
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 fn regular_runtime_control_metadata(
@@ -851,8 +914,20 @@ fn runtime_control_metadata_matches(expected: &fs::Metadata, current: &fs::Metad
     expected.len() == current.len() && runtime_control_identity_matches(expected, current)
 }
 
+fn runtime_control_write_target_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    runtime_control_stable_identity_matches(expected, current)
+}
+
 #[cfg(unix)]
 fn runtime_control_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    runtime_control_stable_identity_matches(expected, current)
+}
+
+#[cfg(unix)]
+fn runtime_control_stable_identity_matches(
+    expected: &fs::Metadata,
+    current: &fs::Metadata,
+) -> bool {
     use std::os::unix::fs::MetadataExt;
 
     expected.dev() == current.dev() && expected.ino() == current.ino()
@@ -862,15 +937,33 @@ fn runtime_control_identity_matches(expected: &fs::Metadata, current: &fs::Metad
 fn runtime_control_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
     use std::os::windows::fs::MetadataExt;
 
-    expected.file_attributes() == current.file_attributes()
-        && expected.creation_time() == current.creation_time()
+    runtime_control_stable_identity_matches(expected, current)
         && expected.last_write_time() == current.last_write_time()
         && expected.file_size() == current.file_size()
+}
+
+#[cfg(windows)]
+fn runtime_control_stable_identity_matches(
+    expected: &fs::Metadata,
+    current: &fs::Metadata,
+) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    expected.file_attributes() == current.file_attributes()
+        && expected.creation_time() == current.creation_time()
 }
 
 #[cfg(not(any(unix, windows)))]
 fn runtime_control_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
     expected.modified().ok() == current.modified().ok()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn runtime_control_stable_identity_matches(
+    expected: &fs::Metadata,
+    current: &fs::Metadata,
+) -> bool {
+    runtime_control_identity_matches(expected, current)
 }
 
 fn append_log(
@@ -1042,6 +1135,49 @@ mod tests {
         assert!(report.requested);
         assert!(request.contains("requested_at_unix"));
         assert!(!request.contains("private message contents"));
+    }
+
+    #[test]
+    fn opened_runtime_control_write_guard_rejects_mismatched_handle() {
+        let home = test_home("opened-runtime-write-guard");
+        fs::create_dir_all(&home).expect("home creates");
+        let target = home.join("status.toml");
+        let replacement = home.join("replacement-status.toml");
+        fs::write(&target, "version = \"1\"\nstate = \"offline\"\n").expect("target writes");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        fs::write(&replacement, "version = \"1\"\nstate = \"running\"\n")
+            .expect("replacement writes");
+
+        let expected = regular_runtime_control_metadata(&target, "inspect runtime control target")
+            .expect("target metadata reads")
+            .expect("target exists");
+        let opened = OpenOptions::new()
+            .write(true)
+            .open(&replacement)
+            .expect("replacement opens");
+
+        let error = validate_opened_runtime_control(
+            &target,
+            "inspect runtime control target",
+            "open runtime control target",
+            &expected,
+            &opened,
+        )
+        .expect_err("mismatched opened handle should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("opened runtime control file does not match inspected path")
+        );
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            "version = \"1\"\nstate = \"offline\"\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&replacement).expect("replacement reads"),
+            "version = \"1\"\nstate = \"running\"\n"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #530

Summary:
- verify opened runtime control write handles before truncating existing files
- split stable write-target identity checks from strict read metadata checks
- add regression coverage for mismatched opened runtime control handles

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- focused local cargo test was attempted but this workstation is missing dlltool.exe


___

## **CodeAnt-AI Description**
**Prevent runtime control writes from targeting the wrong file**

### What Changed
- Writing to an existing runtime control file now checks the file again after opening it, so a changed or swapped file is rejected before anything is erased.
- If the inspected path and the opened file do not match, the write fails with a clear error instead of truncating the wrong file.
- Added coverage for the case where a different file is opened after the original target is inspected.

### Impact
`✅ Fewer runtime state files overwritten by mistake`
`✅ Safer stop and status updates`
`✅ Clearer errors when a runtime control file changes during write`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
