### PR TITLE
Make metadata logs best effort after durable writes

### DIFF
--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -485,7 +485,7 @@ fn upsert_agent(
     }
 
     write_registry(paths, &agents)?;
-    append_agent_log(paths, "agent_registered", &registration.agent_id)?;
+    record_agent_log(paths, "agent_registered", &registration.agent_id);
 
     Ok(registration.agent_id)
 }
@@ -511,7 +511,7 @@ fn update_presence(paths: &StatePaths, heartbeat: PresenceHeartbeat) -> Result<S
     }
 
     write_registry(paths, &agents)?;
-    append_agent_log(paths, "agent_presence", &heartbeat.agent_id)?;
+    record_agent_log(paths, "agent_presence", &heartbeat.agent_id);
 
     Ok(heartbeat.agent_id)
 }
@@ -951,6 +951,10 @@ fn append_agent_log(paths: &StatePaths, event: &str, agent_id: &str) -> Result<(
     Ok(())
 }
 
+fn record_agent_log(paths: &StatePaths, event: &str, agent_id: &str) {
+    let _ = append_agent_log(paths, event, agent_id);
+}
+
 fn write_new_file(path: &Path, contents: &str) -> Result<(), AgentError> {
     write_new_file_with_action(path, contents, "create IPC request", "write IPC request")
 }
@@ -1171,6 +1175,25 @@ mod tests {
             Some(security::AGENT_CARD_SIGNATURE_ALGORITHM)
         );
         assert!(verify_local_agent_record(&agents[0]).expect("signature verifies"));
+    }
+
+    #[test]
+    fn registration_success_does_not_depend_on_agent_log_write() {
+        let home = test_home("register-log-collision");
+        let registration = AgentRegistration::new("agent.codex", "Codex Desktop", "coding-agent")
+            .expect("valid registration");
+        submit_registration(Some(home.clone()), registration).expect("request submits");
+        let paths = StatePaths::from_home(home.clone());
+        let agent_log = paths.logs_dir.join("agents.log");
+        fs::create_dir(&agent_log).expect("agent log collision creates");
+
+        let report = process_gateway_requests(Some(home.clone())).expect("requests process");
+        let agents = list_local_agents(Some(home)).expect("agents read");
+
+        assert_eq!(report.processed, 1);
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].agent_id, "agent.codex");
+        assert!(agent_log.is_dir());
     }
 
     #[test]

--- a/crates/conu-core/src/rooms.rs
+++ b/crates/conu-core/src/rooms.rs
@@ -330,7 +330,7 @@ pub fn create_room(
 
     rooms.push(room.clone());
     write_rooms(&init.paths, &rooms)?;
-    append_room_log(&init.paths, "room_created", &room.room_id, None, 0)?;
+    record_room_log(&init.paths, "room_created", &room.room_id, None, 0);
 
     Ok(RoomCreateReport { room })
 }
@@ -379,13 +379,13 @@ pub fn join_room(
     let room = rooms[index].clone();
 
     write_rooms(&init.paths, &rooms)?;
-    append_room_log(
+    record_room_log(
         &init.paths,
         "room_joined",
         &room.room_id,
         Some(&agent_id),
         0,
-    )?;
+    );
 
     Ok(RoomJoinReport { room, joined: true })
 }
@@ -490,13 +490,13 @@ pub fn publish_room_event(
 
     write_rooms(&init.paths, &rooms)?;
     append_event(&init.paths, event.clone())?;
-    append_room_log(
+    record_room_log(
         &init.paths,
         "room_event_published",
         &room.room_id,
         Some(&from_agent_id),
         payload_bytes,
-    )?;
+    );
 
     Ok(RoomPublishReport {
         room,
@@ -567,13 +567,13 @@ pub fn deliver_remote_room_event_from_paths(
         &to_agent_id,
         payload,
     )?;
-    append_room_log(
+    record_room_log(
         paths,
         "room_event_received",
         &room_id,
         Some(&to_agent_id),
         payload_bytes,
-    )?;
+    );
 
     Ok(entry)
 }
@@ -661,13 +661,13 @@ pub fn set_room_topic_policy(
     });
     policies.push(record.clone());
     write_topic_policies(&init.paths, &policies)?;
-    append_room_log(
+    record_room_log(
         &init.paths,
         "room_topic_policy_updated",
         &record.room_id,
         Some(&record.agent_id),
         0,
-    )?;
+    );
 
     Ok(record)
 }
