### PR TITLE
Commit local message replay ids after delivery

### DIFF
--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -444,7 +444,7 @@ fn process_one_message_request(
     }
 
     let request_id_value = validate_identifier(required(&values, "request_id")?, "request id")?;
-    security::record_replay_id_from_paths(paths, &request_id_value, "message_request")?;
+    security::ensure_replay_id_not_seen_from_paths(paths, &request_id_value, "message_request")?;
     let from_agent_id = required(&values, "from_agent_id")?;
     let to_agent_id = required(&values, "to_agent_id")?;
     let payload = OpaquePayload::from_bytes(payload_from_values(
@@ -465,8 +465,11 @@ fn process_one_message_request(
         message.payload,
     )?;
 
+    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "message_envelope")?;
+    let delivery = deliver_envelope_with_status(paths, envelope, "delivered_local")?;
+    security::record_replay_id_from_paths(paths, &request_id_value, "message_request")?;
     security::record_replay_id_from_paths(paths, &envelope_id, "message_envelope")?;
-    deliver_envelope_with_status(paths, envelope, "delivered_local")
+    Ok(delivery)
 }
 
 fn validate_agents_can_message(
@@ -1484,6 +1487,62 @@ mod tests {
                 .count(),
             0
         );
+    }
+
+    #[test]
+    fn failed_local_delivery_does_not_record_replay_id_before_retry() {
+        let home = test_home("local-delivery-replay-retry");
+        register_agent(&home, "agent.sender");
+        register_agent(&home, "agent.receiver");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("message valid");
+        let submission =
+            submit_local_message(Some(home.clone()), message.clone()).expect("message submits");
+        let paths = StatePaths::from_home(home.clone());
+        let recipient_inbox_dir = paths.message_inbox_dir.join("agent.receiver");
+        fs::write(&recipient_inbox_dir, "not a directory").expect("inbox blocker writes");
+
+        let report = process_message_requests(Some(home.clone()))
+            .expect("delivery failure is archived as rejection");
+
+        assert_eq!(report.delivered, 0);
+        assert_eq!(report.rejected, 1);
+        let replay_cache = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
+        assert!(!replay_cache.contains(&submission.request_id));
+        assert!(!replay_cache.contains("message_envelope"));
+
+        fs::remove_file(&recipient_inbox_dir).expect("inbox blocker removes");
+        let encrypted = security::encrypt_for_storage_from_paths(
+            &paths,
+            message.payload.as_bytes(),
+            &message_request_aad(
+                &submission.request_id,
+                &message.from_agent_id,
+                &message.to_agent_id,
+            ),
+        )
+        .expect("retry payload encrypts");
+        let retry_path = paths.message_ipc_inbox_dir.join("retry.msg");
+        fs::write(
+            &retry_path,
+            render_message_request(&submission.request_id, &message, &encrypted),
+        )
+        .expect("retry request writes");
+
+        let retry_report =
+            process_message_requests(Some(home.clone())).expect("retry request processes");
+        let inbox = list_agent_inbox(Some(home.clone()), "agent.receiver").expect("inbox reads");
+        let replay_cache = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
+
+        assert_eq!(retry_report.delivered, 1);
+        assert_eq!(retry_report.rejected, 0);
+        assert_eq!(inbox.len(), 1);
+        assert!(replay_cache.contains(&submission.request_id));
+        assert!(replay_cache.contains("message_envelope"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #538.\n\n## Summary\n- checks local message request and envelope replay ids before delivery without committing them\n- records the request and envelope replay ids only after successful local inbox delivery\n- adds a retry regression for a failed local delivery that later reuses the same request id\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n\nFocused local test attempt: cargo +stable-x86_64-pc-windows-gnu test -p conu-core failed_local_delivery_does_not_record_replay_id_before_retry -- --exact, blocked by missing dlltool.exe on this workstation.


___

## **CodeAnt-AI Description**
**Delay replay-id recording until local message delivery succeeds**

### What Changed
- Local messages now check for duplicate request and envelope IDs before delivery, but only save those IDs after the message is delivered successfully.
- If local delivery fails, the same message request can be retried instead of being blocked as already processed.
- Added coverage for a failed local delivery that is retried and then delivered successfully.

### Impact
`✅ Reliable local message retries`
`✅ Fewer blocked deliveries after temporary inbox failures`
`✅ Lower chance of losing messages after a failed local send`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
