### PR TITLE
Order remote room event metadata before delivery

### DIFF
--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -389,6 +389,15 @@ pub fn deliver_room_event_from_paths(
     Ok(entry)
 }
 
+pub(crate) fn ensure_room_event_replay_not_seen_from_paths(
+    paths: &StatePaths,
+    envelope_id: &str,
+) -> Result<(), MessageError> {
+    let envelope_id = validate_identifier(envelope_id.to_string(), "envelope id")?;
+    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "room_event_envelope")?;
+    Ok(())
+}
+
 /// List metadata-only local delivery receipts.
 pub fn list_receipts(home_override: Option<PathBuf>) -> Result<Vec<DeliveryReceipt>, MessageError> {
     let paths = StatePaths::resolve(home_override)?;

--- a/crates/conu-core/src/rooms.rs
+++ b/crates/conu-core/src/rooms.rs
@@ -546,13 +546,6 @@ pub fn deliver_remote_room_event_from_paths(
         &topic,
         RoomTopicPermission::Subscribe,
     )?;
-    let entry = messages::deliver_room_event_from_paths(
-        paths,
-        &envelope_id,
-        &from_agent_id,
-        &to_agent_id,
-        payload,
-    )?;
     let event = RoomEvent {
         event_id,
         room_id: room_id.clone(),
@@ -563,7 +556,15 @@ pub fn deliver_remote_room_event_from_paths(
         payload_bytes,
         created_at_unix: current_unix_seconds(),
     };
+    messages::ensure_room_event_replay_not_seen_from_paths(paths, &envelope_id)?;
     append_event_once(paths, event)?;
+    let entry = messages::deliver_room_event_from_paths(
+        paths,
+        &envelope_id,
+        &from_agent_id,
+        &to_agent_id,
+        payload,
+    )?;
     append_room_log(
         paths,
         "room_event_received",
@@ -1934,6 +1935,77 @@ mod tests {
 
         assert!(error.to_string().contains("not allowed to publish"));
         assert!(!error.to_string().contains("private message contents"));
+    }
+
+    #[test]
+    fn failed_remote_room_event_metadata_append_does_not_record_replay_before_retry() {
+        let alice_home = test_home("remote-room-replay-alice");
+        let bob_home = test_home("remote-room-replay-bob");
+        state::init_state(Some(alice_home.clone())).expect("alice initializes");
+        state::init_state(Some(bob_home.clone())).expect("bob initializes");
+        let alice_peer = trust::export_peer_card(Some(alice_home.clone())).expect("alice card");
+        trust::trust_peer_card(Some(bob_home.clone()), alice_peer.clone())
+            .expect("bob trusts alice");
+        policy::set_peer_policy(
+            Some(bob_home.clone()),
+            &alice_peer.node_id,
+            PeerPolicyUpdate {
+                messages: Some(false),
+                streams: Some(false),
+                rooms: Some(true),
+                files: Some(false),
+                mailbox: Some(false),
+            },
+        )
+        .expect("bob grants alice rooms");
+        register_agent(&alice_home, "agent.alice");
+        register_agent(&bob_home, "agent.bob");
+        let alice_agent_card =
+            agents::export_agent_card(Some(alice_home), "agent.alice").expect("alice card");
+        sessions::trust_remote_agent_card(Some(bob_home.clone()), alice_agent_card)
+            .expect("alice remote agent imports");
+        create_room(Some(bob_home.clone()), "room.dev", "Dev Room", "agent.bob")
+            .expect("bob room creates");
+        join_room(Some(bob_home.clone()), "room.dev", "agent.alice").expect("alice remote joins");
+
+        let paths = StatePaths::from_home(bob_home.clone());
+        fs::create_dir(&paths.room_events).expect("room events blocker creates");
+        let delivery = RemoteRoomEventDelivery {
+            envelope_id: "roomenv.retry".to_string(),
+            event_id: "room_event.retry".to_string(),
+            room_id: "room.dev".to_string(),
+            topic: "build".to_string(),
+            peer_node_id: alice_peer.node_id,
+            from_agent_id: "agent.alice".to_string(),
+            to_agent_id: "agent.bob".to_string(),
+            payload: OpaquePayload::from_bytes(b"private retry room event".to_vec()),
+        };
+
+        let error = deliver_remote_room_event_from_paths(&paths, delivery.clone())
+            .expect_err("room event metadata write failure fails before replay commit");
+        let replay_cache = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
+        let inbox =
+            messages::list_agent_inbox(Some(bob_home.clone()), "agent.bob").expect("inbox reads");
+
+        assert!(error.to_string().contains("inspect room events"));
+        assert!(inbox.is_empty());
+        assert!(!replay_cache.contains("roomenv.retry"));
+        assert!(!replay_cache.contains("room_event_envelope"));
+
+        fs::remove_dir(&paths.room_events).expect("room events blocker removes");
+        let entry = deliver_remote_room_event_from_paths(&paths, delivery)
+            .expect("retry delivers after metadata path is repaired");
+        let events = list_room_events(Some(bob_home.clone())).expect("room events read");
+        let inbox =
+            messages::list_agent_inbox(Some(bob_home.clone()), "agent.bob").expect("inbox reads");
+        let replay_cache = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
+
+        assert_eq!(entry.envelope_id, "roomenv.retry");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_id, "room_event.retry");
+        assert_eq!(inbox.len(), 1);
+        assert!(replay_cache.contains("roomenv.retry"));
+        assert!(replay_cache.contains("room_event_envelope"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #540.\n\n## Summary\n- prechecks room-event replay ids before mutating room metadata\n- appends inbound remote room event metadata before local inbox delivery, leaving replay commit after both durable steps\n- adds a regression that fails the room-events store, verifies no inbox/replay side effects, repairs it, and retries the same envelope\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n\nFocused local test attempt: cargo +stable-x86_64-pc-windows-gnu test -p conu-core failed_remote_room_event_metadata_append_does_not_record_replay_before_retry -- --exact, blocked by missing dlltool.exe on this workstation.


___

## **CodeAnt-AI Description**
**Keep remote room event retries safe when metadata write fails**

### What Changed
- Remote room events now check for duplicate delivery before writing room metadata
- If room metadata cannot be saved, the event is not marked as delivered, so the same envelope can be retried after the issue is fixed
- Successful deliveries still record the event, inbox entry, and replay status in the expected order

### Impact
`✅ Retry failed room event deliveries`
`✅ Fewer lost remote room messages`
`✅ No duplicate room event delivery after recovery`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
