### PR TITLE
Commit remote replay IDs after delivery

### DIFF
--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -319,8 +319,10 @@ pub fn deliver_remote_envelope_from_paths(
         payload,
     )?;
 
+    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "relay_envelope")?;
+    let entry = deliver_envelope_with_status(paths, envelope, "delivered_relay")?;
     security::record_replay_id_from_paths(paths, &envelope_id, "relay_envelope")?;
-    deliver_envelope_with_status(paths, envelope, "delivered_relay")
+    Ok(entry)
 }
 
 /// Deliver a peer-decrypted remote stream chunk to a local addressed agent inbox.
@@ -348,13 +350,15 @@ pub fn deliver_remote_stream_chunk_from_paths(
     )?;
     envelope.meta.stream_id = Some(stream_id.clone());
 
-    security::record_replay_id_from_paths(paths, &envelope_id, "relay_stream_chunk")?;
-    deliver_envelope_with_status_and_stream(
+    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "relay_stream_chunk")?;
+    let entry = deliver_envelope_with_status_and_stream(
         paths,
         envelope,
         "delivered_relay_stream",
         Some(stream_id),
-    )
+    )?;
+    security::record_replay_id_from_paths(paths, &envelope_id, "relay_stream_chunk")?;
+    Ok(entry)
 }
 
 /// Deliver an opaque room event to a local subscribed agent inbox.
@@ -379,8 +383,10 @@ pub fn deliver_room_event_from_paths(
         payload,
     )?;
 
+    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "room_event_envelope")?;
+    let entry = deliver_envelope_with_status(paths, envelope, "delivered_room")?;
     security::record_replay_id_from_paths(paths, &envelope_id, "room_event_envelope")?;
-    deliver_envelope_with_status(paths, envelope, "delivered_room")
+    Ok(entry)
 }
 
 /// List metadata-only local delivery receipts.
@@ -2064,6 +2070,44 @@ mod tests {
         assert_eq!(receipts[0].payload_bytes, 24);
         assert!(receipt_file.contains("payload_displayed = false"));
         assert!(!receipt_file.contains("private message contents"));
+    }
+
+    #[test]
+    fn failed_remote_delivery_does_not_record_replay_id_before_retry() {
+        let home = test_home("remote-delivery-replay-retry");
+        register_agent(&home, "agent.receiver");
+        let paths = StatePaths::from_home(home);
+        let inbox_dir = paths.message_inbox_dir.join("agent.receiver");
+        fs::create_dir_all(&inbox_dir).expect("inbox dir creates");
+        let existing = inbox_dir.join("env.retry.env");
+        fs::write(&existing, "existing envelope").expect("existing envelope writes");
+
+        let error = deliver_remote_envelope_from_paths(
+            &paths,
+            "env.retry",
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private retry payload".to_vec()),
+        )
+        .expect_err("delivery collision should fail before replay commit");
+
+        assert!(error.to_string().contains("reserve message delivery file"));
+        let replay_cache = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
+        assert!(!replay_cache.contains("env.retry"));
+
+        fs::remove_file(&existing).expect("existing envelope removes");
+        let entry = deliver_remote_envelope_from_paths(
+            &paths,
+            "env.retry",
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private retry payload".to_vec()),
+        )
+        .expect("retry delivers after collision is cleared");
+
+        assert_eq!(entry.envelope_id, "env.retry");
+        let replay_cache = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
+        assert!(replay_cache.contains("env.retry"));
     }
 
     #[cfg(unix)]

--- a/crates/conu-core/src/security.rs
+++ b/crates/conu-core/src/security.rs
@@ -887,6 +887,21 @@ pub fn decrypt_from_peer_from_paths(
     Ok(plaintext)
 }
 