@@ -1398,6 +1398,16 @@ fn append_room_log(
     Ok(())
 }
 
+fn record_room_log(
+    paths: &StatePaths,
+    event: &'static str,
+    room_id: &str,
+    agent_id: Option<&str>,
+    payload_bytes: usize,
+) {
+    let _ = append_room_log(paths, event, room_id, agent_id, payload_bytes);
+}
+
 fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, RoomError> {
     values
         .get(key)
@@ -1590,6 +1600,24 @@ mod tests {
         assert!(!registry.contains("private message contents"));
         assert!(!event_file.contains("private message contents"));
         assert!(!log.contains("private message contents"));
+    }
+
+    #[test]
+    fn room_create_success_does_not_depend_on_room_log_write() {
+        let home = test_home("room-log-collision");
+        register_agent(&home, "agent.codex");
+        let room_log = StatePaths::from_home(home.clone())
+            .logs_dir
+            .join("rooms.log");
+        fs::create_dir(&room_log).expect("room log collision creates");
+
+        let created = create_room(Some(home.clone()), "room.dev", "Dev Room", "agent.codex")
+            .expect("room creates");
+        let rooms = list_rooms(Some(home)).expect("rooms read");
+
+        assert_eq!(created.room.room_id, "room.dev");
+        assert_eq!(rooms.len(), 1);
+        assert!(room_log.is_dir());
     }
 
     #[test]

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -288,7 +288,7 @@ pub fn sync_routes_from_paths(paths: &StatePaths) -> Result<RouteSyncReport, Rou
 
     write_routes(paths, &routes)?;
     append_probes(paths, &probes)?;
-    append_route_log(paths, &routes)?;
+    record_route_log(paths, &routes);
 
     Ok(report_from_routes(&routes, probes.len()))
 }
@@ -793,6 +793,10 @@ fn append_route_log(paths: &StatePaths, routes: &[RouteRecord]) -> Result<(), Ro
         "write route log",
     )?;
     Ok(())
+}
+
+fn record_route_log(paths: &StatePaths, routes: &[RouteRecord]) {
+    let _ = append_route_log(paths, routes);
 }
 
 fn parse_routes(contents: &str) -> Result<Vec<RouteRecord>, RouteError> {
@@ -1465,6 +1469,25 @@ mod tests {
         assert!(!log.contains("private message contents"));
         assert!(!probes.contains("private message contents"));
         assert!(!log.contains("Review this code"));
+    }
+
+    #[test]
+    fn route_sync_success_does_not_depend_on_route_log_write() {
+        let home = test_home("route-log-collision");
+        let peer = trusted_peer(&home);
+        let route_log = StatePaths::from_home(home.clone())
+            .logs_dir
+            .join("routes.log");
+        fs::create_dir(&route_log).expect("route log collision creates");
+
+        let report = sync_routes(Some(home.clone())).expect("routes sync");
+        let selected = selected_route_for_peer(Some(home), &peer.peer_node_id)
+            .expect("selected route reads")
+            .expect("selected route exists");
+
+        assert_eq!(report.peers, 1);
+        assert_eq!(selected.transport, RouteTransport::RelayWebSocket);
+        assert!(route_log.is_dir());
     }
 
     #[cfg(unix)]

--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -137,7 +137,7 @@ impl RuntimeLease {
     pub fn heartbeat(&self) -> Result<RuntimeStatus, RuntimeError> {
         let status = self.build_status(RuntimeState::Running, current_unix_seconds());
         write_status(&self.paths, &status)?;
-        append_log(&self.paths, "heartbeat", self.pid, &self.node.node_id)?;
+        record_log(&self.paths, "heartbeat", self.pid, &self.node.node_id);
         Ok(status)
     }
 
@@ -206,7 +206,7 @@ impl RuntimeLease {
 
         let status = self.build_status(RuntimeState::Stopping, current_unix_seconds());
         write_status(&self.paths, &status)?;
-        append_log(&self.paths, "stop_requested", self.pid, &self.node.node_id)?;
+        record_log(&self.paths, "stop_requested", self.pid, &self.node.node_id);
         Ok(())
     }
 
@@ -237,7 +237,7 @@ impl RuntimeLease {
         write_status(&self.paths, &status)?;
         remove_file_if_exists(&self.paths.runtime_lock)?;
         remove_file_if_exists(&self.paths.runtime_stop_request)?;
-        append_log(&self.paths, "stopped", self.pid, &self.node.node_id)?;
+        record_log(&self.paths, "stopped", self.pid, &self.node.node_id);
         self.stopped = true;
 
         Ok(status)
@@ -319,34 +319,34 @@ impl RuntimeLease {
                             || relay_report.undelivered > 0
                             || relay_report.rejected > 0
                         {
-                            append_log(
+                            record_log(
                                 &self.paths,
                                 "relay_pump_activity",
                                 self.pid,
                                 &self.node.node_id,
-                            )?;
+                            );
                         }
                     }
                     Err(_) => {
                         report.relay_error = true;
-                        append_log(
+                        record_log(
                             &self.paths,
                             "relay_pump_retry",
                             self.pid,
                             &self.node.node_id,
-                        )?;
+                        );
                     }
                 }
             }
             Ok(false) => {}
             Err(_) => {
                 report.relay_error = true;
-                append_log(
+                record_log(
                     &self.paths,
                     "relay_pump_retry",
                     self.pid,
                     &self.node.node_id,
-                )?;
+                );
             }
         }
 
