### PR TITLE
Guard state writes and appends against size overflow

### DIFF
--- a/crates/conu-core/src/security.rs
+++ b/crates/conu-core/src/security.rs
@@ -914,8 +914,10 @@ pub fn ensure_replay_id_recordable_from_paths(
     if replay_cache_contains_id(&contents, id) {
         return Err(SecurityError::ReplayDetected { id: id.to_string() });
     }
+    let entry = render_replay_cache_entry(id, source);
     state::ensure_regular_state_file_appendable(
         &paths.replay_cache,
+        entry.len(),
         "inspect replay cache",
         "open replay cache",
     )?;
@@ -935,12 +937,7 @@ pub fn record_replay_id_from_paths(
         return Err(SecurityError::ReplayDetected { id: id.to_string() });
     }
 
-    let entry = format!(
-        "\n[[seen]]\nid = \"{}\"\nsource = \"{}\"\nfirst_seen_unix = {}\n",
-        escape_file_value(id),
-        escape_file_value(source),
-        current_unix_seconds()
-    );
+    let entry = render_replay_cache_entry(id, source);
     state::append_regular_state_file(
         &paths.replay_cache,
         &entry,
@@ -950,6 +947,15 @@ pub fn record_replay_id_from_paths(
         "write replay cache",
     )?;
     Ok(())
+}
+
+fn render_replay_cache_entry(id: &str, source: &str) -> String {
+    format!(
+        "\n[[seen]]\nid = \"{}\"\nsource = \"{}\"\nfirst_seen_unix = {}\n",
+        escape_file_value(id),
+        escape_file_value(source),
+        current_unix_seconds()
+    )
 }
 
 fn read_replay_cache_contents(paths: &StatePaths) -> Result<String, SecurityError> {

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -481,6 +481,8 @@ fn write_new_file_with_actions(
     create_action: &'static str,
     write_action: &'static str,
 ) -> Result<(), StateError> {
+    ensure_state_contents_within_limit(path, contents.len(), write_action)?;
+
     let mut file = OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -644,6 +646,8 @@ pub(crate) fn write_regular_state_file(
         }
     }
 
+    ensure_state_contents_within_limit(path, contents.len(), write_action)?;
+
     let mut file = open_existing_regular_state_file_for_write(path, inspect_action, open_action)?;
     file.set_len(0)
         .map_err(|error| StateError::io(open_action, path, error))?;
@@ -665,6 +669,8 @@ pub(crate) fn rewrite_existing_regular_state_file(
             io::Error::new(io::ErrorKind::NotFound, "state file path is missing"),
         ));
     }
+
+    ensure_state_contents_within_limit(path, contents.len(), write_action)?;
 
     let mut file = open_existing_regular_state_file_for_write(path, inspect_action, open_action)?;
     file.set_len(0)
@@ -707,16 +713,72 @@ pub(crate) fn append_regular_state_file(
     }
 
     let mut file = open_existing_regular_state_file_for_append(path, inspect_action, open_action)?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| StateError::io(open_action, path, error))?;
