### PR TITLE
Reject secret-bearing relay endpoints

### DIFF
--- a/crates/conu-core/src/lib.rs
+++ b/crates/conu-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod observability;
 pub mod policy;
 pub mod relay;
 pub mod relay_delivery;
+pub(crate) mod relay_endpoint;
 pub mod rooms;
 pub mod routes;
 pub mod runtime;

--- a/crates/conu-core/src/relay.rs
+++ b/crates/conu-core/src/relay.rs
@@ -14,6 +14,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use native_tls::{HandshakeError, TlsConnector, TlsStream};
 
+use crate::relay_endpoint::{self, RelayEndpointError};
+
 const WEBSOCKET_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 const MAX_HTTP_HEADER_BYTES: usize = 8192;
 const MAX_FRAME_BYTES: usize = 256 * 1024;
@@ -1978,6 +1980,15 @@ enum RelayScheme {
 
 impl ParsedEndpoint {
     fn parse(endpoint: &str) -> Result<Self, RelayFrameError> {
+        relay_endpoint::validate_relay_endpoint(endpoint.to_string()).map_err(|error| {
+            let reason = match error {
+                RelayEndpointError::Scheme => "relay endpoint must start with ws:// or wss://",
+                RelayEndpointError::Empty | RelayEndpointError::Invalid => {
+                    "relay endpoint is invalid"
+                }
+            };
+            RelayFrameError::new(reason)
+        })?;
         let (scheme, rest, default_port) = if let Some(rest) = endpoint.strip_prefix("ws://") {
             (RelayScheme::Ws, rest, 80)
         } else if let Some(rest) = endpoint.strip_prefix("wss://") {
@@ -2819,5 +2830,17 @@ mod tests {
             .expect_err("non websocket endpoint fails");
 
         assert!(error.to_string().contains("ws:// or wss://"));
+    }
+
+    #[test]
+    fn endpoint_parser_rejects_secret_bearing_urls_without_echoing_value() {
+        let secret_endpoint = "wss://user:secret@relay.example.com/conu?token=private#fragment";
+        let error = ParsedEndpoint::parse(secret_endpoint)
+            .expect_err("secret-bearing relay endpoint should fail");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("relay endpoint is invalid"));
+        assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains("token=private"));
     }
 }

--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -25,6 +25,7 @@ use crate::relay::{
     RelayClientFrame, RelayEnvelopeKind, RelayForward, RelayFrameError, RelayHello,
     RelayOpaqueBody, RelayServerFrame, RelayWebSocketClient,
 };
+use crate::relay_endpoint::{self, RelayEndpointError};
 use crate::rooms;
 use crate::security::{self, PeerEncryptedPayload, SecurityError};
 use crate::sessions::{self, SessionError};
@@ -1979,18 +1980,16 @@ fn value_or_empty<'a>(values: &'a HashMap<String, String>, key: &str) -> &'a str
 }
 
 fn validate_endpoint(value: String) -> Result<String, RelayDeliveryError> {
-    let value = value.trim().to_string();
-    if !value.starts_with("ws://") && !value.starts_with("wss://") {
-        return Err(RelayDeliveryError::InvalidRequest {
-            reason: "relay endpoint must start with ws:// or wss://".to_string(),
-        });
-    }
-    if value.len() > 220 || value.chars().any(char::is_whitespace) {
-        return Err(RelayDeliveryError::InvalidRequest {
-            reason: "relay endpoint is invalid".to_string(),
-        });
-    }
-    Ok(value)
+    relay_endpoint::validate_relay_endpoint(value).map_err(|error| {
+        let reason = match error {
+            RelayEndpointError::Empty => "relay endpoint cannot be empty",
+            RelayEndpointError::Scheme => "relay endpoint must start with ws:// or wss://",
+            RelayEndpointError::Invalid => "relay endpoint is invalid",
+        };
+        RelayDeliveryError::InvalidRequest {
+            reason: reason.to_string(),
+        }
+    })
 }
 
 fn validate_identifier(value: String, field: &'static str) -> Result<String, RelayDeliveryError> {
@@ -2491,6 +2490,28 @@ mod tests {
 
         assert!(should_sync);
         assert_eq!(endpoint, "wss://relay.example.com/conu");
+    }
+
+    #[test]
+    fn relay_endpoint_validation_rejects_secret_bearing_config_without_echoing_value() {
+        let home = test_home("runtime-secret-relay-config");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let secret_endpoint = "wss://user:secret@relay.example.com/conu?token=private#fragment";
+        fs::write(
+            &init.paths.config,
+            format!(
+                "version = \"1\"\ndefault_relay = \"{secret_endpoint}\"\nrelay_auto_sync = true\n"
+            ),
+        )
+        .expect("config writes");
+
+        let error = configured_relay_endpoint(&init.paths)
+            .expect_err("secret-bearing relay endpoint should fail");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("relay endpoint is invalid"));
+        assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains("token=private"));
     }
 
     #[cfg(unix)]

