### PR TITLE
Harden release update URL authorities

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -10190,14 +10190,21 @@ fn parse_update_authority(authority: &str, label: &str) -> Result<(String, u16),
 
     let (host, port) = match authority.rsplit_once(':') {
         Some((host, port_text))
-            if !port_text.is_empty() && port_text.chars().all(|c| c.is_ascii_digit()) =>
+            if !host.is_empty()
+                && !port_text.is_empty()
+                && port_text.chars().all(|c| c.is_ascii_digit()) =>
         {
             let port = port_text
                 .parse::<u16>()
                 .map_err(|_| format!("release update policy {label} port is invalid"))?;
             (host, port)
         }
-        _ => (authority, 443),
+        Some((_host, _port_text)) => {
+            return Err(format!(
+                "release update policy {label} authority is invalid"
+            ));
+        }
+        None => (authority, 443),
     };
     Ok((host.trim().to_ascii_lowercase(), port))
 }
@@ -11677,6 +11684,40 @@ mod tests {
 
         assert_eq!(output.code, 1);
         assert!(output.stderr.contains("host must be public"));
+    }
+
+    #[test]
+    fn update_check_rejects_malformed_remote_policy_url_authorities() {
+        for url in [
+            "https://github.com:/conu-0.1.0-update-policy.json",
+            "https://github.com:bad/conu-0.1.0-update-policy.json",
+            "https://github.com:443x/conu-0.1.0-update-policy.json",
+            "https://:443/conu-0.1.0-update-policy.json",
+        ] {
+            let output = run(["update", "check", "--policy-url", url]);
+
+            assert_eq!(output.code, 1, "{url}: {}", output.stderr);
+            assert!(
+                output.stderr.contains("authority is invalid"),
+                "{url}: {}",
+                output.stderr
+            );
+            assert!(!output.stderr.contains("private message contents"));
+        }
+    }
+
+    #[test]
+    fn update_policy_metadata_url_validation_rejects_malformed_authorities() {
+        for url in [
+            "https://github.com:/releases/download/v0.1.0",
+            "https://github.com:bad/releases/download/v0.1.0",
+            "https://github.com:443x/releases/download/v0.1.0",
+            "https://:443/releases/download/v0.1.0",
+        ] {
+            let error =
+                validate_public_https_url(url, "releaseBaseUrl").expect_err("URL should fail");
+            assert!(error.contains("authority is invalid"), "{url}: {error}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject malformed non-bracketed update URL authorities with colon text
- require numeric ports when a non-IPv6 update URL authority includes a port separator
- add regressions for remote policy URLs and policy metadata URL validation

## Validation
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

## Local test note
- cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_check_rejects_malformed_remote_policy_url_authorities -- --nocapture could not run locally because dlltool.exe is missing on this workstation

Closes #603

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened `conu-cli` release update URL authority parsing to reject malformed hosts/ports and prevent ambiguous authorities. Adds regression tests for remote policy and metadata URLs.

- **Bug Fixes**
  - Fail when a colon is present but the host is empty or the port is non-numeric; return "authority is invalid".
  - Use port 443 only when no port is provided.
  - Add tests for malformed authorities in update checks and policy metadata URL validation, ensuring no private content appears in errors.

<sup>Written for commit 2cc9d115c7705fb185a7dd934ea95e10668c6235. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

