### PR TITLE
Validate hosted Pages repository URLs

### DIFF
--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -271,6 +271,80 @@ def main() -> int:
             "absolute https URL",
         )
 
+        encoded_base = temp / "encoded-base"
+        shutil.copytree(dist, encoded_base)
+        repository = read_site_json(encoded_base / SITE_BUNDLE)
+        cache_policy = read_site_json_member(encoded_base / SITE_BUNDLE, "cache-policy.json")
+        encoded_url = f"{BASE_URL}/%2e%2e%2fother"
+        rewrite_repository_base_url(repository, encoded_url)
+        cache_policy["baseUrl"] = encoded_url
+        rewrite_site_zip(
+            encoded_base / SITE_BUNDLE,
+            {
+                "repository.json": json.dumps(repository, indent=2, sort_keys=True).encode("ascii")
+                + b"\n",
+                "cache-policy.json": json.dumps(cache_policy, indent=2, sort_keys=True).encode("ascii")
+                + b"\n",
+            },
+        )
+        sign_site(encoded_base / SITE_BUNDLE)
+        expect_failure(
+            "encoded repository base URL",
+            encoded_base / SITE_BUNDLE,
+            temp / "encoded-base-pages",
+            "baseUrl path must not contain encoded separators",
+        )
+
+        off_origin_key = temp / "off-origin-key"
+        shutil.copytree(dist, off_origin_key)
+        repository = read_site_json(off_origin_key / SITE_BUNDLE)
+        repository["apt"]["keyUrl"] = "https://evil.example/conu-linux-gpg-key.asc"
+        rewrite_site_zip(
+            off_origin_key / SITE_BUNDLE,
+            {"repository.json": json.dumps(repository, indent=2, sort_keys=True).encode("ascii") + b"\n"},
+        )
+        sign_site(off_origin_key / SITE_BUNDLE)
+        expect_failure(
+            "off-origin APT key URL",
+            off_origin_key / SITE_BUNDLE,
+            temp / "off-origin-key-pages",
+            "repository.json apt.keyUrl points outside repository origin",
+        )
+
+        query_download = temp / "query-download"
+        shutil.copytree(dist, query_download)
+        repository = read_site_json(query_download / SITE_BUNDLE)
+        repository["downloads"]["hostedBundleUrl"] += "?token=value"
+        rewrite_site_zip(
+            query_download / SITE_BUNDLE,
+            {"repository.json": json.dumps(repository, indent=2, sort_keys=True).encode("ascii") + b"\n"},
+        )
+        sign_site(query_download / SITE_BUNDLE)
+        expect_failure(
+            "query download URL",
+            query_download / SITE_BUNDLE,
+            temp / "query-download-pages",
+            "repository.json downloads.hostedBundleUrl must not include params, query, or fragment",
+        )
+
+        escaped_download = temp / "escaped-download"
+        shutil.copytree(dist, escaped_download)
+        repository = read_site_json(escaped_download / SITE_BUNDLE)
+        repository["downloads"]["hostedBundleUrl"] = repository["downloads"][
+            "hostedBundleUrl"
+        ].replace("/downloads/", "/downloads/%2e%2e/")
+        rewrite_site_zip(
+            escaped_download / SITE_BUNDLE,
+            {"repository.json": json.dumps(repository, indent=2, sort_keys=True).encode("ascii") + b"\n"},
+        )
+        sign_site(escaped_download / SITE_BUNDLE)
+        expect_failure(
+            "escaped download URL",
+            escaped_download / SITE_BUNDLE,
+            temp / "escaped-download-pages",
+            "repository.json downloads.hostedBundleUrl path must not contain dot segments",
+        )
+
         non_empty_output = temp / "non-empty"
         non_empty_output.mkdir()
         (non_empty_output / "existing.txt").write_text("existing\n", encoding="ascii")
@@ -490,6 +564,27 @@ def read_site_json(path: Path) -> dict:
 def read_site_json_member(path: Path, name: str) -> dict:
     with zipfile.ZipFile(path) as archive:
         return json.loads(archive.read(name).decode("ascii"))
