### PR TITLE
Guard npm download smoke served assets

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -13,6 +13,7 @@ from unittest import mock
 
 def main() -> int:
     smoke = load_smoke_helpers()
+    download_smoke = load_download_smoke_helpers()
 
     with fixture_dir() as root:
         with mock.patch.object(Path, "is_symlink", return_value=True):
@@ -58,6 +59,44 @@ def main() -> int:
                 lambda: smoke.read_manifest_target(archive),
                 "must not be a symlink",
                 "npm smoke symlink archive",
+            )
+
+    with fixture_dir() as root:
+        dist = root / "dist"
+        dist.mkdir()
+        dist.joinpath("conu-0.1.0-host.zip.sha256").write_text("checksum\n", encoding="utf-8")
+        download_smoke.validate_served_dist_assets(dist)
+
+    with fixture_dir() as root:
+        dist = root / "dist"
+        dist.mkdir()
+        dist.joinpath("conu-0.1.0-host.zip.sha256").write_text("checksum\n", encoding="utf-8")
+        with mock.patch.object(
+            Path,
+            "is_symlink",
+            lambda path: path.name.endswith(".sha256"),
+        ):
+            expect_action_failure(
+                lambda: download_smoke.validate_served_dist_assets(dist),
+                "served asset must not be a symlink",
+                "npm download smoke symlink served checksum",
+            )
+
+    with fixture_dir() as root:
+        dist = root / "dist"
+        dist.mkdir()
+        nested = dist / "nested"
+        nested.mkdir()
+        nested.joinpath("asset.txt").write_text("asset\n", encoding="utf-8")
+        with mock.patch.object(
+            Path,
+            "is_symlink",
+            lambda path: path.name == "nested",
+        ):
+            expect_action_failure(
+                lambda: download_smoke.validate_served_dist_assets(dist),
+                "served asset must not be a symlink",
+                "npm download smoke symlink served directory",
             )
 
     with fixture_dir() as root:
@@ -299,6 +338,19 @@ def main() -> int:
 def load_smoke_helpers():
     helper_path = Path(__file__).with_name("smoke-npm-launcher-local.py")
     spec = importlib.util.spec_from_file_location("conu_npm_launcher_local_smoke", helper_path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"could not load helper script {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_download_smoke_helpers():
+    helper_path = Path(__file__).with_name("smoke-npm-launcher-download.py")
+    spec = importlib.util.spec_from_file_location(
+        "conu_npm_launcher_download_smoke",
+        helper_path,
+    )
     if spec is None or spec.loader is None:
         raise SystemExit(f"could not load helper script {helper_path}")
     module = importlib.util.module_from_spec(spec)

--- a/scripts/smoke-npm-launcher-download.py
+++ b/scripts/smoke-npm-launcher-download.py
@@ -44,6 +44,7 @@ def main() -> int:
     archives = sorted(dist.glob("*.zip")) + sorted(dist.glob("*.tar.gz"))
     if not archives:
         raise SystemExit(f"no release archives found in {dist}")
+    validate_served_dist_assets(dist)
 
     smoked = 0
     skipped = 0
@@ -119,6 +120,23 @@ def npm_asset_name(package_dir: Path, local_smoke) -> str:
     platform_key = local_smoke.npm_platform_key()
     extension = ".tar.gz" if platform_key.startswith("linux-") else ".zip"
     return f"conu-{version}-{platform_key}{extension}"
+
+
+def validate_served_dist_assets(dist: Path) -> None:
+    for root, dir_names, file_names in os.walk(dist, followlinks=False):
+        root_path = Path(root)
+        for name in sorted([*dir_names, *file_names]):
+            path = root_path / name
+            relative = path.relative_to(dist).as_posix()
+            if path.is_symlink():
+                raise SystemExit(
+                    f"npm download smoke served asset must not be a symlink: {relative}"
+                )
+            if not path.is_dir() and not path.is_file():
+                raise SystemExit(
+                    "npm download smoke served asset must be a regular file or directory: "
+                    f"{relative}"
+                )
 
 
 def install_npm_package_from_release_base(


### PR DESCRIPTION
## **User description**
## Summary
- reject symlinked files or directories under the npm download smoke `dist` tree before starting the local HTTP server
- keep the smoke server from following symlinked checksum or nested served assets
- add regression coverage for regular served assets, symlinked served checksums, and symlinked served directories

Closes #581

## Validation
- python -m compileall -q scripts/smoke-npm-launcher-download.py scripts/check-npm-launcher-local-smoke-preflight.py
- python scripts/check-npm-launcher-local-smoke-preflight.py
- git diff --check
- python -m compileall -q scripts
- npm run check --prefix packaging/npm/conu-cli
- python scripts/check-tagged-release-readiness-regression.py
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded npm download smoke served assets by validating the `dist` tree and rejecting symlinks before starting the local HTTP server. Prevents serving symlinked files or directories and reduces risk from unexpected asset resolution.

- **Bug Fixes**
  - Added `validate_served_dist_assets(dist)` to block symlinked files and directories.
  - Ensured served assets are only regular files or directories.
  - Extended preflight coverage for normal assets, symlinked checksum, and symlinked nested directory.

<sup>Written for commit 90caea1b80ae2ee3aaf75109691323dec125c163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block symlinked files and folders from npm download smoke tests**

### What Changed
- The npm download smoke check now rejects any symlinked file or folder in the served `dist` output before starting the local server
- Regular release archives and normal served assets still pass through
- Regression checks now cover a valid checksum file, a symlinked checksum file, and a symlinked nested folder

### Impact
`✅ Fewer unsafe asset downloads`
`✅ Clearer npm smoke test failures`
`✅ Safer release artifact serving`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
