### PR TITLE
Validate npm token auth before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -727,7 +727,7 @@ jobs:
       - name: npm publish conflict preflight
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: python scripts/check-npm-publish-preflight.py --registry-check --require-token-env NODE_AUTH_TOKEN
+        run: python scripts/check-npm-publish-preflight.py --registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check
       - name: Publish @conu/cli
         working-directory: packaging/npm/conu-cli
         env:

--- a/scripts/check-npm-publish-preflight-regression.py
+++ b/scripts/check-npm-publish-preflight-regression.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.error import HTTPError
 
 
 SCRIPT = Path(__file__).with_name("check-npm-publish-preflight.py")
@@ -117,6 +118,84 @@ def run_token_tests(module) -> None:
             os.environ[env_name] = original
 
 
+class FakeResponse:
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+    def read(self, _size: int) -> bytes:
+        return self.body
+
+
+def run_token_auth_tests(module) -> None:
+    env_name = "CONU_TEST_NPM_TOKEN"
+    original = os.environ.pop(env_name, None)
+    original_urlopen = module.urlopen
+    token = "token-value"
+    try:
+        assert_raises(
+            lambda: module.validate_token_authentication(None),
+            "requires --require-token-env",
+        )
+
+        os.environ[env_name] = token
+
+        def successful_urlopen(request, timeout):
+            if timeout != 15:
+                raise AssertionError("unexpected token auth timeout")
+            if request.get_header("Authorization") != f"Bearer {token}":
+                raise AssertionError("token auth request did not use bearer authorization")
+            return FakeResponse(200, b'{"username":"imthegoodboy"}')
+
+        module.urlopen = successful_urlopen
+        module.validate_token_authentication(env_name)
+
+        def unauthorized_urlopen(*_args, **_kwargs):
+            raise HTTPError(module.NPM_WHOAMI_URL, 401, "Unauthorized", {}, None)
+
+        module.urlopen = unauthorized_urlopen
+        try:
+            module.validate_token_authentication(env_name)
+        except ValueError as exc:
+            rendered = str(exc)
+            if "authentication failed" not in rendered:
+                raise AssertionError(f"unexpected token auth error: {rendered}") from exc
+            if token in rendered:
+                raise AssertionError("token auth error leaked the token value") from exc
+        else:
+            raise AssertionError("invalid npm token unexpectedly passed authentication")
+
+        def malformed_json_urlopen(*_args, **_kwargs):
+            return FakeResponse(200, b'{"ok": true}')
+
+        module.urlopen = malformed_json_urlopen
+        assert_raises(
+            lambda: module.validate_token_authentication(env_name),
+            "did not return an npm username",
+        )
+
+        def oversized_urlopen(*_args, **_kwargs):
+            return FakeResponse(200, b"x" * (module.MAX_WHOAMI_RESPONSE_BYTES + 1))
+
+        module.urlopen = oversized_urlopen
+        assert_raises(
+            lambda: module.validate_token_authentication(env_name),
+            "response was too large",
+        )
+    finally:
+        module.urlopen = original_urlopen
+        if original is None:
+            os.environ.pop(env_name, None)
+        else:
+            os.environ[env_name] = original
+
+
 def main() -> int:
     module = load_module()
     original_run = subprocess.run
@@ -124,6 +203,7 @@ def main() -> int:
         run_registry_tests(module)
         run_version_consistency_tests(module)
         run_token_tests(module)
+        run_token_auth_tests(module)
     finally:
         module.subprocess.run = original_run
     print("npm publish preflight regression checks passed")

--- a/scripts/check-npm-publish-preflight.py
+++ b/scripts/check-npm-publish-preflight.py
@@ -13,9 +13,13 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+NPM_WHOAMI_URL = "https://registry.npmjs.org/-/whoami"
+MAX_WHOAMI_RESPONSE_BYTES = 4096
 
 
 @dataclass(frozen=True)
@@ -116,6 +120,41 @@ def is_single_line_token_value(value: str) -> bool:
     return all(character > " " and character != "\x7f" for character in value)
 
 
