### PR TITLE
Check npm registry availability in release preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,11 +65,11 @@ jobs:
           CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: python scripts/check-release-secret-env-preflight.py
-      - name: Validate npm token authentication
+      - name: Validate npm token authentication and registry availability
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: python scripts/check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check
+        run: python scripts/check-npm-publish-preflight.py --registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check
       - name: Install signing preflight tools
         if: startsWith(github.ref, 'refs/tags/v')
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gnupg openssl

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -67,11 +67,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo preflight
-      - name: Validate npm token authentication
+      - name: Validate npm token authentication and registry availability
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: python scripts/check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check
+        run: python scripts/check-npm-publish-preflight.py --registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check
   build:
     permissions:
       contents: read
@@ -246,14 +246,14 @@ def run_required_release_preflight_tests(module) -> None:
         module,
         None,
         ready_release().replace(
-            "        run: python scripts/check-npm-publish-preflight.py --require-token-env NODE_AUTH_TOKEN --token-auth-check\n",
+            "        run: python scripts/check-npm-publish-preflight.py --registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check\n",
             "        run: python scripts/check-npm-publish-preflight.py\n",
         ),
     )
     if report.ready:
-        raise AssertionError("missing early npm auth preflight should fail")
-    if "release.yml:release-preflight npm auth command is missing" not in json.dumps(assert_safe_report(report)):
-        raise AssertionError("missing early npm auth preflight issue was not reported")
+        raise AssertionError("missing early npm auth/registry preflight should fail")
+    if "release.yml:release-preflight npm auth/registry command is missing" not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing early npm auth/registry preflight issue was not reported")
 
 
 def run_unsafe_environment_file_write_tests(module) -> None:

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -45,7 +45,7 @@ UNSAFE_GITHUB_ENV_ECHO_RE = re.compile(
 )
 RELEASE_PREFLIGHT_NPM_AUTH_COMMAND = (
     "python scripts/check-npm-publish-preflight.py "
-    "--require-token-env NODE_AUTH_TOKEN --token-auth-check"
+    "--registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check"
 )
 EXPECTED_JOB_PERMISSIONS: dict[tuple[str, str], dict[str, str]] = {
     ("release.yml", "release-preflight"): {
@@ -281,16 +281,23 @@ def audit_required_release_preflight_steps(path: Path) -> tuple[str, ...]:
     if not block:
         return ("release.yml must define release-preflight job",)
 
-    step = extract_named_step_block(block, "Validate npm token authentication")
+    step = extract_named_step_block(
+        block,
+        "Validate npm token authentication and registry availability",
+    )
     if not step:
-        issues.append("release.yml:release-preflight must validate npm token authentication")
+        issues.append(
+            "release.yml:release-preflight must validate npm token authentication and registry availability"
+        )
         return tuple(issues)
     if "if: startsWith(github.ref, 'refs/tags/v')" not in step:
-        issues.append("release.yml:release-preflight npm auth check must be tag-gated")
+        issues.append("release.yml:release-preflight npm auth/registry check must be tag-gated")
     if "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}" not in step:
-        issues.append("release.yml:release-preflight npm auth check must use NODE_AUTH_TOKEN from NPM_TOKEN")
+        issues.append(
+            "release.yml:release-preflight npm auth/registry check must use NODE_AUTH_TOKEN from NPM_TOKEN"
+        )
     if RELEASE_PREFLIGHT_NPM_AUTH_COMMAND not in step:
-        issues.append("release.yml:release-preflight npm auth command is missing")
+        issues.append("release.yml:release-preflight npm auth/registry command is missing")
     return tuple(issues)
 
 


### PR DESCRIPTION
## **User description**
## Summary
- run npm registry availability in the tagged release-preflight npm gate
- keep the token authentication check in the same early step
- update workflow-permissions regression coverage so this early registry guard cannot be removed silently

## Validation
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-npm-publish-preflight-regression.py
- python scripts\\check-python-script-compile.py
- git diff --check
- python scripts\\check-npm-publish-preflight.py --registry-check
- python scripts\\check-tagged-release-readiness.py --repo imthegoodboy/conU --tag v0.1.0 --npm-registry-check --require-ci --require-default-branch-head --json
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Closes #649.


___

## **CodeAnt-AI Description**
Check npm registry availability before tagged releases

### What Changed
- The release preflight step now verifies both npm token access and npm registry availability before a tagged release continues
- The release workflow shows the updated check name so the preflight step is easier to recognize
- Regression coverage now expects the combined auth-and-registry check, so removing it causes a test failure

### Impact
`✅ Fewer release failures from npm registry outages`
`✅ Earlier release checks for npm publish readiness`
`✅ Safer tagged releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an npm registry availability check to the tagged release preflight to catch outages early and reduce failed publishes. Keeps the npm token auth check and updates regression coverage to enforce this guard.

- **New Features**
  - Preflight now validates npm token auth and registry availability using `scripts/check-npm-publish-preflight.py --registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check`.
  - Renamed step to "Validate npm token authentication and registry availability" in `release.yml`.
  - Updated workflow-permissions checks and regression tests to require this combined, tag-gated step using `NODE_AUTH_TOKEN` from `NPM_TOKEN`.

<sup>Written for commit 5259ac94197f1df4d73ad1b2d5b1aa4d42ba421b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

