### PR TITLE
Guard hosted repository cache paths

### DIFF
--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -106,6 +106,32 @@ def main() -> int:
             rewrite_base_url(bad_cache_policy, PLACEHOLDER_BASE_URL, base_url)
             run_checker_expect_failure(base_url, "tokenDisplayed=false", "--expected-version", VERSION)
 
+        unsafe_cache_path = temp / "unsafe-cache-path"
+        shutil.copytree(site_root, unsafe_cache_path)
+        cache_policy_path = unsafe_cache_path / "cache-policy.json"
+        cache_policy = json.loads(cache_policy_path.read_text(encoding="ascii"))
+        cache_policy["rules"][0]["paths"].append("/.git/config")
+        cache_policy_path.write_text(
+            json.dumps(cache_policy, indent=2, sort_keys=True) + "\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        headers_path = unsafe_cache_path / "_headers"
+        headers_path.write_text(
+            headers_path.read_text(encoding="ascii")
+            + "\n/.git/config\n  Cache-Control: no-cache\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        with serve_site(unsafe_cache_path, mode="good") as base_url:
+            rewrite_base_url(unsafe_cache_path, PLACEHOLDER_BASE_URL, base_url)
+            run_checker_expect_failure(
+                base_url,
+                "forbidden local-state segment",
+                "--expected-version",
+                VERSION,
+            )
+
         bad_base_url = temp / "bad-base-url"
         shutil.copytree(site_root, bad_base_url)
         with serve_site(bad_base_url, mode="good") as base_url:

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -34,6 +34,17 @@ FORBIDDEN_TEXT = (
     "payload_hex",
     "ciphertext_body",
 )
+FORBIDDEN_PATH_SEGMENTS = {
+    ".conu",
+    ".git",
+    ".github",
+    "logs",
+    "messages",
+    "node_modules",
+    "routes",
+    "runtime",
+    "security",
+}
 
 
 class EndpointReadinessError(ValueError):
@@ -440,6 +451,24 @@ def require_object(parent: dict[str, Any], key: str, label: str) -> dict[str, An
     return value
 
 
+def validate_repository_path(path: str, label: str) -> str:
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise EndpointReadinessError(f"{label} must be an absolute path")
+    if "\\" in path:
+        raise EndpointReadinessError(f"{label} must not contain backslashes")
+    if "?" in path or "#" in path:
+        raise EndpointReadinessError(f"{label} must not contain query or fragment")
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts[1:]):
+        raise EndpointReadinessError(f"{label} must not contain empty or dot segments")
+    forbidden = sorted({part.lower() for part in parts[1:]} & FORBIDDEN_PATH_SEGMENTS)
+    if forbidden:
+        raise EndpointReadinessError(
+            f"{label} contains forbidden local-state segment: {', '.join(forbidden)}"
+        )
+    return path
+
+
 def parse_cache_rules(cache_policy: dict[str, Any]) -> list[dict[str, Any]]:
     raw_rules = cache_policy.get("rules")
     if not isinstance(raw_rules, list) or not raw_rules:
@@ -460,14 +489,14 @@ def parse_cache_rules(cache_policy: dict[str, Any]) -> list[dict[str, Any]]:
             raise EndpointReadinessError(f"cache-policy.json cache rule {kind} paths are missing")
         clean_paths: list[str] = []
         for path in paths:
-            if not isinstance(path, str) or not path.startswith("/"):
-                raise EndpointReadinessError(f"cache-policy.json cache rule {kind} contains a non-absolute path")
-            if "?" in path or "#" in path:
-                raise EndpointReadinessError(f"cache-policy.json cache rule {kind} contains a query or fragment")
-            if path in seen_paths:
-                raise EndpointReadinessError(f"cache-policy.json duplicates cache path {path}")
-            seen_paths.add(path)
-            clean_paths.append(path)
+            clean_path = validate_repository_path(
+                path,
+                f"cache-policy.json cache rule {kind} path",
+            )
+            if clean_path in seen_paths:
+                raise EndpointReadinessError(f"cache-policy.json duplicates cache path {clean_path}")
+            seen_paths.add(clean_path)
+            clean_paths.append(clean_path)
         rules.append(
             {
                 "kind": kind,
@@ -493,9 +522,7 @@ def parse_headers_file(text: str) -> dict[str, dict[str, str]]:
             name, value = stripped.split(":", 1)
             entries[current_path][name.strip().lower()] = value.strip()
             continue
-        current_path = line.strip()
-        if not current_path.startswith("/"):
-            raise EndpointReadinessError("_headers contains a non-absolute path")
+        current_path = validate_repository_path(line.strip(), "_headers path")
         if current_path in entries:
             raise EndpointReadinessError(f"_headers contains duplicate path: {current_path}")
         entries[current_path] = {}
@@ -583,7 +610,7 @@ def url_to_base_path(base_url: str, value: str, label: str) -> str:
         relative = value_path
     if not relative.startswith("/"):
         relative = f"/{relative}"
-    return relative or "/"
+    return validate_repository_path(relative or "/", f"{label} path")
 
 
 def cache_control_for_path(path: str, rules: list[dict[str, Any]]) -> str:

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -121,6 +121,23 @@ def main() -> int:
         bad_cache_result = run_publisher_raw(bad_cache_control, "--dry-run")
         assert_failure("bad Cache-Control", bad_cache_result, "Cache-Control")
 
+        unsafe_cache_path = temp / "unsafe-cache-path-site"
+        shutil.copytree(site_dir, unsafe_cache_path)
+        cache_policy_path = unsafe_cache_path / "cache-policy.json"
+        cache_policy = json.loads(cache_policy_path.read_text(encoding="ascii"))
+        cache_policy["rules"][0]["paths"].append("/.git/config")
+        cache_policy_path.write_text(
+            json.dumps(cache_policy, indent=2, sort_keys=True) + "\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        unsafe_cache_result = run_publisher_raw(unsafe_cache_path, "--dry-run")
+        assert_failure(
+            "unsafe cache path",
+            unsafe_cache_result,
+            "forbidden local-state segment",
+        )
+
         symlink_site_target = temp / "symlink-site-target"
         shutil.copytree(site_dir, symlink_site_target)
         symlink_site_root = temp / "symlink-site-root"

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -416,16 +416,31 @@ def parse_cache_rules(cache_policy: dict[str, Any]) -> list[dict[str, Any]]:
             raise PublicationError(f"cache-policy.json cache rule {kind} paths are missing")
         clean_paths: list[str] = []
         for path in paths:
-            if not isinstance(path, str) or not path.startswith("/"):
-                raise PublicationError(f"cache-policy.json cache rule {kind} contains a non-absolute path")
-            if "?" in path or "#" in path:
-                raise PublicationError(f"cache-policy.json cache rule {kind} contains a query or fragment")
-            if path in seen_paths:
-                raise PublicationError(f"cache-policy.json duplicates cache path {path}")
-            seen_paths.add(path)
-            clean_paths.append(path)
+            clean_path = validate_cache_path(path, f"cache-policy.json cache rule {kind} path")
+            if clean_path in seen_paths:
+                raise PublicationError(f"cache-policy.json duplicates cache path {clean_path}")
+            seen_paths.add(clean_path)
+            clean_paths.append(clean_path)
         rules.append({"kind": kind, "paths": tuple(clean_paths), "cacheControl": cache_control})
     return rules
+
+
+def validate_cache_path(path: str, label: str) -> str:
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise PublicationError(f"{label} must be an absolute path")
+    if "\\" in path:
+        raise PublicationError(f"{label} must not contain backslashes")
+    if "?" in path or "#" in path:
+        raise PublicationError(f"{label} must not contain query or fragment")
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts[1:]):
+        raise PublicationError(f"{label} must not contain empty or dot segments")
+    forbidden = sorted({part.lower() for part in parts[1:]} & FORBIDDEN_SEGMENTS)
+    if forbidden:
+        raise PublicationError(
+            f"{label} contains forbidden local-state segment: {', '.join(forbidden)}"
+        )
+    return path
 
 
 def collect_files(


### PR DESCRIPTION
## **User description**
## Summary
- Reject unsafe hosted repository cache-policy and _headers paths with backslashes, empty/dot segments, or local-state segments.
- Apply the same cache-policy path guard to S3 publication planning.
- Add endpoint and S3 regression coverage for forbidden local-state cache paths.

## Validation
- python scripts/check-hosted-linux-repository-endpoint-regression.py
- python scripts/check-hosted-linux-repository-s3-publication.py
- python -m compileall -q scripts
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Closes #587

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened hosted repo caching by rejecting unsafe cache-policy and _headers paths and applying the same guard to S3 publication planning. Adds regression tests to block publishing or serving local-state paths like /.git.

- **Bug Fixes**
  - Validate cache paths for endpoint and S3 publisher: no backslashes, queries/fragments, empty/dot segments, or local-state segments (e.g. .git, .github, node_modules, logs, routes, runtime, security, messages, .conu).
  - Enforce validation when parsing cache-policy rules, _headers, and base path resolution; prevent duplicates with clear errors.
  - Add endpoint and S3 dry-run tests that fail on unsafe paths (e.g. "/.git/config").

- **Migration**
  - Audit cache-policy.json and _headers. Remove local-state or dot-segment paths and use absolute forward-slash paths only.

<sup>Written for commit 43576a3000a44011f77b7dbc0978d48760719e0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject unsafe hosted repository cache paths**

### What Changed
- Cache rules, `_headers` paths, and repository paths are now rejected if they use backslashes, query strings, fragment parts, empty or dot segments, or local-state folders like `.git`, `.github`, `node_modules`, and `logs`
- The same path checks now apply when checking the hosted endpoint and when planning S3 publication, so unsafe paths fail before they can be served or uploaded
- Added regression coverage for unsafe paths such as `/.git/config`

### Impact
`✅ Fewer accidental publishes of private repository files`
`✅ Clearer errors for invalid cache and header paths`
`✅ Safer hosted repository releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
