### PR TITLE
Harden release artifact smoke inputs

### DIFF
--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -8,10 +8,28 @@ import stat
 import tempfile
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 
 def main() -> int:
     smoke = load_smoke_helpers()
+
+    with fixture_dir() as root:
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            expect_action_failure(
+                lambda: smoke.validate_input_directory(root / "dist", "release dist directory"),
+                "must not be a symlink",
+                "release smoke symlink dist directory",
+            )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-linked.zip"
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            expect_action_failure(
+                lambda: smoke.read_manifest_target(archive),
+                "must not be a symlink",
+                "release smoke symlink archive",
+            )
 
     with fixture_dir() as root:
         bin_dir = root / "bin"

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import platform
@@ -15,12 +16,16 @@ import tarfile
 import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
+from typing import BinaryIO
 
 
 REQUIRED_BINARIES = ("conu", "conud", "conu-relay", "conu-mcp")
+MAX_ARCHIVE_BYTES = 1_000_000_000
 MAX_MEMBER_BYTES = 512_000_000
 MAX_MEMBER_COUNT = 10_000
 MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+OPEN_BINARY = getattr(os, "O_BINARY", 0)
 
 
 class ExtractState:
@@ -35,9 +40,10 @@ def main() -> int:
     parser.add_argument("dist", type=Path, help="directory containing release archives")
     args = parser.parse_args()
 
-    archives = sorted(args.dist.glob("*.zip")) + sorted(args.dist.glob("*.tar.gz"))
+    dist = validate_input_directory(args.dist, "release dist directory")
+    archives = sorted(dist.glob("*.zip")) + sorted(dist.glob("*.tar.gz"))
     if not archives:
-        raise SystemExit(f"no release archives found in {args.dist}")
+        raise SystemExit(f"no release archives found in {dist}")
 
     smoked = 0
     skipped = 0
@@ -82,49 +88,61 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
     expected_root = expected_archive_root(archive)
     state = ExtractState()
     if archive.suffix == ".zip":
-        with zipfile.ZipFile(archive) as package:
-            found: bytes | None = None
-            root_style: str | None = None
-            for member in package.infolist():
-                normalized, root_style, is_file = validate_zip_member_for_read(
-                    archive.name,
-                    member,
-                    expected_root,
-                    state,
-                    root_style,
-                )
-                if not is_file:
-                    continue
-                if normalized == normalized_name:
-                    if found is not None:
-                        raise SystemExit(
-                            f"{archive.name} contains duplicate archive path: {normalized_name}"
-                        )
-                    found = package.read(member)
-            return found
+        archive_file, _size = open_regular_file(
+            archive,
+            "release archive",
+            max_bytes=MAX_ARCHIVE_BYTES,
+        )
+        with archive_file:
+            with zipfile.ZipFile(archive_file) as package:
+                found: bytes | None = None
+                root_style: str | None = None
+                for member in package.infolist():
+                    normalized, root_style, is_file = validate_zip_member_for_read(
+                        archive.name,
+                        member,
+                        expected_root,
+                        state,
+                        root_style,
+                    )
+                    if not is_file:
+                        continue
+                    if normalized == normalized_name:
+                        if found is not None:
+                            raise SystemExit(
+                                f"{archive.name} contains duplicate archive path: {normalized_name}"
+                            )
+                        found = package.read(member)
+                return found
 
     if archive.name.endswith(".tar.gz"):
-        with tarfile.open(archive, "r|gz") as package:
-            found: bytes | None = None
-            root_style: str | None = None
-            for member in package:
-                normalized, root_style, is_file = validate_tar_member_for_read(
-                    archive.name,
-                    member,
-                    expected_root,
-                    state,
-                    root_style,
-                )
-                if not is_file:
-                    continue
-                if normalized == normalized_name:
-                    if found is not None:
-                        raise SystemExit(
-                            f"{archive.name} contains duplicate archive path: {normalized_name}"
-                        )
-                    file_object = package.extractfile(member)
-                    found = file_object.read() if file_object is not None else None
-            return found
+        archive_file, _size = open_regular_file(
+            archive,
+            "release archive",
+            max_bytes=MAX_ARCHIVE_BYTES,
+        )
+        with archive_file:
+            with tarfile.open(fileobj=archive_file, mode="r|gz") as package:
+                found: bytes | None = None
+                root_style: str | None = None
+                for member in package:
+                    normalized, root_style, is_file = validate_tar_member_for_read(
+                        archive.name,
+                        member,
+                        expected_root,
+                        state,
+                        root_style,
+                    )
+                    if not is_file:
+                        continue
+                    if normalized == normalized_name:
+                        if found is not None:
+                            raise SystemExit(
+                                f"{archive.name} contains duplicate archive path: {normalized_name}"
+                            )
+                        file_object = package.extractfile(member)
+                        found = file_object.read() if file_object is not None else None
+                return found
 
     raise SystemExit(f"unsupported release archive {archive.name}")
 
