### PR TITLE
Harden release URL authority validation

### DIFF
--- a/scripts/check-github-pages-readiness-regression.py
+++ b/scripts/check-github-pages-readiness-regression.py
@@ -104,6 +104,16 @@ def run_audit_tests(module) -> None:
         ),
         "credentials",
     )
+    for bad_url, expected in (
+        ("https://packages.example.com:bad/conu", "authority is invalid"),
+        ("https://packages.example.com:/conu", "authority is invalid"),
+        ("https://:443/conu", "authority must include a host"),
+        ("https://packages.example.com:443x/conu", "authority is invalid"),
+    ):
+        assert_raises(
+            lambda bad_url=bad_url: module.audit_pages_readiness("owner/repo", None, bad_url),
+            expected,
+        )
     assert_raises(
         lambda: module.audit_pages_readiness(
             "owner/repo",

--- a/scripts/check-github-pages-readiness.py
+++ b/scripts/check-github-pages-readiness.py
@@ -55,6 +55,7 @@ def normalize_https_url(value: str, field_name: str) -> str:
         raise ValueError(f"{field_name} must be an absolute HTTPS URL")
     if parsed.params or parsed.query or parsed.fragment:
         raise ValueError(f"{field_name} must not contain params, query, or fragment")
+    netloc = normalize_url_netloc(parsed, field_name)
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise ValueError(f"{field_name} path must not contain dot segments")
@@ -64,7 +65,25 @@ def normalize_https_url(value: str, field_name: str) -> str:
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise ValueError(f"{field_name} path must not contain encoded separators")
     path = "/" + "/".join(parts) if parts else ""
-    return urlunparse(("https", parsed.netloc.lower(), path, "", "", ""))
+    return urlunparse(("https", netloc, path, "", "", ""))
+
+
+def normalize_url_netloc(parsed, field_name: str) -> str:
+    try:
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"{field_name} authority is invalid") from exc
+    if not host:
+        raise ValueError(f"{field_name} authority must include a host")
+    if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise ValueError(f"{field_name} authority is invalid")
+    host = host.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is None:
+        return host
+    return f"{host}:{port}"
 
 
 def default_pages_base_url(repo: str) -> str:

--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -74,6 +74,18 @@ def main() -> int:
                 "--expected-version",
                 VERSION,
             )
+            for bad_url, expected in (
+                (f"{base_url}:bad", "authority"),
+                (f"{base_url}:", "authority"),
+                ("http://:443/conu", "host"),
+                (f"{base_url}:443x", "authority"),
+            ):
+                run_checker_expect_failure(
+                    bad_url,
+                    expected,
+                    "--expected-version",
+                    VERSION,
+                )
 
         missing_cache_header = temp / "missing-cache-header"
         shutil.copytree(site_root, missing_cache_header)

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -253,7 +253,10 @@ def normalize_base_url(raw_value: str, *, allow_loopback_http: bool) -> str:
         raise EndpointReadinessError(
             "hosted Linux repository base URL must not include params, query, or fragment"
         )
-    host = parsed.hostname
+    try:
+        host = parsed.hostname
+    except ValueError as exc:
+        raise EndpointReadinessError("hosted Linux repository base URL authority is invalid") from exc
     if not host:
         raise EndpointReadinessError("hosted Linux repository base URL must include a host")
     scheme = parsed.scheme.lower()
@@ -263,6 +266,7 @@ def normalize_base_url(raw_value: str, *, allow_loopback_http: bool) -> str:
             raise EndpointReadinessError(
                 "hosted Linux repository base URL must be an absolute HTTPS URL"
             )
+    port = validate_url_port(parsed, "hosted Linux repository base URL")
     path_parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in path_parts):
         raise EndpointReadinessError("hosted Linux repository base URL path must not contain dot segments")
@@ -274,8 +278,18 @@ def normalize_base_url(raw_value: str, *, allow_loopback_http: bool) -> str:
             "hosted Linux repository base URL path must not contain encoded separators"
         )
     path = "/" + "/".join(path_parts) if path_parts else ""
-    netloc = normalize_netloc(host_lower, parsed.port)
+    netloc = normalize_netloc(host_lower, port)
     return urlunparse((scheme, netloc, path, "", "", ""))
