### PR TITLE
Preflight replay cache before durable delivery

### DIFF
--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -319,7 +319,7 @@ pub fn deliver_remote_envelope_from_paths(
         payload,
     )?;
 
-    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "relay_envelope")?;
+    security::ensure_replay_id_recordable_from_paths(paths, &envelope_id, "relay_envelope")?;
     let entry = deliver_envelope_with_status(paths, envelope, "delivered_relay")?;
     security::record_replay_id_from_paths(paths, &envelope_id, "relay_envelope")?;
     Ok(entry)
@@ -350,7 +350,7 @@ pub fn deliver_remote_stream_chunk_from_paths(
     )?;
     envelope.meta.stream_id = Some(stream_id.clone());
 
-    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "relay_stream_chunk")?;
+    security::ensure_replay_id_recordable_from_paths(paths, &envelope_id, "relay_stream_chunk")?;
     let entry = deliver_envelope_with_status_and_stream(
         paths,
         envelope,
@@ -383,18 +383,18 @@ pub fn deliver_room_event_from_paths(
         payload,
     )?;
 
-    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "room_event_envelope")?;
+    security::ensure_replay_id_recordable_from_paths(paths, &envelope_id, "room_event_envelope")?;
     let entry = deliver_envelope_with_status(paths, envelope, "delivered_room")?;
     security::record_replay_id_from_paths(paths, &envelope_id, "room_event_envelope")?;
     Ok(entry)
 }
 
-pub(crate) fn ensure_room_event_replay_not_seen_from_paths(
+pub(crate) fn ensure_room_event_replay_recordable_from_paths(
     paths: &StatePaths,
     envelope_id: &str,
 ) -> Result<(), MessageError> {
     let envelope_id = validate_identifier(envelope_id.to_string(), "envelope id")?;
-    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "room_event_envelope")?;
+    security::ensure_replay_id_recordable_from_paths(paths, &envelope_id, "room_event_envelope")?;
     Ok(())
 }
 
@@ -453,7 +453,7 @@ fn process_one_message_request(
     }
 
     let request_id_value = validate_identifier(required(&values, "request_id")?, "request id")?;
