### PR TITLE
Suppress npm extraction tool output

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -10,6 +10,9 @@ const { BINARIES, binarySuffix, vendorDir } = require("../lib/platform");
 const packageRoot = path.resolve(__dirname, "..");
 
 function main() {
+  const installScript = fs.readFileSync(path.join(packageRoot, "scripts", "install.js"), "utf8");
+  expectNotIncludes(installScript, 'stdio: "inherit"', "installer child output privacy guard");
+
   const checkOnly = runNode([path.join(packageRoot, "scripts", "install.js"), "--check-only"]);
   expectNoLocalPath(checkOnly, packageRoot, "check-only package root");
   expectNoLocalPath(checkOnly, vendorDir(), "check-only vendor dir");
@@ -100,6 +103,12 @@ function expectNoLocalPath(output, value, label) {
 function expectIncludes(output, value, label) {
   if (!output.includes(value)) {
     throw new Error(`${label}: expected output to include ${value}`);
+  }
+}
+
+function expectNotIncludes(output, value, label) {
+  if (output.includes(value)) {
+    throw new Error(`${label}: expected output not to include ${value}`);
   }
 }
 

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -125,7 +125,7 @@ function installFromExtractedArchive(root) {
 function extractArchive(archivePath, destination) {
   validateArchiveMembers(archivePath);
 
-  const tar = spawnSync("tar", ["-xf", archivePath, "-C", destination], { stdio: "inherit" });
+  const tar = spawnSync("tar", ["-xf", archivePath, "-C", destination], { stdio: "ignore" });
   if (tar.status === 0) {
     return;
   }
@@ -142,7 +142,7 @@ function extractArchive(archivePath, destination) {
         archivePath,
         destination
       ],
-      { stdio: "inherit" }
+      { stdio: "ignore" }
     );
     if (ps.status === 0) {
       return;


### PR DESCRIPTION
## **User description**
## Summary
- suppress npm archive extraction subprocess stdout/stderr so extraction failures cannot print local temp paths
- add installer privacy regression that fails if `install.js` uses inherited child stdio again

## Validation
- `node packaging/npm/conu-cli/scripts/check-install-output-privacy.js`
- `npm run check --prefix packaging/npm/conu-cli`
- `python scripts\verify-npm-package-contents.py --package @conu/cli`
- `python scripts\verify-npm-package-contents-regression.py`
- `powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

Closes #639

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses stdout/stderr from archive extraction during `@conu/cli` install to avoid leaking local temp paths on failure. Adds a privacy regression check to prevent this from regressing, addressing #639.

- **Bug Fixes**
  - Use `{ stdio: "ignore" }` for `tar` and PowerShell extraction subprocesses instead of `"inherit"`.
  - Add `check-install-output-privacy.js` guard that fails if `install.js` uses inherited stdio and ensures no local paths appear in output.

<sup>Written for commit 0a2a466e9e1c9ffa7499036fec90116f0a8e631e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide installer extraction errors and prevent local path leaks**

### What Changed
- Archive extraction during `@conu/cli` install no longer prints subprocess output, so failed installs do not expose local temp paths.
- Windows zip extraction now uses the same hidden-output behavior as other platforms.
- A privacy check was added to fail if the installer starts inheriting child process output again.

### Impact
`✅ Fewer local path leaks in install failures`
`✅ Cleaner npm install errors`
`✅ Safer installer output privacy`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