+
+
+def validate_url_port(parsed, label: str) -> int | None:
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise EndpointReadinessError(f"{label} authority is invalid") from exc
+    if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise EndpointReadinessError(f"{label} authority is invalid")
+    return port
 
 
 def normalize_netloc(host: str, port: int | None) -> str:

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -50,6 +50,17 @@ def main() -> int:
         assert_pages_output(pages, site)
 
         preparer = load_pages_preparer()
+        for bad_url in (
+            "https://imthegoodboy.github.io:bad/conU",
+            "https://imthegoodboy.github.io:/conU",
+            "https://:443/conU",
+            "https://imthegoodboy.github.io:443x/conU",
+        ):
+            expect_action_failure(
+                lambda bad_url=bad_url: preparer.validate_repository_base_url(bad_url),
+                "authority",
+                "malformed repository base URL authority",
+            )
         expect_zip_bound_failure(
             preparer,
             site,

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -90,6 +90,24 @@ def main() -> int:
             "repository base URL path must not contain encoded separators",
         )
 
+        for bad_url in (
+            "https://packages.example.com:bad/conu",
+            "https://packages.example.com:/conu",
+            "https://:443/conu",
+            "https://packages.example.com:443x/conu",
+        ):
+            malformed_base = run_publisher_raw(
+                site_dir,
+                "--dry-run",
+                "--base-url",
+                bad_url,
+            )
+            assert_failure(
+                "malformed repository base URL authority",
+                malformed_base,
+                "repository base URL authority",
+            )
+
         query_download_url = temp / "query-download-url-site"
         shutil.copytree(site_dir, query_download_url)
         repository_path = query_download_url / "repository.json"
@@ -181,6 +199,24 @@ def main() -> int:
             encoded_separator_endpoint,
             "S3 endpoint URL path must not contain encoded separators",
         )
+
+        for bad_url in (
+            "https://s3.example.com:bad/api",
+            "https://s3.example.com:/api",
+            "https://:443/api",
+            "https://s3.example.com:443x/api",
+        ):
+            malformed_endpoint = run_publisher_raw(
+                site_dir,
+                "--dry-run",
+                "--endpoint-url",
+                bad_url,
+            )
+            assert_failure(
+                "malformed endpoint URL authority",
+                malformed_endpoint,
+                "S3 endpoint URL authority",
+            )
 
         oversized_metadata = temp / "oversized-metadata-site"
         shutil.copytree(site_dir, oversized_metadata)

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -303,6 +303,21 @@ def main() -> int:
             "must not include credentials",
         )
 
+        for index, bad_url in enumerate((
+            "https://packages.example.com:bad/conu",
+            "https://packages.example.com:/conu",
+            "https://:443/conu",
+            "https://packages.example.com:443x/conu",
+        )):
+            malformed_url = temp / f"malformed-url-{index}"
+            shutil.copytree(dist, malformed_url)
+            expect_failure(
+                "malformed base URL authority",
+                malformed_url,
+                bad_url,
+                "authority",
+            )
+
         encoded_base_url = temp / "encoded-base-url"
         shutil.copytree(dist, encoded_base_url)
         expect_failure(

--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -197,6 +197,19 @@ def main() -> int:
             release_base_url="https://token@github.com/imthegoodboy/conU/releases/download/v0.1.0",
         )
 
+        for bad_url in (
+            "https://github.com:bad/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://github.com:/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://:443/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://github.com:443x/imthegoodboy/conU/releases/download/v0.1.0",
+        ):
+            expect_failure(
+                "malformed release base URL authority",
+                dist,
+                "authority",
+                release_base_url=bad_url,
+            )
+
         expect_failure(
             "release base URL with raw dot segment",
             dist,

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -432,6 +432,31 @@ def run_custom_repository_tests(module) -> None:
     ):
         raise AssertionError("encoded custom repository base URL separator failure was missing")
 
