### PR TITLE
Harden release update policy base URLs

### DIFF
--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -191,6 +191,34 @@ def main() -> int:
         )
 
         expect_failure(
+            "release base URL with credentials",
+            dist,
+            "must not include credentials",
+            release_base_url="https://token@github.com/imthegoodboy/conU/releases/download/v0.1.0",
+        )
+
+        expect_failure(
+            "release base URL with raw dot segment",
+            dist,
+            "path must not contain dot segments",
+            release_base_url="https://github.com/imthegoodboy/conU/releases/download/../v0.1.0",
+        )
+
+        expect_failure(
+            "release base URL with encoded dot segment",
+            dist,
+            "path must not contain dot segments",
+            release_base_url="https://github.com/imthegoodboy/conU/releases/download/%2e%2e/v0.1.0",
+        )
+
+        expect_failure(
+            "release base URL with encoded separator",
+            dist,
+            "path must not contain encoded separators",
+            release_base_url="https://github.com/imthegoodboy/conU/releases/download/v0.1.0%2fother",
+        )
+
+        expect_failure(
             "tag mismatch",
             dist,
             "does not match version",

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -14,7 +14,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, BinaryIO
-from urllib.parse import quote, urlparse, urlunparse
+from urllib.parse import quote, unquote, urlparse, urlunparse
 
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
@@ -228,10 +228,16 @@ def validate_release_base_url(raw: str, repo: str, tag: str) -> str:
         raise SystemExit("release update policy base URL must not include credentials")
     if parsed.params or parsed.query or parsed.fragment:
         raise SystemExit("release update policy base URL must not include params, query, or fragment")
-    normalized_path = "/" + "/".join(part for part in parsed.path.split("/") if part)
-    if normalized_path == "/":
-        normalized_path = ""
-    return urlunparse(("https", parsed.netloc, normalized_path, "", "", ""))
+    parts = [part for part in parsed.path.split("/") if part]
+    if any(part in {".", ".."} for part in parts):
+        raise SystemExit("release update policy base URL path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise SystemExit("release update policy base URL path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise SystemExit("release update policy base URL path must not contain encoded separators")
+    normalized_path = "/" + "/".join(parts) if parts else ""
+    return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
 
 
 def build_update_policy(


### PR DESCRIPTION
## Summary
- reject release update policy base URL raw and encoded dot segments
- reject encoded path separators before generating update metadata URLs
- add regressions for credentials, traversal-shaped paths, and encoded separators

## Validation
- python scripts/check-release-update-policy.py
- python scripts/check-release-update-download-gate.py
- python scripts/check-tagged-release-readiness-regression.py
- python -m compileall -q scripts
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Closes #595

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened release update policy base URL validation to block credentials, dot segments (raw or encoded), and encoded separators. Also normalizes the path and lowercases the host, with new regression checks to prevent traversal-shaped URLs.

- **Bug Fixes**
  - Reject base URLs with credentials.
  - Reject raw and percent-encoded dot segments in paths.
  - Reject percent-encoded path separators before generating metadata URLs.
  - Normalize path and lowercase host; add regression cases in `scripts/check-release-update-policy.py`.

<sup>Written for commit 6c6ea45afc2d3ef4c7e796c19394e85c365b756d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

