### PR TITLE
Keep direct delivery independent from metadata logs

### DIFF
--- a/crates/conu-core/src/direct_transport.rs
+++ b/crates/conu-core/src/direct_transport.rs
@@ -434,13 +434,13 @@ pub fn send_direct_message_from_paths(
         local_node_id,
     )?;
     validate_delivery_ack(paths, local_node_id, &peer, &envelope_id, &response)?;
-    append_direct_log(
+    record_direct_log(
         paths,
         "outbox_sent",
         &envelope_id,
         &peer.peer_node_id,
         encrypted.plaintext_len,
-    )?;
+    );
 
     Ok(DirectDeliveryReport {
         envelope_id,
@@ -497,13 +497,13 @@ pub fn send_direct_stream_chunk_from_paths(
         local_node_id,
     )?;
     validate_delivery_ack(paths, local_node_id, &peer, &envelope_id, &response)?;
-    append_direct_log(
+    record_direct_log(
         paths,
         "outbox_sent",
         &envelope_id,
         &peer.peer_node_id,
         encrypted.plaintext_len,
-    )?;
+    );
 
     Ok(DirectDeliveryReport {
         envelope_id,
@@ -546,7 +546,7 @@ fn send_direct_envelope(
             reason: "direct acknowledgement peer mismatch".to_string(),
         });
     }
-    append_direct_log(paths, "ack_received", &envelope_id, &peer.peer_node_id, 0)?;
+    record_direct_log(paths, "ack_received", &envelope_id, &peer.peer_node_id, 0);
     Ok(values)
 }
 
@@ -573,7 +573,7 @@ async fn accept_direct_frames(
             Ok(None) => report.received += 1,
             Err(_) => {
                 report.rejected += 1;
-                append_direct_log(paths, "inbox_rejected", "", "", 0)?;
+                record_direct_log(paths, "inbox_rejected", "", "", 0);
             }
         }
     }
@@ -745,13 +745,13 @@ fn receive_direct_frame(
         encrypted.plaintext_len,
         &encrypted,
     );
-    append_direct_log(
+    record_direct_log(
         paths,
         "inbox_delivered",
         &envelope_id,
         &from_node_id,
         body.plaintext_len,
-    )?;
+    );
 
     Ok((response, entry))
 }
@@ -1341,6 +1341,18 @@ fn is_multicast_or_broadcast(address: IpAddr) -> bool {
     }
 }
 
+fn record_direct_log(
+    paths: &StatePaths,
+    event: &str,
+    envelope_id: &str,
+    peer_node_id: &str,
+    bytes: usize,
+) {
+    // Direct delivery success is owned by peer acknowledgement and durable inbox state,
+    // not by optional metadata-log persistence.
+    let _ = append_direct_log(paths, event, envelope_id, peer_node_id, bytes);
+}
+
 fn append_direct_log(
     paths: &StatePaths,
     event: &str,
@@ -1842,6 +1854,79 @@ mod tests {
         assert_eq!(inbox[0].kind, "message");
         assert!(log.contains("payload=not_observed"));
         assert!(!log.contains("private direct message"));
+    }
+
+    #[test]
+    fn direct_delivery_success_does_not_depend_on_direct_log_writes() {
+        let _direct_guard = direct_quic_test_lock();
+        let alice_home = test_home("log-collision-alice");
+        let bob_home = test_home("log-collision-bob");
+        let bob_endpoint = free_loopback_endpoint();
+        state::init_state(Some(bob_home.clone())).expect("bob state initializes");
+        fs::write(
+            StatePaths::from_home(bob_home.clone()).config,
+            format!("version = \"1\"\ndirect_quic_endpoint = \"{bob_endpoint}\"\n"),
+        )
+        .expect("bob config writes");
+        let alice_card =
+            trust::export_peer_card(Some(alice_home.clone())).expect("alice card exports");
+        let bob_card = trust::export_peer_card(Some(bob_home.clone())).expect("bob card exports");
+        let bob_peer =
+            trust::trust_peer_card(Some(alice_home.clone()), bob_card).expect("alice trusts bob");
+        let alice_peer =
+            trust::trust_peer_card(Some(bob_home.clone()), alice_card).expect("bob trusts alice");
+        grant_peer_policy(&alice_home, &bob_peer.peer_node_id, true, false);
+        grant_peer_policy(&bob_home, &alice_peer.peer_node_id, true, false);
+        register_stream_agent(&alice_home, "agent.alice");
+        register_stream_agent(&bob_home, "agent.bob");
+        let alice_direct_log = StatePaths::from_home(alice_home.clone())
+            .logs_dir
+            .join("direct.log");
+        let bob_direct_log = StatePaths::from_home(bob_home.clone())
+            .logs_dir
+            .join("direct.log");
+        fs::create_dir(&alice_direct_log).expect("alice direct log collision creates");
+        fs::create_dir(&bob_direct_log).expect("bob direct log collision creates");
+
+        let bob_paths = StatePaths::from_home(bob_home.clone());
+        let bob_node = state::read_state(Some(bob_home.clone()))
+            .expect("bob state")
+            .node
+            .expect("bob node")
+            .node_id;
+        let mut server = DirectRuntimeServer::new().expect("server starts");
+        let handle = std::thread::spawn(move || {
+            server
+                .tick_from_paths(&bob_paths, &bob_node, direct_quic_test_timeout())
+                .expect("server tick")
+        });
+        std::thread::sleep(direct_quic_test_startup_delay());
+
+        let alice_paths = StatePaths::from_home(alice_home.clone());
+        let alice_node = state::read_state(Some(alice_home))
+            .expect("alice state")
+            .node
+            .expect("alice node")
+            .node_id;
+        let message = RemoteMessage::new(
+            "agent.alice",
+            "agent.bob",
+            &bob_peer.peer_node_id,
+            OpaquePayload::from_bytes(b"private direct message".to_vec()),
+        )
+        .expect("message valid");
+        let sent = send_direct_message_from_paths(&alice_paths, &alice_node, message)
+            .expect("message sends despite direct log collisions");
+        let server_report = handle.join().expect("server joins");
+        let inbox =
+            messages::list_agent_inbox(Some(bob_home), "agent.bob").expect("bob inbox reads");
+
+        assert_eq!(sent.route, "direct-quic");
+        assert_eq!(server_report.received, 1);
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].kind, "message");
+        assert!(alice_direct_log.is_dir());
+        assert!(bob_direct_log.is_dir());
     }
 
     fn register_stream_agent(home: &Path, agent_id: &str) {


### PR DESCRIPTION
## **User description**
## Summary\n- Treat direct QUIC metadata log writes as best-effort so a peer-accepted message or stream chunk is not reported as failed only because direct.log cannot be appended.\n- Add a regression where both peers have direct.log path collisions and direct message delivery still succeeds without exposing payloads.\n\nCloses #548\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n- attempted: cargo +stable-x86_64-pc-windows-gnu test -p conu-core direct_delivery_success_does_not_depend_on_direct_log_writes -- --nocapture (blocked locally: dlltool.exe missing while compiling windows-sys/getrandom)


___

## **CodeAnt-AI Description**
**Keep direct message delivery working when direct log files cannot be written**

### What Changed
- Direct message, stream chunk, acknowledgement, and rejection events now continue without failing delivery when the metadata log cannot be updated
- Added a regression test showing direct delivery still succeeds when both peers have direct.log path collisions
- The new test also confirms the message reaches the recipient inbox and stays private

### Impact
`✅ Fewer direct delivery failures from log-file collisions`
`✅ Messages still arrive even when direct.log cannot be written`
`✅ Safer direct delivery with preserved message privacy`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
