### PR TITLE
Reject blank release secret values

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -157,6 +157,13 @@ def run_env_file_tests(module) -> None:
         )
         if whitespace_values["NPM_TOKEN"] != whitespace_secret:
             raise AssertionError("env file parser trimmed secret value whitespace")
+        if module.missing_required_values(
+            whitespace_values,
+            ("NPM_TOKEN",),
+        ):
+            raise AssertionError("env file parser treated padded secret value as missing")
+        if module.missing_required_values({"NPM_TOKEN": "   "}, ("NPM_TOKEN",)) != ("NPM_TOKEN",):
+            raise AssertionError("whitespace-only env file secret value should be missing")
 
         directory_env_file = temp_path / "directory.env"
         directory_env_file.mkdir()
@@ -330,6 +337,12 @@ def run_dry_run_tests(module) -> None:
             lambda: module.configure_release_secrets("owner/repo", "gh", partial, dry_run=True),
             missing_name,
         )
+        blank = dict(values)
+        blank[missing_name] = "   "
+        assert_raises(
+            lambda: module.configure_release_secrets("owner/repo", "gh", blank, dry_run=True),
+            missing_name,
+        )
 
         calls = []
 
@@ -437,6 +450,28 @@ def run_env_file_main_tests(module) -> None:
                 raise AssertionError("env-file check output omitted checked secret names")
             if SENSITIVE_SENTINEL in rendered:
                 raise AssertionError("env-file check output leaked a secret value")
+
+            blank_env_file = Path(temp_dir) / "blank.env"
+            blank_lines = [
+                f"{name}={SENSITIVE_SENTINEL}"
+                for name in module.REQUIRED_RELEASE_SECRETS
+            ]
+            blank_lines[0] = f"{module.REQUIRED_RELEASE_SECRETS[0]}=   "
+            secure_write_text(blank_env_file, "\n".join(blank_lines) + "\n")
+            exit_code, rendered = call_main(
+                [
+                    "set-github-release-secrets.py",
+                    "--env-file",
+                    str(blank_env_file),
+                    "--check-env-file",
+                ]
+            )
+            if exit_code == 0:
+                raise AssertionError("env-file check should fail on blank secret values")
+            if module.REQUIRED_RELEASE_SECRETS[0] not in rendered:
+                raise AssertionError("blank-value report omitted the blank secret name")
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("blank-value report leaked a secret value")
 
             exit_code, rendered = call_main(
                 [

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -159,7 +159,11 @@ def validate_env_file_permissions(mode: int, path: Path) -> None:
 
 
 def missing_required_values(values: Mapping[str, str], names: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(name for name in names if not values.get(name))
+    return tuple(
+        name
+        for name in names
+        if (value := values.get(name)) is None or value.strip() == ""
+    )
 
 
 def set_secret(gh: str, repo: str, name: str, value: str) -> None:


### PR DESCRIPTION
## **User description**
Closes #617\n\nSummary:\n- Treat missing and whitespace-only release secret values as missing.\n- Preserve exact nonblank secret values, including intentional leading/trailing whitespace.\n- Add parser, dry-run, and --check-env-file regressions for blank-value rejection without leaking secret values.\n\nValidation:\n- python scripts/set-github-release-secrets-regression.py\n- python -m py_compile scripts/set-github-release-secrets.py scripts/set-github-release-secrets-regression.py\n- git diff --check\n- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject blank release secret values to prevent misconfigured releases. Whitespace-only values are treated as missing, while nonblank values keep their exact whitespace; parser, dry-run, and `--check-env-file` paths enforce this without leaking secrets.

- **Bug Fixes**
  - Updated `missing_required_values` to flag `None` and `value.strip() == ""`.
  - Added regression tests for env-file parsing, dry-run, and `--check-env-file` to verify rejection and secret-safe output.

<sup>Written for commit 5c8be69a7519ee9557dd314a0699a2f91d112caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Reject blank release secret values during release setup

### What Changed
- Release secrets with only spaces are now treated as missing and block setup
- Secrets with intentional leading or trailing spaces are still kept exactly as entered
- Dry runs and env-file checks now catch blank secret values and report the secret name without exposing the value

### Impact
`✅ Fewer failed release setups`
`✅ Clearer env-file validation`
`✅ Lower risk of secret leaks in error output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
