### PR TITLE
Harden trust store write handle verification

### DIFF
--- a/crates/conu-core/src/trust.rs
+++ b/crates/conu-core/src/trust.rs
@@ -744,12 +744,13 @@ fn write_trust_file(
     open_action: &'static str,
     write_action: &'static str,
 ) -> Result<(), TrustError> {
-    let mut file = if regular_trust_file_metadata(path, open_action)?.is_some() {
-        OpenOptions::new()
+    let mut file = if let Some(metadata) = regular_trust_file_metadata(path, open_action)? {
+        let file = OpenOptions::new()
             .write(true)
-            .truncate(true)
             .open(path)
-            .map_err(|error| TrustError::io(open_action, path, error))?
+            .map_err(|error| TrustError::io(open_action, path, error))?;
+        validate_opened_regular_trust_file(path, open_action, &metadata, &file)?;
+        file
     } else {
         OpenOptions::new()
             .write(true)
@@ -758,8 +759,54 @@ fn write_trust_file(
             .map_err(|error| TrustError::io(create_action, path, error))?
     };
 
+    file.set_len(0)
+        .map_err(|error| TrustError::io(open_action, path, error))?;
     file.write_all(contents.as_bytes())
         .map_err(|error| TrustError::io(write_action, path, error))
+}
+
+fn validate_opened_regular_trust_file(
+    path: &Path,
+    action: &'static str,
+    expected_metadata: &fs::Metadata,
+    file: &fs::File,
+) -> Result<(), TrustError> {
+    let Some(path_metadata) = regular_trust_file_metadata(path, action)? else {
+        return Err(TrustError::io(
+            action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "trust file path is missing"),
+        ));
+    };
+    if !trust_file_metadata_matches(expected_metadata, &path_metadata) {
+        return Err(TrustError::io(
+            action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "trust file path changed while opening",
+            ),
+        ));
+    }
+
+    let opened_metadata = file
+        .metadata()
+        .map_err(|error| TrustError::io(action, path, error))?;
+    if !opened_metadata.is_file()
+        || opened_metadata.len() > MAX_TRUST_FILE_BYTES
+        || !trust_file_metadata_matches(expected_metadata, &opened_metadata)
+    {
+        return Err(TrustError::io(
+            action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "opened trust file does not match inspected path",
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 fn regular_trust_file_metadata(
@@ -1413,6 +1460,47 @@ mod tests {
 
         assert!(error.contains("trust file exceeds"));
         assert!(!error.contains(private_marker));
+    }
+
+    #[test]
+    fn opened_trust_write_guard_rejects_mismatched_handle() {
+        let home = test_home("opened-trust-write-guard");
+        fs::create_dir_all(&home).expect("home creates");
+        let target = home.join("trust-target.toml");
+        let replacement = home.join("trust-replacement.toml");
+        fs::write(&target, "version = \"1\"\n").expect("target writes");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        fs::write(&replacement, "version = \"1\"\nchanged = true\n").expect("replacement writes");
+
+        let expected = regular_trust_file_metadata(&target, "inspect trust write target")
+            .expect("target metadata reads")
+            .expect("target exists");
+        let opened = OpenOptions::new()
+            .write(true)
+            .open(&replacement)
+            .expect("replacement opens");
+
+        let error = validate_opened_regular_trust_file(
+            &target,
+            "inspect trust write target",
+            &expected,
+            &opened,
+        )
+        .expect_err("mismatched opened handle should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("opened trust file does not match inspected path")
+        );
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            "version = \"1\"\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&replacement).expect("replacement reads"),
+            "version = \"1\"\nchanged = true\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #534\n\n## Summary\n- open existing trust files without truncating first\n- verify the opened handle still matches the inspected trust path\n- add a regression for mismatched opened trust handles\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n\nFocused local test attempt was blocked by missing dlltool.exe on this workstation; CI covers Rust tests on hosted OS runners.


___

## **CodeAnt-AI Description**
**Prevent trust file writes from targeting the wrong file**

### What Changed
- Trust file updates now re-check the file after opening it, so a changed path or mismatched file is rejected instead of being overwritten.
- Existing trust files are cleared before writing new contents, avoiding leftover data from previous writes.
- Added a regression test that confirms a mismatched opened file is refused and the original files stay unchanged.

### Impact
`✅ Safer trust file updates`
`✅ Fewer accidental overwrites`
`✅ Clearer failures when a trust file changes mid-write`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