+    invalid_base_authority = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_custom_secrets(module),
+        variable_values={
+            module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com:bad/conu",
+            module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+            module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+            module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com",
+            module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+        },
+        pages_payload=None,
+        release_payload=None,
+        npm_registry_check=False,
+    )
+    if invalid_base_authority.ready:
+        raise AssertionError("malformed custom repository base URL authority should fail")
+    parsed_invalid_base_authority = assert_safe_report(invalid_base_authority)
+    if (
+        "custom repository base URL authority is invalid"
+        not in json.dumps(parsed_invalid_base_authority)
+    ):
+        raise AssertionError("malformed custom repository base URL authority failure was missing")
+
     invalid_endpoint_paths = module.audit_tagged_release_readiness(
         repo="owner/repo",
         tag=TAG,
@@ -481,6 +506,31 @@ def run_custom_repository_tests(module) -> None:
         not in json.dumps(parsed_invalid_endpoint_separator)
     ):
         raise AssertionError("encoded custom repository endpoint URL separator failure was missing")
+
+    invalid_endpoint_authority = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_custom_secrets(module),
+        variable_values={
+            module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/",
+            module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+            module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+            module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com:/api",
+            module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+        },
+        pages_payload=None,
+        release_payload=None,
+        npm_registry_check=False,
+    )
+    if invalid_endpoint_authority.ready:
+        raise AssertionError("malformed custom repository endpoint URL authority should fail")
+    parsed_invalid_endpoint_authority = assert_safe_report(invalid_endpoint_authority)
+    if (
+        "custom repository S3 endpoint URL authority is invalid"
+        not in json.dumps(parsed_invalid_endpoint_authority)
+    ):
+        raise AssertionError("malformed custom repository endpoint URL authority failure was missing")
 
 
 def run_safe_failure_tests(module) -> None:

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -278,6 +278,7 @@ def normalize_custom_base_url(raw: str) -> str:
         raise ValueError("custom repository base URL must be an absolute HTTPS URL")
     if parsed.params or parsed.query or parsed.fragment:
         raise ValueError("custom repository base URL must not include params, query, or fragment")
+    netloc = normalize_url_netloc(parsed, "custom repository base URL")
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise ValueError("custom repository base URL path must not contain dot segments")
@@ -287,7 +288,7 @@ def normalize_custom_base_url(raw: str) -> str:
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise ValueError("custom repository base URL path must not contain encoded separators")
     path = "/" + "/".join(parts) if parts else ""
-    return urlunparse(("https", parsed.netloc.lower(), path, "", "", ""))
+    return urlunparse(("https", netloc, path, "", "", ""))
 
 
 def validate_bucket(raw: str) -> str:
@@ -330,6 +331,7 @@ def validate_endpoint_url(raw: str) -> str:
         raise ValueError("custom repository S3 endpoint URL must not include params, query, or fragment")
     if not parsed.scheme or not parsed.netloc:
         raise ValueError("custom repository S3 endpoint URL must be absolute")
+    netloc = normalize_url_netloc(parsed, "custom repository S3 endpoint URL")
     host = (parsed.hostname or "").lower()
     scheme = parsed.scheme.lower()
     if scheme != "https" and not (scheme == "http" and is_loopback_host(host)):
@@ -343,7 +345,25 @@ def validate_endpoint_url(raw: str) -> str:
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise ValueError("custom repository S3 endpoint URL path must not contain encoded separators")
     path = "/" + "/".join(parts) if parts else ""
-    return urlunparse((scheme, parsed.netloc.lower(), path, "", "", ""))
+    return urlunparse((scheme, netloc, path, "", "", ""))
+
+
+def normalize_url_netloc(parsed, label: str) -> str:
+    try:
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"{label} authority is invalid") from exc
+    if not host:
+        raise ValueError(f"{label} authority must include a host")
+    if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise ValueError(f"{label} authority is invalid")
+    host = host.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is None:
+        return host
+    return f"{host}:{port}"
 
 
 def validate_region(raw: str) -> str:

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -190,6 +190,7 @@ def validate_base_url(raw: str) -> str:
         raise SystemExit("hosted Linux repository base URL must be an absolute https URL")
     if parsed.params or parsed.query or parsed.fragment:
         raise SystemExit("hosted Linux repository base URL must not include params, query, or fragment")
+    netloc = normalize_url_netloc(parsed, "hosted Linux repository base URL")
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise SystemExit("hosted Linux repository base URL path must not contain dot segments")
@@ -199,7 +200,25 @@ def validate_base_url(raw: str) -> str:
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise SystemExit("hosted Linux repository base URL path must not contain encoded separators")
     normalized_path = "/" + "/".join(parts) if parts else ""