@@ -374,22 +374,22 @@ impl RuntimeLease {
                             || relay_report.undelivered > 0
                             || relay_report.rejected > 0
                         {
-                            append_log(
+                            record_log(
                                 &self.paths,
                                 "relay_pump_activity",
                                 self.pid,
                                 &self.node.node_id,
-                            )?;
+                            );
                         }
                     }
                     Err(_) => {
                         report.relay_error = true;
-                        append_log(
+                        record_log(
                             &self.paths,
                             "relay_pump_retry",
                             self.pid,
                             &self.node.node_id,
-                        )?;
+                        );
                     }
                 }
             }
@@ -397,12 +397,12 @@ impl RuntimeLease {
             Err(_) => {
                 report.relay_error = true;
                 relay_pump.disconnect();
-                append_log(
+                record_log(
                     &self.paths,
                     "relay_pump_retry",
                     self.pid,
                     &self.node.node_id,
-                )?;
+                );
             }
         }
 
@@ -420,12 +420,12 @@ impl RuntimeLease {
         match server.tick_from_paths(&self.paths, &self.node.node_id, wait) {
             Ok(_) => Ok(()),
             Err(_) => {
-                append_log(
+                record_log(
                     &self.paths,
                     "direct_quic_retry",
                     self.pid,
                     &self.node.node_id,
-                )?;
+                );
                 Ok(())
             }
         }
@@ -447,22 +447,22 @@ impl RuntimeLease {
                 report.direct_received = direct_report.received;
                 report.direct_rejected = direct_report.rejected;
                 if direct_report.received > 0 || direct_report.rejected > 0 {
-                    append_log(
+                    record_log(
                         &self.paths,
                         "direct_quic_activity",
                         self.pid,
                         &self.node.node_id,
-                    )?;
+                    );
                 }
             }
             Err(_) => {
                 report.direct_error = true;
-                append_log(
+                record_log(
                     &self.paths,
                     "direct_quic_retry",
                     self.pid,
                     &self.node.node_id,
-                )?;
+                );
             }
         }
         Ok(())
@@ -584,7 +584,7 @@ pub fn acquire_runtime(home_override: Option<PathBuf>) -> Result<RuntimeLease, R
 
     let starting = lease.build_status(RuntimeState::Starting, started_at_unix);
     write_status(&lease.paths, &starting)?;
-    append_log(&lease.paths, "started", lease.pid, &lease.node.node_id)?;
+    record_log(&lease.paths, "started", lease.pid, &lease.node.node_id);
     lease.heartbeat()?;
 
     Ok(lease)
@@ -610,12 +610,12 @@ pub fn request_runtime_stop(home_override: Option<PathBuf>) -> Result<StopReport
             "truncate runtime stop request",
             "write runtime stop request",
         )?;
