### PR TITLE
Guard runtime control directory scope

### DIFF
--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -679,6 +679,7 @@ fn read_runtime_from_paths(paths: &StatePaths) -> Result<RuntimeStatus, RuntimeE
 }
 
 fn write_status(paths: &StatePaths, status: &RuntimeStatus) -> Result<(), RuntimeError> {
+    ensure_runtime_control_directory(paths)?;
     let contents = format!(
         "version = \"{}\"\nstate = \"{}\"\npid = {}\nnode_id = \"{}\"\nstarted_at_unix = {}\nheartbeat_at_unix = {}\nlocal_endpoint = \"{}\"\n",
         STATUS_VERSION,
@@ -702,6 +703,7 @@ fn write_status(paths: &StatePaths, status: &RuntimeStatus) -> Result<(), Runtim
 }
 
 fn write_lock(paths: &StatePaths, pid: u32, started_at_unix: u64) -> Result<(), RuntimeError> {
+    ensure_runtime_control_directory(paths)?;
     let contents = format!("pid = {pid}\nstarted_at_unix = {started_at_unix}\n");
     let mut file = OpenOptions::new()
         .write(true)
@@ -875,6 +877,14 @@ fn validate_opened_runtime_control(
     Ok(())
 }
 
+fn ensure_runtime_control_directory(paths: &StatePaths) -> Result<(), RuntimeError> {
+    if state::state_directory_exists(&paths.runtime_dir, "inspect runtime directory")? {
+        Ok(())
+    } else {
+        state::ensure_state_directory(&paths.runtime_dir).map_err(RuntimeError::State)
+    }
+}
+
 fn regular_runtime_control_metadata(
     path: &Path,
     action: &'static str,
@@ -1015,6 +1025,7 @@ fn offline_status(paths: &StatePaths) -> RuntimeStatus {
 }
 
 fn clear_runtime_files(paths: &StatePaths) -> Result<(), RuntimeError> {
+    ensure_runtime_control_directory(paths)?;
     remove_file_if_exists(&paths.runtime_lock)?;
     remove_file_if_exists(&paths.runtime_stop_request)
 }
@@ -1261,6 +1272,104 @@ mod tests {
         assert!(
             fs::symlink_metadata(&paths.runtime_status)
                 .expect("status symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_status_write_rejects_runtime_directory_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("status-write-dir-symlink");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = test_home("status-write-dir-target");
+        fs::create_dir_all(&home).expect("home creates");
+        fs::create_dir_all(&outside).expect("outside runtime creates");
+        fs::write(outside.join("status.toml"), "outside status\n").expect("outside status writes");
+        symlink(&outside, &paths.runtime_dir).expect("runtime dir symlink creates");
+        let status = RuntimeStatus {
+            state: RuntimeState::Running,
+            pid: Some(process::id()),
+            node_id: Some("node_test".to_string()),
+            started_at_unix: Some(1),
+            heartbeat_at_unix: Some(1),
+            local_endpoint: LOCAL_ENDPOINT.to_string(),
+            status_path: paths.runtime_status.clone(),
+            lock_path: paths.runtime_lock.clone(),
+        };
+
+        let error = write_status(&paths, &status)
+            .expect_err("runtime dir symlink status write should fail closed");
+
+        assert!(error.to_string().contains("inspect runtime directory"));
+        assert_eq!(
+            fs::read_to_string(outside.join("status.toml")).expect("outside status reads"),
+            "outside status\n"
+        );
+        assert!(
+            fs::symlink_metadata(&paths.runtime_dir)
+                .expect("runtime dir symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_lock_write_rejects_runtime_directory_symlink_without_creating_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("lock-write-dir-symlink");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = test_home("lock-write-dir-target");
+        fs::create_dir_all(&home).expect("home creates");
+        fs::create_dir_all(&outside).expect("outside runtime creates");
+        symlink(&outside, &paths.runtime_dir).expect("runtime dir symlink creates");
+
+        let error = write_lock(&paths, 123, 1)
+            .expect_err("runtime dir symlink lock write should fail closed");
+
+        assert!(error.to_string().contains("inspect runtime directory"));
+        assert!(!outside.join("conud.lock").exists());
+        assert!(
+            fs::symlink_metadata(&paths.runtime_dir)
+                .expect("runtime dir symlink metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clear_runtime_files_rejects_runtime_directory_symlink_without_deleting_targets() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("clear-runtime-dir-symlink");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = test_home("clear-runtime-dir-target");
+        fs::create_dir_all(&home).expect("home creates");
+        fs::create_dir_all(&outside).expect("outside runtime creates");
+        fs::write(outside.join("conud.lock"), "outside lock\n").expect("outside lock writes");
+        fs::write(outside.join("stop.request"), "outside stop\n").expect("outside stop writes");
+        symlink(&outside, &paths.runtime_dir).expect("runtime dir symlink creates");
+
+        let error = clear_runtime_files(&paths)
+            .expect_err("runtime dir symlink cleanup should fail closed");
+
+        assert!(error.to_string().contains("inspect runtime directory"));
+        assert_eq!(
+            fs::read_to_string(outside.join("conud.lock")).expect("outside lock reads"),
+            "outside lock\n"
+        );
+        assert_eq!(
+            fs::read_to_string(outside.join("stop.request")).expect("outside stop reads"),
+            "outside stop\n"
+        );
+        assert!(
+            fs::symlink_metadata(&paths.runtime_dir)
+                .expect("runtime dir symlink metadata")
                 .file_type()
                 .is_symlink()
         );


### PR DESCRIPTION
## **User description**
Closes #532

Summary:
- validate the runtime control directory before status and lock writes
- validate the runtime control directory before clearing lock/stop files
- add symlinked-runtime-directory regressions for status writes, lock writes, and cleanup

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- focused local cargo test was attempted but this workstation is missing dlltool.exe


___

## **CodeAnt-AI Description**
**Stop runtime status, lock, and cleanup actions from following a symlinked runtime directory**

### What Changed
- Runtime status writes, lock creation, and runtime file cleanup now first verify the runtime directory itself, instead of operating through a symlinked directory
- If the runtime directory is a symlink, these actions fail without writing outside files or deleting files in the target location
- Added coverage for rejected symlinked runtime directories during status writes, lock writes, and cleanup

### Impact
`✅ Fewer unintended writes outside the runtime directory`
`✅ Safer lock and status file handling`
`✅ Safer cleanup when the runtime directory is redirected`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime directory validation to ensure proper state and prevent potential errors during runtime control operations and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->