+    ensure_state_append_within_limit(path, metadata.len(), contents.len(), write_action)?;
     file.write_all(contents.as_bytes())
         .map_err(|error| StateError::io(write_action, path, error))
 }
 
 pub(crate) fn ensure_regular_state_file_appendable(
     path: &Path,
+    additional_bytes: usize,
     inspect_action: &'static str,
     open_action: &'static str,
 ) -> Result<(), StateError> {
-    open_existing_regular_state_file_for_append(path, inspect_action, open_action).map(|_| ())
+    let file = open_existing_regular_state_file_for_append(path, inspect_action, open_action)?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| StateError::io(open_action, path, error))?;
+    ensure_state_append_within_limit(path, metadata.len(), additional_bytes, open_action)
+}
+
+fn ensure_state_contents_within_limit(
+    path: &Path,
+    contents_len: usize,
+    action: &'static str,
+) -> Result<(), StateError> {
+    if contents_len as u64 > MAX_STATE_FILE_BYTES {
+        return Err(StateError::io(
+            action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("state file exceeds {MAX_STATE_FILE_BYTES} bytes"),
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_state_append_within_limit(
+    path: &Path,
+    current_len: u64,
+    additional_bytes: usize,
+    action: &'static str,
+) -> Result<(), StateError> {
+    let Some(new_len) = current_len.checked_add(additional_bytes as u64) else {
+        return Err(StateError::io(
+            action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("state file exceeds {MAX_STATE_FILE_BYTES} bytes"),
+            ),
+        ));
+    };
+    if new_len > MAX_STATE_FILE_BYTES {
+        return Err(StateError::io(
+            action,
+            path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("state file exceeds {MAX_STATE_FILE_BYTES} bytes"),
+            ),
+        ));
+    }
+    Ok(())
 }
 
 fn open_existing_regular_state_file_for_write(
@@ -1199,6 +1261,80 @@ mod tests {
         let optional_error = optional_error.to_string();
         assert!(optional_error.contains("state file exceeds"));
         assert!(!optional_error.contains(private_marker));
+    }
+
+    #[test]
+    fn write_regular_state_file_rejects_oversized_contents_without_truncating_existing_file() {
+        let home = test_home("oversized-state-write");
+        fs::create_dir_all(&home).expect("home creates");
+        let path = home.join("state.toml");
+        let original = "version = \"1\"\nstatus = \"kept\"\n";
+        fs::write(&path, original).expect("state writes");
+        let oversized = "a".repeat((MAX_STATE_FILE_BYTES + 1) as usize);
+
+        let error = write_regular_state_file(
+            &path,
+            &oversized,
+            "inspect oversized state write",
+            "create oversized state",
+            "open oversized state",
+            "write oversized state",
+        )
+        .expect_err("oversized state write fails before truncating");
+
+        assert!(error.to_string().contains("state file exceeds"));
+        assert_eq!(
+            fs::read_to_string(&path).expect("state reads"),
+            original,
+            "oversized write must not truncate existing state"
+        );
+    }
+
+    #[test]
+    fn append_regular_state_file_rejects_oversized_new_file() {
+        let home = test_home("oversized-state-append-new");
+        fs::create_dir_all(&home).expect("home creates");
+        let path = home.join("state.log");
+        let oversized = "a".repeat((MAX_STATE_FILE_BYTES + 1) as usize);
+
+        let error = append_regular_state_file(
+            &path,
+            &oversized,
+            "inspect oversized state append",
+            "create oversized append state",
+            "open oversized append state",
+            "write oversized append state",
+        )
+        .expect_err("oversized append create fails");
+
+        assert!(error.to_string().contains("state file exceeds"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn append_regular_state_file_rejects_growth_past_limit_without_modifying_file() {
+        let home = test_home("oversized-state-append-existing");
+        fs::create_dir_all(&home).expect("home creates");
+        let path = home.join("state.log");
+        let original = "a".repeat((MAX_STATE_FILE_BYTES - 2) as usize);
+        fs::write(&path, &original).expect("state writes");
+
+        let error = append_regular_state_file(
+            &path,
+            "bbb",
+            "inspect bounded state append",
+            "create bounded append state",
+            "open bounded append state",
+            "write bounded append state",
+        )
+        .expect_err("append beyond state limit fails");
+
+        assert!(error.to_string().contains("state file exceeds"));
+        assert_eq!(
+            fs::read_to_string(&path).expect("state reads"),
+            original,
+            "oversized append must leave existing state unchanged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- enforce the existing max state-file size before creating, rewriting, or appending state files
- make replay-cache recordable preflight account for the replay entry bytes it needs to append
- add regressions proving oversized writes/appends fail before creating or mutating state files

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- attempted: cargo +stable-x86_64-pc-windows-gnu test -p conu-core append_regular_state_file_rejects -- --nocapture (blocked locally: dlltool.exe missing)

Closes #556


___

## **CodeAnt-AI Description**
**Prevent oversized state updates from changing files**

### What Changed
- Oversized state writes are now rejected before an existing file is truncated or replaced
- Appends now check the final file size before writing, so oversized updates fail without changing the file
- Replay ID prechecks now use the full size of the entry that would be added, so records are refused earlier when the replay cache would exceed its limit
- Added regression coverage for oversized writes, new-file appends, and appends that would push an existing file past the limit

### Impact
`✅ No state loss on oversized writes`
`✅ Fewer corrupted replay cache updates`
`✅ Earlier failures for oversized state files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
