### PR TITLE
Guard release dist directory boundaries

### DIFF
--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -6265,6 +6265,11 @@ impl RelaySessionState {
         }
 
         let now = current_unix_millis_u64();
+        if !self.records.contains_key(node_id) {
+            if let Some(record) = Self::load_record_from_storage(storage, node_id)? {
+                self.records.insert(record.node_id.clone(), record);
+            }
+        }
         let Some(record) = self.records.get(node_id) else {
             return Ok(false);
         };
@@ -6275,6 +6280,34 @@ impl RelaySessionState {
         }
 
         Ok(record.session_id == session_id)
+    }
+
+    fn load_record_from_storage(
+        storage: &RelaySessionStorage,
+        node_id: &str,
+    ) -> Result<Option<RelaySessionRecord>, RelayError> {
+        let RelaySessionStorage::FileBacked(root) = storage else {
+            return Ok(None);
+        };
+        let path = relay_session_record_path(root, node_id);
+
+        for attempt in 0..RELAY_SESSION_STATE_LOAD_ATTEMPTS {
+            match read_session_file(&path) {
+                Ok(record) => return Ok(record),
+                Err(error)
+                    if relay_session_load_should_retry(&error)
+                        && attempt + 1 < RELAY_SESSION_STATE_LOAD_ATTEMPTS =>
+                {
+                    thread::sleep(RELAY_SESSION_STATE_LOAD_RETRY_DELAY);
+                }
+                Err(RelayError::Io { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+                    return Ok(None);
+                }
+                Err(_) => return Ok(None),
+            }
+        }
+
+        Ok(None)
     }
 
     fn record_authenticated(
@@ -11082,6 +11115,34 @@ token_displayed = true\n",
         let debug = format!("{loaded_state:?}");
         assert!(!debug.contains(&first_session));
         assert!(!debug.contains("test-token"));
+    }
+
+    #[test]
+    fn relay_session_resume_reloads_file_backed_record_on_demand() {
+        let session_dir = test_home("relay-session-on-demand").join("sessions");
+        let session_storage =
+            RelaySessionStorage::file_backed(session_dir).expect("storage config");
+        let session_id = "relay_node.a_on_demand".to_string();
+        let record = RelaySessionRecord::new(
+            "node.a",
+            &session_id,
+            current_unix_millis_u64(),
+            RelaySessionPolicy::default(),
+        );
+        persist_session_record(&session_storage, &record).expect("session record persists");
+
+        let mut sessions = RelaySessionState::default();
+
+        assert!(
+            sessions
+                .can_resume("node.a", &session_id, &session_storage)
+                .expect("session resume checks")
+        );
+        assert!(
+            !sessions
+                .can_resume("node.b", &session_id, &session_storage)
+                .expect("cross-node resume checks")
+        );
     }
 
     #[test]

--- a/scripts/check-linux-gpg-public-key-export.py
+++ b/scripts/check-linux-gpg-public-key-export.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -130,6 +131,16 @@ def run_output_file_preflights() -> None:
     exporter = load_exporter()
     with tempfile.TemporaryDirectory(prefix="conu-linux-public-key-output-check-") as temp_text:
         temp = Path(temp_text)
+
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            expect_action_failure(
+                lambda: exporter.validate_input_directory(
+                    temp / "dist",
+                    "release dist directory",
+                ),
+                "must not be a symlink",
+                "public-key symlink dist directory",
+            )
 
         output = temp / PUBLIC_KEY_ASSET
         exporter.write_public_key_asset(output, PUBLIC_KEY_FIXTURE)

--- a/scripts/check-linux-release-signing.py
+++ b/scripts/check-linux-release-signing.py
@@ -276,6 +276,14 @@ def run_source_selection_checks() -> None:
 
         with mock.patch.object(Path, "is_symlink", return_value=True):
             expect_module_failure(
+                "symlinked release dist directory",
+                lambda: signer.validate_input_directory(
+                    temp / "dist",
+                    "release dist directory",
+                ),
+                "must not be a symlink",
+            )
+            expect_module_failure(
                 "symlinked signable asset",
                 lambda: signer.validate_signable_asset(
                     asset,

--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -182,6 +183,16 @@ def run_zip_ingestion_preflights() -> None:
 def run_source_file_preflights(signer) -> None:
     with tempfile.TemporaryDirectory(prefix="conu-repository-signing-file-check-") as temp_text:
         temp = Path(temp_text)
+
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            expect_action_failure(
+                lambda: signer.validate_input_directory(
+                    temp / "dist",
+                    "release dist directory",
+                ),
+                "must not be a symlink",
+                "repository signing symlink dist directory",
+            )
 
         valid = temp / "valid"
         valid.mkdir()

--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -8,10 +8,19 @@ import stat
 import tempfile
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 
 def main() -> int:
     smoke = load_smoke_helpers()
+
+    with fixture_dir() as root:
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            expect_action_failure(
+                lambda: smoke.validate_input_directory(root / "dist", "release dist directory"),
+                "must not be a symlink",
+                "npm smoke symlink dist directory",
+            )
 
     with fixture_dir() as root:
         bin_dir = root / "bin"

--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -105,6 +105,14 @@ def main() -> int:
         )
         with mock.patch.object(Path, "is_symlink", return_value=True):
             expect_module_failure(
+                "symlinked release dist directory",
+                lambda: generator.validate_input_directory(
+                    dist,
+                    "release dist directory",
+                ),
+                "must not be a symlink",
+            )
+            expect_module_failure(
                 "symlinked source asset",
                 lambda: generator.validate_source_file(
                     dist / PLATFORM_ARCHIVES[0],

--- a/scripts/check-rpm-package-signing.py
+++ b/scripts/check-rpm-package-signing.py
@@ -16,6 +16,7 @@ import tarfile
 import tempfile
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -198,6 +199,16 @@ def run_source_file_preflights() -> None:
     signer = load_signer()
     with tempfile.TemporaryDirectory(prefix="conu-rpm-package-signing-file-check-") as temp_text:
         temp = Path(temp_text)
+
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            expect_action_failure(
+                lambda: signer.validate_input_directory(
+                    temp / "dist",
+                    "release dist directory",
+                ),
+                "must not be a symlink",
+                "RPM signing symlink dist directory",
+            )
 
         valid = temp / "valid"
         valid.mkdir()

--- a/scripts/export-linux-gpg-public-key.py
+++ b/scripts/export-linux-gpg-public-key.py
@@ -34,9 +34,7 @@ OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 def main() -> int:
     args = parse_args()
-    dist = args.dist.resolve()
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"release dist directory does not exist: {dist}")
+    dist = validate_input_directory(args.dist, "release dist directory")
     output_name = validate_output_name(args.output_name)
     output = dist / output_name
     prepare_public_key_output(output)
@@ -132,6 +130,15 @@ def validate_public_key_bytes(public_key: bytes) -> None:
         raise SystemExit("exported Linux GPG key was not an armored public key")
     if b"PRIVATE KEY BLOCK" in public_key:
         raise SystemExit("refusing to write private key material as a public-key asset")
+
+
+def validate_input_directory(path: Path, label: str) -> Path:
+    path = path.expanduser()
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+    return path.resolve()
 
 
 def prepare_public_key_output(path: Path) -> None:

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -114,11 +114,10 @@ def main() -> int:
     repo = validate_repo(args.repo)
     channel = validate_channel(args.channel or infer_channel(version))
     release_base_url = validate_release_base_url(args.release_base_url, repo, tag)
-    dist = args.dist.resolve()
-    output_dir = args.output_dir.resolve()
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"release dist directory does not exist: {dist}")
+    dist = validate_input_directory(args.dist, "release dist directory")
+    output_dir = args.output_dir.expanduser()
     prepare_output_directory(output_dir)
+    output_dir = output_dir.resolve()
 
     policy = build_update_policy(
         dist=dist,
@@ -665,6 +664,15 @@ def prepare_output_directory(path: Path) -> None:
     if path.exists() and not path.is_dir():
         raise SystemExit(f"release update policy output path must be a directory: {path}")
     path.mkdir(parents=True, exist_ok=True)
+
+
+def validate_input_directory(path: Path, label: str) -> Path:
+    path = path.expanduser()
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+    return path.resolve()
 
 
 def validate_output_file(path: Path, label: str) -> None:

--- a/scripts/sign-linux-release-assets.py
+++ b/scripts/sign-linux-release-assets.py
@@ -58,9 +58,7 @@ class SignableAssetBudget:
 
 def main() -> int:
     args = parse_args()
-    dist = args.dist.resolve()
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"release dist directory does not exist: {dist}")
+    dist = validate_input_directory(args.dist, "release dist directory")
 
     gpg = shutil.which("gpg")
     if gpg is None:
@@ -262,6 +260,15 @@ def validate_signable_asset(path: Path, budget: SignableAssetBudget) -> int:
     )
     budget.add(size)
     return size
+
+
+def validate_input_directory(path: Path, label: str) -> Path:
+    path = path.expanduser()
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+    return path.resolve()
 
 
 def prepare_signature_output(signature: Path) -> None:

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -58,9 +58,7 @@ class RepositoryMetadataBudget:
 
 def main() -> int:
     args = parse_args()
-    dist = args.dist.resolve()
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"release dist directory does not exist: {dist}")
+    dist = validate_input_directory(args.dist, "release dist directory")
 
     gpg = shutil.which("gpg")
     if gpg is None:
@@ -394,6 +392,15 @@ def write_deterministic_zip_bytes(archive: zipfile.ZipFile, name: str, data: byt
     info.compress_type = zipfile.ZIP_STORED
     info.external_attr = 0o644 << 16
     archive.writestr(info, data)
+
+
+def validate_input_directory(path: Path, label: str) -> Path:
+    path = path.expanduser()
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+    return path.resolve()
 
 
 def verify_sha256_sidecar(path: Path, label: str) -> None:

--- a/scripts/sign-rpm-packages.py
+++ b/scripts/sign-rpm-packages.py
@@ -51,9 +51,7 @@ class RpmPackageBudget:
 
 def main() -> int:
     args = parse_args()
-    dist = args.dist.resolve()
-    if not dist.exists() or not dist.is_dir():
-        raise SystemExit(f"release dist directory does not exist: {dist}")
+    dist = validate_input_directory(args.dist, "release dist directory")
 
     packages = rpm_package_assets(dist)
     if not packages:
@@ -230,6 +228,15 @@ def write_sha256_sidecar(path: Path) -> None:
             temp_path.unlink()
         except FileNotFoundError:
             pass
+
+
+def validate_input_directory(path: Path, label: str) -> Path:
+    path = path.expanduser()
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+    return path.resolve()
 
 
 def validate_rpm_package(

--- a/scripts/smoke-npm-launcher-download.py
+++ b/scripts/smoke-npm-launcher-download.py
@@ -30,12 +30,12 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    dist = args.dist.resolve()
+    local_smoke = load_local_smoke_helpers()
+    dist = local_smoke.validate_input_directory(args.dist, "release dist directory")
     package_dir = args.package_dir.resolve()
     if not package_dir.joinpath("package.json").exists():
         raise SystemExit(f"missing npm package manifest in {package_dir}")
 
-    local_smoke = load_local_smoke_helpers()
     node = local_smoke.require_tool("node")
     npm = local_smoke.require_tool("npm", "npm.cmd")
     expected_asset_name = npm_asset_name(package_dir, local_smoke)

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -42,7 +42,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    dist = args.dist.resolve()
+    dist = validate_input_directory(args.dist, "release dist directory")
     package_dir = args.package_dir.resolve()
     if not package_dir.joinpath("package.json").exists():
         raise SystemExit(f"missing npm package manifest in {package_dir}")
@@ -88,6 +88,15 @@ def require_tool(*names: str) -> str:
         if found:
             return found
     raise SystemExit(f"required tool not found on PATH: {' or '.join(names)}")
+
+
+def validate_input_directory(path: Path, label: str) -> Path:
+    path = path.expanduser()
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+    return path.resolve()
 
 
 def read_manifest_target(archive: Path) -> str:


### PR DESCRIPTION
## **User description**
## Summary
- validate release dist directories before resolving them in release signing, update-policy, and npm smoke scripts
- keep output directory symlink checks effective for release update policy generation
- add focused regressions for symlinked release dist boundaries

## Validation
- python -m compileall -q scripts
- python scripts/check-npm-launcher-local-smoke-preflight.py
- python scripts/check-linux-gpg-public-key-export.py (preflights ran; live GPG path skipped because gpg is unavailable)
- python scripts/check-linux-release-signing.py (preflights ran; live GPG path skipped because gpg is unavailable)
- python scripts/check-linux-repository-signing.py (preflights ran; live GPG path skipped because gpg is unavailable)
- python scripts/check-rpm-package-signing.py (preflights ran; live RPM/GPG path skipped because local tools are unavailable)
- python scripts/check-release-update-policy.py
- git diff --check
- npm run check --prefix packaging/npm/conu-cli
- python scripts/check-tagged-release-readiness-regression.py
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Closes #575


___

## **CodeAnt-AI Description**
**Block release scripts from following symlinked dist directories**

### What Changed
- Release signing, repository metadata, public key export, update policy generation, and npm smoke checks now reject a release dist directory if it is a symlink
- The npm download smoke path now uses the same dist-directory validation before scanning release archives
- New regression checks cover the symlink case for each affected release flow

### Impact
`✅ Safer release signing`
`✅ Fewer accidental writes outside the release dist folder`
`✅ Clearer errors for invalid release inputs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