-    return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
+    return urlunparse(("https", netloc, normalized_path, "", "", ""))
+
+
+def normalize_url_netloc(parsed, label: str) -> str:
+    try:
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise SystemExit(f"{label} authority is invalid") from exc
+    if not host:
+        raise SystemExit(f"{label} authority must include a host")
+    if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise SystemExit(f"{label} authority is invalid")
+    host = host.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is None:
+        return host
+    return f"{host}:{port}"
 
 
 def hosted_repository_bundle_filename(version: str) -> str:

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -228,6 +228,7 @@ def validate_release_base_url(raw: str, repo: str, tag: str) -> str:
         raise SystemExit("release update policy base URL must not include credentials")
     if parsed.params or parsed.query or parsed.fragment:
         raise SystemExit("release update policy base URL must not include params, query, or fragment")
+    netloc = normalize_url_netloc(parsed, "release update policy base URL")
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise SystemExit("release update policy base URL path must not contain dot segments")
@@ -237,7 +238,25 @@ def validate_release_base_url(raw: str, repo: str, tag: str) -> str:
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise SystemExit("release update policy base URL path must not contain encoded separators")
     normalized_path = "/" + "/".join(parts) if parts else ""
-    return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
+    return urlunparse(("https", netloc, normalized_path, "", "", ""))
+
+
+def normalize_url_netloc(parsed, label: str) -> str:
+    try:
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise SystemExit(f"{label} authority is invalid") from exc
+    if not host:
+        raise SystemExit(f"{label} authority must include a host")
+    if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise SystemExit(f"{label} authority is invalid")
+    host = host.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is None:
+        return host
+    return f"{host}:{port}"
 
 
 def build_update_policy(

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -513,6 +513,7 @@ def validate_repository_base_url(raw: str) -> str:
         raise SystemExit("repository.json baseUrl must be an absolute https URL")
     if parsed.params or parsed.query or parsed.fragment:
         raise SystemExit("repository.json baseUrl must not include params, query, or fragment")
+    netloc = normalize_url_netloc(parsed, "repository.json baseUrl")
     path_parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in path_parts):
         raise SystemExit("repository.json baseUrl path must not contain dot segments")
@@ -522,7 +523,25 @@ def validate_repository_base_url(raw: str) -> str:
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise SystemExit("repository.json baseUrl path must not contain encoded separators")
     normalized_path = "/" + "/".join(path_parts) if path_parts else ""
-    return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
+    return urlunparse(("https", netloc, normalized_path, "", "", ""))
+
+
+def normalize_url_netloc(parsed, label: str) -> str:
+    try:
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise SystemExit(f"{label} authority is invalid") from exc
+    if not host:
+        raise SystemExit(f"{label} authority must include a host")
+    if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise SystemExit(f"{label} authority is invalid")
+    host = host.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is None:
+        return host
+    return f"{host}:{port}"
 
 
 def url_to_base_path(base_url: str, value: object, label: str) -> str:

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -316,6 +316,7 @@ def validate_endpoint_url(raw: str) -> str:
         raise PublicationError("S3 endpoint URL must not include params, query, or fragment")
     if not parsed.scheme or not parsed.netloc:
         raise PublicationError("S3 endpoint URL must be absolute")
+    netloc = normalize_url_netloc(parsed, "S3 endpoint URL")
     host = (parsed.hostname or "").lower()
     scheme = parsed.scheme.lower()
     if scheme != "https" and not (scheme == "http" and is_loopback_host(host)):
@@ -329,7 +330,7 @@ def validate_endpoint_url(raw: str) -> str:
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise PublicationError("S3 endpoint URL path must not contain encoded separators")
     path = "/" + "/".join(parts) if parts else ""
-    return urlunparse((scheme, parsed.netloc.lower(), path, "", "", ""))
+    return urlunparse((scheme, netloc, path, "", "", ""))
 
 
 def is_loopback_host(host: str) -> bool:
