### PR TITLE
Redact npm installer local paths

### DIFF
--- a/packaging/npm/conu-cli/package.json
+++ b/packaging/npm/conu-cli/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "postinstall": "node scripts/install.js",
-    "check": "node scripts/install.js --check-only && node scripts/check-archive-preflight.js && node scripts/check-checksum-verification.js && node scripts/check-extract-selection.js && node scripts/check-local-binary-dir.js && node scripts/check-install-target.js && node scripts/check-download-policy.js && node scripts/check-download-limits.js"
+    "check": "node scripts/install.js --check-only && node scripts/check-install-output-privacy.js && node scripts/check-archive-preflight.js && node scripts/check-checksum-verification.js && node scripts/check-extract-selection.js && node scripts/check-local-binary-dir.js && node scripts/check-install-target.js && node scripts/check-download-policy.js && node scripts/check-download-limits.js"
   },
   "engines": {
     "node": ">=22 <23 || >=24 <25"

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const { BINARIES, binarySuffix, vendorDir } = require("../lib/platform");
+
+const packageRoot = path.resolve(__dirname, "..");
+
+function main() {
+  const checkOnly = runNode([path.join(packageRoot, "scripts", "install.js"), "--check-only"]);
+  expectNoLocalPath(checkOnly, packageRoot, "check-only package root");
+  expectNoLocalPath(checkOnly, vendorDir(), "check-only vendor dir");
+  expectIncludes(checkOnly, "pathDisplayed=false", "check-only path display guard");
+
+  withFixture((root) => {
+    const packageCopy = path.join(root, "package");
+    const binaryDir = path.join(root, "override-binaries");
+    copyPackage(packageRoot, packageCopy);
+    writeBinaries(binaryDir);
+
+    const output = runNode([path.join(packageCopy, "scripts", "install.js")], {
+      CONU_NPM_BINARY_DIR: binaryDir,
+      CONU_NPM_SKIP_DOWNLOAD: "",
+      CONU_NPM_DIST_BASE: "",
+      CONU_NPM_ALLOW_UNVERIFIED: ""
+    });
+
+    expectNoLocalPath(output, root, "local install temp root");
+    expectNoLocalPath(output, binaryDir, "local install source dir");
+    expectNoLocalPath(output, path.join(packageCopy, "vendor"), "local install vendor dir");
+    expectIncludes(output, "sourcePathDisplayed=false", "local install source path guard");
+  });
+
+  console.log("install output privacy check passed");
+}
+
+function runNode(args, envOverrides = {}) {
+  const env = { ...process.env, ...envOverrides };
+  for (const [name, value] of Object.entries(envOverrides)) {
+    if (value === "") {
+      delete env[name];
+    }
+  }
+  const result = spawnSync(process.execPath, args, {
+    cwd: packageRoot,
+    env,
+    encoding: "utf8",
+    errors: "replace",
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  if (result.status !== 0) {
+    throw new Error(`node command failed with ${result.status}: ${output}`);
+  }
+  return output;
+}
+
+function withFixture(callback) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "conu-install-output-privacy-"));
+  try {
+    callback(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function copyPackage(source, destination) {
+  fs.cpSync(source, destination, {
+    recursive: true,
+    filter: (entry) => {
+      const relative = path.relative(source, entry);
+      if (!relative) {
+        return true;
+      }
+      const firstPart = relative.split(path.sep)[0];
+      return !["node_modules", "vendor"].includes(firstPart);
+    }
+  });
+}
+
+function writeBinaries(binaryDir) {
+  fs.mkdirSync(binaryDir, { recursive: true });
+  const suffix = binarySuffix();
+  for (const name of BINARIES) {
+    fs.writeFileSync(path.join(binaryDir, `${name}${suffix}`), `${name}\n`);
+  }
+}
+
+function expectNoLocalPath(output, value, label) {
+  const normalized = String(value);
+  if (normalized && output.includes(normalized)) {
+    throw new Error(`${label}: output displayed local path ${normalized}`);
+  }
+}
+
+function expectIncludes(output, value, label) {
+  if (!output.includes(value)) {
+    throw new Error(`${label}: expected output to include ${value}`);
+  }
+}
+
+main();

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -51,7 +51,7 @@ async function main() {
   if (checkOnly) {
     console.log(`conU npm package ${version}`);
     console.log(`platform asset: ${asset}`);
-    console.log(`vendor dir: ${vendorDir()}`);
+    console.log("vendor dir: managed by package; pathDisplayed=false");
     return;
   }
 
@@ -107,7 +107,7 @@ function installFromLocalDir(sourceDir) {
   for (const name of BINARIES) {
     installBinary(binaries[name], name);
   }
-  console.log(`installed conU binaries from ${sourceDir}`);
+  console.log("installed conU binaries from local override; sourcePathDisplayed=false");
 }
 
 function installFromExtractedArchive(root) {
@@ -149,7 +149,7 @@ function extractArchive(archivePath, destination) {
     }
   }
 
-  throw new Error(`failed to extract ${archivePath}`);
+  throw new Error(`failed to extract ${asset}; pathDisplayed=false`);
 }
 
 function downloadOptionalText(url, maxBytes) {

--- a/scripts/verify-npm-package-contents.py
+++ b/scripts/verify-npm-package-contents.py
@@ -94,6 +94,7 @@ PACKAGES = (
                 "scripts/check-download-limits.js",
                 "scripts/check-download-policy.js",
                 "scripts/check-extract-selection.js",
+                "scripts/check-install-output-privacy.js",
                 "scripts/check-install-target.js",
                 "scripts/check-local-binary-dir.js",
                 "scripts/install.js",


### PR DESCRIPTION
## **User description**
Closes #637.\n\n## Summary\n- redacts @conu/cli npm check-only vendor path output\n- redacts CONU_NPM_BINARY_DIR source path output for local override installs\n- avoids printing temp archive paths on extraction failure\n- adds a packaged npm installer output privacy regression\n- updates npm package content allowlist for the new regression script\n\n## Validation\n- node packaging/npm/conu-cli/scripts/check-install-output-privacy.js\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts/verify-npm-package-contents.py --package @conu/cli\n- python scripts/verify-npm-package-contents-regression.py\n- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts local paths from the `@conu/cli` npm installer output to protect privacy and adds a regression check to enforce it. Prevents leaking vendor, override source, and temp archive paths during checks, installs, and failures.

- **Bug Fixes**
  - Hide vendor dir in check-only output; add "pathDisplayed=false" guard.
  - Hide local override source dir; add "sourcePathDisplayed=false" guard.
  - Stop printing temp archive paths on extraction errors.

- **New Features**
  - Add `scripts/check-install-output-privacy.js` and run it in the package `check` script.
  - Update the package content allowlist to include the new script.

<sup>Written for commit 7318447c9886e91351c7480d0ea35fd3e9c6f8cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact local install paths from npm installer output**

### What Changed
- Installer messages no longer print local paths for the package root, vendor directory, local override binaries, or failed archive extraction.
- Check-only output now shows a privacy-safe vendor message instead of the actual directory path.
- Local override installs now confirm the source without revealing the source folder path.
- Added a privacy check that blocks these paths from appearing in npm installer output, and included it in the package check run.

### Impact
`✅ Fewer local path leaks in npm install logs`
`✅ Safer check-only output`
`✅ Clearer failure messages without exposing temp paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation output no longer displays local filesystem paths, improving privacy and security.

* **Chores**
  * Added automated privacy validation checks to the installation process to prevent filesystem path leakage in console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->