### PR TITLE
Guard hosted repository S3 site roots

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -121,6 +121,17 @@ def main() -> int:
         bad_cache_result = run_publisher_raw(bad_cache_control, "--dry-run")
         assert_failure("bad Cache-Control", bad_cache_result, "Cache-Control")
 
+        symlink_site_target = temp / "symlink-site-target"
+        shutil.copytree(site_dir, symlink_site_target)
+        symlink_site_root = temp / "symlink-site-root"
+        if try_symlink(symlink_site_target, symlink_site_root, target_is_directory=True):
+            symlink_site_result = run_publisher_raw(symlink_site_root, "--dry-run")
+            assert_failure(
+                "symlinked site directory",
+                symlink_site_result,
+                "site directory must not be a symlink",
+            )
+
         symlink_metadata = temp / "symlink-metadata-site"
         shutil.copytree(site_dir, symlink_metadata)
         metadata_target = temp / "repository-target.json"

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -234,9 +234,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def build_publish_plan(args: argparse.Namespace) -> PublishPlan:
-    site_dir = args.site_dir.resolve()
-    if not site_dir.exists() or not site_dir.is_dir():
-        raise PublicationError(f"site directory does not exist: {args.site_dir}")
+    site_dir = validate_site_directory(args.site_dir)
     bucket = validate_bucket(args.bucket)
     prefix = validate_prefix(args.prefix)
     validate_endpoint_url(args.endpoint_url)
@@ -265,6 +263,15 @@ def build_publish_plan(args: argparse.Namespace) -> PublishPlan:
         prefix=prefix,
         files=files,
     )
+
+
+def validate_site_directory(path: Path) -> Path:
+    site_dir = path.expanduser()
+    if site_dir.is_symlink():
+        raise PublicationError(f"site directory must not be a symlink: {path}")
+    if not site_dir.exists() or not site_dir.is_dir():
+        raise PublicationError(f"site directory does not exist: {path}")
+    return site_dir.resolve()
 
 
 def validate_bucket(raw: str) -> str:


### PR DESCRIPTION
## **User description**
## Summary
- reject symlinked hosted repository S3 site root directories before resolving paths
- add S3 publication regression coverage for symlinked site roots

Fixes #583

## Validation
- python scripts/check-hosted-linux-repository-s3-publication.py
- python -m compileall -q scripts
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent publishing from symlinked hosted repository S3 site roots. Adds a clear error and regression coverage to fail fast on unsafe `site_dir` configurations.

- **Bug Fixes**
  - Validate `site_dir` to reject symlinks before resolving paths; returns "site directory must not be a symlink".
  - Added S3 publication regression test to ensure the dry-run publisher fails on symlinked site roots.

<sup>Written for commit fa6664ae75c926cb0c3603e9ded530e3bad654af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject symlinked site directories before publishing**

### What Changed
- Publishing now stops if the site root is a symlink, instead of following it
- The existing publication check now covers this case with a regression test

### Impact
`✅ Safer hosted repository publishes`
`✅ Fewer accidental uploads from redirected site roots`
`✅ Clearer validation errors for invalid publish paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Site publishing now validates site directories and rejects symlinked paths with clear error messaging to prevent publication errors.

* **Tests**
  * Added regression test validating that symlinked site directories are properly rejected during the publication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->