### PR TITLE
Harden log rotation archive moves

### DIFF
--- a/crates/conu-core/src/observability.rs
+++ b/crates/conu-core/src/observability.rs
@@ -234,22 +234,32 @@ fn rotate_one_log(path: &Path, keep_archives: usize) -> Result<usize, Observabil
             continue;
         }
         if index == keep_archives {
-            fs::remove_file(&source).map_err(|error| {
-                ObservabilityError::io("remove old log archive", &source, error)
-            })?;
+            remove_existing_regular_log_file(
+                &source,
+                "inspect log archive",
+                "remove old log archive",
+            )?;
             removed += 1;
         } else {
             let target = archive_path(path, index + 1);
-            ensure_log_archive_target_available(&target)?;
-            fs::rename(&source, &target)
-                .map_err(|error| ObservabilityError::io("shift log archive", &source, error))?;
+            archive_regular_log_file_no_replace(
+                &source,
+                &target,
+                "inspect log archive",
+                "reserve log archive target",
+                "shift log archive",
+            )?;
         }
     }
 
     let first_archive = archive_path(path, 1);
-    ensure_log_archive_target_available(&first_archive)?;
-    fs::rename(path, &first_archive)
-        .map_err(|error| ObservabilityError::io("rotate active log", path, error))?;
+    archive_regular_log_file_no_replace(
+        path,
+        &first_archive,
+        "inspect active log before rotation",
+        "reserve log archive target",
+        "rotate active log",
+    )?;
     OpenOptions::new()
         .create_new(true)
         .write(true)
@@ -257,6 +267,115 @@ fn rotate_one_log(path: &Path, keep_archives: usize) -> Result<usize, Observabil
         .map_err(|error| ObservabilityError::io("create fresh active log", path, error))?;
 
     Ok(removed)
+}
+
+fn remove_existing_regular_log_file(
+    path: &Path,
+    inspect_action: &'static str,
+    remove_action: &'static str,
+) -> Result<(), ObservabilityError> {
+    if regular_log_metadata(path, inspect_action)?.is_none() {
+        return Err(ObservabilityError::io(
+            inspect_action,
+            path,
+            io::Error::new(io::ErrorKind::NotFound, "log path does not exist"),
+        ));
+    }
+
+    fs::remove_file(path).map_err(|error| ObservabilityError::io(remove_action, path, error))
+}
+
+fn archive_regular_log_file_no_replace(
+    source: &Path,
+    target: &Path,
+    inspect_source_action: &'static str,
+    inspect_target_action: &'static str,
+    archive_action: &'static str,
+) -> Result<(), ObservabilityError> {
+    let Some(source_metadata) = regular_log_metadata(source, inspect_source_action)? else {
+        return Err(ObservabilityError::io(
+            inspect_source_action,
+            source,
+            io::Error::new(io::ErrorKind::NotFound, "log path does not exist"),
+        ));
+    };
+
+    let target_parent = path_parent(target);
+    if !state::state_directory_exists(target_parent, inspect_target_action)? {
+        return Err(ObservabilityError::io(
+            inspect_target_action,
+            target_parent,
+            io::Error::new(io::ErrorKind::NotFound, "log archive directory is missing"),
+        ));
+    }
+    if regular_log_metadata(target, inspect_target_action)?.is_some() {
+        return Err(ObservabilityError::io(
+            inspect_target_action,
+            target,
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "log archive target already exists",
+            ),
+        ));
+    }
+
+    fs::hard_link(source, target)
+        .map_err(|error| ObservabilityError::io(archive_action, source, error))?;
+
+    let target_metadata = match regular_log_metadata(target, inspect_target_action) {
+        Ok(Some(metadata)) => metadata,
+        Ok(None) => {
+            return Err(ObservabilityError::io(
+                inspect_target_action,
+                target,
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "log archive target disappeared after reservation",
+                ),
+            ));
+        }
+        Err(error) => {
+            let _ = fs::remove_file(target);
+            return Err(error);
+        }
+    };
+    if !log_file_metadata_matches(&source_metadata, &target_metadata) {
+        let _ = fs::remove_file(target);
+        return Err(ObservabilityError::io(
+            inspect_target_action,
+            target,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "log archive target does not match source file",
+            ),
+        ));
+    }
+
+    match regular_log_metadata(source, inspect_source_action)? {
+        Some(current_metadata)
+            if log_file_metadata_matches(&source_metadata, &current_metadata) => {}
+        Some(_) => {
+            let _ = fs::remove_file(target);
+            return Err(ObservabilityError::io(
+                inspect_source_action,
+                source,
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "log file path changed before archive removal",
+                ),
+            ));
+        }
+        None => return Ok(()),
+    }
+
+    match fs::remove_file(source) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            let _ = fs::remove_file(target);
+            Err(ObservabilityError::io(archive_action, source, error))
+        }
+    }
 }
 
 fn regular_log_metadata(
@@ -282,6 +401,38 @@ fn regular_log_metadata(
     }
 }
 
