### PR TITLE
Preflight npm token auth during secret setup

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -285,8 +285,8 @@ def run_value_preflight_tests(module) -> None:
     finally:
         module.subprocess.run = original_run
 
-    if len(calls) != 2:
-        raise AssertionError(f"expected two value preflight calls, got {len(calls)}")
+    if len(calls) != 3:
+        raise AssertionError(f"expected three value preflight calls, got {len(calls)}")
     rendered = "\n".join(" ".join(args) for args, _kwargs in calls)
     if "check-platform-signing-secrets-preflight.py" not in rendered:
         raise AssertionError("platform signing secret value preflight was not called")
@@ -294,6 +294,10 @@ def run_value_preflight_tests(module) -> None:
         raise AssertionError("OpenSSL requirement was not passed to platform preflight")
     if "check-linux-signing-secrets-preflight.py" not in rendered:
         raise AssertionError("Linux signing secret preflight was not called")
+    if "check-npm-publish-preflight.py" not in rendered:
+        raise AssertionError("npm token authentication preflight was not called")
+    if "--token-auth-check" not in rendered:
+        raise AssertionError("npm token authentication flag was not passed")
     if SENSITIVE_SENTINEL in rendered:
         raise AssertionError("secret value was passed in value preflight arguments")
     for _args, kwargs in calls:

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -205,6 +205,16 @@ def run_value_preflights(
                 str(SCRIPT_DIR / "check-linux-signing-secrets-preflight.py"),
             ],
         ),
+        (
+            "npm token authentication preflight",
+            [
+                python_executable,
+                str(SCRIPT_DIR / "check-npm-publish-preflight.py"),
+                "--require-token-env",
+                "NPM_TOKEN",
+                "--token-auth-check",
+            ],
+        ),
     ]
     env = None
     if values is not None:


### PR DESCRIPTION
## **User description**
## Summary
- include npm token authentication in `set-github-release-secrets.py --preflight-values`
- reuse the token-safe npm publish preflight before release secrets are written to GitHub
- update setup regression coverage to require the npm auth preflight while keeping secret values out of subprocess arguments and output

## Validation
- `python scripts\set-github-release-secrets-regression.py`
- `python scripts\check-npm-publish-preflight-regression.py`
- live `python scripts\check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check` with token provided through env only
- `python scripts\check-python-script-compile.py`
- `powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

Closes #643

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added npm token authentication preflight to `set-github-release-secrets.py` to validate publish credentials before writing GitHub release secrets. Reuses the token-safe `check-npm-publish-preflight.py` and keeps secrets out of subprocess args and output.

- **New Features**
  - Run npm token auth preflight during `--preflight-values` with `--require-token-env NPM_TOKEN` and `--token-auth-check`.
  - Update regression to expect three preflight calls and verify the npm check runs without exposing secret values.

<sup>Written for commit 8a836ac9c8873417c14cbb44727a0ecffb68cf14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Check npm publish access before writing release secrets**

### What Changed
- Release secret setup now runs an npm token authentication check before secrets are written.
- The setup flow keeps the npm token out of command arguments and console output while running this check.
- Regression coverage now expects the npm authentication step alongside the existing signing-secret checks.

### Impact
`✅ Fewer release setup failures`
`✅ Earlier npm credential checks`
`✅ Lower risk of secret exposure during setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
