### PR TITLE
Audit workflow hardening in tagged release readiness

### DIFF
--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -91,6 +91,30 @@ def assert_safe_report(report) -> dict[str, object]:
     return parsed
 
 
+class WorkflowPermissionsFixture:
+    def __init__(self, *, ready: bool, issues: tuple[str, ...] = ()) -> None:
+        self.ready = ready
+        self.issues = issues
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "schema": "conu.githubWorkflowPermissions.v1",
+            "ready": self.ready,
+            "workflowCount": 2,
+            "checkedWorkflows": ["ci.yml", "release.yml"],
+            "workflowsWithExplicitTopLevelPermissions": ["ci.yml", "release.yml"],
+            "jobsWithWritePermissions": ["release.yml:github-release"],
+            "unsafeEnvironmentFileWrites": [],
+            "forbiddenEvents": [],
+            "issues": list(self.issues),
+            "payloadDisplayed": False,
+            "tokenDisplayed": False,
+            "tokenHashDisplayed": False,
+            "keyMaterialDisplayed": False,
+            "contentsDisplayed": False,
+        }
+
+
 def run_ready_pages_tests(module) -> None:
     report = module.audit_tagged_release_readiness(
         repo="owner/repo",
@@ -113,6 +137,32 @@ def run_ready_pages_tests(module) -> None:
         raise AssertionError("CI check should be skipped by default")
     if parsed["releaseBranch"]["checked"] is not False:
         raise AssertionError("release branch check should be skipped by default")
+    if parsed["workflowPermissions"]["ready"] is not True:
+        raise AssertionError("workflow permissions should be included in tagged release readiness")
+
+
+def run_workflow_permissions_tests(module) -> None:
+    report = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        variable_values={},
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        workflow_permissions=WorkflowPermissionsFixture(
+            ready=False,
+            issues=("release.yml must define release-preflight job",),
+        ),
+    )
+    if report.ready:
+        raise AssertionError("workflow permissions failure should fail tagged release readiness")
+    parsed = assert_safe_report(report)
+    if parsed["workflowPermissions"]["ready"] is not False:
+        raise AssertionError("workflow permissions readiness should be reported as failed")
+    if "workflow readiness: release.yml must define release-preflight job" not in json.dumps(parsed):
+        raise AssertionError("workflow permissions issue was not included in top-level issues")
 
 
 def run_ci_readiness_tests(module) -> None:
@@ -596,6 +646,7 @@ def main() -> int:
     module = load_module()
     run_tag_validation_tests(module)
     run_ready_pages_tests(module)
+    run_workflow_permissions_tests(module)
     run_ci_readiness_tests(module)
     run_release_branch_readiness_tests(module)
     run_missing_secret_tests(module)

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -155,6 +155,7 @@ class TaggedReleaseReadiness:
     npm_registry: NpmRegistryReadiness
     ci: CiReadiness
     release_branch: ReleaseBranchReadiness
+    workflow_permissions: Any
     issues: tuple[str, ...]
 
     def as_json(self) -> dict[str, Any]:
@@ -170,6 +171,7 @@ class TaggedReleaseReadiness:
             "npmRegistry": self.npm_registry.as_json(),
             "ci": self.ci.as_json(),
             "releaseBranch": self.release_branch.as_json(),
+            "workflowPermissions": self.workflow_permissions.as_json(),
             "issues": list(self.issues),
             "payloadDisplayed": False,
             "tokenDisplayed": False,
@@ -716,6 +718,15 @@ def audit_release_branch_readiness(
     )
 
 