-        append_log(
+        record_log(
             &paths,
             "stop_requested_by_cli",
             process::id(),
             status.node_id.as_deref().unwrap_or("unknown"),
-        )?;
+        );
         Ok(StopReport {
             requested: true,
             status,
@@ -1001,6 +1001,10 @@ fn append_log(
         "write runtime log",
     )?;
     Ok(())
+}
+
+fn record_log(paths: &StatePaths, event: &str, pid: u32, node_id: &str) {
+    let _ = append_log(paths, event, pid, node_id);
 }
 
 fn runtime_is_stale(status: &RuntimeStatus) -> bool {
@@ -1494,6 +1498,22 @@ mod tests {
         assert!(log.contains("payload=not_observed"));
         assert!(!log.contains("private message contents"));
         assert!(!log.contains("Review this code"));
+    }
+
+    #[test]
+    fn runtime_heartbeat_success_does_not_depend_on_log_write() {
+        let home = test_home("runtime-log-collision");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let runtime_log = init.paths.logs_dir.join("conud.log");
+        fs::create_dir(&runtime_log).expect("runtime log collision creates");
+
+        let lease = acquire_runtime(Some(home.clone())).expect("runtime starts");
+        let status = lease.heartbeat().expect("heartbeat writes");
+        let read_back = read_runtime(Some(home)).expect("runtime reads");
+
+        assert_eq!(status.state, RuntimeState::Running);
+        assert_eq!(read_back.state, RuntimeState::Running);
+        assert!(runtime_log.is_dir());
     }
 
     #[test]

--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -226,7 +226,7 @@ pub fn sync_remote_sessions_from_paths(
         .map_err(|_| SessionError::InvalidRecord {
             reason: "failed to queue signed agent-card exchange".to_string(),
         })?;
-    append_session_log(paths, &sessions, remote_agents.len())?;
+    record_session_log(paths, &sessions, remote_agents.len());
 
     Ok(report_from_sessions(&sessions, remote_agents.len()))
 }
@@ -841,6 +841,10 @@ fn append_session_log(
     Ok(())
 }
 
+fn record_session_log(paths: &StatePaths, sessions: &[RemoteSession], remote_agents: usize) {
+    let _ = append_session_log(paths, sessions, remote_agents);
+}
+
 fn parse_key_values(contents: &str) -> HashMap<String, String> {
     let mut values = HashMap::new();
 
@@ -1057,6 +1061,23 @@ mod tests {
         assert!(log.contains("payload=not_observed"));
         assert!(!log.contains("private message contents"));
         assert!(!log.contains("Review this code"));
+    }
+
+    #[test]
+    fn session_sync_success_does_not_depend_on_session_log_write() {
+        let home = test_home("session-log-collision");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let joined = trust::join_pairing_code(Some(home.clone()), &invite.code).expect("joins");
+        let session_log = init.paths.logs_dir.join("sessions.log");
+        fs::create_dir(&session_log).expect("session log collision creates");
+
+        let report = sync_remote_sessions(Some(home.clone())).expect("sync succeeds");
+        let sessions = list_remote_sessions(Some(home)).expect("sessions read");
+
+        assert_eq!(report.connected, 1);
+        assert_eq!(sessions[0].peer_node_id, joined.peer.peer_node_id);
+        assert!(session_log.is_dir());
     }
 
     #[cfg(unix)]

--- a/crates/conu-core/src/streams.rs
+++ b/crates/conu-core/src/streams.rs
@@ -216,7 +216,7 @@ pub fn open_stream(
     streams.push(stream.clone());
     write_streams(&init.paths, &streams)?;
     append_event(&init.paths, event_for(&stream, "opened", 0, now))?;
-    append_stream_log(&init.paths, "stream_opened", &stream, 0)?;
+    record_stream_log(&init.paths, "stream_opened", &stream, 0);
 
     Ok(StreamOpenReport { stream })
 }
@@ -326,7 +326,7 @@ pub fn write_stream(
 
     write_streams(&init.paths, &streams)?;
     append_event(&init.paths, event.clone())?;
-    append_stream_log(&init.paths, "stream_chunk", &stream, payload_bytes)?;
+    record_stream_log(&init.paths, "stream_chunk", &stream, payload_bytes);
 
     Ok(StreamWriteReport { stream, event })
 }
@@ -356,7 +356,7 @@ pub fn close_stream(
 
     write_streams(&init.paths, &streams)?;
     append_event(&init.paths, event.clone())?;
-    append_stream_log(&init.paths, "stream_closed", &stream, 0)?;
+    record_stream_log(&init.paths, "stream_closed", &stream, 0);
 
     Ok(StreamCloseReport { stream, event })
 }
@@ -718,6 +718,15 @@ fn append_stream_log(
     Ok(())
 }
 
+fn record_stream_log(
+    paths: &StatePaths,
+    event: &'static str,
+    stream: &StreamRecord,
+    payload_bytes: usize,
+) {
+    let _ = append_stream_log(paths, event, stream, payload_bytes);
+}
+
 fn required(values: &HashMap<String, String>, key: &'static str) -> Result<String, StreamError> {
     values
         .get(key)
@@ -851,6 +860,33 @@ mod tests {
     }
 
     #[test]
+    fn stream_lifecycle_success_does_not_depend_on_stream_log_write() {
+        let home = test_home("stream-log-collision");
+        register_agent(&home, "agent.a");
+        register_agent(&home, "agent.b");
+        let stream_log = StatePaths::from_home(home.clone())
+            .logs_dir
+            .join("streams.log");
+        fs::create_dir(&stream_log).expect("stream log collision creates");
+
+        let opened =
+            open_stream(Some(home.clone()), "agent.a", "agent.b", "message").expect("opens");
+        let written = write_stream(
+            Some(home.clone()),
+            &opened.stream.stream_id,
+            OpaquePayload::from_bytes(b"private message contents".to_vec()),
+        )
+        .expect("writes");
+        let closed = close_stream(Some(home.clone()), &opened.stream.stream_id).expect("closes");
+        let events = list_events(Some(home)).expect("events read");
+
+        assert_eq!(written.stream.chunks_written, 1);
+        assert_eq!(closed.stream.state, StreamState::Closed);
+        assert_eq!(events.len(), 3);
+        assert!(stream_log.is_dir());
+    }
+
+    #[test]
     fn stream_write_enforces_backpressure_window() {
         let home = test_home("stream-backpressure");
         register_agent(&home, "agent.a");
@@ -968,7 +1004,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn stream_log_rejects_symlink_without_writing_target() {
+    fn stream_log_symlink_does_not_block_persisted_stream_open() {
         use std::os::unix::fs::symlink;
 
         let home = test_home("log-symlink");
@@ -980,10 +1016,11 @@ mod tests {
         fs::write(&outside, outside_contents).expect("outside log writes");
         symlink(&outside, paths.logs_dir.join("streams.log")).expect("stream log symlink creates");
 
-        let error = open_stream(Some(home), "agent.a", "agent.b", "message")
-            .expect_err("symlinked stream log fails closed");
+        let opened = open_stream(Some(home.clone()), "agent.a", "agent.b", "message")
+            .expect("stream opens despite symlinked stream log");
+        let streams = list_streams(Some(home)).expect("streams read");
 
-        assert!(error.to_string().contains("inspect stream log"));
+        assert_eq!(opened.stream.stream_id, streams[0].stream_id);
         assert_eq!(
             fs::read_to_string(&outside).expect("outside log reads"),
             outside_contents


### PR DESCRIPTION
## **User description**
## Summary\n- Keep payload-safe metadata logs best-effort after durable state writes in agent, stream, route, session, room, and runtime paths.\n- Preserve fail-closed behavior for the actual state files, registries, events, receipts, and payload storage.\n- Add regressions proving committed operations still succeed when their metadata log path is unavailable as a regular file.\n\nCloses #552\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n- attempted: cargo +stable-x86_64-pc-windows-gnu test -p conu-core registration_success_does_not_depend_on_agent_log_write -- --nocapture (blocked locally: dlltool.exe missing while compiling windows-sys/getrandom)


___

## **CodeAnt-AI Description**
**Keep core actions successful when log writes fail**

### What Changed
- Creating, updating, syncing, and stopping now complete even if the matching log file cannot be written
- Agent registration and presence updates still save, even when the agent log path is blocked
- Stream open/write/close, room create/join/publish, session sync, route sync, and runtime heartbeat or stop requests still finish after their main data is saved
- Added tests showing these flows succeed when the log file already exists as a directory

### Impact
`✅ Fewer failed syncs and registrations`
`✅ Fewer room, stream, and session operations blocked by log issues`
`✅ More reliable runtime and route updates when logs are unavailable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Core operations are now resilient to logging failures—agent registration, room management, route sync, runtime heartbeats, session sync, and stream operations will succeed even if logs cannot be written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->