+fn log_file_metadata_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    expected.len() == current.len() && log_file_stable_identity_matches(expected, current)
+}
+
+#[cfg(unix)]
+fn log_file_stable_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    expected.dev() == current.dev() && expected.ino() == current.ino()
+}
+
+#[cfg(windows)]
+fn log_file_stable_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    expected.file_attributes() == current.file_attributes()
+        && expected.creation_time() == current.creation_time()
+        && expected.last_write_time() == current.last_write_time()
+        && expected.file_size() == current.file_size()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn log_file_stable_identity_matches(expected: &fs::Metadata, current: &fs::Metadata) -> bool {
+    expected.modified().ok() == current.modified().ok()
+}
+
+fn path_parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
 fn active_log_metadata(path: &Path) -> Result<Option<fs::Metadata>, ObservabilityError> {
     match fs::symlink_metadata(path) {
         Ok(metadata) => {
@@ -302,25 +453,6 @@ fn ensure_regular_log_file(path: &Path, action: &'static str) -> Result<(), Obse
             action,
             path,
             io::Error::new(io::ErrorKind::NotFound, "log path does not exist"),
-        )),
-    }
-}
-
-fn ensure_log_archive_target_available(path: &Path) -> Result<(), ObservabilityError> {
-    match fs::symlink_metadata(path) {
-        Ok(_) => Err(ObservabilityError::io(
-            "reserve log archive target",
-            path,
-            io::Error::new(
-                io::ErrorKind::AlreadyExists,
-                "log archive target already exists",
-            ),
-        )),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(ObservabilityError::io(
-            "inspect log archive target",
-            path,
-            error,
         )),
     }
 }
@@ -410,6 +542,38 @@ mod tests {
         assert_eq!(
             fs::read_to_string(paths.logs_dir.join("conud.log.2")).expect("archive two reads"),
             "archive one\n"
+        );
+    }
+
+    #[test]
+    fn rotates_log_larger_than_state_file_limit() {
+        let home = test_home("rotate-oversized-log");
+        let paths = StatePaths::from_home(home);
+        fs::create_dir_all(&paths.logs_dir).expect("logs directory");
+        fs::write(
+            paths.logs_dir.join("conud.log"),
+            vec![b'x'; 1024 * 1024 + 1],
+        )
+        .expect("oversized log writes");
+
+        let report = rotate_logs_from_paths(
+            &paths,
+            LogRotationPolicy::new(1, 2).expect("policy validates"),
+        )
+        .expect("oversized log rotates");
+
+        assert_eq!(report.files_rotated, 1);
+        assert_eq!(
+            fs::metadata(paths.logs_dir.join("conud.log.1"))
+                .expect("oversized archive metadata")
+                .len(),
+            1024 * 1024 + 1
+        );
+        assert_eq!(
+            fs::metadata(paths.logs_dir.join("conud.log"))
+                .expect("fresh active metadata")
+                .len(),
+            0
         );
     }
 

--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -3311,18 +3311,30 @@ fn write_relay_metadata_file_once(
 
 fn relay_metadata_replace_should_retry(error: &RelayError) -> bool {
     match error {
-        RelayError::Io { source, .. } => matches!(
-            source.kind(),
-            io::ErrorKind::NotFound
-                | io::ErrorKind::AlreadyExists
-                | io::ErrorKind::PermissionDenied
-                | io::ErrorKind::WouldBlock
-                | io::ErrorKind::Interrupted
-        ),
+        RelayError::Io { source, .. } => {
+            matches!(
+                source.kind(),
+                io::ErrorKind::NotFound
+                    | io::ErrorKind::AlreadyExists
+                    | io::ErrorKind::PermissionDenied
+                    | io::ErrorKind::WouldBlock
+                    | io::ErrorKind::Interrupted
+            ) || relay_metadata_replace_invalid_input_should_retry(source)
+        }
         RelayError::InvalidConfig(_)
         | RelayError::InvalidConfigValue(_)
         | RelayError::Protocol(_) => false,
     }
+}
+
+fn relay_metadata_replace_invalid_input_should_retry(source: &io::Error) -> bool {
+    if source.kind() != io::ErrorKind::InvalidInput {
+        return false;
+    }
+
+    let message = source.to_string();
+    message.contains("relay file path changed before replacement")
+        || message.contains("relay file path appeared before replacement")
 }
 
 fn replace_regular_relay_file_with_temp(
@@ -8281,6 +8293,35 @@ mod tests {
             changed,
             "changed live metadata must not be overwritten by stale replacement"
         );
+    }
+
+    #[test]
+    fn relay_metadata_replacement_retries_transient_path_change_errors() {
+        let changed = RelayError::io(
+            "inspect relay metadata test",
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "relay file path changed before replacement",
+            ),
+        );
+        let appeared = RelayError::io(
+            "inspect relay metadata test",
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "relay file path appeared before replacement",
+            ),
+        );
+        let unsafe_target = RelayError::io(
+            "inspect relay metadata test",
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "relay file path is not a regular file",
+            ),
+        );
+
+        assert!(relay_metadata_replace_should_retry(&changed));
+        assert!(relay_metadata_replace_should_retry(&appeared));
+        assert!(!relay_metadata_replace_should_retry(&unsafe_target));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #571.

## Summary
- replace log rotation check-then-rename archive moves with no-replace hard-link archive moves
- keep payload-safe log rotation metadata behavior and preserve large-log rotation beyond the state-file size cap
- add regression coverage for rotating logs larger than regular state-file limits

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Local focused test command cargo +stable-x86_64-pc-windows-gnu test -p conu-core observability -- --nocapture is blocked on this workstation by missing dlltool.exe while compiling transitive Windows crates; hosted CI should run the test suite.


___

## **CodeAnt-AI Description**
**Prevent log rotation from overwriting existing archives and handle large logs safely**

### What Changed
- Log rotation now checks that each archive slot is free before moving a log into it, so existing archives are not overwritten.
- If an archive or active log changes during rotation, the rotation stops and leaves the files unchanged instead of risking the wrong file being moved or removed.
- Rotating a log larger than the usual state file limit now works and keeps the full log content in the new archive.
- Added coverage for rotating an oversized log.

### Impact
`✅ Fewer overwritten log archives`
`✅ Safer log rotation under file changes`
`✅ Reliable rotation of large logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
