### PR TITLE
Harden hosted repository readiness URLs

### DIFF
--- a/scripts/check-github-pages-readiness-regression.py
+++ b/scripts/check-github-pages-readiness-regression.py
@@ -77,6 +77,13 @@ def run_audit_tests(module) -> None:
     assert_not_ready_for(module, "public", False, "public")
     assert_not_ready_for(module, "html_url", "https://packages.example.com/conu/", "default base URL")
     assert_not_ready_for(module, "source", {"branch": "gh-pages", "path": "/"}, "main:/")
+    credentialed_payload = ready_payload()
+    credentialed_payload["html_url"] = f"https://user:{SENSITIVE_SENTINEL}@owner.github.io/repo/"
+    credentialed_report = module.audit_pages_readiness("owner/repo", credentialed_payload)
+    if credentialed_report.ready:
+        raise AssertionError("credentialed Pages html_url should not be ready")
+    if SENSITIVE_SENTINEL in json.dumps(credentialed_report.as_json()):
+        raise AssertionError("credentialed Pages html_url leaked into readiness report")
 
     custom = module.audit_pages_readiness(
         "owner/repo",
@@ -88,6 +95,30 @@ def run_audit_tests(module) -> None:
     assert_raises(
         lambda: module.audit_pages_readiness("owner/repo", None, "http://packages.example.com/conu"),
         "HTTPS",
+    )
+    assert_raises(
+        lambda: module.audit_pages_readiness(
+            "owner/repo",
+            None,
+            f"https://user:{SENSITIVE_SENTINEL}@packages.example.com/conu",
+        ),
+        "credentials",
+    )
+    assert_raises(
+        lambda: module.audit_pages_readiness(
+            "owner/repo",
+            None,
+            "https://packages.example.com/conu/%2e%2e/v0.1.0",
+        ),
+        "dot segments",
+    )
+    assert_raises(
+        lambda: module.audit_pages_readiness(
+            "owner/repo",
+            None,
+            "https://packages.example.com/conu/v0.1.0%2fother",
+        ),
+        "encoded separators",
     )
     default_custom = module.audit_pages_readiness(
         "owner/repo",

--- a/scripts/check-github-pages-readiness.py
+++ b/scripts/check-github-pages-readiness.py
@@ -10,7 +10,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 from github_release_secrets import find_gh, infer_repo, run_gh_json
 
@@ -49,11 +49,21 @@ def normalize_https_url(value: str, field_name: str) -> str:
     if not raw:
         raise ValueError(f"{field_name} must not be empty")
     parsed = urlparse(raw)
+    if parsed.username or parsed.password:
+        raise ValueError(f"{field_name} must not include credentials")
     if parsed.scheme.lower() != "https" or not parsed.netloc:
         raise ValueError(f"{field_name} must be an absolute HTTPS URL")
     if parsed.params or parsed.query or parsed.fragment:
         raise ValueError(f"{field_name} must not contain params, query, or fragment")
-    path = parsed.path.rstrip("/")
+    parts = [part for part in parsed.path.split("/") if part]
+    if any(part in {".", ".."} for part in parts):
+        raise ValueError(f"{field_name} path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise ValueError(f"{field_name} path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise ValueError(f"{field_name} path must not contain encoded separators")
+    path = "/" + "/".join(parts) if parts else ""
     return urlunparse(("https", parsed.netloc.lower(), path, "", "", ""))
 
 
@@ -69,7 +79,7 @@ def normalize_payload_url(payload: dict[str, Any]) -> str:
     try:
         return normalize_https_url(value, "GitHub Pages html_url")
     except ValueError:
-        return value.strip()
+        return ""
 
 
 def source_is_main_root(payload: dict[str, Any]) -> bool:

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -382,6 +382,56 @@ def run_custom_repository_tests(module) -> None:
         if expected not in rendered_invalid_optional:
             raise AssertionError(f"expected optional variable failure was missing: {expected}")
 
+    invalid_base_paths = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_custom_secrets(module),
+        variable_values={
+            module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/%2e%2e/v0.1.0",
+            module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+            module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+            module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com",
+            module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+        },
+        pages_payload=None,
+        release_payload=None,
+        npm_registry_check=False,
+    )
+    if invalid_base_paths.ready:
+        raise AssertionError("encoded custom repository base URL dot segment should fail")
+    parsed_invalid_base_paths = assert_safe_report(invalid_base_paths)
+    if (
+        "custom repository base URL path must not contain dot segments"
+        not in json.dumps(parsed_invalid_base_paths)
+    ):
+        raise AssertionError("encoded custom repository base URL dot segment failure was missing")
+
+    invalid_base_separator = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_custom_secrets(module),
+        variable_values={
+            module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/v0.1.0%2fother",
+            module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+            module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+            module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com",
+            module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+        },
+        pages_payload=None,
+        release_payload=None,
+        npm_registry_check=False,
+    )
+    if invalid_base_separator.ready:
+        raise AssertionError("encoded custom repository base URL separator should fail")
+    parsed_invalid_base_separator = assert_safe_report(invalid_base_separator)
+    if (
+        "custom repository base URL path must not contain encoded separators"
+        not in json.dumps(parsed_invalid_base_separator)
+    ):
+        raise AssertionError("encoded custom repository base URL separator failure was missing")
+
 
 def run_safe_failure_tests(module) -> None:
     invalid = module.audit_tagged_release_readiness(

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -13,7 +13,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote, urlparse, urlunparse
+from urllib.parse import quote, unquote, urlparse, urlunparse
 
 from github_release_secrets import (
     REQUIRED_RELEASE_SECRETS,
@@ -281,6 +281,11 @@ def normalize_custom_base_url(raw: str) -> str:
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise ValueError("custom repository base URL path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise ValueError("custom repository base URL path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise ValueError("custom repository base URL path must not contain encoded separators")
     path = "/" + "/".join(parts) if parts else ""
     return urlunparse(("https", parsed.netloc.lower(), path, "", "", ""))
 


### PR DESCRIPTION
## **User description**
## Summary
- reject credentialed URLs in GitHub Pages readiness normalization
- reject raw/decoded dot segments and encoded separators in Pages/custom repository readiness URL paths
- keep invalid Pages payload URLs out of readiness report fields
- add regressions for credential redaction and encoded traversal-shaped paths

## Validation
- python scripts/check-github-pages-readiness-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- python -m compileall -q scripts
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Closes #597

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened hosted repository readiness URL handling by rejecting credentialed URLs and traversal-shaped paths, and by sanitizing what we include in reports. This prevents sensitive data leaks and invalid URLs from passing readiness checks.

- **Bug Fixes**
  - Reject credentials in GitHub Pages `html_url` and custom base URLs.
  - Block raw/decoded dot segments and encoded separators (e.g., `%2e%2e`, `%2f`) in URL paths.
  - Exclude invalid Pages payload URLs from readiness report fields to avoid leaking sensitive data.
  - Add regression tests for credential redaction and traversal-shaped paths.

<sup>Written for commit d8b6d41b46273c126b105af0428f6361065924b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject unsafe hosted repository URLs and keep them out of readiness reports**

### What Changed
- Hosted repository readiness now rejects URLs with embedded credentials, dot segments, or encoded path separators.
- GitHub Pages readiness no longer exposes invalid `html_url` values in reports when the URL cannot be safely normalized.
- Added regression checks for credentialed URLs and traversal-shaped paths in both Pages and tagged release readiness.

### Impact
`✅ Fewer unsafe repository URLs passing readiness checks`
`✅ Clearer readiness errors for invalid hosted URLs`
`✅ Lower risk of leaking sensitive URL details in reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
