### PR TITLE
Reject multiline platform signing text secrets

### DIFF
--- a/scripts/check-platform-signing-secrets-preflight-regression.py
+++ b/scripts/check-platform-signing-secrets-preflight-regression.py
@@ -61,6 +61,15 @@ def main() -> int:
     assert_failed(failed, "Apple ID")
     assert_not_leaked(failed.stdout, SENTINEL)
 
+    multiline_text_env = minimal_env(base64.b64encode(b"not-a-real-pkcs12").decode("ascii"))
+    multiline_text_env[
+        module.MACOS_CODESIGN_IDENTITY_ENV
+    ] = f"Developer ID Application: conU Regression\nINJECTED={SENTINEL}"
+    multiline_text_env[module.MACOS_NOTARY_PASSWORD_ENV] = f"app-password\t{SENTINEL}"
+    failed = run_preflight(multiline_text_env, "--skip-pkcs12-parse")
+    assert_failed(failed, "single-line text value")
+    assert_not_leaked(failed.stdout, SENTINEL)
+
     openssl = shutil.which("openssl")
     if openssl is None:
         print("Platform signing-secret OpenSSL parse regression skipped: openssl is unavailable")

--- a/scripts/check-platform-signing-secrets-preflight.py
+++ b/scripts/check-platform-signing-secrets-preflight.py
@@ -237,6 +237,15 @@ def validate_text_secret_shapes(
     checks: dict[str, bool],
     issues: list[str],
 ) -> None:
+    for key, name in TEXT_SECRET_ENVS:
+        value = env.get(name, "")
+        if not value:
+            continue
+        valid = is_single_line_text_secret(value)
+        checks[f"{key}SingleLine"] = valid
+        if not valid:
+            issues.append(f"{name} must be a single-line text value without control characters")
+
     apple_id = env.get(MACOS_NOTARY_APPLE_ID_ENV, "")
     if apple_id:
         valid = "@" in apple_id and not any(character.isspace() for character in apple_id)
@@ -250,6 +259,10 @@ def validate_text_secret_shapes(
         checks["macosNotaryTeamIdShapeValid"] = valid
         if not valid:
             issues.append(f"{MACOS_NOTARY_TEAM_ID_ENV} must be a 10-character uppercase Apple Team ID")
+
+
+def is_single_line_text_secret(value: str) -> bool:
+    return all(character >= " " and character != "\x7f" for character in value)
 
 
 def validate_timestamp_url(


### PR DESCRIPTION
## **User description**
Closes #611

## Summary
- reject CR/LF/tab/control-character values in platform signing text secrets before tagged release jobs use them
- keep platform signing preflight failures sanitized without echoing secret values
- add regression coverage for a multiline/code-sign identity injection sentinel

## Validation
- python scripts/check-platform-signing-secrets-preflight-regression.py
- python -m py_compile scripts/check-platform-signing-secrets-preflight.py scripts/check-platform-signing-secrets-preflight-regression.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects multi-line and control-character values in platform signing text secrets during preflight. Prevents bad secrets from breaking tagged release jobs and avoids leaking secret content.

- **Bug Fixes**
  - Validate all platform signing text secrets with a single-line check; reject CR, LF, tabs, and other control characters.
  - Sanitize preflight error output to avoid echoing secret values.
  - Add regression test covering a multiline code-sign identity injection sentinel and tabbed notary password.

<sup>Written for commit e13966a170196a40551e4ae2c0317d1e9ccc8317. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Reject multi-line and control-character values in platform signing secrets

### What Changed
- Platform signing text secrets are now blocked if they contain new lines, tabs, or other control characters
- Preflight checks now show a plain error message instead of exposing the secret value
- Added regression coverage for a multi-line code-sign identity value and a tabbed notary password

### Impact
`✅ Fewer broken tagged release jobs`
`✅ Safer secret validation errors`
`✅ Lower risk of secret content leaking in logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
