### PR TITLE
Harden IPC and relay archive moves

### DIFF
--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -853,9 +853,14 @@ fn ensure_request_archive_targets_available(
 fn move_request(request_path: &Path, target_dir: &Path) -> Result<(), AgentError> {
     state::ensure_state_directory(target_dir)?;
     let target = request_archive_target(request_path, target_dir);
-    ensure_ipc_archive_target_available(&target)?;
-    fs::rename(request_path, &target)
-        .map_err(|error| AgentError::io("move IPC request", request_path, error))
+    state::archive_regular_state_file_no_replace(
+        request_path,
+        &target,
+        "inspect IPC request before archive",
+        "reserve IPC archive target",
+        "move IPC request",
+    )?;
+    Ok(())
 }
 
 fn reject_request(
@@ -873,8 +878,46 @@ fn reject_request(
         "create IPC rejection reason",
         "write IPC rejection reason",
     )?;
-    fs::rename(request_path, &target)
-        .map_err(|error| AgentError::io("move rejected IPC request", request_path, error))
+    archive_ipc_request_no_replace(
+        request_path,
+        &target,
+        "inspect rejected IPC request before archive",
+        "reserve IPC archive target",
+        "move rejected IPC request",
+    )?;
+    Ok(())
+}
+
+fn archive_ipc_request_no_replace(
+    request_path: &Path,
+    target: &Path,
+    inspect_source_action: &'static str,
+    inspect_target_action: &'static str,
+    archive_action: &'static str,
+) -> Result<(), AgentError> {
+    match state::archive_regular_state_file_no_replace(
+        request_path,
+        target,
+        inspect_source_action,
+        inspect_target_action,
+        archive_action,
+    ) {
+        Ok(()) => Ok(()),
+        Err(state::StateError::Io { source, .. })
+            if source.kind() == io::ErrorKind::InvalidInput && path_is_symlink(request_path) =>
+        {
+            ensure_ipc_archive_target_available(target)?;
+            fs::rename(request_path, target)
+                .map_err(|error| AgentError::io(archive_action, request_path, error))
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn path_is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_symlink())
+        .unwrap_or(false)
 }
 
 fn request_archive_target(request_path: &Path, target_dir: &Path) -> PathBuf {

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -1436,9 +1436,46 @@ fn move_relay_request(
 ) -> Result<(), RelayDeliveryError> {
     state::ensure_state_directory(target_dir)?;
     let target = relay_archive_target(target_dir, request_path, extension);
-    ensure_relay_archive_target_available(&target)?;
-    fs::rename(request_path, &target)
-        .map_err(|error| RelayDeliveryError::io("move relay request marker", request_path, error))
+    archive_relay_request_no_replace(
+        request_path,
+        &target,
+        "inspect relay request before archive",
+        "reserve relay archive target",
+        "move relay request marker",
+    )?;
+    Ok(())
+}
+
+fn archive_relay_request_no_replace(
+    request_path: &Path,
+    target: &Path,
+    inspect_source_action: &'static str,
+    inspect_target_action: &'static str,
+    archive_action: &'static str,
+) -> Result<(), RelayDeliveryError> {
+    match state::archive_regular_state_file_no_replace(
+        request_path,
+        target,
+        inspect_source_action,
+        inspect_target_action,
+        archive_action,
+    ) {
+        Ok(()) => Ok(()),
+        Err(state::StateError::Io { source, .. })
+            if source.kind() == io::ErrorKind::InvalidInput && path_is_symlink(request_path) =>
+        {
+            ensure_relay_archive_target_available(target)?;
+            fs::rename(request_path, target)
+                .map_err(|error| RelayDeliveryError::io(archive_action, request_path, error))
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn path_is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_symlink())
+        .unwrap_or(false)
 }
 
 fn relay_archive_target(target_dir: &Path, request_path: &Path, extension: &str) -> PathBuf {

--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -683,6 +683,99 @@ pub(crate) fn remove_existing_regular_state_file(
     fs::remove_file(path).map_err(|error| StateError::io(remove_action, path, error))
 }
 
+pub(crate) fn archive_regular_state_file_no_replace(
+    source: &Path,
+    target: &Path,
+    inspect_source_action: &'static str,
+    inspect_target_action: &'static str,
+    archive_action: &'static str,
+) -> Result<(), StateError> {
+    let Some(source_metadata) = regular_state_file_metadata(source, inspect_source_action)? else {
+        return Err(StateError::io(
+            inspect_source_action,
+            source,
+            io::Error::new(io::ErrorKind::NotFound, "state file path is missing"),
+        ));
+    };
+    let target_parent = state_file_parent(target);
+    if regular_state_directory_metadata(target_parent, inspect_target_action)?.is_none() {
+        return Err(StateError::io(
+            inspect_target_action,
+            target_parent,
+            io::Error::new(io::ErrorKind::NotFound, "state directory path is missing"),
+        ));
+    }
+    if regular_state_file_metadata(target, inspect_target_action)?.is_some() {
+        return Err(StateError::io(
+            inspect_target_action,
+            target,
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "archive target already exists",
+            ),
+        ));
+    }
+
+    if let Err(error) = fs::hard_link(source, target) {
+        return Err(StateError::io(archive_action, source, error));
+    }
+
+    let target_metadata = match regular_state_file_metadata(target, inspect_target_action) {
+        Ok(Some(metadata)) => metadata,
+        Ok(None) => {
+            return Err(StateError::io(
+                inspect_target_action,
+                target,
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "archive target disappeared after reservation",
+                ),
+            ));
+        }
+        Err(error) => {
+            let _ = fs::remove_file(target);
+            return Err(error);
+        }
+    };
+    if !state_file_metadata_matches(&source_metadata, &target_metadata) {
+        let _ = fs::remove_file(target);
+        return Err(StateError::io(
+            inspect_target_action,
+            target,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "archive target does not match source file",
+            ),
+        ));
+    }
+
+    match regular_state_file_metadata(source, inspect_source_action)? {
+        Some(current_metadata)
+            if state_file_metadata_matches(&source_metadata, &current_metadata) => {}
+        Some(_) => {
+            let _ = fs::remove_file(target);
+            return Err(StateError::io(
+                inspect_source_action,
+                source,
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "state file path changed before archive removal",
+                ),
+            ));
+        }
+        None => return Ok(()),
+    }
+
+    match fs::remove_file(source) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            let _ = fs::remove_file(target);
+            Err(StateError::io(archive_action, source, error))
+        }
+    }
+}
+
 pub(crate) fn append_regular_state_file(
     path: &Path,
     contents: &str,
@@ -1348,6 +1441,59 @@ mod tests {
             error
                 .to_string()
                 .contains("inspect removable missing state")
+        );
+    }
+
+    #[test]
+    fn archive_regular_state_file_no_replace_moves_source_to_empty_target() {
+        let home = test_home("archive-state-file");
+        fs::create_dir_all(&home).expect("home creates");
+        let source = home.join("request.req");
+        let target = home.join("processed.req");
+        fs::write(&source, "version = \"1\"\nstatus = \"queued\"\n").expect("source writes");
+
+        archive_regular_state_file_no_replace(
+            &source,
+            &target,
+            "inspect archive source",
+            "reserve archive target",
+            "archive state file",
+        )
+        .expect("state file archives");
+
+        assert!(!source.exists());
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            "version = \"1\"\nstatus = \"queued\"\n"
+        );
+    }
+
+    #[test]
+    fn archive_regular_state_file_no_replace_refuses_existing_target_without_clobber() {
+        let home = test_home("archive-state-file-collision");
+        fs::create_dir_all(&home).expect("home creates");
+        let source = home.join("request.req");
+        let target = home.join("processed.req");
+        fs::write(&source, "version = \"1\"\nstatus = \"queued\"\n").expect("source writes");
+        fs::write(&target, "version = \"1\"\nstatus = \"existing\"\n").expect("target writes");
+
+        let error = archive_regular_state_file_no_replace(
+            &source,
+            &target,
+            "inspect archive source",
+            "reserve archive target",
+            "archive state file",
+        )
+        .expect_err("existing archive target should fail closed");
+
+        assert!(error.to_string().contains("reserve archive target"));
+        assert_eq!(
+            fs::read_to_string(&target).expect("target reads"),
+            "version = \"1\"\nstatus = \"existing\"\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&source).expect("source reads"),
+            "version = \"1\"\nstatus = \"queued\"\n"
         );
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- add a shared no-replace state archive helper for processed request moves
- use it for local agent IPC processed/rejected archives
- use it for relay outbox sent/rejected archives

Fixes #569

## Validation
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Note: focused local GNU test execution was attempted, but this Windows environment is missing `dlltool.exe` while compiling transitive Windows crates. GitHub CI should run the Rust test matrix on hosted runners.


___

## **CodeAnt-AI Description**
**Prevent archived request files from being overwritten**

### What Changed
- Request files moved into IPC and relay archive folders now fail if the target file already exists, instead of replacing it.
- Archived request files are checked before and after the move so the original file contents are preserved only when the source and destination still match.
- Added coverage for successful archive moves and for collisions that should leave both files unchanged.

### Impact
`✅ No lost archived requests`
`✅ Safer IPC request handling`
`✅ Fewer relay archive collisions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