+def audit_workflow_permissions(workflow_dir: Path | None = None) -> Any:
+    workflow_module = load_script_module(
+        "check-github-workflow-permissions.py",
+        "check_github_workflow_permissions_for_tagged_release",
+    )
+    target_dir = workflow_dir if workflow_dir is not None else ROOT / ".github" / "workflows"
+    return workflow_module.audit_workflows(workflow_module.find_workflow_paths(target_dir))
+
+
 def combine_issues(
     release_secrets: Any,
     linux_repository: LinuxRepositoryReadiness,
@@ -723,6 +734,7 @@ def combine_issues(
     npm_registry: NpmRegistryReadiness,
     ci: CiReadiness,
     release_branch: ReleaseBranchReadiness,
+    workflow_permissions: Any,
 ) -> tuple[str, ...]:
     issues: list[str] = []
     for name in release_secrets.missing:
@@ -741,6 +753,8 @@ def combine_issues(
         issues.append(f"CI readiness: {issue}")
     for issue in release_branch.issues:
         issues.append(f"release branch readiness: {issue}")
+    for issue in workflow_permissions.issues:
+        issues.append(f"workflow readiness: {issue}")
     return tuple(issues)
 
 
@@ -763,6 +777,8 @@ def audit_tagged_release_readiness(
     release_branch: str = DEFAULT_RELEASE_BRANCH,
     release_target_sha: str = "",
     release_branch_sha: str = "",
+    workflow_permissions: Any | None = None,
+    workflow_dir: Path | None = None,
 ) -> TaggedReleaseReadiness:
     release_secrets = audit_secret_names(repo, secret_names)
     linux_repository = audit_linux_repository(repo, variable_values, secret_names, pages_payload)
@@ -784,6 +800,11 @@ def audit_tagged_release_readiness(
         target_sha=release_target_sha,
         branch_sha=release_branch_sha,
     )
+    workflow_readiness = (
+        workflow_permissions
+        if workflow_permissions is not None
+        else audit_workflow_permissions(workflow_dir)
+    )
     issues = combine_issues(
         release_secrets,
         linux_repository,
@@ -791,6 +812,7 @@ def audit_tagged_release_readiness(
         npm_registry,
         ci,
         branch_readiness,
+        workflow_readiness,
     )
     return TaggedReleaseReadiness(
         repo=repo,
@@ -803,6 +825,7 @@ def audit_tagged_release_readiness(
         npm_registry=npm_registry,
         ci=ci,
         release_branch=branch_readiness,
+        workflow_permissions=workflow_readiness,
         issues=issues,
     )
 
@@ -814,7 +837,7 @@ def print_text_report(report: TaggedReleaseReadiness) -> None:
         branch_note = " and release branch check" if report.release_branch.checked else ""
         print(
             "Tagged release readiness passed"
-            f"{npm_note}{ci_note}{branch_note}: "
+            f"{npm_note}{ci_note}{branch_note} and workflow permissions check: "
             f"{report.repo}@{report.tag} ({report.linux_repository.mode})"
         )
         return


### PR DESCRIPTION
## **User description**
## Summary
- include the GitHub workflow permissions audit in tagged release readiness reports
- fail tagged release readiness when workflow permission/preflight hardening regresses
- add regression coverage for the workflow readiness section and failure path

## Validation
- python scripts\\check-tagged-release-readiness-regression.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-python-script-compile.py
- git diff --check
- python scripts\\check-tagged-release-readiness.py --repo imthegoodboy/conU --tag v0.1.0 --npm-registry-check --require-ci --require-default-branch-head --json
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Closes #647.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub workflow permissions audit to tagged release readiness and blocks releases when hardening regresses. Reports now include `workflowPermissions` and surface issues at the top level for quick triage. Closes #647.

- **New Features**
  - Include `workflowPermissions` in JSON output and CLI success text; any workflow issues fail overall readiness.
  - New `audit_workflow_permissions()` loads `check-github-workflow-permissions.py` and scans `.github/workflows`; `audit_tagged_release_readiness()` now supports `workflow_permissions` and `workflow_dir` overrides.
  - Add regression coverage with a fixture and tests in `scripts/check-tagged-release-readiness-regression.py` to validate inclusion and failure messaging.

<sup>Written for commit 41fb3b7eb3daed5c0599e0f834ef5dd98e35ed78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Include workflow permission checks in tagged release readiness**

### What Changed
- Tagged release readiness now reports workflow permission checks alongside the existing release checks
- A workflow permission issue now causes the overall release readiness check to fail and appears in the top-level issue list
- Successful readiness output now says the workflow permissions check passed
- Regression coverage was added to verify both the new workflow check and its failure path

### Impact
`✅ Fewer releases approved with unsafe workflow permissions`
`✅ Clearer tagged release readiness reports`
`✅ Earlier detection of missing release preflight workflow checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow permissions readiness checks to the release audit process.
  * Release readiness reports now include workflow permissions status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->