+
+
+def rewrite_repository_base_url(repository: dict, base_url: str) -> None:
+    repository["baseUrl"] = base_url
+    repository["apt"]["sourceList"] = (
+        f"deb [signed-by=/usr/share/keyrings/{PUBLIC_KEY}] {base_url}/apt ./"
+    )
+    repository["apt"]["repositoryUrl"] = f"{base_url}/apt"
+    repository["apt"]["keyUrl"] = f"{base_url}/apt/{PUBLIC_KEY}"
+    repository["rpm"]["repositoryUrl"] = f"{base_url}/rpm"
+    repository["rpm"]["repoFileUrl"] = f"{base_url}/install/conu.repo"
+    repository["rpm"]["keyUrl"] = f"{base_url}/rpm/{PUBLIC_KEY}"
+    repository["downloads"]["hostedBundleUrl"] = f"{base_url}/downloads/{HOSTED_BUNDLE}"
+    repository["downloads"]["hostedBundleChecksumUrl"] = (
+        f"{base_url}/downloads/{HOSTED_BUNDLE}.sha256"
+    )
+    repository["downloads"]["hostedBundleSignatureUrl"] = (
+        f"{base_url}/downloads/{HOSTED_BUNDLE}.asc"
+    )
+    repository["cachePolicy"]["policyUrl"] = f"{base_url}/cache-policy.json"
+    repository["cachePolicy"]["headersFileUrl"] = f"{base_url}/_headers"
 
 
 def sign_site(path: Path) -> None:

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -294,6 +294,24 @@ def main() -> int:
             "must not include params, query, or fragment",
         )
 
+        credential_url = temp / "credential-url"
+        shutil.copytree(dist, credential_url)
+        expect_failure(
+            "base URL with credentials",
+            credential_url,
+            "https://token@example.com/conu",
+            "must not include credentials",
+        )
+
+        encoded_base_url = temp / "encoded-base-url"
+        shutil.copytree(dist, encoded_base_url)
+        expect_failure(
+            "encoded base URL",
+            encoded_base_url,
+            f"{BASE_URL}/%2e%2e%2fother",
+            "path must not contain encoded separators",
+        )
+
     print("Hosted Linux repository site regression checks passed")
     return 0
 

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -14,7 +14,7 @@ import sys
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
@@ -184,14 +184,22 @@ def validate_base_url(raw: str) -> str:
             "CONU_LINUX_REPOSITORY_BASE_URL"
         )
     parsed = urlparse(raw)
+    if parsed.username or parsed.password:
+        raise SystemExit("hosted Linux repository base URL must not include credentials")
     if parsed.scheme != "https" or not parsed.netloc:
         raise SystemExit("hosted Linux repository base URL must be an absolute https URL")
     if parsed.params or parsed.query or parsed.fragment:
         raise SystemExit("hosted Linux repository base URL must not include params, query, or fragment")
