### PR TITLE
Preflight room event store before publish fanout

### DIFF
--- a/crates/conu-core/src/rooms.rs
+++ b/crates/conu-core/src/rooms.rs
@@ -472,6 +472,8 @@ pub fn publish_room_event(
     let local_recipients = local_room_recipients(&init.paths, &room, &from_agent_id, &event.topic)?;
     let remote_recipients =
         remote_room_recipients(&init.paths, &room, &from_agent_id, &event.topic)?;
+    read_events(&init.paths)?;
+
     let local_deliveries = deliver_room_event_to_local_participants(
         &init.paths,
         &event,
@@ -2047,6 +2049,36 @@ mod tests {
 
         assert!(error.to_string().contains("registered locally"));
         assert!(!error.to_string().contains("private message contents"));
+    }
+
+    #[test]
+    fn room_publish_event_store_error_fails_before_fanout() {
+        let home = test_home("publish-event-store-preflight");
+        register_agent(&home, "agent.codex");
+        register_agent(&home, "agent.hermes");
+        create_room(Some(home.clone()), "room.dev", "Dev Room", "agent.codex")
+            .expect("room creates");
+        join_room(Some(home.clone()), "room.dev", "agent.hermes").expect("hermes joins");
+        let paths = StatePaths::from_home(home.clone());
+        fs::create_dir(&paths.room_events).expect("room events blocker creates");
+
+        let error = publish_room_event(
+            Some(home.clone()),
+            "room.dev",
+            "agent.hermes",
+            "build",
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect_err("invalid event store should fail before fanout");
+        let inbox = messages::list_agent_inbox(Some(home.clone()), "agent.codex")
+            .expect("recipient inbox reads");
+        let rooms = list_rooms(Some(home)).expect("rooms read");
+
+        assert!(error.to_string().contains("inspect room events"));
+        assert!(!error.to_string().contains("private message contents"));
+        assert!(inbox.is_empty());
+        assert_eq!(rooms[0].events_published, 0);
+        assert_eq!(rooms[0].bytes_published, 0);
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- preflight the room event metadata store before local or remote room publish fanout
- keep invalid event-store failures from writing subscriber inboxes or updating persisted room counters
- add a regression covering the fail-before-fanout behavior without exposing payload contents

Closes #544

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Focused local test attempt: cargo +stable-x86_64-pc-windows-gnu test -p conu-core rooms::tests::room_publish_event_store_error_fails_before_fanout -- --exact is blocked on this workstation by missing dlltool.exe while compiling windows-sys/getrandom; GitHub CI should cover tests.


___

## **CodeAnt-AI Description**
**Fail room event publishing before any fanout if the event store cannot be read**

### What Changed
- Publishing a room event now stops up front if the room event store is unavailable or invalid.
- When this happens, no participant inboxes are written and room publish counters stay unchanged.
- The failure message now points to the room events store issue instead of exposing message contents.

### Impact
`✅ Fewer partial room posts`
`✅ No inbox writes on publish failure`
`✅ Clearer room event storage errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
