### PR TITLE
Authenticate npm token in release preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,11 @@ jobs:
           CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: python scripts/check-release-secret-env-preflight.py
+      - name: Validate npm token authentication
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: python scripts/check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check
       - name: Install signing preflight tools
         if: startsWith(github.ref, 'refs/tags/v')
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gnupg openssl

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -67,6 +67,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo preflight
+      - name: Validate npm token authentication
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: python scripts/check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check
   build:
     permissions:
       contents: read
@@ -236,6 +241,21 @@ def run_expected_job_permission_tests(module) -> None:
         raise AssertionError("extra expected permission issue was not reported")
 
 
+def run_required_release_preflight_tests(module) -> None:
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: python scripts/check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check\n",
+            "        run: python scripts/check-npm-publish-preflight.py\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing early npm auth preflight should fail")
+    if "release.yml:release-preflight npm auth command is missing" not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing early npm auth preflight issue was not reported")
+
+
 def run_unsafe_environment_file_write_tests(module) -> None:
     report = with_fixture(
         module,
@@ -265,6 +285,7 @@ def main() -> int:
     run_forbidden_event_tests(module)
     run_unexpected_job_write_tests(module)
     run_expected_job_permission_tests(module)
+    run_required_release_preflight_tests(module)
     run_unsafe_environment_file_write_tests(module)
     print("GitHub workflow permissions regression checks passed")
     return 0

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -43,6 +43,10 @@ SECRET_LIKE_ENV_TOKENS = (
 UNSAFE_GITHUB_ENV_ECHO_RE = re.compile(
     r"\becho\s+[\"']?([A-Z0-9_]+)=\$([A-Z0-9_]+)"
 )
+RELEASE_PREFLIGHT_NPM_AUTH_COMMAND = (
+    "python scripts/check-npm-publish-preflight.py "
+    "--require-token-env NODE_AUTH_TOKEN --token-auth-check"
+)
 EXPECTED_JOB_PERMISSIONS: dict[tuple[str, str], dict[str, str]] = {
     ("release.yml", "release-preflight"): {
         "actions": "read",
@@ -228,6 +232,68 @@ def audit_environment_file_writes(path: Path) -> tuple[str, ...]:
     return tuple(findings)
 
 
+def extract_job_block(text: str, job_name: str) -> str:
+    lines = text.splitlines()
+    start_index = None
+    for index, line in enumerate(lines):
+        if line == f"  {job_name}:":
+            start_index = index
+            break
+    if start_index is None:
+        return ""
+
+    block = [lines[start_index]]
+    for line in lines[start_index + 1 :]:
+        if line.startswith("  ") and not line.startswith("    ") and line.strip().endswith(":"):
+            break
+        block.append(line)
+    return "\n".join(block)
+
+
+def extract_named_step_block(job_block: str, step_name: str) -> str:
+    lines = job_block.splitlines()
+    start_index = None
+    for index, line in enumerate(lines):
+        if line.strip() == f"- name: {step_name}":
+            start_index = index
+            break
+    if start_index is None:
+        return ""
+
+    block = [lines[start_index]]
+    for line in lines[start_index + 1 :]:
+        if line.startswith("      - "):
+            break
+        block.append(line)
+    return "\n".join(block)
+
+
+def audit_required_release_preflight_steps(path: Path) -> tuple[str, ...]:
+    if path.name != "release.yml":
+        return ()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
+
+    block = extract_job_block(text, "release-preflight")
+    issues: list[str] = []
+    if not block:
+        return ("release.yml must define release-preflight job",)
+
+    step = extract_named_step_block(block, "Validate npm token authentication")
+    if not step:
+        issues.append("release.yml:release-preflight must validate npm token authentication")
+        return tuple(issues)
+    if "if: startsWith(github.ref, 'refs/tags/v')" not in step:
+        issues.append("release.yml:release-preflight npm auth check must be tag-gated")
+    if "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}" not in step:
+        issues.append("release.yml:release-preflight npm auth check must use NODE_AUTH_TOKEN from NPM_TOKEN")
+    if RELEASE_PREFLIGHT_NPM_AUTH_COMMAND not in step:
+        issues.append("release.yml:release-preflight npm auth command is missing")
+    return tuple(issues)
+
+
 def is_secret_like_env_name(name: str) -> bool:
     return any(token in name for token in SECRET_LIKE_ENV_TOKENS)
 
@@ -326,6 +392,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
         for finding in audit_environment_file_writes(path):
             unsafe_env_writes.append(finding)
             issues.append(finding)
+        issues.extend(audit_required_release_preflight_steps(path))
 
         events = event_names(workflow_trigger(payload))
         for event in events:


### PR DESCRIPTION
## **User description**
## Summary
- authenticate `NPM_TOKEN` in the tagged `release-preflight` job before artifact build/sign/upload work starts
- add workflow hygiene coverage that requires the release-preflight npm auth step to stay tag-gated and wired through `NODE_AUTH_TOKEN`

## Validation
- `python scripts\check-github-workflow-permissions.py`
- `python scripts\check-github-workflow-permissions-regression.py`
- `python scripts\check-npm-publish-preflight-regression.py`
- `python scripts\check-npm-publish-preflight.py`
- `python scripts\check-python-script-compile.py`
- `powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

Closes #645

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticate the npm token early in the tagged `release-preflight` job. Add checks to enforce tag-gating and `NODE_AUTH_TOKEN` usage so builds don’t proceed with a missing or invalid token.

- **New Features**
  - Add “Validate npm token authentication” step in `.github/workflows/release.yml` that sets `NODE_AUTH_TOKEN` from `NPM_TOKEN` and runs `python scripts/check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check`.
  - Add audits and regression tests in `scripts/check-github-workflow-permissions.py` and `scripts/check-github-workflow-permissions-regression.py` to require the step, enforce tag-gating, and fail if the command or env wiring changes.

<sup>Written for commit 742ffa4f5d5fbdcb5d88e04935dff432f27921a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Check npm token authentication before release builds run**

### What Changed
- The release preflight job now verifies the npm token is valid before continuing with packaging and signing steps.
- The check only runs on tagged releases and uses the npm token through the expected auth environment variable.
- Workflow checks now fail if this release preflight validation is removed, changed, or no longer tag-gated.

### Impact
`✅ Fewer release failures from invalid npm tokens`
`✅ Earlier release blocking when npm auth is broken`
`✅ Safer tagged releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