-    security::ensure_replay_id_not_seen_from_paths(paths, &request_id_value, "message_request")?;
+    security::ensure_replay_id_recordable_from_paths(paths, &request_id_value, "message_request")?;
     let from_agent_id = required(&values, "from_agent_id")?;
     let to_agent_id = required(&values, "to_agent_id")?;
     let payload = OpaquePayload::from_bytes(payload_from_values(
@@ -474,7 +474,7 @@ fn process_one_message_request(
         message.payload,
     )?;
 
-    security::ensure_replay_id_not_seen_from_paths(paths, &envelope_id, "message_envelope")?;
+    security::ensure_replay_id_recordable_from_paths(paths, &envelope_id, "message_envelope")?;
     let delivery = deliver_envelope_with_status(paths, envelope, "delivered_local")?;
     security::record_replay_id_from_paths(paths, &request_id_value, "message_request")?;
     security::record_replay_id_from_paths(paths, &envelope_id, "message_envelope")?;
@@ -1559,6 +1559,30 @@ mod tests {
         assert!(replay_cache.contains("message_envelope"));
     }
 
+    #[test]
+    fn local_delivery_requires_recordable_replay_cache_before_inbox_write() {
+        let home = test_home("local-delivery-replay-recordable");
+        register_agent(&home, "agent.sender");
+        register_agent(&home, "agent.receiver");
+        let message = LocalMessage::new(
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private local payload".to_vec()),
+        )
+        .expect("message is valid");
+        submit_local_message(Some(home.clone()), message).expect("message request submits");
+        let paths = StatePaths::from_home(home.clone());
+        make_replay_cache_read_only(&paths);
+
+        let report =
+            process_message_requests(Some(home.clone())).expect("request failure is archived");
+        let inbox = list_agent_inbox(Some(home), "agent.receiver").expect("inbox reads");
+
+        assert_eq!(report.delivered, 0);
+        assert_eq!(report.rejected, 1);
+        assert!(inbox.is_empty());
+    }
+
     #[cfg(unix)]
     #[test]
     fn symlinked_message_request_is_rejected_without_reading_target() {
@@ -2184,6 +2208,63 @@ mod tests {
     }
 
     #[test]
+    fn remote_delivery_requires_recordable_replay_cache_before_inbox_write() {
+        let home = test_home("remote-delivery-replay-recordable");
+        register_agent(&home, "agent.receiver");
+        let paths = StatePaths::from_home(home.clone());
+        make_replay_cache_read_only(&paths);
+
+        let error = deliver_remote_envelope_from_paths(
+            &paths,
+            "env.recordable",
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private delivered payload".to_vec()),
+        )
+        .expect_err("readonly replay cache fails before delivery");
+        let inbox = list_agent_inbox(Some(home), "agent.receiver").expect("inbox reads");
+        let receipt_count = fs::read_dir(&paths.message_receipts_dir)
+            .expect("receipts read")
+            .count();
+
+        assert!(error.to_string().contains("open replay cache"));
+        assert!(inbox.is_empty());
+        assert_eq!(receipt_count, 0);
+    }
+
+    #[test]
+    fn remote_stream_delivery_requires_recordable_replay_cache_before_inbox_write() {
+        let home = test_home("remote-stream-replay-recordable");
+        register_agent_with_capabilities(
+            &home,
+            "agent.receiver",
+            AgentCapabilities {
+                messages: false,
+                streams: true,
+                files: false,
+                rooms: false,
+                presence: false,
+            },
+        );
+        let paths = StatePaths::from_home(home.clone());
+        make_replay_cache_read_only(&paths);
+
+        let error = deliver_remote_stream_chunk_from_paths(
+            &paths,
+            "streamenv.recordable",
+            "stream.1",
+            "agent.sender",
+            "agent.receiver",
+            OpaquePayload::from_bytes(b"private stream payload".to_vec()),
+        )
+        .expect_err("readonly replay cache fails before stream delivery");
+        let inbox = list_agent_inbox(Some(home), "agent.receiver").expect("inbox reads");
+
+        assert!(error.to_string().contains("open replay cache"));
+        assert!(inbox.is_empty());
+    }
+
+    #[test]
     fn remote_delivery_success_does_not_depend_on_message_log_write() {
         let home = test_home("remote-delivery-log-collision");
         register_agent(&home, "agent.receiver");
@@ -2251,6 +2332,14 @@ mod tests {
         agents::submit_registration(Some(home.to_path_buf()), registration)
             .expect("registration submits");
         agents::process_gateway_requests(Some(home.to_path_buf())).expect("registration processes");
+    }
+
+    fn make_replay_cache_read_only(paths: &StatePaths) {
+        let mut permissions = fs::metadata(&paths.replay_cache)
+            .expect("replay cache metadata")
+            .permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&paths.replay_cache, permissions).expect("replay cache made readonly");
     }
 
     fn test_home(label: &str) -> PathBuf {

--- a/crates/conu-core/src/rooms.rs
+++ b/crates/conu-core/src/rooms.rs
@@ -558,7 +558,7 @@ pub fn deliver_remote_room_event_from_paths(
         payload_bytes,
         created_at_unix: current_unix_seconds(),
     };
-    messages::ensure_room_event_replay_not_seen_from_paths(paths, &envelope_id)?;
+    messages::ensure_room_event_replay_recordable_from_paths(paths, &envelope_id)?;
     append_event_once(paths, event)?;
     let entry = messages::deliver_room_event_from_paths(
         paths,
@@ -2039,6 +2039,60 @@ mod tests {
     }
 
     #[test]
+    fn remote_room_event_requires_recordable_replay_cache_before_event_or_inbox_write() {
+        let alice_home = test_home("remote-room-replay-recordable-alice");
+        let bob_home = test_home("remote-room-replay-recordable-bob");
+        state::init_state(Some(alice_home.clone())).expect("alice initializes");
+        state::init_state(Some(bob_home.clone())).expect("bob initializes");
+        let alice_peer = trust::export_peer_card(Some(alice_home.clone())).expect("alice card");
+        trust::trust_peer_card(Some(bob_home.clone()), alice_peer.clone())
+            .expect("bob trusts alice");
+        policy::set_peer_policy(
+            Some(bob_home.clone()),
+            &alice_peer.node_id,
+            PeerPolicyUpdate {
+                messages: Some(false),
+                streams: Some(false),
+                rooms: Some(true),
+                files: Some(false),
+                mailbox: Some(false),
+            },
+        )
+        .expect("bob grants alice rooms");
+        register_agent(&alice_home, "agent.alice");
+        register_agent(&bob_home, "agent.bob");
+        let alice_agent_card =
+            agents::export_agent_card(Some(alice_home), "agent.alice").expect("alice card");
+        sessions::trust_remote_agent_card(Some(bob_home.clone()), alice_agent_card)
+            .expect("alice remote agent imports");
+        create_room(Some(bob_home.clone()), "room.dev", "Dev Room", "agent.bob")
+            .expect("bob room creates");
+        join_room(Some(bob_home.clone()), "room.dev", "agent.alice").expect("alice remote joins");
+
+        let paths = StatePaths::from_home(bob_home.clone());
+        make_replay_cache_read_only(&paths);
+        let delivery = RemoteRoomEventDelivery {
+            envelope_id: "roomenv.recordable".to_string(),
+            event_id: "room_event.recordable".to_string(),
+            room_id: "room.dev".to_string(),
+            topic: "build".to_string(),
+            peer_node_id: alice_peer.node_id,
+            from_agent_id: "agent.alice".to_string(),
+            to_agent_id: "agent.bob".to_string(),
+            payload: OpaquePayload::from_bytes(b"private retry room event".to_vec()),
+        };
+
+        let error = deliver_remote_room_event_from_paths(&paths, delivery)
+            .expect_err("readonly replay cache fails before room delivery");
+        let events = list_room_events(Some(bob_home.clone())).expect("events read");
+        let inbox = messages::list_agent_inbox(Some(bob_home), "agent.bob").expect("inbox reads");
+
+        assert!(error.to_string().contains("open replay cache"));
+        assert!(events.is_empty());
+        assert!(inbox.is_empty());
+    }
+
+    #[test]
     fn room_publish_requires_joined_agent() {
         let home = test_home("requires-joined");
         register_agent(&home, "agent.codex");
@@ -2179,6 +2233,14 @@ mod tests {
             AgentRegistration::new(agent_id, agent_id, "test-agent").expect("valid agent");
         submit_registration(Some(home.to_path_buf()), registration).expect("submits");
         process_gateway_requests(Some(home.to_path_buf())).expect("processes");
+    }
+
+    fn make_replay_cache_read_only(paths: &StatePaths) {
+        let mut permissions = fs::metadata(&paths.replay_cache)
+            .expect("replay cache metadata")
+            .permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&paths.replay_cache, permissions).expect("replay cache made readonly");
     }
 
     fn test_home(name: &str) -> PathBuf {

--- a/crates/conu-core/src/security.rs
+++ b/crates/conu-core/src/security.rs
@@ -902,6 +902,26 @@ pub fn ensure_replay_id_not_seen_from_paths(
     Ok(())
 }
 
+/// Check an idempotency/replay id and verify it can be committed later.
+pub fn ensure_replay_id_recordable_from_paths(
+    paths: &StatePaths,
+    id: &str,
+    source: &str,
+) -> Result<(), SecurityError> {
+    validate_replay_value(id, "replay id")?;
+    validate_replay_value(source, "replay source")?;
+    let contents = read_replay_cache_contents(paths)?;
+    if replay_cache_contains_id(&contents, id) {
+        return Err(SecurityError::ReplayDetected { id: id.to_string() });
+    }
+    state::ensure_regular_state_file_appendable(
+        &paths.replay_cache,
+        "inspect replay cache",
+        "open replay cache",
+    )?;
+    Ok(())
+}
+
 /// Record an idempotency/replay id and reject duplicates.
 pub fn record_replay_id_from_paths(
     paths: &StatePaths,

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -711,6 +711,14 @@ pub(crate) fn append_regular_state_file(
         .map_err(|error| StateError::io(write_action, path, error))
 }
 
+pub(crate) fn ensure_regular_state_file_appendable(
+    path: &Path,
+    inspect_action: &'static str,
+    open_action: &'static str,
+) -> Result<(), StateError> {
+    open_existing_regular_state_file_for_append(path, inspect_action, open_action).map(|_| ())
+}
+
 fn open_existing_regular_state_file_for_write(
     path: &Path,
     inspect_action: &'static str,


### PR DESCRIPTION
## **User description**
## Summary
- add replay-cache appendability preflight before local/remote message, stream, and room delivery writes
- keep room-event replay preflight ahead of remote room event metadata writes
- add regressions proving read-only replay cache failures do not leave inbox, receipt, or room-event state behind

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- attempted: cargo +stable-x86_64-pc-windows-gnu test -p conu-core recordable_replay_cache -- --nocapture (blocked locally: dlltool.exe missing)

Closes #554


___

## **CodeAnt-AI Description**
**Check replay cache access before any delivery is written**

### What Changed
- Message, stream, and room deliveries now fail early if the replay cache cannot be appended, instead of writing inbox, receipt, or room-event data first
- Remote room event delivery now checks the replay cache before creating room event records or inbox entries
- Tests now cover read-only replay cache failures to confirm no delivery state is left behind

### Impact
`✅ Fewer partial deliveries when the replay cache is locked`
`✅ No inbox or room-event writes after replay cache failures`
`✅ Clearer failure handling for duplicate or unsafe replay records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
