### PR TITLE
Guard hosted endpoint metadata URLs

### DIFF
--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -120,6 +120,25 @@ def main() -> int:
             )
             run_checker_expect_failure(base_url, "repository.json baseUrl", "--expected-version", VERSION)
 
+        query_download_url = temp / "query-download-url"
+        shutil.copytree(site_root, query_download_url)
+        with serve_site(query_download_url, mode="good") as base_url:
+            rewrite_base_url(query_download_url, PLACEHOLDER_BASE_URL, base_url)
+            repository_path = query_download_url / "repository.json"
+            repository = json.loads(repository_path.read_text(encoding="ascii"))
+            repository["downloads"]["hostedBundleUrl"] += "?token=value"
+            repository_path.write_text(
+                json.dumps(repository, indent=2, sort_keys=True) + "\n",
+                encoding="ascii",
+                newline="\n",
+            )
+            run_checker_expect_failure(
+                base_url,
+                "must not include params, query, or fragment",
+                "--expected-version",
+                VERSION,
+            )
+
     print("Hosted Linux repository endpoint regression checks passed")
     return 0
 

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -407,7 +407,8 @@ def validate_repository_json(base_url: str, repository: dict[str, Any]) -> str:
         raise EndpointReadinessError("repository.json expected cachePolicy.hostMustApply=true")
     for field in ("hostedBundleUrl", "hostedBundleChecksumUrl", "hostedBundleSignatureUrl"):
         value = downloads.get(field)
-        if not isinstance(value, str) or not value.startswith(f"{base_url}/downloads/"):
+        path = url_to_base_path(base_url, value, f"repository.json downloads.{field}")
+        if not path.startswith("/downloads/"):
             raise EndpointReadinessError(f"repository.json downloads.{field} must point under baseUrl")
     return version
 
@@ -563,10 +564,17 @@ def url_to_base_path(base_url: str, value: str, label: str) -> str:
         raise EndpointReadinessError(f"{label} must be a URL string")
     parsed_base = urlparse(base_url)
     parsed_value = urlparse(value)
+    if parsed_value.username or parsed_value.password:
+        raise EndpointReadinessError(f"{label} must not include credentials")
+    if parsed_value.params or parsed_value.query or parsed_value.fragment:
+        raise EndpointReadinessError(f"{label} must not include params, query, or fragment")
     if (parsed_value.scheme, parsed_value.netloc) != (parsed_base.scheme, parsed_base.netloc):
         raise EndpointReadinessError(f"{label} points outside repository origin")
     base_path = parsed_base.path.rstrip("/")
     value_path = parsed_value.path.rstrip("/")
+    path_parts = [part for part in parsed_value.path.split("/") if part]
+    if any(part in {".", ".."} for part in path_parts):
+        raise EndpointReadinessError(f"{label} path must not contain dot segments")
     if base_path:
         if value_path != base_path and not value_path.startswith(f"{base_path}/"):
             raise EndpointReadinessError(f"{label} points outside repository path")


### PR DESCRIPTION
## **User description**
## Summary
- reject credentials, params, query strings, fragments, and dot segments in hosted repository metadata URLs
- validate repository.json download URLs through the same base-path parser used for sampled endpoint paths
- add regression coverage for query-bearing hosted bundle URLs

Fixes #585

## Validation
- python scripts/check-hosted-linux-repository-endpoint-regression.py
- python -m compileall -q scripts
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened validation for hosted repository metadata URLs to block unsafe patterns and ensure all `repository.json` download links stay under the base URL. Adds regression coverage to prevent query-bearing hosted bundle URLs.

- **Bug Fixes**
  - Validate `downloads.hostedBundleUrl`, `hostedBundleChecksumUrl`, and `hostedBundleSignatureUrl` with the shared base-path parser.
  - Reject URLs with credentials, params, query strings, fragments, or dot segments.
  - Add regression check that a query string in `hostedBundleUrl` is rejected.

<sup>Written for commit 4c20896832d54e037f81ca630d028666cb0a0af7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Block unsafe URLs in hosted repository metadata

### What Changed
- Hosted bundle download links are now checked for credentials, query strings, fragments, and dot segments before they are accepted
- Links must stay under the repository base path and match the expected origin
- Regression coverage now rejects a hosted bundle URL that includes a query string

### Impact
`✅ Safer repository metadata URLs`
`✅ Fewer invalid hosted bundle links`
`✅ Clearer rejection of malformed download URLs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
