### PR TITLE
Harden release update client URL paths

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -10157,6 +10157,7 @@ fn parse_https_update_url(
     {
         return Err(format!("release update policy {label} URL is invalid"));
     }
+    validate_update_url_path(&path_and_query, label)?;
 
     let (host, port) = parse_update_authority(authority, label)?;
     validate_update_public_host(&host, label)?;
@@ -10199,6 +10200,61 @@ fn parse_update_authority(authority: &str, label: &str) -> Result<(String, u16),
         _ => (authority, 443),
     };
     Ok((host.trim().to_ascii_lowercase(), port))
+}
+
+fn validate_update_url_path(path_and_query: &str, label: &str) -> Result<(), String> {
+    let path = path_and_query.split('?').next().unwrap_or_default();
+    for segment in path.split('/').filter(|segment| !segment.is_empty()) {
+        if segment == "." || segment == ".." {
+            return Err(format!(
+                "release update policy {label} path must not contain dot segments"
+            ));
+        }
+        let decoded = percent_decode_update_path_segment(segment, label)?;
+        if decoded == b"." || decoded == b".." {
+            return Err(format!(
+                "release update policy {label} path must not contain dot segments"
+            ));
+        }
+        if decoded.contains(&b'/') || decoded.contains(&b'\\') {
+            return Err(format!(
+                "release update policy {label} path must not contain encoded separators"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn percent_decode_update_path_segment(segment: &str, label: &str) -> Result<Vec<u8>, String> {
+    let bytes = segment.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len() {
+                return Err(format!("release update policy {label} URL is invalid"));
+            }
+            let high = hex_value(bytes[index + 1])
+                .ok_or_else(|| format!("release update policy {label} URL is invalid"))?;
+            let low = hex_value(bytes[index + 2])
+                .ok_or_else(|| format!("release update policy {label} URL is invalid"))?;
+            decoded.push((high << 4) | low);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    Ok(decoded)
+}
+
+fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
 }
 
 fn validate_update_public_host(host: &str, label: &str) -> Result<(), String> {
@@ -11621,6 +11677,60 @@ mod tests {
 
         assert_eq!(output.code, 1);
         assert!(output.stderr.contains("host must be public"));
+    }
+
+    #[test]
+    fn update_check_rejects_traversal_shaped_remote_policy_url_paths() {
+        for (url, expected) in [
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/../conu-0.1.0-update-policy.json",
+                "path must not contain dot segments",
+            ),
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/%2e%2e/conu-0.1.0-update-policy.json",
+                "path must not contain dot segments",
+            ),
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/v0.1.0%2fother/conu-0.1.0-update-policy.json",
+                "path must not contain encoded separators",
+            ),
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/v0.1.0%5cother/conu-0.1.0-update-policy.json",
+                "path must not contain encoded separators",
+            ),
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/bad%zz/conu-0.1.0-update-policy.json",
+                "URL is invalid",
+            ),
+        ] {
+            let output = run(["update", "check", "--policy-url", url]);
+
+            assert_eq!(output.code, 1, "{url}: {}", output.stderr);
+            assert!(output.stderr.contains(expected), "{url}: {}", output.stderr);
+            assert!(!output.stderr.contains("private message contents"));
+        }
+    }
+
+    #[test]
+    fn update_policy_metadata_url_validation_rejects_traversal_shaped_paths() {
+        for (url, expected) in [
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/../v0.1.0",
+                "path must not contain dot segments",
+            ),
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/%2e%2e/v0.1.0",
+                "path must not contain dot segments",
+            ),
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/v0.1.0%2fother",
+                "path must not contain encoded separators",
+            ),
+        ] {
+            let error =
+                validate_public_https_url(url, "releaseBaseUrl").expect_err("URL should fail");
+            assert!(error.contains(expected), "{url}: {error}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- reject raw dot segments, encoded dot segments, and encoded path separators in release update client URL paths
- apply the guard in the shared update URL parser used by policy URLs, sidecar URLs, asset URLs, and redirects
- add regressions for traversal-shaped remote policy URLs and policy metadata URL validation

## Validation
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

## Local test note
- cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_check_rejects_traversal_shaped_remote_policy_url_paths -- --nocapture could not run locally because dlltool.exe is missing on this workstation
- cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_policy_metadata_url_validation_rejects_traversal_shaped_paths -- --nocapture hit the same dlltool.exe toolchain blocker
- cargo check with the default MSVC toolchain also cannot run locally because link.exe is missing

Closes #601

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened update URL path validation to block traversal via dot segments and encoded separators. Affects policy, sidecar, asset, and redirect URL parsing.

- **Bug Fixes**
  - Percent-decode each path segment and reject "." or "..".
  - Reject encoded "/" and "\" in segments; error on malformed percent encodings.
  - Applied the guard in the shared HTTPS update URL parser.
  - Added regression tests for traversal-shaped policy URLs and metadata URL validation.

<sup>Written for commit 9ff7336b49194d0f28e3bd95b0dab325a5247ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block unsafe paths in release update URLs**

### What Changed
- Release update URLs now reject path traversal patterns like `../` and encoded `..`
- URLs also fail when a path segment hides `/` or `\` through encoding, or when percent-encoding is malformed
- The same checks now apply to policy URLs and policy metadata URLs, with new regression coverage for these cases

### Impact
`✅ Fewer update URL traversal bypasses`
`✅ Safer remote policy checks`
`✅ Clearer errors for invalid release URLs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
