### PR TITLE
Harden custom Linux repository release preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,26 +123,15 @@ jobs:
       - name: Validate custom Linux repository publication config
         if: startsWith(github.ref, 'refs/tags/v') && vars.CONU_LINUX_REPOSITORY_BASE_URL != ''
         env:
+          CONU_LINUX_REPOSITORY_BASE_URL: ${{ vars.CONU_LINUX_REPOSITORY_BASE_URL }}
           CONU_LINUX_REPOSITORY_S3_BUCKET: ${{ vars.CONU_LINUX_REPOSITORY_S3_BUCKET }}
+          CONU_LINUX_REPOSITORY_S3_PREFIX: ${{ vars.CONU_LINUX_REPOSITORY_S3_PREFIX }}
+          CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL: ${{ vars.CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL }}
+          CONU_LINUX_REPOSITORY_AWS_REGION: ${{ vars.CONU_LINUX_REPOSITORY_AWS_REGION }}
           CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID: ${{ secrets.CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID }}
           CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY: ${{ secrets.CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY }}
-        run: |
-          set -eu
-          missing=""
-          for name in \
-            CONU_LINUX_REPOSITORY_S3_BUCKET \
-            CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID \
-            CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY; do
-            eval "value=\${$name:-}"
-            if [ -z "$value" ]; then
-              missing="$missing $name"
-            fi
-          done
-          if [ -n "$missing" ]; then
-            echo "::error::Custom Linux repository base URL is configured, but custom publication setting(s) are missing:$missing"
-            exit 1
-          fi
-          echo "Custom Linux repository publication config is present."
+          CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN: ${{ secrets.CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN }}
+        run: python scripts/check-custom-linux-repository-publication-preflight.py
       - name: Note unsigned smoke mode
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: echo "Non-tag release workflow run; signing and npm publication secrets are not required."