+/// Check an idempotency/replay id without committing it.
+pub fn ensure_replay_id_not_seen_from_paths(
+    paths: &StatePaths,
+    id: &str,
+    source: &str,
+) -> Result<(), SecurityError> {
+    validate_replay_value(id, "replay id")?;
+    validate_replay_value(source, "replay source")?;
+    let contents = read_replay_cache_contents(paths)?;
+    if replay_cache_contains_id(&contents, id) {
+        return Err(SecurityError::ReplayDetected { id: id.to_string() });
+    }
+    Ok(())
+}
+
 /// Record an idempotency/replay id and reject duplicates.
 pub fn record_replay_id_from_paths(
     paths: &StatePaths,
@@ -895,22 +910,9 @@ pub fn record_replay_id_from_paths(
 ) -> Result<(), SecurityError> {
     validate_replay_value(id, "replay id")?;
     validate_replay_value(source, "replay source")?;
-    state::ensure_state_directory(&paths.home)?;
-    state::ensure_state_directory(&paths.security_dir)?;
-    ensure_replay_cache(paths)?;
-
-    let contents = state::read_optional_regular_state_file(
-        &paths.replay_cache,
-        "inspect replay cache",
-        "read replay cache",
-    )?
-    .unwrap_or_default();
-    for line in contents.lines().map(str::trim) {
-        if let Some(value) = line.strip_prefix("id = ") {
-            if clean_value(value) == id {
-                return Err(SecurityError::ReplayDetected { id: id.to_string() });
-            }
-        }
+    let contents = read_replay_cache_contents(paths)?;
+    if replay_cache_contains_id(&contents, id) {
+        return Err(SecurityError::ReplayDetected { id: id.to_string() });
     }
 
     let entry = format!(
@@ -928,6 +930,26 @@ pub fn record_replay_id_from_paths(
         "write replay cache",
     )?;
     Ok(())
+}
+
+fn read_replay_cache_contents(paths: &StatePaths) -> Result<String, SecurityError> {
+    state::ensure_state_directory(&paths.home)?;
+    state::ensure_state_directory(&paths.security_dir)?;
+    ensure_replay_cache(paths)?;
+
+    Ok(state::read_optional_regular_state_file(
+        &paths.replay_cache,
+        "inspect replay cache",
+        "read replay cache",
+    )?
+    .unwrap_or_default())
+}
+
+fn replay_cache_contains_id(contents: &str, id: &str) -> bool {
+    contents.lines().map(str::trim).any(|line| {
+        line.strip_prefix("id = ")
+            .is_some_and(|value| clean_value(value) == id)
+    })
 }
 
 fn ensure_identity_signing_key(paths: &StatePaths) -> Result<bool, SecurityError> {
@@ -4382,6 +4404,22 @@ mod tests {
             .expect_err("duplicate fails");
 
         assert!(matches!(duplicate, SecurityError::ReplayDetected { .. }));
+    }
+
+    #[test]
+    fn replay_cache_precheck_does_not_record_id() {
+        let home = test_home("replay-precheck");
+        let paths = StatePaths::from_home(home);
+        ensure_security_state_from_paths(&paths).expect("security state initializes");
+
+        ensure_replay_id_not_seen_from_paths(&paths, "request_precheck", "message_request")
+            .expect("unused id prechecks");
+
+        let contents = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
+        assert!(!contents.contains("request_precheck"));
+
+        record_replay_id_from_paths(&paths, "request_precheck", "message_request")
+            .expect("prechecked id still records");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #536\n\n## Summary\n- add a replay precheck that does not commit the ID\n- record remote message, stream-chunk, and room-event replay IDs only after successful local delivery\n- add a regression proving failed remote delivery can be retried after the local collision is cleared\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n\nFocused local test attempt was blocked by missing dlltool.exe on this workstation; CI covers Rust tests on hosted OS runners.


___

## **CodeAnt-AI Description**
**Avoid marking remote deliveries as seen until they actually succeed**

### What Changed
- Remote messages, stream chunks, and room events now check for duplicate replay IDs before delivery, then save the ID only after the local inbox write succeeds
- Failed remote deliveries no longer block a later retry if the original failure was caused by a local collision
- Replay checks can now run without creating a replay entry, matching the new delivery flow

### Impact
`✅ Fewer lost remote messages after local write conflicts`
`✅ Retry succeeds after a temporary inbox collision`
`✅ Clearer replay protection for remote deliveries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
