### PR TITLE
Keep message delivery independent from metadata logs

### DIFF
--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -649,7 +649,7 @@ fn deliver_envelope_with_status_stream_and_receipt(
         let _ = fs::remove_file(&envelope_path);
         return Err(error);
     }
-    append_message_log(paths, &entry, status)?;
+    record_message_log(paths, &entry, status);
 
     Ok(entry)
 }
@@ -1107,6 +1107,11 @@ fn append_message_log(
         "write message log",
     )?;
     Ok(())
+}
+
+fn record_message_log(paths: &StatePaths, entry: &InboxEntry, status: &str) {
+    // Durable inbox and receipt writes own delivery success. Metadata logs are best-effort.
+    let _ = append_message_log(paths, entry, status);
 }
 
 fn write_new_file(path: &Path, contents: &str) -> Result<(), MessageError> {
@@ -2176,6 +2181,39 @@ mod tests {
         assert_eq!(entry.envelope_id, "env.retry");
         let replay_cache = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
         assert!(replay_cache.contains("env.retry"));
+    }
+
+    #[test]
+    fn remote_delivery_success_does_not_depend_on_message_log_write() {
+        let home = test_home("remote-delivery-log-collision");
+        register_agent(&home, "agent.receiver");
+        let paths = StatePaths::from_home(home);
+        let message_log = paths.logs_dir.join("messages.log");
+        fs::create_dir(&message_log).expect("message log collision creates");
+
+        let entry = deliver_remote_envelope_from_paths(
+            &paths,
+            "env.log.collision",
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private delivered payload".to_vec()),
+        )
+        .expect("delivery succeeds despite message log collision");
+
+        let envelope_path = paths
+            .message_inbox_dir
+            .join("agent.receiver")
+            .join("env.log.collision.env");
+        let receipt_count = fs::read_dir(&paths.message_receipts_dir)
+            .expect("receipts read")
+            .count();
+        let replay_cache = fs::read_to_string(&paths.replay_cache).expect("replay cache reads");
+
+        assert_eq!(entry.envelope_id, "env.log.collision");
+        assert!(envelope_path.exists());
+        assert_eq!(receipt_count, 1);
+        assert!(replay_cache.contains("env.log.collision"));
+        assert!(message_log.is_dir());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
## Summary\n- Make message delivery treat messages.log append as best-effort after encrypted inbox envelope and receipt persistence succeed.\n- Add a regression proving remote delivery still commits inbox, receipt, and replay state when messages.log is unavailable as a regular file.\n\nCloses #550\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n- attempted: cargo +stable-x86_64-pc-windows-gnu test -p conu-core remote_delivery_success_does_not_depend_on_message_log_write -- --nocapture (blocked locally: dlltool.exe missing while compiling windows-sys/getrandom)


___

## **CodeAnt-AI Description**
**Message delivery no longer depends on writing the metadata log**

### What Changed
- Remote message delivery now succeeds even if `messages.log` cannot be written
- Delivered messages still save the inbox copy, receipt, and replay state before the log is updated
- Added coverage for deliveries when the log path already exists as a directory

### Impact
`✅ Fewer message delivery failures`
`✅ Delivery still completes during log write problems`
`✅ More reliable inbox and receipt saving`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