@@ -345,6 +346,7 @@ def validate_base_url(raw: str) -> str:
         raise PublicationError("repository base URL must be an absolute HTTPS URL")
     if parsed.params or parsed.query or parsed.fragment:
         raise PublicationError("repository base URL must not include params, query, or fragment")
+    netloc = normalize_url_netloc(parsed, "repository base URL")
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise PublicationError("repository base URL path must not contain dot segments")
@@ -354,7 +356,25 @@ def validate_base_url(raw: str) -> str:
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise PublicationError("repository base URL path must not contain encoded separators")
     normalized_path = "/" + "/".join(parts) if parts else ""
-    return urlunparse(("https", parsed.netloc.lower(), normalized_path, "", "", ""))
+    return urlunparse(("https", netloc, normalized_path, "", "", ""))
+
+
+def normalize_url_netloc(parsed, label: str) -> str:
+    try:
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise PublicationError(f"{label} authority is invalid") from exc
+    if not host:
+        raise PublicationError(f"{label} authority must include a host")
+    if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise PublicationError(f"{label} authority is invalid")
+    host = host.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is None:
+        return host
+    return f"{host}:{port}"
 
 
 def read_json_file(path: Path, label: str) -> dict[str, Any]:


### PR DESCRIPTION
## **User description**
## Summary
- reject malformed URL authorities in release update, GitHub Pages, hosted Linux repository, endpoint, and S3 publication validators
- normalize public URL authorities from validated hostname/port instead of raw netloc text
- add regressions for bad ports, empty ports, and empty-host authorities

## Validation
- python -m py_compile scripts/check-github-pages-readiness.py scripts/check-tagged-release-readiness.py scripts/generate-release-update-policy.py scripts/generate-hosted-linux-repository-site.py scripts/prepare-hosted-linux-repository-pages.py scripts/publish-hosted-linux-repository-s3.py scripts/check-hosted-linux-repository-endpoint.py scripts/check-github-pages-readiness-regression.py scripts/check-tagged-release-readiness-regression.py scripts/check-release-update-policy.py scripts/check-hosted-linux-repository-site.py scripts/check-hosted-linux-repository-pages.py scripts/check-hosted-linux-repository-s3-publication.py scripts/check-hosted-linux-repository-endpoint-regression.py
- python scripts/check-github-pages-readiness-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- python scripts/check-release-update-policy.py
- python scripts/check-hosted-linux-repository-site.py
- python scripts/check-hosted-linux-repository-pages.py
- python scripts/check-hosted-linux-repository-endpoint-regression.py
- python scripts/check-hosted-linux-repository-s3-publication.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Closes #605

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened URL authority (host/port) validation across release and repository tooling to block malformed inputs and generate canonical authorities. This prevents bad ports or empty hosts from slipping through and standardizes how we build public URLs.

- **Bug Fixes**
  - Reject malformed authorities: non-numeric/partial ports (e.g., ":bad", trailing ":"), empty host, and invalid port tokens.
  - Applied across release update policy, tagged release readiness, GitHub Pages readiness, hosted Linux repository site/pages, endpoint check, and S3 publication.
  - Added regression tests for malformed base URLs and S3 endpoint URLs.

- **Refactors**
  - Added helpers to parse and normalize authorities from `hostname`/`port` and to validate ports; lower-case hosts and bracket IPv6 when needed.
  - Build URLs from normalized authorities instead of raw `netloc`, removing casing inconsistencies and colon edge cases.

<sup>Written for commit 9113ee36646f96802dade7b6ccf9916a8ee3e6b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject malformed URL authorities in release and repository validation**

### What Changed
- URLs with bad or incomplete host/port parts are now rejected across release, Pages, hosted repository, endpoint, and S3 checks
- URLs with an empty host or a trailing colon now fail with a clear authority error instead of being accepted
- Valid URLs are still normalized to a consistent host and port before use

### Impact
`✅ Fewer release URL validation gaps`
`✅ Clearer errors for broken repository links`
`✅ Safer publishing and readiness checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation across repository, release, and endpoint configurations to detect and reject malformed host/port formats with improved error messages.
  * Improved handling of IPv6 addresses in URLs.
  * Fixed edge cases in URL authority normalization.

* **Tests**
  * Expanded regression coverage for malformed URL formats and invalid authority cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->