### PR TITLE
Reject malformed signing timestamp URLs

### DIFF
--- a/scripts/check-platform-signing-secrets-preflight-regression.py
+++ b/scripts/check-platform-signing-secrets-preflight-regression.py
@@ -46,6 +46,14 @@ def main() -> int:
     assert_failed(failed, "strict base64")
     assert_not_leaked(failed.stdout, SENTINEL)
 
+    malformed_timestamp_env = minimal_env(base64.b64encode(b"not-a-real-pkcs12").decode("ascii"))
+    malformed_timestamp_env[
+        module.WINDOWS_TIMESTAMP_URL_ENV
+    ] = f"https://timestamp-{SENTINEL}.example.invalid:"
+    failed = run_preflight(malformed_timestamp_env, "--skip-pkcs12-parse")
+    assert_failed(failed, "valid host and authority")
+    assert_not_leaked(failed.stdout, SENTINEL)
+
     invalid_apple_env = minimal_env(base64.b64encode(b"not-a-real-pkcs12").decode("ascii"))
     invalid_apple_env[module.MACOS_NOTARY_APPLE_ID_ENV] = f"{SENTINEL} invalid"
     invalid_apple_env[module.MACOS_NOTARY_TEAM_ID_ENV] = "not-a-team-id"

--- a/scripts/check-platform-signing-secrets-preflight.py
+++ b/scripts/check-platform-signing-secrets-preflight.py
@@ -262,9 +262,17 @@ def validate_timestamp_url(
         return
 
     parsed = urlparse(value)
+    try:
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        host = None
+        port = None
     valid = (
         parsed.scheme in {"http", "https"}
         and bool(parsed.netloc)
+        and bool(host)
+        and not (port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"))
         and not parsed.username
         and parsed.password is None
         and not parsed.query
@@ -274,7 +282,7 @@ def validate_timestamp_url(
     checks["windowsTimestampUrlValid"] = valid
     if not valid:
         issues.append(
-            f"{WINDOWS_TIMESTAMP_URL_ENV} must be an absolute http(s) URL without credentials, query, or fragment"
+            f"{WINDOWS_TIMESTAMP_URL_ENV} must be an absolute http(s) URL with a valid host and authority, without credentials, query, or fragment"
         )
 
 


### PR DESCRIPTION
## **User description**
## Summary
- validate `CONU_WINDOWS_TIMESTAMP_URL` host/authority in the platform signing preflight
- reject malformed timestamp URL authorities without echoing the configured value
- add a regression for malformed timestamp URL authority sanitization

## Validation
- `python scripts/check-platform-signing-secrets-preflight-regression.py`
- `python -m py_compile scripts/check-platform-signing-secrets-preflight.py scripts/check-platform-signing-secrets-preflight-regression.py`
- `git diff --check`
- `python scripts/check-github-workflow-permissions.py`
- `powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions`

Closes #607

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed Windows signing timestamp URLs during preflight and tighten authority validation. Prevents leaking the configured value when validation fails.

- **Bug Fixes**
  - Validate Windows timestamp URL host/authority: require http(s), real host, no credentials/query/fragment, and no stray colon or invalid port.
  - Add a regression test that rejects a malformed URL and confirms the value is not echoed.

<sup>Written for commit 4689242dc7a0d7dbf8b6d4efa78fe076e3945852. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject malformed Windows signing timestamp URLs**

### What Changed
- Preflight now rejects Windows timestamp URLs that have a malformed host or authority, including invalid trailing colons and bad port formatting
- The failure message now tells users the URL must have a valid host and authority, along with no credentials, query, or fragment
- Added a regression check to confirm malformed timestamp URLs are rejected without exposing the configured value

### Impact
`✅ Fewer signing setup failures`
`✅ Clearer timestamp URL validation errors`
`✅ Less risk of leaking invalid secret values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
