### PR TITLE
Retry relay metadata replacement races

### DIFF
--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -44,6 +44,8 @@ const RELAY_ABUSE_FILE_VERSION: &str = "1";
 const HOSTED_TENANT_FILE_VERSION: &str = "1";
 const RELAY_SESSION_STATE_LOAD_ATTEMPTS: usize = 6;
 const RELAY_SESSION_STATE_LOAD_RETRY_DELAY: Duration = Duration::from_millis(20);
+const RELAY_METADATA_REPLACE_ATTEMPTS: usize = 6;
+const RELAY_METADATA_REPLACE_RETRY_DELAY: Duration = Duration::from_millis(20);
 const LOCAL_DEV_TOKEN: &str = "local-dev-token";
 const MIN_PUBLIC_BIND_TOKEN_LEN: usize = 24;
 const MAX_TOKEN_LEN: usize = 200;
@@ -3247,6 +3249,37 @@ fn write_relay_metadata_file(
     write_temp_action: &'static str,
     replace_action: &'static str,
 ) -> Result<(), RelayError> {
+    for attempt in 0..RELAY_METADATA_REPLACE_ATTEMPTS {
+        match write_relay_metadata_file_once(
+            path,
+            contents,
+            inspect_action,
+            create_temp_action,
+            write_temp_action,
+            replace_action,
+        ) {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if relay_metadata_replace_should_retry(&error)
+                    && attempt + 1 < RELAY_METADATA_REPLACE_ATTEMPTS =>
+            {
+                thread::sleep(RELAY_METADATA_REPLACE_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    unreachable!("relay metadata replacement loop always returns")
+}
+
+fn write_relay_metadata_file_once(
+    path: &Path,
+    contents: &str,
+    inspect_action: &'static str,
+    create_temp_action: &'static str,
+    write_temp_action: &'static str,
+    replace_action: &'static str,
+) -> Result<(), RelayError> {
     let expected_metadata = inspect_optional_regular_relay_file(path, inspect_action)?;
     let temp_path = relay_metadata_temp_path(path)?;
     let mut file = OpenOptions::new()
@@ -3274,6 +3307,22 @@ fn write_relay_metadata_file(
         let _ = fs::remove_file(&temp_path);
     }
     result
+}
+
+fn relay_metadata_replace_should_retry(error: &RelayError) -> bool {
+    match error {
+        RelayError::Io { source, .. } => matches!(
+            source.kind(),
+            io::ErrorKind::NotFound
+                | io::ErrorKind::AlreadyExists
+                | io::ErrorKind::PermissionDenied
+                | io::ErrorKind::WouldBlock
+                | io::ErrorKind::Interrupted
+        ),
+        RelayError::InvalidConfig(_)
+        | RelayError::InvalidConfigValue(_)
+        | RelayError::Protocol(_) => false,
+    }
 }
 
 fn replace_regular_relay_file_with_temp(


### PR DESCRIPTION
## **User description**
## Summary
- retry transient relay metadata replacement races around staged file swaps
- preserve the low-level stale-target rejection while letting the top-level writer recover from Windows restart races
- addresses the post-merge main CI Windows failure from run 26731036780

## Validation
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-relay --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-relay --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings


___

## **CodeAnt-AI Description**
**Retry relay metadata file replacement when Windows file races happen**

### What Changed
- Relay metadata updates now retry a few times when a temporary replacement fails because the file is briefly unavailable, already replaced, or blocked by the operating system.
- If the replacement still fails for a real config or protocol problem, the error is returned immediately.
- Temporary files are still cleaned up when a replacement attempt fails.

### Impact
`✅ Fewer relay startup failures on Windows`
`✅ More reliable metadata updates during file swaps`
`✅ Clearer handling of transient file access races`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