--- a/crates/conu-core/src/relay_endpoint.rs
+++ b/crates/conu-core/src/relay_endpoint.rs
@@ -1,0 +1,156 @@
+//! Relay endpoint URL validation shared by trust, routes, sessions, and delivery.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RelayEndpointError {
+    Empty,
+    Scheme,
+    Invalid,
+}
+
+pub(crate) fn validate_relay_endpoint(value: String) -> Result<String, RelayEndpointError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(RelayEndpointError::Empty);
+    }
+    if !value.starts_with("ws://") && !value.starts_with("wss://") {
+        return Err(RelayEndpointError::Scheme);
+    }
+    if value.len() > 220
+        || value.chars().any(char::is_whitespace)
+        || value.contains('@')
+        || value.contains('?')
+        || value.contains('#')
+        || value.contains('\\')
+    {
+        return Err(RelayEndpointError::Invalid);
+    }
+
+    let rest = value
+        .strip_prefix("ws://")
+        .or_else(|| value.strip_prefix("wss://"))
+        .ok_or(RelayEndpointError::Scheme)?;
+    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
+    validate_authority(authority)?;
+    validate_path(path)?;
+    Ok(value)
+}
+
+fn validate_authority(authority: &str) -> Result<(), RelayEndpointError> {
+    if authority.is_empty() {
+        return Err(RelayEndpointError::Invalid);
+    }
+
+    if let Some(host_port) = authority.strip_prefix('[') {
+        let Some((host, port_suffix)) = host_port.split_once(']') else {
+            return Err(RelayEndpointError::Invalid);
+        };
+        if host.is_empty()
+            || !host.contains(':')
+            || host.chars().any(char::is_whitespace)
+            || host.chars().any(|character| matches!(character, '[' | ']'))
+        {
+            return Err(RelayEndpointError::Invalid);
+        }
+        if port_suffix.is_empty() {
+            return Ok(());
+        }
+        let Some(port) = port_suffix.strip_prefix(':') else {
+            return Err(RelayEndpointError::Invalid);
+        };
+        return validate_port(port);
+    }
+
+    if authority
+        .chars()
+        .any(|character| matches!(character, '[' | ']'))
+    {
+        return Err(RelayEndpointError::Invalid);
+    }
+
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((host, port)) => (host, Some(port)),
+        None => (authority, None),
+    };
+    if host.is_empty()
+        || host.contains(':')
+        || host.chars().any(char::is_whitespace)
+        || host
+            .chars()
+            .any(|character| matches!(character, '/' | '\\'))
+    {
+        return Err(RelayEndpointError::Invalid);
+    }
+    if let Some(port) = port {
+        validate_port(port)?;
+    }
+    Ok(())
+}
+
+fn validate_port(port: &str) -> Result<(), RelayEndpointError> {
+    if port.is_empty() || !port.parse::<u16>().is_ok_and(|port| port > 0) {
+        return Err(RelayEndpointError::Invalid);
+    }
+    Ok(())
+}
+
+fn validate_path(path: &str) -> Result<(), RelayEndpointError> {
+    if path.contains('\\') {
+        return Err(RelayEndpointError::Invalid);
+    }
+    if path
+        .split('/')
+        .any(|part| matches!(part, "." | "..") || part.contains('%'))
+    {
+        return Err(RelayEndpointError::Invalid);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RelayEndpointError, validate_relay_endpoint};
+
+    #[test]
+    fn relay_endpoint_validation_accepts_supported_shapes() {
+        for endpoint in [
+            "ws://127.0.0.1:8787",
+            "wss://relay.example.com/conu",
+            "wss://relay.example.com",
+            "ws://[::1]:8787/relay",
+        ] {
+            assert_eq!(
+                validate_relay_endpoint(endpoint.to_string()).as_deref(),
+                Ok(endpoint)
+            );
+        }
+    }
+
+    #[test]
+    fn relay_endpoint_validation_rejects_secret_bearing_or_malformed_urls() {
+        for endpoint in [
+            "",
+            "https://relay.example.com/conu",
+            "wss://user:secret@relay.example.com/conu",
+            "wss://relay.example.com/conu?token=secret",
+            "wss://relay.example.com/conu#secret",
+            "wss://relay.example.com:",
+            "wss://relay.example.com:notaport",
+            "wss:///conu",
+            "wss://relay.example.com/../admin",
+            "wss://relay.example.com/%2e%2e/admin",
+        ] {
+            assert!(
+                validate_relay_endpoint(endpoint.to_string()).is_err(),
+                "{endpoint} should be rejected"
+            );
+        }
+        assert_eq!(
+            validate_relay_endpoint("".to_string()),
+            Err(RelayEndpointError::Empty)
+        );
+        assert_eq!(
+            validate_relay_endpoint("https://relay.example.com".to_string()),
+            Err(RelayEndpointError::Scheme)
+        );
+    }
+}

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -1017,7 +1017,7 @@ fn validate_endpoint(value: String) -> Result<String, RouteError> {
         let reason = match error {
             RelayEndpointError::Empty => "endpoint cannot be empty",
             RelayEndpointError::Scheme => "relay endpoint must start with ws:// or wss://",
-            RelayEndpointError::Invalid => "endpoint is invalid",
+            RelayEndpointError::Invalid => "relay endpoint is invalid",
         };
         RouteError::InvalidRecord {
             reason: reason.to_string(),

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -20,6 +20,8 @@ use crate::trust::{self, TrustStatus, TrustedPeer};
 const ROUTE_VERSION: &str = "1";
 const DEFAULT_RELAY_ENDPOINT: &str = "ws://127.0.0.1:8787";
 const RELAY_WEBSOCKET_LATENCY_MS: u64 = 80;
+const DIRECT_QUIC_INVALID_ENDPOINT: &str = "quic://invalid";
+const DIRECT_QUIC_UNCONFIGURED_ENDPOINT: &str = "quic://unconfigured";
 const DIRECT_QUIC_PROBE_FAILED: &str = "direct_quic_probe_failed";
 const NAT_TRAVERSAL_UNAVAILABLE: &str = "nat_traversal_unavailable";
 const CANDIDATE_SOURCE_NONE: &str = "none";
@@ -446,8 +448,8 @@ impl DirectCandidate {
     fn display_endpoint(&self) -> String {
         match self.endpoint.as_deref() {
             Some(endpoint) if valid_direct_endpoint(endpoint) => endpoint.to_string(),
-            Some(_) => "quic://invalid".to_string(),
-            None => "quic://unconfigured".to_string(),
+            Some(_) => DIRECT_QUIC_INVALID_ENDPOINT.to_string(),
+            None => DIRECT_QUIC_UNCONFIGURED_ENDPOINT.to_string(),
         }
     }
 }
@@ -1027,7 +1029,7 @@ fn validate_route_endpoint(value: String, transport: RouteTransport) -> Result<S
     let value = value.trim().to_string();
     match transport {
         RouteTransport::DirectQuic => {
-            if value != "quic://invalid" {
+            if !is_direct_route_placeholder(&value) {
                 direct_transport::validate_direct_peer_endpoint(&value).map_err(|_| {
                     RouteError::InvalidRecord {
                         reason: "endpoint is invalid".to_string(),
@@ -1038,6 +1040,13 @@ fn validate_route_endpoint(value: String, transport: RouteTransport) -> Result<S
         }
         RouteTransport::RelayWebSocket => validate_endpoint(value),
     }
+}
+
+fn is_direct_route_placeholder(value: &str) -> bool {
+    matches!(
+        value,
+        DIRECT_QUIC_INVALID_ENDPOINT | DIRECT_QUIC_UNCONFIGURED_ENDPOINT
+    )
 }
 
 fn valid_direct_endpoint(value: &str) -> bool {
@@ -1228,6 +1237,7 @@ mod tests {
             RouteTransport::RelayWebSocket
         );
         assert_eq!(direct.state, RouteState::Unavailable);
+        assert_eq!(direct.endpoint, DIRECT_QUIC_UNCONFIGURED_ENDPOINT);
         assert!(!direct.direct_attempted);
         assert_eq!(
             direct.failure_reason.as_deref(),
@@ -1329,7 +1339,7 @@ mod tests {
             selected.expect("selected").transport,
             RouteTransport::RelayWebSocket
         );
-        assert_eq!(direct.endpoint, "quic://invalid");
+        assert_eq!(direct.endpoint, DIRECT_QUIC_INVALID_ENDPOINT);
         assert!(!direct.direct_attempted);
         assert_eq!(
             direct.failure_reason.as_deref(),
@@ -1346,7 +1356,7 @@ mod tests {
             route_id(
                 &peer.peer_node_id,
                 RouteTransport::DirectQuic,
-                Some("quic://invalid")
+                Some(DIRECT_QUIC_INVALID_ENDPOINT)
             )
         );
         assert_ne!(
@@ -1418,7 +1428,7 @@ mod tests {
             selected.expect("selected").transport,
             RouteTransport::RelayWebSocket
         );
-        assert_eq!(direct.endpoint, "quic://invalid");
+        assert_eq!(direct.endpoint, DIRECT_QUIC_INVALID_ENDPOINT);
         assert!(!direct.direct_attempted);
         assert_eq!(
             direct.failure_reason.as_deref(),

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::direct_transport;
+use crate::relay_endpoint::{self, RelayEndpointError};
 use crate::state::{self, StateError, StatePaths};
 use crate::trust::{self, TrustStatus, TrustedPeer};
 
@@ -858,12 +859,14 @@ fn parse_probes(contents: &str) -> Result<Vec<RouteProbe>, RouteError> {
 fn route_from_values(values: &HashMap<String, String>) -> Result<RouteRecord, RouteError> {
     let latency_ms = parse_u64(&required(values, "latency_ms")?)?;
     let failure_reason = optional_clean(values.get("failure_reason"));
+    let transport = RouteTransport::from_str(&required(values, "transport")?);
+    let endpoint = validate_route_endpoint(required(values, "endpoint")?, transport)?;
     Ok(RouteRecord {
         route_id: validate_identifier(required(values, "route_id")?, "route id")?,
         peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
         display_name: validate_display_name(required(values, "display_name")?)?,
-        transport: RouteTransport::from_str(&required(values, "transport")?),
-        endpoint: validate_endpoint(required(values, "endpoint")?)?,
+        transport,
+        endpoint,
         state: RouteState::from_str(&required(values, "state")?),
         score: parse_u16(&required(values, "score")?)?,
         latency_ms: if latency_ms == 0 {
@@ -890,12 +893,14 @@ fn route_from_values(values: &HashMap<String, String>) -> Result<RouteRecord, Ro
 
 fn probe_from_values(values: &HashMap<String, String>) -> Result<RouteProbe, RouteError> {
     let latency_ms = parse_u64(&required(values, "latency_ms")?)?;
+    let transport = RouteTransport::from_str(&required(values, "transport")?);
+    let endpoint = validate_route_endpoint(required(values, "endpoint")?, transport)?;
     Ok(RouteProbe {
         probe_id: validate_identifier(required(values, "probe_id")?, "probe id")?,
         route_id: validate_identifier(required(values, "route_id")?, "route id")?,
         peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
-        transport: RouteTransport::from_str(&required(values, "transport")?),
-        endpoint: validate_endpoint(required(values, "endpoint")?)?,
+        transport,
+        endpoint,
         outcome: validate_identifier(required(values, "outcome")?, "outcome")?,
         score: parse_u16(&required(values, "score")?)?,
         latency_ms: if latency_ms == 0 {
@@ -1006,18 +1011,33 @@ fn validate_display_name(value: String) -> Result<String, RouteError> {
 }
 
 fn validate_endpoint(value: String) -> Result<String, RouteError> {
+    relay_endpoint::validate_relay_endpoint(value).map_err(|error| {
+        let reason = match error {
+            RelayEndpointError::Empty => "endpoint cannot be empty",
+            RelayEndpointError::Scheme => "relay endpoint must start with ws:// or wss://",
+            RelayEndpointError::Invalid => "endpoint is invalid",
+        };
+        RouteError::InvalidRecord {
+            reason: reason.to_string(),
+        }
+    })
+}
+
+fn validate_route_endpoint(value: String, transport: RouteTransport) -> Result<String, RouteError> {
     let value = value.trim().to_string();
-    if value.is_empty() {
-        return Err(RouteError::InvalidRecord {
-            reason: "endpoint cannot be empty".to_string(),
-        });
+    match transport {
+        RouteTransport::DirectQuic => {
+            if value != "quic://invalid" {
+                direct_transport::validate_direct_peer_endpoint(&value).map_err(|_| {
+                    RouteError::InvalidRecord {
+                        reason: "endpoint is invalid".to_string(),
+                    }
+                })?;
+            }
+            Ok(value)
+        }
+        RouteTransport::RelayWebSocket => validate_endpoint(value),
     }
-    if value.len() > 220 || value.chars().any(char::is_whitespace) {
-        return Err(RouteError::InvalidRecord {
-            reason: "endpoint is invalid".to_string(),
-        });
-    }
-    Ok(value)
 }
 
 fn valid_direct_endpoint(value: &str) -> bool {
@@ -1344,6 +1364,27 @@ mod tests {
             assert!(!contents.contains("BEGIN PRIVATE KEY"));
             assert!(!contents.contains("private message contents"));
         }
+    }
+
+    #[test]
+    fn relay_endpoint_config_rejects_secret_bearing_url_without_echoing_value() {
+        let home = test_home("secret-relay-route-config");
+        trusted_peer(&home);
+        let secret_endpoint = "wss://user:secret@relay.example.com/conu?token=private#fragment";
+        fs::write(
+            StatePaths::from_home(home.clone()).config,
+            format!(
+                "version = \"1\"\ndefault_relay = \"{secret_endpoint}\"\nnat_profile = \"public\"\n"
+            ),
+        )
+        .expect("config writes");
+
+        let error = sync_routes(Some(home)).expect_err("secret-bearing relay endpoint should fail");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("endpoint is invalid"));
+        assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains("token=private"));
     }
 
     #[test]

--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -13,10 +13,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use conu_protocol::AgentCapabilities;
 
 use crate::agents::{self, AgentPresence, SignedAgentCard};
-use crate::relay_delivery;
+use crate::relay_endpoint::{self, RelayEndpointError};
 use crate::routes::{self, RouteTransport};
 use crate::state::{self, StateError, StatePaths};
 use crate::trust::{self, TrustStatus, TrustedPeer};
+use crate::{direct_transport, relay_delivery};
 
 const SESSION_VERSION: &str = "1";
 const DEFAULT_RELAY_ENDPOINT: &str = "ws://127.0.0.1:8787";
@@ -657,12 +658,14 @@ fn parse_remote_agents(contents: &str) -> Result<Vec<RemoteAgentRecord>, Session
 }
 
 fn session_from_values(values: &HashMap<String, String>) -> Result<RemoteSession, SessionError> {
+    let route = validate_identifier(required(values, "route")?, "route")?;
+    let relay_endpoint = validate_endpoint(required(values, "relay_endpoint")?, &route)?;
     Ok(RemoteSession {
         peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
         display_name: validate_display_name(required(values, "display_name")?)?,
         state: RemoteSessionState::from_str(&required(values, "state")?),
-        route: validate_identifier(required(values, "route")?, "route")?,
-        relay_endpoint: validate_endpoint(required(values, "relay_endpoint")?)?,
+        route,
+        relay_endpoint,
         reconnect_attempts: parse_u64(&required(values, "reconnect_attempts")?)?,
         remote_agent_count: parse_usize(&required(values, "remote_agent_count")?)?,
         last_seen_unix: parse_u64(&required(values, "last_seen_unix")?)?,
@@ -810,7 +813,7 @@ fn relay_endpoint(paths: &StatePaths) -> Result<String, SessionError> {
         .filter(|value| !value.trim().is_empty())
         .cloned()
         .unwrap_or_else(|| DEFAULT_RELAY_ENDPOINT.to_string());
-    validate_endpoint(endpoint)
+    validate_endpoint(endpoint, "relay-websocket")
 }
 
 fn append_session_log(
@@ -929,24 +932,33 @@ fn validate_display_name(value: String) -> Result<String, SessionError> {
     Ok(value)
 }
 
-fn validate_endpoint(value: String) -> Result<String, SessionError> {
+fn validate_endpoint(value: String, route: &str) -> Result<String, SessionError> {
     let value = value.trim().to_string();
     if value.is_empty() {
         return Err(SessionError::InvalidRecord {
             reason: "relay endpoint cannot be empty".to_string(),
         });
     }
-    if value.len() > 200 {
-        return Err(SessionError::InvalidRecord {
-            reason: "relay endpoint is too long".to_string(),
-        });
+    match route {
+        "direct-quic" => {
+            direct_transport::validate_direct_peer_endpoint(&value).map_err(|_| {
+                SessionError::InvalidRecord {
+                    reason: "session endpoint is invalid".to_string(),
+                }
+            })?;
+            Ok(value)
+        }
+        _ => relay_endpoint::validate_relay_endpoint(value).map_err(|error| {
+            let reason = match error {
+                RelayEndpointError::Empty => "relay endpoint cannot be empty",
+                RelayEndpointError::Scheme => "relay endpoint must start with ws:// or wss://",
+                RelayEndpointError::Invalid => "relay endpoint is invalid",
+            };
+            SessionError::InvalidRecord {
+                reason: reason.to_string(),
+            }
+        }),
     }
-    if value.chars().any(char::is_whitespace) {
-        return Err(SessionError::InvalidRecord {
-            reason: "relay endpoint cannot contain whitespace".to_string(),
-        });
-    }
-    Ok(value)
 }
 
 fn parse_u64(value: &str) -> Result<u64, SessionError> {
@@ -1061,6 +1073,28 @@ mod tests {
         assert!(log.contains("payload=not_observed"));
         assert!(!log.contains("private message contents"));
         assert!(!log.contains("Review this code"));
+    }
+
+    #[test]
+    fn session_sync_rejects_secret_bearing_relay_endpoint_without_echoing_value() {
+        let home = test_home("session-secret-relay-config");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        trust::join_pairing_code(Some(home.clone()), &invite.code).expect("joins");
+        let secret_endpoint = "wss://user:secret@relay.example.com/conu?token=private#fragment";
+        fs::write(
+            &init.paths.config,
+            format!("version = \"1\"\ndefault_relay = \"{secret_endpoint}\"\n"),
+        )
+        .expect("config writes");
+
+        let error = sync_remote_sessions(Some(home))
+            .expect_err("secret-bearing relay endpoint should fail");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("relay endpoint is invalid"));
+        assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains("token=private"));
     }
 
     #[test]

--- a/crates/conu-core/src/trust.rs
+++ b/crates/conu-core/src/trust.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::relay_endpoint::{self, RelayEndpointError};
 use crate::state::{self, StateError, StatePaths};
 use crate::{direct_transport, security};
 
@@ -1206,23 +1207,16 @@ fn validate_display_name(value: String) -> Result<String, TrustError> {
 }
 
 fn validate_endpoint(value: String) -> Result<String, TrustError> {
-    let value = value.trim().to_string();
-    if value.is_empty() {
-        return Err(TrustError::InvalidRequest {
-            reason: "relay endpoint cannot be empty".to_string(),
-        });
-    }
-    if !value.starts_with("ws://") && !value.starts_with("wss://") {
-        return Err(TrustError::InvalidRequest {
-            reason: "relay endpoint must start with ws:// or wss://".to_string(),
-        });
-    }
-    if value.len() > 220 || value.chars().any(char::is_whitespace) {
-        return Err(TrustError::InvalidRequest {
-            reason: "relay endpoint is invalid".to_string(),
-        });
-    }
-    Ok(value)
+    relay_endpoint::validate_relay_endpoint(value).map_err(|error| {
+        let reason = match error {
+            RelayEndpointError::Empty => "relay endpoint cannot be empty",
+            RelayEndpointError::Scheme => "relay endpoint must start with ws:// or wss://",
+            RelayEndpointError::Invalid => "relay endpoint is invalid",
+        };
+        TrustError::InvalidRequest {
+            reason: reason.to_string(),
+        }
+    })
 }
 
 fn validate_hex(value: String, field: &'static str) -> Result<String, TrustError> {
@@ -1751,6 +1745,47 @@ mod tests {
             peer.relay_endpoint.as_deref(),
             Some("wss://relay.example.com/conu")
         );
+    }
+
+    #[test]
+    fn relay_endpoint_rejects_secret_bearing_config_without_echoing_value() {
+        let home = test_home("secret-relay-config");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let secret_endpoint = "wss://user:secret@relay.example.com/conu?token=private#fragment";
+        fs::write(
+            &init.paths.config,
+            format!("version = \"1\"\ndefault_relay = \"{secret_endpoint}\"\n"),
+        )
+        .expect("config writes");
+
+        let error = configured_relay_endpoint(&init.paths)
+            .expect_err("secret-bearing relay endpoint should fail");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("relay endpoint is invalid"));
+        assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains("token=private"));
+    }
+
+    #[test]
+    fn legacy_peer_card_rejects_secret_bearing_relay_endpoint_without_echoing_value() {
+        let alice_home = test_home("secret-card-alice");
+        let bob_home = test_home("secret-card-bob");
+        let mut bob_card = export_peer_card(Some(bob_home)).expect("bob card exports");
+        bob_card.relay_endpoint =
+            "wss://user:secret@relay.example.com/conu?token=private#fragment".to_string();
+        bob_card.signing_public_key_hex = None;
+        bob_card.signature_algorithm = None;
+        bob_card.signature_key_id = None;
+        bob_card.signature_hex = None;
+
+        let error = trust_peer_card(Some(alice_home), bob_card)
+            .expect_err("secret-bearing relay endpoint should fail");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("relay endpoint is invalid"));
+        assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains("token=private"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- add a shared relay endpoint URL guard for core relay/trust/session/route surfaces
- reject relay URLs with embedded credentials, query strings, fragments, malformed authorities, bad ports, unsafe paths, or whitespace
- keep direct route validation on the direct transport validator while preserving the sanitized `quic://invalid` placeholder
- add regressions that ensure secret-bearing relay endpoints fail without echoing the secret marker

## Validation
- `cargo metadata --format-version 1 --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions`

Local Rust test execution was blocked by missing local linker tools: MSVC `link.exe` is absent and GNU `dlltool.exe` is absent. CI should run the full Rust matrix.

Closes #609

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared validator that rejects secret-bearing or malformed relay endpoints across trust, routes, sessions, relay delivery, and the relay parser. Aligns route/session errors and keeps direct QUIC validation and placeholders, with tests to ensure secrets never appear in errors.

- **Bug Fixes**
  - Reject relay URLs with credentials, query strings, fragments, whitespace, backslashes, unsafe paths, malformed authorities, or bad ports.
  - Require ws:// or wss:// schemes.
  - Standardize route/session error messages (empty, scheme, invalid) and ensure errors/logs never echo secret values; add regression tests for configs, cards, and parsing.

- **Refactors**
  - Introduced shared relay_endpoint validator and wired it into trust, routes, sessions, relay delivery, and relay parsing.
  - Scoped endpoint checks by transport; keep direct QUIC validation and preserve quic://invalid and quic://unconfigured placeholders.

<sup>Written for commit 912d7890fac2e7e775fafa9f4093b0a5cfdee53a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Reject secret-bearing relay endpoints across relay, route, session, and trust flows**

### What Changed
- Relay endpoints now reject embedded credentials, query strings, fragments, bad ports, unsafe paths, backslashes, whitespace, and non-websocket schemes.
- The same relay URL checks are used when reading relay settings, syncing sessions, handling routes, processing relay requests, and trusting peer records.
- Direct QUIC endpoints keep their separate validation, including the `quic://invalid` placeholder used for direct routes.
- New checks make sure validation errors do not echo secret values back in the message.

### Impact
`✅ Fewer secret leaks in error messages`
`✅ Safer relay endpoint setup`
`✅ Fewer failed syncs from malformed relay URLs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