@@ -306,85 +324,134 @@ def extract_archive(archive: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     state = ExtractState()
     if archive.suffix == ".zip":
-        with zipfile.ZipFile(archive) as package:
-            for member in package.infolist():
-                if member.filename.endswith("/"):
-                    if member.file_size != 0:
-                        raise SystemExit(
-                            f"{archive.name} contains directory member with data: "
-                            f"{member.filename}"
+        archive_file, _size = open_regular_file(
+            archive,
+            "release archive",
+            max_bytes=MAX_ARCHIVE_BYTES,
+        )
+        with archive_file:
+            with zipfile.ZipFile(archive_file) as package:
+                for member in package.infolist():
+                    if member.filename.endswith("/"):
+                        if member.file_size != 0:
+                            raise SystemExit(
+                                f"{archive.name} contains directory member with data: "
+                                f"{member.filename}"
+                            )
+                        validate_extract_entry(
+                            archive.name,
+                            member.filename,
+                            0,
+                            state,
+                            allow_empty=True,
                         )
-                    validate_extract_entry(
+                        continue
+                    if member.flag_bits & 0x1:
+                        raise SystemExit(
+                            f"{archive.name} contains encrypted zip member: {member.filename}"
+                        )
+                    file_type = (member.external_attr >> 16) & 0o170000
+                    if file_type == stat.S_IFLNK:
+                        raise SystemExit(
+                            f"{archive.name} contains unsupported link member: {member.filename}"
+                        )
+                    if file_type not in {0, stat.S_IFREG}:
+                        raise SystemExit(
+                            f"{archive.name} contains unsupported zip member: {member.filename}"
+                        )
+                    output_path = checked_extract_path(
                         archive.name,
+                        destination,
                         member.filename,
-                        0,
+                        member.file_size,
                         state,
-                        allow_empty=True,
                     )
-                    continue
-                if member.flag_bits & 0x1:
-                    raise SystemExit(
-                        f"{archive.name} contains encrypted zip member: {member.filename}"
-                    )
-                file_type = (member.external_attr >> 16) & 0o170000
-                if file_type == stat.S_IFLNK:
-                    raise SystemExit(
-                        f"{archive.name} contains unsupported link member: {member.filename}"
-                    )
-                if file_type not in {0, stat.S_IFREG}:
-                    raise SystemExit(
-                        f"{archive.name} contains unsupported zip member: {member.filename}"
-                    )
-                output_path = checked_extract_path(
-                    archive.name,
-                    destination,
-                    member.filename,
-                    member.file_size,
-                    state,
-                )
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                output_path.write_bytes(package.read(member))
-                unix_mode = (member.external_attr >> 16) & 0o777
-                if unix_mode:
-                    output_path.chmod(unix_mode)
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    output_path.write_bytes(package.read(member))
+                    unix_mode = (member.external_attr >> 16) & 0o777
+                    if unix_mode:
+                        output_path.chmod(unix_mode)
         return
 
     if archive.name.endswith(".tar.gz"):
-        with tarfile.open(archive, "r|gz") as package:
-            for member in package:
-                if member.isdir():
-                    if member.size != 0:
-                        raise SystemExit(
-                            f"{archive.name} contains directory member with data: {member.name}"
+        archive_file, _size = open_regular_file(
+            archive,
+            "release archive",
+            max_bytes=MAX_ARCHIVE_BYTES,
+        )
+        with archive_file:
+            with tarfile.open(fileobj=archive_file, mode="r|gz") as package:
+                for member in package:
+                    if member.isdir():
+                        if member.size != 0:
+                            raise SystemExit(
+                                f"{archive.name} contains directory member with data: {member.name}"
+                            )
+                        validate_extract_entry(
+                            archive.name,
+                            member.name,
+                            0,
+                            state,
+                            allow_empty=True,
                         )
-                    validate_extract_entry(
+                        continue
+                    if not member.isfile():
+                        raise SystemExit(
+                            f"{archive.name} contains unsupported non-file member: {member.name}"
+                        )
+                    output_path = checked_extract_path(
                         archive.name,
+                        destination,
                         member.name,
-                        0,
+                        member.size,
                         state,
-                        allow_empty=True,
                     )
-                    continue
-                if not member.isfile():
-                    raise SystemExit(
-                        f"{archive.name} contains unsupported non-file member: {member.name}"
-                    )
-                output_path = checked_extract_path(
-                    archive.name,
-                    destination,
-                    member.name,
-                    member.size,
-                    state,
-                )
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                file_object = package.extractfile(member)
-                if file_object is None:
-                    raise SystemExit(f"{archive.name} could not read member {member.name}")
-                output_path.write_bytes(file_object.read())
-                output_path.chmod(member.mode & 0o777)
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    file_object = package.extractfile(member)
+                    if file_object is None:
+                        raise SystemExit(f"{archive.name} could not read member {member.name}")
+                    output_path.write_bytes(file_object.read())
+                    output_path.chmod(member.mode & 0o777)
         return
 
     raise SystemExit(f"unsupported release archive {archive.name}")
+
+
+def validate_input_directory(path: Path, label: str) -> Path:
+    path = path.expanduser()
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path}")
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist: {path}")
+    return path.resolve()
+
+
+def open_regular_file(path: Path, label: str, *, max_bytes: int) -> tuple[BinaryIO, int]:
+    if path.is_symlink():
+        raise SystemExit(f"{label} must not be a symlink: {path.name}")
+    if not path.exists():
+        raise SystemExit(f"missing {label}: {path.name}")
+    flags = os.O_RDONLY | OPEN_BINARY | OPEN_NOFOLLOW
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise SystemExit(f"{label} must not be a symlink: {path.name}") from exc
+        if not path.exists():
+            raise SystemExit(f"missing {label}: {path.name}") from exc
+        if not path.is_file():
+            raise SystemExit(f"{label} must be a regular file: {path.name}") from exc
+        raise SystemExit(f"{label} could not be opened: {path.name}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"{label} must be a regular file: {path.name}")
+        if metadata.st_size > max_bytes:
+            raise SystemExit(f"{label} is too large: {path.name}")
+        return os.fdopen(fd, "rb"), metadata.st_size
+    except BaseException:
+        os.close(fd)
+        raise
 
 
 def checked_extract_path(


### PR DESCRIPTION
## **User description**
## Summary
- reject symlinked release smoke dist directories before archive discovery
- open release smoke archives through no-follow regular-file handles for manifest reads and extraction
- add regression coverage for symlinked smoke dist/archive inputs

Closes #577

## Validation
- python -m compileall -q scripts/smoke-release-artifacts.py scripts/check-release-artifact-smoke-preflight.py
- python scripts/check-release-artifact-smoke-preflight.py
- python scripts/check-release-artifact-verifier.py
- python scripts/check-tagged-release-readiness-regression.py
- python scripts/check-github-workflow-permissions.py --json
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the release smoke scripts to block symlinked inputs and ensure archives are opened as regular files with no-follow handles, preventing symlink traversal and unsafe reads. Adds size limits and regression tests for safer manifest reads and extraction.

- **Bug Fixes**
  - Reject symlinked dist directories before archive discovery.
  - Open archives via O_NOFOLLOW regular-file handles; reject non-regular files and missing files.
  - Enforce max archive size (`MAX_ARCHIVE_BYTES`) and validate input directories with `validate_input_directory`.
  - Read/extract zip/tar using file objects tied to no-follow handles.
  - Add regression coverage for symlinked dist and archive inputs.

<sup>Written for commit 485fbf6223f1c1991248222438fba8e092459712. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Block symlinked release smoke inputs and only read archives from regular files

### What Changed
- Release smoke now rejects symlinked input directories and archive files before reading them
- Archives are only opened when they are regular files, and oversized archives are rejected
- Zip and tar smoke checks still read manifests and extract files, but now avoid unsafe link and non-file inputs
- Added regression coverage for symlinked dist directories and symlinked archive inputs

### Impact
`✅ Safer release smoke checks`
`✅ Fewer symlink-based archive reads`
`✅ Clearer release input failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