+def validate_token_authentication(env_name: str | None) -> None:
+    if not env_name:
+        raise ValueError("--token-auth-check requires --require-token-env")
+
+    validate_required_token(env_name)
+    token = os.environ[env_name]
+    request = Request(NPM_WHOAMI_URL, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urlopen(request, timeout=15) as response:
+            body = response.read(MAX_WHOAMI_RESPONSE_BYTES + 1)
+            status = response.status
+    except HTTPError as exc:
+        if exc.code in (401, 403):
+            raise ValueError(f"npm token authentication failed for {env_name}") from exc
+        raise ValueError(
+            f"npm token authentication check failed for {env_name}: HTTP {exc.code}"
+        ) from exc
+    except (OSError, TimeoutError, URLError) as exc:
+        raise ValueError(f"npm token authentication check failed for {env_name}") from exc
+
+    if status != 200:
+        raise ValueError(f"npm token authentication check failed for {env_name}: HTTP {status}")
+    if len(body) > MAX_WHOAMI_RESPONSE_BYTES:
+        raise ValueError(f"npm token authentication check response was too large for {env_name}")
+
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"npm token authentication check returned invalid JSON for {env_name}") from exc
+
+    username = parsed.get("username")
+    if not isinstance(username, str) or not is_single_line_token_value(username):
+        raise ValueError(f"npm token authentication check did not return an npm username for {env_name}")
+
+
 def npm_version_exists(npm: str, package: PackageInfo) -> bool:
     result = subprocess.run(
         [npm, "view", f"{package.name}@{package.version}", "version", "--json"],
@@ -196,6 +235,11 @@ def parse_args() -> argparse.Namespace:
         help="require this environment variable to be non-empty without printing its value",
     )
     parser.add_argument(
+        "--token-auth-check",
+        action="store_true",
+        help="verify the required npm token can authenticate without printing its value",
+    )
+    parser.add_argument(
         "--npm",
         default="",
         help=argparse.SUPPRESS,
@@ -212,6 +256,8 @@ def main() -> int:
         packages = tuple(validate_manifest(repo, rule) for rule in selected_packages(args.package))
         validate_package_version_consistency(packages)
         validate_required_token(args.require_token_env or None)
+        if args.token_auth_check:
+            validate_token_authentication(args.require_token_env or None)
 
         if args.registry_check:
             npm = args.npm or find_npm()
@@ -222,8 +268,13 @@ def main() -> int:
         return 1
 
     checked = ", ".join(f"{package.name}@{package.version}" for package in packages)
-    registry_note = " with registry availability" if args.registry_check else ""
-    print(f"npm publish preflight passed{registry_note}: {checked}")
+    notes = []
+    if args.registry_check:
+        notes.append("registry availability")
+    if args.token_auth_check:
+        notes.append("token authentication")
+    note = f" with {' and '.join(notes)}" if notes else ""
+    print(f"npm publish preflight passed{note}: {checked}")
     return 0
 
 


### PR DESCRIPTION
## **User description**
## Summary
- add an npm token authentication preflight that calls the npm `/-/whoami` endpoint through an Authorization header without printing token material
- wire the tagged npm publish preflight to verify token auth before either package publish runs
- add regression coverage for token auth success, auth failure, invalid whoami response, oversized response, and token-safe error text

## Validation
- `python scripts\check-npm-publish-preflight-regression.py`
- `python scripts\check-npm-publish-preflight.py`
- live `python scripts\check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check` with token provided through env only
- `python scripts\check-npm-publish-preflight.py --registry-check`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-github-workflow-permissions.py`
- `python scripts\check-github-workflow-permissions-regression.py`
- `powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

Closes #641

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the npm token before publish by calling the `/-/whoami` endpoint so we fail fast on invalid credentials. This prevents publish attempts with bad tokens and keeps error output token-safe.

- New Features
  - Added `--token-auth-check` to `scripts/check-npm-publish-preflight.py`; verifies the token via `/-/whoami` with Bearer auth, requires 200 + `username`, caps response to 4KB, and never prints the token.
  - Updated release workflow to pass `--token-auth-check` with `NODE_AUTH_TOKEN` before publishing.
  - Added regression tests for success, 401/403, malformed/invalid or oversized responses, and token-safe error messages.

<sup>Written for commit f0755fa2661b6e4c81533d2185dec3d737aa0c66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Check npm token access before publishing**

### What Changed
- Tagged npm releases now verify the token can actually authenticate before publish starts, so bad credentials fail fast
- The preflight now checks npm’s account lookup response and rejects missing usernames, invalid responses, and oversized responses
- Authentication errors stay token-safe and do not print the token value
- Release workflow now runs this token check alongside the existing registry availability check
- Regression coverage was added for successful auth, auth failures, malformed responses, oversized responses, and token-safe errors

### Impact
`✅ Fewer failed npm publishes`
`✅ Earlier failure for invalid tokens`
`✅ Clearer publish preflight errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened npm package publishing validation with enhanced token authentication checks to ensure secure releases.

* **Tests**
  * Expanded token authentication test coverage for credential validation and response handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->