### PR TITLE
Harden hosted S3 endpoint URLs

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -146,6 +146,42 @@ def main() -> int:
         )
         assert_failure("bad endpoint URL", bad_endpoint, "S3 endpoint URL must use HTTPS")
 
+        raw_dot_endpoint = run_publisher_raw(
+            site_dir,
+            "--dry-run",
+            "--endpoint-url",
+            "https://s3.example.com/api/../v1",
+        )
+        assert_failure(
+            "raw dot endpoint URL",
+            raw_dot_endpoint,
+            "S3 endpoint URL path must not contain dot segments",
+        )
+
+        encoded_dot_endpoint = run_publisher_raw(
+            site_dir,
+            "--dry-run",
+            "--endpoint-url",
+            "https://s3.example.com/api/%2e%2e/v1",
+        )
+        assert_failure(
+            "encoded dot endpoint URL",
+            encoded_dot_endpoint,
+            "S3 endpoint URL path must not contain dot segments",
+        )
+
+        encoded_separator_endpoint = run_publisher_raw(
+            site_dir,
+            "--dry-run",
+            "--endpoint-url",
+            "https://s3.example.com/api%2fv1",
+        )
+        assert_failure(
+            "encoded separator endpoint URL",
+            encoded_separator_endpoint,
+            "S3 endpoint URL path must not contain encoded separators",
+        )
+
         oversized_metadata = temp / "oversized-metadata-site"
         shutil.copytree(site_dir, oversized_metadata)
         (oversized_metadata / "repository.json").write_text(

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -432,6 +432,56 @@ def run_custom_repository_tests(module) -> None:
     ):
         raise AssertionError("encoded custom repository base URL separator failure was missing")
 
+    invalid_endpoint_paths = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_custom_secrets(module),
+        variable_values={
+            module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/",
+            module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+            module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+            module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com/api/%2e%2e/v1",
+            module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+        },
+        pages_payload=None,
+        release_payload=None,
+        npm_registry_check=False,
+    )
+    if invalid_endpoint_paths.ready:
+        raise AssertionError("encoded custom repository endpoint URL dot segment should fail")
+    parsed_invalid_endpoint_paths = assert_safe_report(invalid_endpoint_paths)
+    if (
+        "custom repository S3 endpoint URL path must not contain dot segments"
+        not in json.dumps(parsed_invalid_endpoint_paths)
+    ):
+        raise AssertionError("encoded custom repository endpoint URL dot segment failure was missing")
+
+    invalid_endpoint_separator = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_custom_secrets(module),
+        variable_values={
+            module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/",
+            module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+            module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+            module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com/api%2fv1",
+            module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+        },
+        pages_payload=None,
+        release_payload=None,
+        npm_registry_check=False,
+    )
+    if invalid_endpoint_separator.ready:
+        raise AssertionError("encoded custom repository endpoint URL separator should fail")
+    parsed_invalid_endpoint_separator = assert_safe_report(invalid_endpoint_separator)
+    if (
+        "custom repository S3 endpoint URL path must not contain encoded separators"
+        not in json.dumps(parsed_invalid_endpoint_separator)
+    ):
+        raise AssertionError("encoded custom repository endpoint URL separator failure was missing")
+
 
 def run_safe_failure_tests(module) -> None:
     invalid = module.audit_tagged_release_readiness(

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -331,9 +331,19 @@ def validate_endpoint_url(raw: str) -> str:
     if not parsed.scheme or not parsed.netloc:
         raise ValueError("custom repository S3 endpoint URL must be absolute")
     host = (parsed.hostname or "").lower()
-    if parsed.scheme != "https" and not (parsed.scheme == "http" and is_loopback_host(host)):
+    scheme = parsed.scheme.lower()
+    if scheme != "https" and not (scheme == "http" and is_loopback_host(host)):
         raise ValueError("custom repository S3 endpoint URL must use HTTPS except loopback HTTP")
-    return urlunparse((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+    parts = [part for part in parsed.path.split("/") if part]
+    if any(part in {".", ".."} for part in parts):
+        raise ValueError("custom repository S3 endpoint URL path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise ValueError("custom repository S3 endpoint URL path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise ValueError("custom repository S3 endpoint URL path must not contain encoded separators")
+    path = "/" + "/".join(parts) if parts else ""
+    return urlunparse((scheme, parsed.netloc.lower(), path, "", "", ""))
 
 
 def validate_region(raw: str) -> str:

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -317,9 +317,19 @@ def validate_endpoint_url(raw: str) -> str:
     if not parsed.scheme or not parsed.netloc:
         raise PublicationError("S3 endpoint URL must be absolute")
     host = (parsed.hostname or "").lower()
-    if parsed.scheme != "https" and not (parsed.scheme == "http" and is_loopback_host(host)):
+    scheme = parsed.scheme.lower()
+    if scheme != "https" and not (scheme == "http" and is_loopback_host(host)):
         raise PublicationError("S3 endpoint URL must use HTTPS except loopback HTTP")
-    return urlunparse((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+    parts = [part for part in parsed.path.split("/") if part]
+    if any(part in {".", ".."} for part in parts):
+        raise PublicationError("S3 endpoint URL path must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise PublicationError("S3 endpoint URL path must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise PublicationError("S3 endpoint URL path must not contain encoded separators")
+    path = "/" + "/".join(parts) if parts else ""
+    return urlunparse((scheme, parsed.netloc.lower(), path, "", "", ""))
 
 
 def is_loopback_host(host: str) -> bool:


### PR DESCRIPTION
## **User description**
## Summary
- reject raw and encoded dot segments in custom hosted S3 endpoint URL paths
- reject encoded path separators in S3 endpoint URL paths
- apply the same guard in tagged release readiness and the actual S3 publisher
- add regressions for raw dot, encoded dot, and encoded separator endpoint paths

## Validation
- python scripts/check-hosted-linux-repository-s3-publication.py
- python scripts/check-tagged-release-readiness-regression.py
- python -m compileall -q scripts
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Closes #599

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened validation for hosted S3 endpoint URLs to block path traversal and encoded separator bypasses in both the publisher and tagged release readiness. Adds regression tests for raw/encoded dot segments and encoded '/' in paths. Closes #599.

- **Bug Fixes**
  - Disallow '.' and '..' path segments, including percent-encoded forms.
  - Disallow percent-encoded path separators in path components.
  - Apply the same checks in tagged release readiness and the S3 publisher; normalize scheme/host to lowercase, canonicalize path; enforce HTTPS except loopback HTTP.

<sup>Written for commit 1f6bda764d5902affef16b5d10d21cdf97e05e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block unsafe S3 endpoint URLs in publication checks**

### What Changed
- S3 endpoint URLs now reject path segments like `.` and `..`, including percent-encoded forms
- S3 endpoint URLs now reject encoded `/` or `\` in path segments
- The same checks now apply in both the release readiness check and the S3 publisher
- Endpoint URLs are normalized to use lowercase scheme and host before use

### Impact
`✅ Fewer broken S3 uploads from unsafe endpoint paths`
`✅ Lower risk of path traversal in release publishing`
`✅ Clearer failure messages for invalid custom endpoints`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
