### PR TITLE
Redact smoke state paths from readiness logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg openssl
       - name: Python script compile
         run: python scripts/check-python-script-compile.py
+      - name: Smoke output privacy regression
+        run: python scripts/check-smoke-output-privacy.py
       - name: Release version consistency
         run: python scripts/verify-release-versions.py
       - name: Release artifact verifier regression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg openssl
       - name: Python script compile
         run: python scripts/check-python-script-compile.py
+      - name: Smoke output privacy regression
+        run: python scripts/check-smoke-output-privacy.py
       - name: Release version consistency
         run: python scripts/verify-release-versions.py
       - name: Release artifact verifier regression

--- a/scripts/check-smoke-output-privacy.py
+++ b/scripts/check-smoke-output-privacy.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Check smoke scripts keep local state paths out of readiness logs."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE_SCRIPTS = (
+    ROOT / "scripts" / "smoke-local.ps1",
+    ROOT / "scripts" / "smoke-identity-retirement.ps1",
+    ROOT / "scripts" / "smoke-relay-daemon.ps1",
+)
+OUTPUT_COMMANDS = ("Write-Host", "throw")
+FORBIDDEN_OUTPUT_FRAGMENTS = (
+    "CONU_HOME=",
+    "nodeA=",
+    "nodeB=",
+    "relay=",
+    "$conuSmokeHome",
+    "$smokeHome",
+    "$smokeRoot",
+    "$homeA",
+    "$homeB",
+    "$StateHome",
+    "$resolvedSmoke",
+)
+
+
+def main() -> int:
+    issues: list[str] = []
+    for path in SMOKE_SCRIPTS:
+        check_output_lines(path, issues)
+        check_success_guard(path, issues)
+
+    check_identity_cleanup(ROOT / "scripts" / "smoke-identity-retirement.ps1", issues)
+    check_relay_output_suppression(ROOT / "scripts" / "smoke-relay-daemon.ps1", issues)
+
+    if issues:
+        print("smoke output privacy check failed", file=sys.stderr)
+        for issue in issues:
+            print(f"issue: {issue}", file=sys.stderr)
+        return 1
+
+    print("smoke output privacy check passed")
+    return 0
+
+
+def check_output_lines(path: Path, issues: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    for index, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped.startswith(OUTPUT_COMMANDS):
+            continue
+        for fragment in FORBIDDEN_OUTPUT_FRAGMENTS:
+            if fragment in stripped:
+                issues.append(
+                    f"{path.relative_to(ROOT)}:line {index} prints local smoke state marker {fragment}"
+                )
+
+
+def check_success_guard(path: Path, issues: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    if "statePathDisplayed=false" not in text:
+        issues.append(f"{path.relative_to(ROOT)} is missing statePathDisplayed=false success guard")
+
+
+def check_identity_cleanup(path: Path, issues: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    required_fragments = (
+        "$previousConuHome = $env:CONU_HOME",
+        "finally {",
+        "Remove-Item Env:CONU_HOME -ErrorAction SilentlyContinue",
+        "$env:CONU_HOME = $previousConuHome",
+        "Remove-Item -LiteralPath $resolvedSmoke.Path -Recurse -Force",
+    )
+    for fragment in required_fragments:
+        if fragment not in text:
+            issues.append(
+                f"{path.relative_to(ROOT)} is missing cleanup fragment {fragment!r}"
+            )
+
+
+def check_relay_output_suppression(path: Path, issues: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    if "commandOutputDisplayed=false" not in text:
+        issues.append(f"{path.relative_to(ROOT)} is missing commandOutputDisplayed=false guard")
+    if "$($output -join" in text:
+        issues.append(f"{path.relative_to(ROOT)} can echo captured command output on failure")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-identity-retirement.ps1
+++ b/scripts/smoke-identity-retirement.ps1
@@ -5,56 +5,71 @@ param(
 $ErrorActionPreference = "Stop"
 
 $smokeHome = Join-Path $env:TEMP ("conu-identity-retire-smoke-" + [guid]::NewGuid().ToString("N"))
-New-Item -ItemType Directory -Force $smokeHome | Out-Null
-$env:CONU_HOME = $smokeHome
+$previousConuHome = $env:CONU_HOME
 
 function Invoke-Conu {
     param([Parameter(ValueFromRemainingArguments = $true)][string[]]$ConuArgs)
     & cargo "+$Toolchain" run -q -p conu-cli -- @ConuArgs
 }
 
-Invoke-Conu init | Out-Null
-$before = Invoke-Conu identity export --json | ConvertFrom-Json
-$rotateRaw = Invoke-Conu security rotate identity --confirm-peer-refresh --json
-$exportRaw = Invoke-Conu identity export --json
-$retireRaw = Invoke-Conu security retire identity --confirm-peer-refresh-complete --json
+try {
+    New-Item -ItemType Directory -Force $smokeHome | Out-Null
+    $env:CONU_HOME = $smokeHome
 
-if ($rotateRaw -match "secret_key_hex|dpapi_hex|private|plaintext") {
-    throw "identity rotation output exposed sensitive marker: $rotateRaw"
-}
-if ($retireRaw -match "secret_key_hex|dpapi_hex|private|plaintext") {
-    throw "identity retirement output exposed sensitive marker: $retireRaw"
-}
+    Invoke-Conu init | Out-Null
+    $before = Invoke-Conu identity export --json | ConvertFrom-Json
+    $rotateRaw = Invoke-Conu security rotate identity --confirm-peer-refresh --json
+    $exportRaw = Invoke-Conu identity export --json
+    $retireRaw = Invoke-Conu security retire identity --confirm-peer-refresh-complete --json
 
-$after = $exportRaw | ConvertFrom-Json
-$retire = $retireRaw | ConvertFrom-Json
-if ($before.signatureKeyId -eq $after.signatureKeyId) {
-    throw "signature key id did not change"
-}
-if ($before.exchangePublicKeyHex -eq $after.exchangePublicKeyHex) {
-    throw "exchange public key did not change"
-}
-if ($retire.status -ne "retired") {
-    throw "unexpected retirement status: $($retire.status)"
-}
-if ($retire.contentsDisplayed -ne $false) {
-    throw "contentsDisplayed was not false"
-}
-if ($retire.peerCardRefreshConfirmed -ne $true) {
-    throw "peerCardRefreshConfirmed was not true"
-}
-if ($retire.retiredIdentityKeys -lt 2) {
-    throw "expected at least two retired identity keys, got $($retire.retiredIdentityKeys)"
-}
+    if ($rotateRaw -match "secret_key_hex|dpapi_hex|private|plaintext") {
+        throw "identity rotation output exposed sensitive marker; commandOutputDisplayed=false"
+    }
+    if ($retireRaw -match "secret_key_hex|dpapi_hex|private|plaintext") {
+        throw "identity retirement output exposed sensitive marker; commandOutputDisplayed=false"
+    }
 
-$archiveDir = Join-Path $smokeHome "security\identity-keys"
-$archiveCount = 0
-if (Test-Path $archiveDir) {
-    $archiveCount = @(Get-ChildItem -Path $archiveDir -Filter *.key).Count
-}
-if ($archiveCount -ne 0) {
-    throw "expected no remaining identity key archives, found $archiveCount"
-}
+    $after = $exportRaw | ConvertFrom-Json
+    $retire = $retireRaw | ConvertFrom-Json
+    if ($before.signatureKeyId -eq $after.signatureKeyId) {
+        throw "signature key id did not change"
+    }
+    if ($before.exchangePublicKeyHex -eq $after.exchangePublicKeyHex) {
+        throw "exchange public key did not change"
+    }
+    if ($retire.status -ne "retired") {
+        throw "unexpected retirement status: $($retire.status)"
+    }
+    if ($retire.contentsDisplayed -ne $false) {
+        throw "contentsDisplayed was not false"
+    }
+    if ($retire.peerCardRefreshConfirmed -ne $true) {
+        throw "peerCardRefreshConfirmed was not true"
+    }
+    if ($retire.retiredIdentityKeys -lt 2) {
+        throw "expected at least two retired identity keys, got $($retire.retiredIdentityKeys)"
+    }
 
-Write-Host "conU identity archive retirement smoke passed"
-Write-Host "CONU_HOME=$smokeHome"
+    $archiveDir = Join-Path $smokeHome "security\identity-keys"
+    $archiveCount = 0
+    if (Test-Path $archiveDir) {
+        $archiveCount = @(Get-ChildItem -Path $archiveDir -Filter *.key).Count
+    }
+    if ($archiveCount -ne 0) {
+        throw "expected no remaining identity key archives, found $archiveCount"
+    }
+
+    Write-Host "conU identity archive retirement smoke passed; statePathDisplayed=false"
+}
+finally {
+    if ($null -eq $previousConuHome) {
+        Remove-Item Env:CONU_HOME -ErrorAction SilentlyContinue
+    } else {
+        $env:CONU_HOME = $previousConuHome
+    }
+
+    $resolvedSmoke = Resolve-Path $smokeHome -ErrorAction SilentlyContinue
+    if ($null -ne $resolvedSmoke -and $resolvedSmoke.Path.StartsWith([System.IO.Path]::GetTempPath(), [System.StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $resolvedSmoke.Path -Recurse -Force
+    }
+}

--- a/scripts/smoke-local.ps1
+++ b/scripts/smoke-local.ps1
@@ -55,7 +55,7 @@ try {
         throw "Smoke command failed: conu doctor did not report localInstallReady=true"
     }
 
-    Write-Host "conU smoke passed with CONU_HOME=$conuSmokeHome"
+    Write-Host "conU smoke passed; statePathDisplayed=false"
 }
 finally {
     Remove-Item Env:CONU_HOME -ErrorAction SilentlyContinue

--- a/scripts/smoke-relay-daemon.ps1
+++ b/scripts/smoke-relay-daemon.ps1
@@ -59,7 +59,7 @@ function Invoke-Conu {
             $output = $InputText | & $script:ConuPath @Arguments
         }
         if ($LASTEXITCODE -ne 0) {
-            throw "conu $($Arguments -join ' ') failed with code $LASTEXITCODE`n$($output -join "`n")"
+            throw "conu smoke command failed with code $LASTEXITCODE; commandOutputDisplayed=false"
         }
         return ($output -join "`n")
     }
@@ -157,7 +157,7 @@ function Start-ConuRuntime {
         }
     }
 
-    throw "conUD did not publish a running heartbeat for $StateHome"
+    throw "conUD did not publish a running heartbeat for smoke state; statePathDisplayed=false"
 }
 
 function Wait-ForInbox {
@@ -207,7 +207,7 @@ try {
     if ($relayProcess.HasExited) {
         throw "conu-relay exited early with code $($relayProcess.ExitCode)"
     }
-    Write-Host "relay started at $relayEndpoint"
+    Write-Host "relay started on loopback smoke endpoint; endpointDisplayed=false"
 
     Invoke-Conu -StateHome $homeA -Arguments @("init") | Out-Null
     Invoke-Conu -StateHome $homeB -Arguments @("init") | Out-Null
@@ -258,10 +258,7 @@ try {
         throw "Smoke payload appeared in conU-owned state"
     }
 
-    Write-Host "conU relay daemon smoke passed"
-    Write-Host "relay=$relayEndpoint"
-    Write-Host "nodeA=$homeA"
-    Write-Host "nodeB=$homeB"
+    Write-Host "conU relay daemon smoke passed; statePathDisplayed=false; endpointDisplayed=false"
 }
 finally {
     Stop-ConuRuntime -StateHome $homeA -Process $conudProcessA

--- a/scripts/verify-production-readiness.ps1
+++ b/scripts/verify-production-readiness.ps1
@@ -271,6 +271,9 @@ try {
         Invoke-ReadinessStep "python compile" {
             & python scripts/check-python-script-compile.py
         }
+        Invoke-ReadinessStep "smoke output privacy regression" {
+            & python scripts/check-smoke-output-privacy.py
+        }
         Invoke-ReadinessStep "release version consistency" {
             & python scripts/verify-release-versions.py
         }


### PR DESCRIPTION
## **User description**
Closes #635.\n\n## Summary\n- redact temporary CONU_HOME/node state paths from smoke success and failure output\n- restore and remove the identity retirement smoke CONU_HOME in a finally block\n- add a smoke output privacy regression to CI, release package checks, and local production readiness\n\n## Validation\n- python scripts/check-smoke-output-privacy.py\n- python scripts/check-python-script-compile.py\n- python scripts/check-github-workflow-permissions.py\n- python scripts/check-github-workflow-permissions-regression.py\n- PowerShell script parsing for smoke/readiness scripts\n- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts local smoke state paths and sensitive output from readiness logs and adds a privacy regression check to CI, release, and local readiness. Addresses #635.

- **Bug Fixes**
  - Updated smoke scripts to stop printing `CONU_HOME`, node paths, and relay endpoints; replaced with guarded messages (`statePathDisplayed=false`, `endpointDisplayed=false`, `commandOutputDisplayed=false`).
  - Wrapped identity retirement smoke in try/finally to restore/remove `CONU_HOME` and delete the temp state dir; removed failure messages that echo captured command output.

- **New Features**
  - Added `scripts/check-smoke-output-privacy.py` to enforce forbidden output fragments and required guards, plus cleanup checks.
  - Wired the privacy check into `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `scripts/verify-production-readiness.ps1`.

<sup>Written for commit a3fb1ed8947b0841687286b8ca48c35260837809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide local smoke paths and captured output from readiness logs**

### What Changed
- Smoke checks no longer print temporary home paths, relay endpoints, or captured command output in success and failure messages.
- The identity retirement smoke now restores the previous home setting and removes its temporary state directory even when something fails.
- A new privacy regression check blocks future smoke output that exposes local state paths or command output, and it runs in CI, release checks, and local readiness checks.

### Impact
`✅ Fewer leaked local paths in smoke logs`
`✅ Clearer failure messages during readiness checks`
`✅ Lower risk of exposing captured command output in CI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
