### PR TITLE
Guard release workflow env file writes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,11 +339,22 @@ jobs:
             --password "$MACOS_NOTARY_PASSWORD" \
             --keychain "$keychain_path"
           rm -f "$cert_path"
-          {
-            echo "CONU_MACOS_CODESIGN_IDENTITY=$MACOS_CODESIGN_IDENTITY"
-            echo "CONU_MACOS_KEYCHAIN=$keychain_path"
-            echo "CONU_MACOS_NOTARY_KEYCHAIN_PROFILE=conu-notary-profile"
-          } >> "$GITHUB_ENV"
+
+          append_github_env() {
+            name="$1"
+            value="$2"
+            case "$value" in
+              *$'\n'*|*$'\r'*|*$'\t'*|*$'\177'*)
+                echo "::error::$name must be a single-line value before writing to GITHUB_ENV"
+                exit 1
+                ;;
+            esac
+            printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
+          }
+
+          append_github_env CONU_MACOS_CODESIGN_IDENTITY "$MACOS_CODESIGN_IDENTITY"
+          append_github_env CONU_MACOS_KEYCHAIN "$keychain_path"
+          append_github_env CONU_MACOS_NOTARY_KEYCHAIN_PROFILE "conu-notary-profile"
       - name: Build package
         env:
           CONU_WINDOWS_SIGN_CERT_PFX_BASE64: ${{ secrets.CONU_WINDOWS_SIGN_CERT_PFX_BASE64 }}

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -236,6 +236,28 @@ def run_expected_job_permission_tests(module) -> None:
         raise AssertionError("extra expected permission issue was not reported")
 
 
+def run_unsafe_environment_file_write_tests(module) -> None:
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - run: echo build\n",
+            "      - run: |\n"
+            "          {\n"
+            "            echo \"CONU_MACOS_CODESIGN_IDENTITY=$MACOS_CODESIGN_IDENTITY\"\n"
+            "          } >> \"$GITHUB_ENV\"\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("unsafe GITHUB_ENV secret-derived echo should fail")
+    parsed = assert_safe_report(report)
+    rendered = json.dumps(parsed)
+    if "echoes secret-derived MACOS_CODESIGN_IDENTITY directly to GITHUB_ENV" not in rendered:
+        raise AssertionError("unsafe GITHUB_ENV write issue was not reported")
+    if not parsed["unsafeEnvironmentFileWrites"]:
+        raise AssertionError("unsafe GITHUB_ENV write finding was not listed")
+
+
 def main() -> int:
     module = load_module()
     run_ready_tests(module)
@@ -243,6 +265,7 @@ def main() -> int:
     run_forbidden_event_tests(module)
     run_unexpected_job_write_tests(module)
     run_expected_job_permission_tests(module)
