### PR TITLE
Validate hosted S3 repository URLs

### DIFF
--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -165,6 +165,27 @@ def main() -> int:
                 VERSION,
             )
 
+        escaped_dot_download_url = temp / "escaped-dot-download-url"
+        shutil.copytree(site_root, escaped_dot_download_url)
+        with serve_site(escaped_dot_download_url, mode="good") as base_url:
+            rewrite_base_url(escaped_dot_download_url, PLACEHOLDER_BASE_URL, base_url)
+            repository_path = escaped_dot_download_url / "repository.json"
+            repository = json.loads(repository_path.read_text(encoding="ascii"))
+            repository["downloads"]["hostedBundleUrl"] = repository["downloads"][
+                "hostedBundleUrl"
+            ].replace("/downloads/", "/downloads/%2e%2e/")
+            repository_path.write_text(
+                json.dumps(repository, indent=2, sort_keys=True) + "\n",
+                encoding="ascii",
+                newline="\n",
+            )
+            run_checker_expect_failure(
+                base_url,
+                "path must not contain dot segments",
+                "--expected-version",
+                VERSION,
+            )
+
     print("Hosted Linux repository endpoint regression checks passed")
     return 0
 

--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -68,6 +68,12 @@ def main() -> int:
                 VERSION,
                 allow_loopback_http=False,
             )
+            run_checker_expect_failure(
+                f"{base_url}/%2e%2e%2fother",
+                "encoded separators",
+                "--expected-version",
+                VERSION,
+            )
 
         missing_cache_header = temp / "missing-cache-header"
         shutil.copytree(site_root, missing_cache_header)

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -12,7 +12,7 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import urljoin, urlparse, urlunparse
+from urllib.parse import unquote, urljoin, urlparse, urlunparse
 from urllib.request import Request, urlopen
 
 
@@ -265,6 +265,9 @@ def normalize_base_url(raw_value: str, *, allow_loopback_http: bool) -> str:
             )
     path_parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in path_parts):
+        raise EndpointReadinessError("hosted Linux repository base URL path must not contain dot segments")
+    decoded_path_parts = [unquote(part) for part in path_parts]
+    if any(part in {".", ".."} for part in decoded_path_parts):
         raise EndpointReadinessError("hosted Linux repository base URL path must not contain dot segments")
     path = "/" + "/".join(path_parts) if path_parts else ""
     netloc = normalize_netloc(host_lower, parsed.port)
@@ -602,6 +605,16 @@ def url_to_base_path(base_url: str, value: str, label: str) -> str:
     path_parts = [part for part in parsed_value.path.split("/") if part]
     if any(part in {".", ".."} for part in path_parts):
         raise EndpointReadinessError(f"{label} path must not contain dot segments")
+    decoded_path_parts = [unquote(part) for part in path_parts]
+    if any(part in {".", ".."} for part in decoded_path_parts):
+        raise EndpointReadinessError(f"{label} path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_path_parts):
+        raise EndpointReadinessError(f"{label} path must not contain encoded separators")
+    forbidden = sorted({part.lower() for part in decoded_path_parts} & FORBIDDEN_PATH_SEGMENTS)
+    if forbidden:
+        raise EndpointReadinessError(
+            f"{label} path contains forbidden local-state segment: {', '.join(forbidden)}"
+        )
     if base_path:
         if value_path != base_path and not value_path.startswith(f"{base_path}/"):
             raise EndpointReadinessError(f"{label} points outside repository path")

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -269,6 +269,10 @@ def normalize_base_url(raw_value: str, *, allow_loopback_http: bool) -> str:
     decoded_path_parts = [unquote(part) for part in path_parts]
     if any(part in {".", ".."} for part in decoded_path_parts):
         raise EndpointReadinessError("hosted Linux repository base URL path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_path_parts):
+        raise EndpointReadinessError(
+            "hosted Linux repository base URL path must not contain encoded separators"
+        )
     path = "/" + "/".join(path_parts) if path_parts else ""
     netloc = normalize_netloc(host_lower, parsed.port)
     return urlunparse((scheme, netloc, path, "", "", ""))

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -78,6 +78,23 @@ def main() -> int:
         )
         assert_failure("base URL mismatch", mismatch, "repository.json baseUrl does not match")
 
+        query_download_url = temp / "query-download-url-site"
+        shutil.copytree(site_dir, query_download_url)
+        repository_path = query_download_url / "repository.json"
+        repository = json.loads(repository_path.read_text(encoding="ascii"))
+        repository["downloads"]["hostedBundleUrl"] += "?token=value"
+        repository_path.write_text(
+            json.dumps(repository, indent=2, sort_keys=True) + "\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        query_download_result = run_publisher_raw(query_download_url, "--dry-run")
+        assert_failure(
+            "query download URL",
+            query_download_result,
+            "must not include params, query, or fragment",
+        )
+
         forbidden = temp / "forbidden-site"
         shutil.copytree(site_dir, forbidden)
         (forbidden / "README.txt").write_text("NPM_TOKEN\n", encoding="ascii")

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -78,6 +78,18 @@ def main() -> int:
         )
         assert_failure("base URL mismatch", mismatch, "repository.json baseUrl does not match")
 
+        encoded_base_result = run_publisher_raw(
+            site_dir,
+            "--dry-run",
+            "--base-url",
+            f"{BASE_URL}/%2e%2e%2fother",
+        )
+        assert_failure(
+            "encoded base URL",
+            encoded_base_result,
+            "repository base URL path must not contain encoded separators",
+        )
+
         query_download_url = temp / "query-download-url-site"
         shutil.copytree(site_dir, query_download_url)
         repository_path = query_download_url / "repository.json"

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -95,6 +95,25 @@ def main() -> int:
             "must not include params, query, or fragment",
         )
 