--- a/scripts/check-custom-linux-repository-publication-preflight.py
+++ b/scripts/check-custom-linux-repository-publication-preflight.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Validate custom hosted Linux repository publication config before release."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAGGED_READINESS = Path(__file__).with_name("check-tagged-release-readiness.py")
+
+BASE_URL_ENV = "CONU_LINUX_REPOSITORY_BASE_URL"
+BUCKET_ENV = "CONU_LINUX_REPOSITORY_S3_BUCKET"
+PREFIX_ENV = "CONU_LINUX_REPOSITORY_S3_PREFIX"
+ENDPOINT_ENV = "CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL"
+REGION_ENV = "CONU_LINUX_REPOSITORY_AWS_REGION"
+ACCESS_KEY_ENV = "CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID"
+SECRET_KEY_ENV = "CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY"
+SESSION_TOKEN_ENV = "CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN"
+MAX_SECRET_VALUE_BYTES = 8192
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        os.chdir(ROOT)
+        report = audit_environment(os.environ)
+    except (OSError, ValueError) as exc:
+        report = failure_report(str(exc))
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif report["ready"]:
+        print("Custom Linux repository publication preflight passed.")
+    else:
+        print("Custom Linux repository publication preflight failed.")
+        if report["missing"]:
+            print("Missing required environment variable(s):")
+            for name in report["missing"]:
+                print(f"  - {name}")
+        if report["issues"]:
+            print("Issue(s):")
+            for issue in report["issues"]:
+                print(f"  - {issue}")
+
+    return 0 if report["ready"] else 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print a machine-readable report without secret values",
+    )
+    return parser.parse_args()
+
+
+def audit_environment(env: Mapping[str, str]) -> dict[str, object]:
+    readiness = load_tagged_readiness()
+    missing: list[str] = []
+    issues: list[str] = []
+    checks: dict[str, bool] = {}
+
+    validate_required_variable(
+        env,
+        BASE_URL_ENV,
+        readiness.normalize_custom_base_url,
+        "customBaseUrl",
+        missing,
+        issues,
+        checks,
+    )
+    validate_required_variable(
+        env,
+        BUCKET_ENV,
+        readiness.validate_bucket,
+        "customBucket",
+        missing,
+        issues,
+        checks,
+    )
+    validate_optional_variable(
+        env,
+        PREFIX_ENV,
+        readiness.validate_prefix,
+        "customPrefixValid",
+        issues,
+        checks,
+    )
+    validate_optional_variable(
+        env,
+        ENDPOINT_ENV,
+        readiness.validate_endpoint_url,
+        "customEndpointValid",
+        issues,
+        checks,
+    )
+    validate_optional_variable(
+        env,
+        REGION_ENV,
+        readiness.validate_region,
+        "customRegionValid",
+        issues,
+        checks,
+    )
+
+    for name in (ACCESS_KEY_ENV, SECRET_KEY_ENV):
+        validate_required_secret(env, name, missing, issues, checks)
+    validate_optional_secret(env, SESSION_TOKEN_ENV, issues, checks)
+
+    ready = not missing and not issues
+    return {
+        "schema": "conu.customLinuxRepositoryPublicationPreflight.v1",
+        "ready": ready,
+        "checks": checks,
+        "missing": tuple(sorted(set(missing))),
+        "issues": tuple(issues),
+        "payloadDisplayed": False,
+        "contentsDisplayed": False,
+        "tokenDisplayed": False,
+        "tokenHashDisplayed": False,
+        "keyMaterialDisplayed": False,
+        "secretValuesDisplayed": False,
+    }
+
+
+def load_tagged_readiness():
+    spec = importlib.util.spec_from_file_location(
+        "check_tagged_release_readiness_for_custom_repository_preflight",
+        TAGGED_READINESS,
+    )
+    if spec is None or spec.loader is None:
+        raise ValueError("could not load tagged release readiness validators")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def validate_required_variable(
+    env: Mapping[str, str],
+    name: str,
+    validator,
+    key: str,
+    missing: list[str],
+    issues: list[str],
+    checks: dict[str, bool],
+) -> None:
+    value = env.get(name, "")
+    configured = value.strip() != ""
+    checks[f"{key}Configured"] = configured
+    checks[f"{key}Valid"] = False
+    if not configured:
+        missing.append(name)
+        return
+    try:
+        validator(value)
+    except ValueError as exc:
+        issues.append(str(exc))
+        return
+    checks[f"{key}Valid"] = True
+
+
+def validate_optional_variable(
+    env: Mapping[str, str],
+    name: str,
+    validator,
+    check_name: str,
+    issues: list[str],
+    checks: dict[str, bool],
+) -> None:
+    value = env.get(name, "")
+    checks[check_name] = True
+    if value.strip() == "":
+        return
+    try:
+        validator(value)
+    except ValueError as exc:
+        checks[check_name] = False
+        issues.append(str(exc))
+
+
+def validate_required_secret(
+    env: Mapping[str, str],
+    name: str,
+    missing: list[str],
+    issues: list[str],
+    checks: dict[str, bool],
+) -> None:
+    value = env.get(name, "")
+    configured = value.strip() != ""
+    checks[f"{name}Configured"] = configured
+    checks[f"{name}ShapeValid"] = False
+    if not configured:
+        missing.append(name)
+        return
+    if validate_secret_shape(name, value, issues):
+        checks[f"{name}ShapeValid"] = True
+
+
+def validate_optional_secret(
+    env: Mapping[str, str],
+    name: str,
+    issues: list[str],
+    checks: dict[str, bool],
+) -> None:
+    value = env.get(name, "")
+    configured = value != ""
+    checks[f"{name}Configured"] = configured
+    checks[f"{name}ShapeValid"] = True
+    if not configured:
+        return
+    if value.strip() == "":
+        checks[f"{name}ShapeValid"] = False
+        issues.append(f"{name} must not be blank when configured")
+        return
+    if not validate_secret_shape(name, value, issues):
+        checks[f"{name}ShapeValid"] = False
+
+
+def validate_secret_shape(name: str, value: str, issues: list[str]) -> bool:
+    valid = True
+    if len(value.encode("utf-8")) > MAX_SECRET_VALUE_BYTES:
+        issues.append(f"{name} is too large")
+        valid = False
+    if not is_single_line_secret_value(value):
+        issues.append(f"{name} must be a single-line secret value without whitespace or control characters")
+        valid = False
+    return valid
+
+
+def is_single_line_secret_value(value: str) -> bool:
+    return all(character > " " and character != "\x7f" for character in value)
+
+
+def failure_report(issue: str) -> dict[str, object]:
+    return {
+        "schema": "conu.customLinuxRepositoryPublicationPreflight.v1",
+        "ready": False,
+        "checks": {},
+        "missing": (),
+        "issues": (issue,),
+        "payloadDisplayed": False,
+        "contentsDisplayed": False,
+        "tokenDisplayed": False,
+        "tokenHashDisplayed": False,
+        "keyMaterialDisplayed": False,
+        "secretValuesDisplayed": False,
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SITE_CHECKER = ROOT / "scripts" / "check-hosted-linux-repository-site.py"
 PAGES_PREPARER = ROOT / "scripts" / "prepare-hosted-linux-repository-pages.py"
 PUBLISHER = ROOT / "scripts" / "publish-hosted-linux-repository-s3.py"
+PREFLIGHT = ROOT / "scripts" / "check-custom-linux-repository-publication-preflight.py"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 VERSION = "0.1.0"
@@ -24,6 +25,7 @@ BUCKET = "conu-packages-fixture"
 PREFIX = "public/conu"
 HOSTED_BUNDLE = f"conu-{VERSION}-hosted-linux-repositories.zip"
 SITE_BUNDLE = f"conu-{VERSION}-hosted-linux-repository-site.zip"
+SENSITIVE_SENTINEL = "do-not-print-this-secret-value"
 
 
 def main() -> int:
@@ -309,6 +311,7 @@ def main() -> int:
             symlink_entry_result = run_publisher_raw(symlink_entry, "--dry-run")
             assert_failure("symlinked site entry", symlink_entry_result, "site entry must not be a symlink")
 
+    assert_preflight()
     assert_workflow_wiring()
     print("Hosted Linux repository S3 publication regression checks passed")
     return 0
@@ -504,6 +507,105 @@ def assert_failure(description: str, result: subprocess.CompletedProcess[str], e
         raise AssertionError(f"{description} failed with {result.stdout!r}, expected {expected!r}")
 
 
+def assert_preflight() -> None:
+    valid = run_preflight_raw(preflight_env())
+    if valid.returncode != 0:
+        raise AssertionError(f"custom repository preflight failed unexpectedly: {valid.stdout!r}")
+    valid_report = json.loads(valid.stdout)
+    assert_safe_preflight_report(valid_report)
+    if not valid_report["ready"]:
+        raise AssertionError(f"custom repository preflight should be ready: {valid_report!r}")
+
+    missing_env = preflight_env()
+    missing_env.pop("CONU_LINUX_REPOSITORY_S3_BUCKET")
+    missing_env["CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY"] = "   "
+    missing = run_preflight_raw(missing_env)
+    if missing.returncode == 0:
+        raise AssertionError("missing custom repository preflight config unexpectedly passed")
+    missing_report = json.loads(missing.stdout)
+    assert_safe_preflight_report(missing_report)
+    for name in (
+        "CONU_LINUX_REPOSITORY_S3_BUCKET",
+        "CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY",
+    ):
+        if name not in missing_report["missing"]:
+            raise AssertionError(f"custom repository preflight did not report missing {name}")
+
+    invalid_env = preflight_env()
+    invalid_env["CONU_LINUX_REPOSITORY_BASE_URL"] = (
+        f"https://user:{SENSITIVE_SENTINEL}@packages.example.com/conu"
+    )
+    invalid_env["CONU_LINUX_REPOSITORY_S3_PREFIX"] = "bad//prefix"
+    invalid_env["CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL"] = (
+        f"https://user:{SENSITIVE_SENTINEL}@s3.example.com"
+    )
+    invalid_env["CONU_LINUX_REPOSITORY_AWS_REGION"] = "us east 1"
+    invalid_env["CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID"] = (
+        f"access-key\n{SENSITIVE_SENTINEL}"
+    )
+    invalid = run_preflight_raw(invalid_env)
+    if invalid.returncode == 0:
+        raise AssertionError("invalid custom repository preflight config unexpectedly passed")
+    invalid_report = json.loads(invalid.stdout)
+    assert_safe_preflight_report(invalid_report)
+    rendered = json.dumps(invalid_report)
+    for expected in (
+        "custom repository base URL must not include credentials",
+        "custom repository S3 prefix must not contain empty path segments",
+        "custom repository S3 endpoint URL must not include credentials",
+        "custom repository AWS region must not contain whitespace",
+        "single-line secret value",
+    ):
+        if expected not in rendered:
+            raise AssertionError(f"custom repository preflight missed {expected!r}")
+
+
+def preflight_env() -> dict[str, str]:
+    return {
+        "CONU_LINUX_REPOSITORY_BASE_URL": BASE_URL,
+        "CONU_LINUX_REPOSITORY_S3_BUCKET": BUCKET,
+        "CONU_LINUX_REPOSITORY_S3_PREFIX": PREFIX,
+        "CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL": "https://s3.example.com",
+        "CONU_LINUX_REPOSITORY_AWS_REGION": "us-east-1",
+        "CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID": "AKIAEXAMPLEKEY",
+        "CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY": "secret/access+key=example",
+        "CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN": "optional-session-token",
+    }
+
+
+def run_preflight_raw(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    run_env = os.environ.copy()
+    for name in preflight_env():
+        run_env.pop(name, None)
+    run_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(PREFLIGHT), "--json"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=run_env,
+    )
+
+
+def assert_safe_preflight_report(report: dict[str, object]) -> None:
+    rendered = json.dumps(report)
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("custom repository preflight leaked a secret value")
+    for flag in (
+        "payloadDisplayed",
+        "contentsDisplayed",
+        "tokenDisplayed",
+        "tokenHashDisplayed",
+        "keyMaterialDisplayed",
+        "secretValuesDisplayed",
+    ):
+        if report.get(flag) is not False:
+            raise AssertionError(f"custom repository preflight report did not set {flag}=false")
+
+
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:
     try:
         os.symlink(target, link, target_is_directory=target_is_directory)
@@ -522,6 +624,7 @@ def assert_workflow_wiring() -> None:
         "Publish Custom Linux Repository S3 Site",
         "Linux Repository Publication Gate",
         "CONU_LINUX_REPOSITORY_S3_BUCKET",
+        "python scripts/check-custom-linux-repository-publication-preflight.py",
         "python scripts/publish-hosted-linux-repository-s3.py",
         "needs: [github-release, linux-repository-pages, custom-linux-repository-publish]",
         "needs: [github-release, linux-repository-publication]",


### PR DESCRIPTION
## **User description**
## Summary
- Replace the custom Linux repository shell-only release gate with a sanitized Python preflight.
- Validate custom base URL, S3 bucket, optional prefix/endpoint/region, and required AWS secret value shape before tagged publication.
- Extend S3 publication regression coverage to prove malformed config fails without printing secret values.

## Validation
- python -m py_compile scripts\\check-custom-linux-repository-publication-preflight.py scripts\\check-hosted-linux-repository-s3-publication.py scripts\\check-tagged-release-readiness.py
- python scripts\\check-hosted-linux-repository-s3-publication.py
- python scripts\\check-tagged-release-readiness-regression.py
- python scripts\\check-github-workflow-permissions-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

Closes #623

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the shell gate with a Python preflight that validates custom Linux repository config before tagged releases. Hardened checks and tests so bad configs fail fast without leaking secrets. Closes #623.

- **New Features**
  - Added `scripts/check-custom-linux-repository-publication-preflight.py` to validate `CONU_LINUX_REPOSITORY_BASE_URL`, `CONU_LINUX_REPOSITORY_S3_BUCKET`, optional `S3_PREFIX`, `S3_ENDPOINT_URL`, `AWS_REGION`, and AWS secret value shape.
  - Wired `release.yml` to run the preflight on tagged builds, passing `CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN` when present.

- **Bug Fixes**
  - Extended S3 publication regression checks to ensure malformed config fails and never prints secret values (includes sentinel leak detection).
  - Preflight outputs a safe JSON report and concise errors only; no key material or tokens are displayed.

<sup>Written for commit b60c07dc4a891b9c02e3a93c3e26a2858a702064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Harden custom Linux repository release checks before tagged publication

### What Changed
- Tagged releases now run a dedicated preflight check for custom Linux repository publishing instead of only checking that a few values are present.
- The check now verifies the repository address, S3 bucket, optional prefix, endpoint, region, and secret values, and it rejects invalid or blank inputs before release continues.
- The release workflow now passes the optional session token and additional custom repository settings into the check.
- Regression coverage now proves that malformed settings fail safely and that secret values are not shown in the output.

### Impact
`✅ Fewer release-time configuration failures`
`✅ Clearer preflight errors for custom repository publishing`
`✅ Lower risk of secret values appearing in logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