+    run_unsafe_environment_file_write_tests(module)
     print("GitHub workflow permissions regression checks passed")
     return 0
 

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +30,19 @@ ALLOWED_PERMISSION_KEYS = (
 TOP_LEVEL_PERMISSIONS = {
     "contents": "read",
 }
+SECRET_LIKE_ENV_TOKENS = (
+    "PASSWORD",
+    "TOKEN",
+    "SECRET",
+    "KEY",
+    "IDENTITY",
+    "P12",
+    "PFX",
+    "GPG",
+)
+UNSAFE_GITHUB_ENV_ECHO_RE = re.compile(
+    r"\becho\s+[\"']?([A-Z0-9_]+)=\$([A-Z0-9_]+)"
+)
 EXPECTED_JOB_PERMISSIONS: dict[tuple[str, str], dict[str, str]] = {
     ("release.yml", "release-preflight"): {
         "actions": "read",
@@ -66,6 +80,7 @@ class WorkflowPermissionsReadiness:
     checked_workflows: tuple[str, ...]
     workflows_with_explicit_top_level_permissions: tuple[str, ...]
     jobs_with_write_permissions: tuple[str, ...]
+    unsafe_environment_file_writes: tuple[str, ...]
     forbidden_events: tuple[str, ...]
     issues: tuple[str, ...]
 
@@ -79,6 +94,7 @@ class WorkflowPermissionsReadiness:
                 self.workflows_with_explicit_top_level_permissions
             ),
             "jobsWithWritePermissions": list(self.jobs_with_write_permissions),
+            "unsafeEnvironmentFileWrites": list(self.unsafe_environment_file_writes),
             "forbiddenEvents": list(self.forbidden_events),
             "issues": list(self.issues),
             "payloadDisplayed": False,
@@ -190,6 +206,38 @@ def load_workflow(path: Path) -> dict[str, Any]:
     return payload
 
 
+def audit_environment_file_writes(path: Path) -> tuple[str, ...]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
+
+    findings: list[str] = []
+    for index, line in enumerate(lines):
+        match = UNSAFE_GITHUB_ENV_ECHO_RE.search(line.strip())
+        if match is None:
+            continue
+        output_name, source_name = match.groups()
+        if not is_secret_like_env_name(output_name) and not is_secret_like_env_name(source_name):
+            continue
+        if not has_nearby_github_env_redirect(lines, index):
+            continue
+        findings.append(
+            f"{path.name}:line {index + 1} echoes secret-derived {source_name} directly to GITHUB_ENV"
+        )
+    return tuple(findings)
+
+
+def is_secret_like_env_name(name: str) -> bool:
+    return any(token in name for token in SECRET_LIKE_ENV_TOKENS)
+
+
+def has_nearby_github_env_redirect(lines: list[str], index: int) -> bool:
+    start = max(0, index - 3)
+    end = min(len(lines), index + 4)
+    return any("GITHUB_ENV" in lines[position] for position in range(start, end))
+
+
 def workflow_trigger(payload: dict[str, Any]) -> Any:
     if "on" in payload:
         return payload["on"]
@@ -265,6 +313,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
     checked: list[str] = []
     explicit_top_level: list[str] = []
     write_jobs: list[str] = []
+    unsafe_env_writes: list[str] = []
     forbidden_events_seen: set[str] = set()
 
     if not workflow_paths:
@@ -274,6 +323,9 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
         workflow_name = path.name
         checked.append(workflow_name)
         payload = load_workflow(path)
+        for finding in audit_environment_file_writes(path):
+            unsafe_env_writes.append(finding)
+            issues.append(finding)
 
         events = event_names(workflow_trigger(payload))
         for event in events:
@@ -351,6 +403,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
         checked_workflows=tuple(sorted(checked)),
         workflows_with_explicit_top_level_permissions=tuple(sorted(explicit_top_level)),
         jobs_with_write_permissions=tuple(sorted(write_jobs)),
+        unsafe_environment_file_writes=tuple(sorted(unsafe_env_writes)),
         forbidden_events=tuple(sorted(forbidden_events_seen)),
         issues=tuple(issues),
     )


### PR DESCRIPTION
## **User description**
Closes #613

## Summary
- replace direct macOS signing GITHUB_ENV echo assignments with a guarded append helper
- reject newline/tab/control-character values before writing release environment entries
- extend workflow readiness checks to flag future direct secret-derived echo writes to GITHUB_ENV

## Validation
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-github-workflow-permissions.py
- python -m py_compile scripts/check-github-workflow-permissions.py scripts/check-github-workflow-permissions-regression.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the release workflow to prevent unsafe writes to `GITHUB_ENV` and added CI checks to catch regressions. This reduces the risk of leaking secret-like values and enforces single-line env entries.

- **Refactors**
  - Replaced direct env writes in `release.yml` with `append_github_env` that validates values (rejects newline/tab/control chars) before appending `CONU_MACOS_CODESIGN_IDENTITY`, `CONU_MACOS_KEYCHAIN`, and `CONU_MACOS_NOTARY_KEYCHAIN_PROFILE`.

- **New Features**
  - Extended `scripts/check-github-workflow-permissions.py` to detect secret-derived `echo ... >> $GITHUB_ENV` patterns and report them.
  - Added a regression test in `scripts/check-github-workflow-permissions-regression.py` to ensure unsafe writes are flagged.

<sup>Written for commit a05bdc41900b340f0693c4cb20f2b045f2ac4b2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block unsafe release workflow writes to `GITHUB_ENV`**

### What Changed
- The macOS release workflow now refuses to write release environment values if they contain line breaks, tabs, or control characters, and stops with a clear error instead of writing them.
- Release environment values are now written one at a time, which avoids direct multi-line echo writes to `GITHUB_ENV`.
- The workflow permission check now flags secret-like values being echoed directly into `GITHUB_ENV`, and the regression test suite covers this case.

### Impact
`✅ Safer release environment writes`
`✅ Fewer accidental secret leaks in release workflows`
`✅ Earlier detection of unsafe GitHub Actions env file writes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
