### PR TITLE
Validate hosted S3 headers policy

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -121,6 +121,20 @@ def main() -> int:
         bad_cache_result = run_publisher_raw(bad_cache_control, "--dry-run")
         assert_failure("bad Cache-Control", bad_cache_result, "Cache-Control")
 
+        bad_headers = temp / "bad-headers-site"
+        shutil.copytree(site_dir, bad_headers)
+        (bad_headers / "_headers").write_text(
+            "/repository.json\n  Cache-Control: public, max-age=31536000, immutable\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        bad_headers_result = run_publisher_raw(bad_headers, "--dry-run")
+        assert_failure(
+            "bad _headers cache policy",
+            bad_headers_result,
+            "_headers Cache-Control rules",
+        )
+
         unsafe_cache_path = temp / "unsafe-cache-path-site"
         shutil.copytree(site_dir, unsafe_cache_path)
         cache_policy_path = unsafe_cache_path / "cache-policy.json"

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -247,10 +247,14 @@ def build_publish_plan(args: argparse.Namespace) -> PublishPlan:
 
     repository = read_json_file(site_dir / "repository.json", "repository.json")
     cache_policy = read_json_file(site_dir / "cache-policy.json", "cache-policy.json")
+    headers_text = read_bounded_ascii_file(site_dir / "_headers", "_headers", max_bytes=MAX_METADATA_BYTES)
+    assert_no_forbidden_text(headers_text, "_headers")
     base_url = validate_base_url(args.base_url or str(repository.get("baseUrl", "")))
     version = validate_repository_json(repository, base_url, args.expected_version)
     validate_cache_policy_json(cache_policy, base_url, version)
     rules = parse_cache_rules(cache_policy)
+    headers_entries = parse_headers_file(headers_text)
+    validate_headers_match_policy(headers_entries, rules)
 
     files = collect_files(site_dir, bucket, prefix, rules)
     if not files:
@@ -441,6 +445,45 @@ def validate_cache_path(path: str, label: str) -> str:
             f"{label} contains forbidden local-state segment: {', '.join(forbidden)}"
         )
     return path
+
+
+def parse_headers_file(text: str) -> dict[str, dict[str, str]]:
+    entries: dict[str, dict[str, str]] = {}
+    current_path: str | None = None
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith(" ") or line.startswith("\t"):
+            if current_path is None:
+                raise PublicationError("_headers contains a header before any path")
+            stripped = line.strip()
+            if ":" not in stripped:
+                raise PublicationError("_headers contains a malformed header line")
+            name, value = stripped.split(":", 1)
+            entries[current_path][name.strip().lower()] = value.strip()
+            continue
+        current_path = validate_cache_path(line.strip(), "_headers path")
+        if current_path in entries:
+            raise PublicationError(f"_headers contains duplicate path: {current_path}")
+        entries[current_path] = {}
+    return entries
+
+
+def validate_headers_match_policy(
+    headers_entries: dict[str, dict[str, str]],
+    rules: list[dict[str, Any]],
+) -> None:
+    expected = {
+        path: {"cache-control": rule["cacheControl"]}
+        for rule in rules
+        for path in rule["paths"]
+    }
+    actual = {
+        path: {"cache-control": headers.get("cache-control", "")}
+        for path, headers in headers_entries.items()
+    }
+    if actual != expected:
+        raise PublicationError("_headers Cache-Control rules do not match cache-policy.json")
 
 
 def collect_files(


### PR DESCRIPTION
## **User description**
## Summary
- Validate the public _headers file during S3 publication planning.
- Require _headers Cache-Control entries to match cache-policy.json before any upload plan or confirm run proceeds.
- Add an S3 publication regression for mismatched _headers cache metadata.

## Validation
- python scripts/check-hosted-linux-repository-s3-publication.py
- python -m compileall -q scripts
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Closes #589

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `_headers` Cache-Control rules against `cache-policy.json` during S3 publish planning to prevent mismatched caching. Blocks both dry-run and confirm when rules differ.

- **New Features**
  - Parse `_headers` and validate format, paths, and duplicates.
  - Compare per-path `Cache-Control` with `cache-policy.json`; raise on any diff.
  - Read `_headers` with size bounds and forbid unsafe text.
  - Add regression test to fail on mismatched `_headers` cache metadata.

<sup>Written for commit c35fbf6e9bad9de81feaef6400a0715504b65bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block S3 publication when `_headers` cache settings do not match the publish policy**

### What Changed
- S3 publish planning now checks the `_headers` file before any upload starts.
- Publishing is blocked if `_headers` has a different `Cache-Control` value than `cache-policy.json`.
- The planner also rejects malformed, duplicate, or unsafe `_headers` entries.
- Added a regression check that confirms mismatched `_headers` cache metadata fails the dry run.

### Impact
`✅ Fewer cache policy mismatches during publish`
`✅ Fewer accidental stale-file cache settings`
`✅ Earlier publish failures for invalid _headers files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