+        escaped_dot_download_url = temp / "escaped-dot-download-url-site"
+        shutil.copytree(site_dir, escaped_dot_download_url)
+        repository_path = escaped_dot_download_url / "repository.json"
+        repository = json.loads(repository_path.read_text(encoding="ascii"))
+        repository["downloads"]["hostedBundleUrl"] = repository["downloads"][
+            "hostedBundleUrl"
+        ].replace("/downloads/", "/downloads/%2e%2e/")
+        repository_path.write_text(
+            json.dumps(repository, indent=2, sort_keys=True) + "\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        escaped_dot_result = run_publisher_raw(escaped_dot_download_url, "--dry-run")
+        assert_failure(
+            "escaped dot download URL",
+            escaped_dot_result,
+            "path must not contain dot segments",
+        )
+
         forbidden = temp / "forbidden-site"
         shutil.copytree(site_dir, forbidden)
         (forbidden / "README.txt").write_text("NPM_TOKEN\n", encoding="ascii")

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -373,10 +373,64 @@ def validate_repository_json(
     for guard in ("payloadDisplayed", "tokenDisplayed", "keyMaterialDisplayed"):
         if repository.get(guard) is not False:
             raise PublicationError(f"repository.json expected {guard}=false")
-    for key in ("apt", "rpm", "downloads", "cachePolicy"):
-        if not isinstance(repository.get(key), dict):
-            raise PublicationError(f"repository.json {key} metadata is missing")
+    apt = require_object(repository, "apt", "repository.json")
+    rpm = require_object(repository, "rpm", "repository.json")
+    downloads = require_object(repository, "downloads", "repository.json")
+    cache_policy = require_object(repository, "cachePolicy", "repository.json")
+
+    expected_fields = {
+        "apt.repositoryUrl": (apt.get("repositoryUrl"), f"{base_url}/apt"),
+        "apt.keyUrl": (apt.get("keyUrl"), f"{base_url}/apt/{PUBLIC_KEY_NAME}"),
+        "rpm.repositoryUrl": (rpm.get("repositoryUrl"), f"{base_url}/rpm"),
+        "rpm.repoFileUrl": (rpm.get("repoFileUrl"), f"{base_url}/install/conu.repo"),
+        "rpm.keyUrl": (rpm.get("keyUrl"), f"{base_url}/rpm/{PUBLIC_KEY_NAME}"),
+        "cachePolicy.policyUrl": (cache_policy.get("policyUrl"), f"{base_url}/cache-policy.json"),
+        "cachePolicy.headersFileUrl": (cache_policy.get("headersFileUrl"), f"{base_url}/_headers"),
+    }
+    for name, (actual, expected) in expected_fields.items():
+        if actual != expected:
+            raise PublicationError(f"repository.json {name} does not match baseUrl")
+    if cache_policy.get("hostMustApply") is not True:
+        raise PublicationError("repository.json expected cachePolicy.hostMustApply=true")
+    for field in ("hostedBundleUrl", "hostedBundleChecksumUrl", "hostedBundleSignatureUrl"):
+        path = url_to_base_path(base_url, downloads.get(field), f"repository.json downloads.{field}")
+        if not path.startswith("/downloads/"):
+            raise PublicationError(f"repository.json downloads.{field} must point under baseUrl")
     return version
+
+
+def require_object(parent: dict[str, Any], key: str, label: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        raise PublicationError(f"{label} {key} metadata is missing")
+    return value
+
+
+def url_to_base_path(base_url: str, value: str, label: str) -> str:
+    if not isinstance(value, str):
+        raise PublicationError(f"{label} must be a URL string")
+    parsed_base = urlparse(base_url)
+    parsed_value = urlparse(value)
+    if parsed_value.username or parsed_value.password:
+        raise PublicationError(f"{label} must not include credentials")
+    if parsed_value.params or parsed_value.query or parsed_value.fragment:
+        raise PublicationError(f"{label} must not include params, query, or fragment")
+    if (parsed_value.scheme, parsed_value.netloc) != (parsed_base.scheme, parsed_base.netloc):
+        raise PublicationError(f"{label} points outside repository origin")
+    base_path = parsed_base.path.rstrip("/")
+    value_path = parsed_value.path.rstrip("/")
+    path_parts = [part for part in parsed_value.path.split("/") if part]
+    if any(part in {".", ".."} for part in path_parts):
+        raise PublicationError(f"{label} path must not contain dot segments")
+    if base_path:
+        if value_path != base_path and not value_path.startswith(f"{base_path}/"):
+            raise PublicationError(f"{label} points outside repository path")
+        relative = value_path[len(base_path) :]
+    else:
+        relative = value_path
+    if not relative.startswith("/"):
+        relative = f"/{relative}"
+    return validate_cache_path(relative or "/", f"{label} path")
 
 
 def validate_cache_policy_json(

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -19,7 +19,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, BinaryIO
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -338,6 +338,9 @@ def validate_base_url(raw: str) -> str:
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise PublicationError("repository base URL path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise PublicationError("repository base URL path must not contain dot segments")
     normalized_path = "/" + "/".join(parts) if parts else ""
     return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
 
@@ -422,6 +425,16 @@ def url_to_base_path(base_url: str, value: str, label: str) -> str:
     path_parts = [part for part in parsed_value.path.split("/") if part]
     if any(part in {".", ".."} for part in path_parts):
         raise PublicationError(f"{label} path must not contain dot segments")
+    decoded_path_parts = [unquote(part) for part in path_parts]
+    if any(part in {".", ".."} for part in decoded_path_parts):
+        raise PublicationError(f"{label} path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_path_parts):
+        raise PublicationError(f"{label} path must not contain encoded separators")
+    forbidden = sorted({part.lower() for part in decoded_path_parts} & FORBIDDEN_SEGMENTS)
+    if forbidden:
+        raise PublicationError(
+            f"{label} path contains forbidden local-state segment: {', '.join(forbidden)}"
+        )
     if base_path:
         if value_path != base_path and not value_path.startswith(f"{base_path}/"):
             raise PublicationError(f"{label} points outside repository path")

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -341,6 +341,8 @@ def validate_base_url(raw: str) -> str:
     decoded_parts = [unquote(part) for part in parts]
     if any(part in {".", ".."} for part in decoded_parts):
         raise PublicationError("repository base URL path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise PublicationError("repository base URL path must not contain encoded separators")
     normalized_path = "/" + "/".join(parts) if parts else ""
     return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
 


### PR DESCRIPTION
## Summary
- Validate repository.json APT, RPM, cache-policy, and download URL metadata before S3 publication planning.
- Reject repository and download metadata URLs with credentials, params, query strings, fragments, raw or percent-encoded dot segments, encoded separators, forbidden local-state segments, or origin/path escapes.
- Apply the encoded path and base URL guards to the live hosted endpoint checker as well.
- Add S3 and endpoint regressions for query-bearing, percent-encoded hosted bundle, and encoded base URL metadata.

## Validation
- python scripts/check-hosted-linux-repository-endpoint-regression.py
- python scripts/check-hosted-linux-repository-s3-publication.py
- python -m compileall -q scripts
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Closes #591