-    normalized_path = "/" + "/".join(part for part in parsed.path.split("/") if part)
-    if normalized_path == "/":
-        normalized_path = ""
-    return urlunparse(("https", parsed.netloc, normalized_path, "", "", ""))
+    parts = [part for part in parsed.path.split("/") if part]
+    if any(part in {".", ".."} for part in parts):
+        raise SystemExit("hosted Linux repository base URL path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise SystemExit("hosted Linux repository base URL path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise SystemExit("hosted Linux repository base URL path must not contain encoded separators")
+    normalized_path = "/" + "/".join(parts) if parts else ""
+    return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
 
 
 def hosted_repository_bundle_filename(version: str) -> str:

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -14,7 +14,7 @@ import sys
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
@@ -445,9 +445,7 @@ def validate_repository_json(version: str, data: bytes) -> str:
     base_url = repository.get("baseUrl")
     if not isinstance(base_url, str):
         raise SystemExit("repository.json baseUrl is missing")
-    parsed = urlparse(base_url)
-    if parsed.scheme != "https" or not parsed.netloc or parsed.params or parsed.query or parsed.fragment:
-        raise SystemExit("repository.json baseUrl must be an absolute https URL without params, query, or fragment")
+    base_url = validate_repository_base_url(base_url)
     expected = {
         "payloadDisplayed": False,
         "tokenDisplayed": False,
@@ -458,22 +456,129 @@ def validate_repository_json(version: str, data: bytes) -> str:
             raise SystemExit(f"repository.json expected {key}=false")
     apt = repository.get("apt")
     rpm = repository.get("rpm")
-    if not isinstance(apt, dict) or not isinstance(rpm, dict):
-        raise SystemExit("repository.json apt/rpm metadata is missing")
-    if apt.get("repositoryUrl") != f"{base_url}/apt":
-        raise SystemExit("repository.json APT repository URL does not match baseUrl")
-    if rpm.get("repositoryUrl") != f"{base_url}/rpm":
-        raise SystemExit("repository.json RPM repository URL does not match baseUrl")
+    downloads = repository.get("downloads")
+    if not isinstance(apt, dict) or not isinstance(rpm, dict) or not isinstance(downloads, dict):
+        raise SystemExit("repository.json apt/rpm/download metadata is missing")
+    hosted_bundle = f"conu-{version}-hosted-linux-repositories.zip"
+    expected_paths = {
+        "repository.json apt.repositoryUrl": (apt.get("repositoryUrl"), "/apt"),
+        "repository.json apt.keyUrl": (apt.get("keyUrl"), f"/apt/{PUBLIC_KEY_NAME}"),
+        "repository.json rpm.repositoryUrl": (rpm.get("repositoryUrl"), "/rpm"),
+        "repository.json rpm.repoFileUrl": (rpm.get("repoFileUrl"), "/install/conu.repo"),
+        "repository.json rpm.keyUrl": (rpm.get("keyUrl"), f"/rpm/{PUBLIC_KEY_NAME}"),
+        "repository.json downloads.hostedBundleUrl": (
+            downloads.get("hostedBundleUrl"),
+            f"/downloads/{hosted_bundle}",
+        ),
+        "repository.json downloads.hostedBundleChecksumUrl": (
+            downloads.get("hostedBundleChecksumUrl"),
+            f"/downloads/{hosted_bundle}.sha256",
+        ),
+        "repository.json downloads.hostedBundleSignatureUrl": (
+            downloads.get("hostedBundleSignatureUrl"),
+            f"/downloads/{hosted_bundle}.asc",
+        ),
+    }
+    for label, (actual, expected_path) in expected_paths.items():
+        if url_to_base_path(base_url, actual, label) != expected_path:
+            raise SystemExit(f"{label} does not match baseUrl")
+    expected_source = f"deb [signed-by=/usr/share/keyrings/{PUBLIC_KEY_NAME}] {base_url}/apt ./"
+    if apt.get("sourceList") != expected_source:
+        raise SystemExit("repository.json APT source list does not match baseUrl")
     cache_policy = repository.get("cachePolicy")
     if not isinstance(cache_policy, dict):
         raise SystemExit("repository.json cachePolicy metadata is missing")
-    if cache_policy.get("policyUrl") != f"{base_url}/cache-policy.json":
+    if url_to_base_path(
+        base_url,
+        cache_policy.get("policyUrl"),
+        "repository.json cachePolicy.policyUrl",
+    ) != "/cache-policy.json":
         raise SystemExit("repository.json cache policy URL does not match baseUrl")
-    if cache_policy.get("headersFileUrl") != f"{base_url}/_headers":
+    if url_to_base_path(
+        base_url,
+        cache_policy.get("headersFileUrl"),
+        "repository.json cachePolicy.headersFileUrl",
+    ) != "/_headers":
         raise SystemExit("repository.json cache headers URL does not match baseUrl")
     if cache_policy.get("hostMustApply") is not True:
         raise SystemExit("repository.json expected cachePolicy.hostMustApply=true")
     return base_url
+
+
+def validate_repository_base_url(raw: str) -> str:
+    parsed = urlparse(raw.strip())
+    if parsed.username or parsed.password:
+        raise SystemExit("repository.json baseUrl must not include credentials")
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise SystemExit("repository.json baseUrl must be an absolute https URL")
+    if parsed.params or parsed.query or parsed.fragment:
+        raise SystemExit("repository.json baseUrl must not include params, query, or fragment")
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if any(part in {".", ".."} for part in path_parts):
+        raise SystemExit("repository.json baseUrl path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in path_parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise SystemExit("repository.json baseUrl path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise SystemExit("repository.json baseUrl path must not contain encoded separators")
+    normalized_path = "/" + "/".join(path_parts) if path_parts else ""
+    return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
+
+
+def url_to_base_path(base_url: str, value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise SystemExit(f"{label} must be a URL string")
+    parsed_base = urlparse(base_url)
+    parsed_value = urlparse(value)
+    if parsed_value.username or parsed_value.password:
+        raise SystemExit(f"{label} must not include credentials")
+    if parsed_value.params or parsed_value.query or parsed_value.fragment:
+        raise SystemExit(f"{label} must not include params, query, or fragment")
+    if (parsed_value.scheme, parsed_value.netloc.lower()) != (
+        parsed_base.scheme,
+        parsed_base.netloc.lower(),
+    ):
+        raise SystemExit(f"{label} points outside repository origin")
+    base_path = parsed_base.path.rstrip("/")
+    value_path = parsed_value.path.rstrip("/")
+    path_parts = [part for part in parsed_value.path.split("/") if part]
+    if any(part in {".", ".."} for part in path_parts):
+        raise SystemExit(f"{label} path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in path_parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise SystemExit(f"{label} path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise SystemExit(f"{label} path must not contain encoded separators")
+    forbidden = sorted({part.lower() for part in decoded_parts} & FORBIDDEN_SEGMENTS)
+    if forbidden:
+        raise SystemExit(
+            f"{label} path contains forbidden local-state segment: {', '.join(forbidden)}"
+        )
+    if base_path:
+        if value_path != base_path and not value_path.startswith(f"{base_path}/"):
+            raise SystemExit(f"{label} points outside repository path")
+        relative = value_path[len(base_path) :]
+    else:
+        relative = value_path
+    if not relative.startswith("/"):
+        relative = f"/{relative}"
+    return validate_repository_path(relative or "/", f"{label} path")
+
+
+def validate_repository_path(path: str, label: str) -> str:
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise SystemExit(f"{label} must be an absolute path")
+    if "\\" in path:
+        raise SystemExit(f"{label} must not contain backslashes")
+    if "?" in path or "#" in path:
+        raise SystemExit(f"{label} must not contain query or fragment")
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts[1:]):
+        raise SystemExit(f"{label} must not contain empty or dot segments")
+    forbidden = sorted({part.lower() for part in parts[1:]} & FORBIDDEN_SEGMENTS)
+    if forbidden:
+        raise SystemExit(f"{label} contains forbidden local-state segment: {', '.join(forbidden)}")
+    return path
 
 
 def validate_cache_policy_json(version: str, base_url: str, data: bytes) -> None:


### PR DESCRIPTION
## **User description**
## Summary
- harden hosted Linux repository site generation against credentialed and encoded unsafe base URLs
- make GitHub Pages preparation validate repository.json apt/rpm/download/cache-policy URLs against the normalized base URL
- add regressions for encoded base paths, off-origin key URLs, query-bearing download URLs, and escaped download path segments

## Validation
- python scripts/check-hosted-linux-repository-site.py
- python scripts/check-hosted-linux-repository-pages.py
- python scripts/check-hosted-linux-repository-s3-publication.py
- python scripts/check-hosted-linux-repository-endpoint-regression.py
- python scripts/check-hosted-linux-repositories.py
- python -m compileall -q scripts
- python scripts/check-tagged-release-readiness-regression.py
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Closes #593

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened hosted Linux Pages and site generation by validating `baseUrl` and repository metadata URLs to block unsafe and off‑origin links. This prevents credentialed, encoded, query/fragment URLs and keeps paths within the repository origin.

- **Bug Fixes**
  - Validate `baseUrl`: absolute `https`, no credentials/params, no dot segments or encoded separators; normalize path and host.
  - Enforce `repository.json` `apt`, `rpm`, `downloads`, and `cachePolicy` URLs match `baseUrl`, stay on origin/path, and use expected paths; verify APT source list.
  - Add regression checks for encoded base paths, off‑origin key URLs, query download URLs, escaped download segments, and credentialed base URLs.

<sup>Written for commit f40177879d5067f8ded2d7bec98bf74cdf1903aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block unsafe hosted repository links and reject malformed base URLs**

### What Changed
- Hosted repository sites now reject base URLs with credentials, dot segments, or encoded path separators.
- Repository metadata links are checked against the same base location, including APT, RPM, download, cache policy, and key files.
- Bad links are now blocked when they point off-origin or include query strings, escaped path segments, or local-state paths.
- Regression checks were added for credentialed base URLs, encoded paths, off-origin key URLs, and unsafe download links.

### Impact
`✅ Safer hosted repository links`
`✅ Fewer broken package download pages`
`✅ Lower risk of publishing unsafe metadata`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
