### PR TITLE
Harden pairing invite archive moves

### DIFF
--- a/crates/conu-core/src/trust.rs
+++ b/crates/conu-core/src/trust.rs
@@ -513,14 +513,20 @@ fn write_pairing_invite_with_mode(
 }
 
 fn move_used_invite(paths: &StatePaths, invite: &PairingInvite) -> Result<(), TrustError> {
+    ensure_pairing_invite_directory(paths)?;
     ensure_pairing_used_directory(paths)?;
     let source = paths
         .pairing_invites_dir
         .join(format!("{}.pair", invite.code));
     let target = paths.pairing_used_dir.join(format!("{}.pair", invite.code));
-    ensure_path_available(&target, "reserve used pairing invitation")?;
-    fs::rename(&source, &target)
-        .map_err(|error| TrustError::io("move used pairing invitation", &source, error))
+    state::archive_regular_state_file_no_replace(
+        &source,
+        &target,
+        "inspect used pairing invitation before archive",
+        "reserve used pairing invitation",
+        "move used pairing invitation",
+    )
+    .map_err(TrustError::from)
 }
 
 fn ensure_used_invite_target_available(
@@ -2079,6 +2085,81 @@ mod tests {
             fs::read_to_string(outside.join("invites").join("123456.pair"))
                 .expect("outside invite reads"),
             test_pairing_invite_contents()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn used_pairing_invite_symlink_is_rejected_without_moving_target() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("pairing-used-source-symlink");
+        let invite = create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let paths = StatePaths::from_home(home.clone());
+        let pending_path = paths
+            .pairing_invites_dir
+            .join(format!("{}.pair", invite.code));
+        let used_path = paths.pairing_used_dir.join(format!("{}.pair", invite.code));
+        let outside = home.with_extension("outside-pairing-used-source");
+        fs::write(&outside, test_pairing_invite_contents()).expect("outside invite writes");
+        fs::remove_file(&pending_path).expect("pending invite removes");
+        symlink(&outside, &pending_path).expect("pending invite symlink creates");
+
+        let error = move_used_invite(&paths, &invite)
+            .expect_err("symlinked pending invite should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("inspect used pairing invitation before archive")
+        );
+        assert!(!used_path.exists());
+        assert_eq!(
+            fs::read_to_string(&outside).expect("outside invite reads"),
+            test_pairing_invite_contents()
+        );
+        assert!(
+            fs::symlink_metadata(&pending_path)
+                .expect("pending invite metadata")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pairing_invites_directory_symlink_is_rejected_without_moving_invite() {
+        use std::os::unix::fs::symlink;
+
+        let home = test_home("pairing-invites-dir-move-symlink");
+        let invite = create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let paths = StatePaths::from_home(home.clone());
+        let outside = home.with_extension("outside-pairing-invites-dir-move");
+        let outside_invite = outside.join(format!("{}.pair", invite.code));
+        fs::remove_dir_all(&paths.pairing_invites_dir).expect("invites dir removes");
+        fs::create_dir_all(&outside).expect("outside invites dir creates");
+        fs::write(&outside_invite, test_pairing_invite_contents()).expect("outside invite writes");
+        symlink(&outside, &paths.pairing_invites_dir).expect("invites dir symlink creates");
+
+        let error = move_used_invite(&paths, &invite)
+            .expect_err("symlinked invites directory should fail closed");
+
+        assert!(error.to_string().contains("state directory"));
+        assert_eq!(
+            fs::read_to_string(&outside_invite).expect("outside invite reads"),
+            test_pairing_invite_contents()
+        );
+        assert!(
+            !paths
+                .pairing_used_dir
+                .join(format!("{}.pair", invite.code))
+                .exists()
+        );
+        assert!(
+            fs::symlink_metadata(&paths.pairing_invites_dir)
+                .expect("invites dir metadata")
+                .file_type()
+                .is_symlink()
         );
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- archive used pairing invites through the no-replace state archive helper
- validate the pending invite directory before moving an invite to used
- add Unix regressions for symlinked pending invite paths and invite directories

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-core --all-targets -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Local executable tests are blocked on this machine by missing Windows linkers: GNU needs dlltool.exe and MSVC needs link.exe. Hosted CI should run the Unix-only symlink regressions.

Closes #573


___

## **CodeAnt-AI Description**
**Reject unsafe moves when archiving used pairing invites**

### What Changed
- Moving a used pairing invite now fails if the pending invite directory is unsafe or replaced with a symlink
- The invite is only archived after checking the source and target are in the expected state directories
- Added Unix regression tests for a symlinked pending invite file and a symlinked pending invite directory

### Impact
`✅ Safer invite archiving`
`✅ Fewer accidental file moves outside the app state`
`✅ Clearer failures when pairing files are tampered with`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
