### PR TITLE
Audit release publication job gates

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -72,7 +72,19 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: python scripts/check-npm-publish-preflight.py --registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check
+  packages:
+    needs: release-preflight
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo packages
+  production-readiness:
+    needs:
+      - release-preflight
+    runs-on: windows-2025-vs2026
+    steps:
+      - run: echo smoke
   build:
+    needs: [packages, production-readiness]
     permissions:
       contents: read
       id-token: write
@@ -81,12 +93,14 @@ jobs:
     steps:
       - run: echo build
   github-release:
+    needs: build
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
       - run: echo release
   linux-repository-pages:
+    needs: github-release
     permissions:
       contents: read
       pages: write
@@ -95,12 +109,19 @@ jobs:
     steps:
       - run: echo pages
   custom-linux-repository-publish:
+    needs: github-release
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
       - run: echo custom
+  linux-repository-publication:
+    needs: [github-release, linux-repository-pages, custom-linux-repository-publish]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo repository
   npm-publish:
+    needs: [github-release, linux-repository-publication]
     permissions:
       contents: read
       id-token: write
@@ -256,6 +277,47 @@ def run_required_release_preflight_tests(module) -> None:
         raise AssertionError("missing early npm auth/registry preflight issue was not reported")
 
 
+def run_required_release_job_needs_tests(module) -> None:
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "    needs: [packages, production-readiness]\n",
+            "    needs: packages\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing production-readiness build gate should fail")
+    if "release.yml:build must depend on production-readiness" not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing build production-readiness dependency was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "    needs: [github-release, linux-repository-publication]\n",
+            "    needs: github-release\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing npm publish repository-publication gate should fail")
+    if "release.yml:npm-publish must depend on linux-repository-publication" not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing npm publish repository-publication dependency was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "  packages:\n    needs: release-preflight\n",
+            "  packages:\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing package preflight dependency should fail")
+    if "release.yml:packages must depend on release-preflight" not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing package preflight dependency was not reported")
+
+
 def run_unsafe_environment_file_write_tests(module) -> None:
     report = with_fixture(
         module,
@@ -286,6 +348,7 @@ def main() -> int:
     run_unexpected_job_write_tests(module)
     run_expected_job_permission_tests(module)
     run_required_release_preflight_tests(module)
+    run_required_release_job_needs_tests(module)
     run_unsafe_environment_file_write_tests(module)
     print("GitHub workflow permissions regression checks passed")
     return 0

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -75,6 +75,19 @@ EXPECTED_JOB_PERMISSIONS: dict[tuple[str, str], dict[str, str]] = {
         "id-token": "write",
     },
 }
+EXPECTED_RELEASE_JOB_NEEDS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("release.yml", "packages"): ("release-preflight",),
+    ("release.yml", "production-readiness"): ("release-preflight",),
+    ("release.yml", "build"): ("packages", "production-readiness"),
+    ("release.yml", "github-release"): ("build",),
+    ("release.yml", "linux-repository-pages"): ("github-release",),
+    ("release.yml", "custom-linux-repository-publish"): ("github-release",),
+    (
+        "release.yml",
+        "linux-repository-publication",
+    ): ("github-release", "linux-repository-pages", "custom-linux-repository-publish"),
+    ("release.yml", "npm-publish"): ("github-release", "linux-repository-publication"),
+}
 
 
 @dataclass(frozen=True)
@@ -130,6 +143,16 @@ def scalar_value(value: str) -> str:
     return value.strip().strip("\"'")
 
 
+def parse_inline_sequence(value: str) -> list[str] | None:
+    text = scalar_value(value)
+    if not text.startswith("[") or not text.endswith("]"):
+        return None
+    inner = text[1:-1].strip()
+    if not inner:
+        return []
+    return [scalar_value(item.strip()) for item in inner.split(",")]
+
+
 def parse_mapping_at(items: list[tuple[int, str, str]], start: int, base_indent: int, value: str) -> dict[str, str] | str:
     if value:
         return scalar_value(value)
@@ -141,6 +164,26 @@ def parse_mapping_at(items: list[tuple[int, str, str]], start: int, base_indent:
             continue
         mapping[key] = scalar_value(child_value)
     return mapping
+
+
+def parse_sequence_at(
+    items: list[tuple[int, str, str]],
+    start: int,
+    base_indent: int,
+    value: str,
+) -> list[str] | str:
+    inline_sequence = parse_inline_sequence(value)
+    if inline_sequence is not None:
+        return inline_sequence
+    if value:
+        return scalar_value(value)
+    sequence: list[str] = []
+    for indent, key, child_value in items[start + 1 :]:
+        if indent <= base_indent:
+            break
+        if indent == base_indent + 2 and key == "-":
+            sequence.append(scalar_value(child_value))
+    return sequence
 
 
 def parse_events_at(items: list[tuple[int, str, str]], start: int, base_indent: int, value: str) -> str | dict[str, Any]:
@@ -174,6 +217,8 @@ def parse_jobs_at(items: list[tuple[int, str, str]], start: int, base_indent: in
                 break
             if indent == base_indent + 4 and key == "permissions":
                 jobs[job_name]["permissions"] = parse_mapping_at(items, index, indent, value)
+            elif indent == base_indent + 4 and key == "needs":
+                jobs[job_name]["needs"] = parse_sequence_at(items, index, indent, value)
     return jobs
 
 
@@ -345,6 +390,21 @@ def normalize_permissions(value: Any, *, scope: str) -> dict[str, str] | str | N
     return normalized
 
 
+def normalize_needs(value: Any, *, scope: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if not isinstance(value, list):
+        raise ValueError(f"{scope} needs must be a string or list of strings")
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"{scope} needs entries must be strings")
+        normalized.append(item)
+    return tuple(normalized)
+
+
 def format_job(workflow_name: str, job_name: str) -> str:
     return f"{workflow_name}:{job_name}"
 
@@ -379,6 +439,26 @@ def audit_mapping(
         if key not in expected:
             issues.append(f"{scope} has extra permission {key}={value}")
     return issues
+
+
+def audit_release_job_needs(workflow_name: str, jobs: dict[str, Any]) -> tuple[str, ...]:
+    issues: list[str] = []
+    for (expected_workflow, job_name), expected_needs in EXPECTED_RELEASE_JOB_NEEDS.items():
+        if expected_workflow != workflow_name:
+            continue
+        scope = format_job(workflow_name, job_name)
+        job_payload = jobs.get(job_name)
+        if job_payload is None:
+            issues.append(f"{workflow_name} must define {job_name} job")
+            continue
+        if not isinstance(job_payload, dict):
+            continue
+        actual_needs = normalize_needs(job_payload.get("needs"), scope=scope)
+        actual_needs_set = set(actual_needs)
+        for expected_need in expected_needs:
+            if expected_need not in actual_needs_set:
+                issues.append(f"{scope} must depend on {expected_need}")
+    return tuple(issues)
 
 
 def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsReadiness:
@@ -430,6 +510,8 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
         if not isinstance(jobs, dict):
             issues.append(f"{workflow_name} must define jobs as a mapping")
             continue
+
+        issues.extend(audit_release_job_needs(workflow_name, jobs))
 
         for job_name, job_payload in jobs.items():
             if not isinstance(job_name, str):


### PR DESCRIPTION
## **User description**
## Summary\n- require critical tagged-release jobs to keep their package, smoke, release, repository, and npm dependency gates\n- teach the dependency-free workflow parser to read scalar, block-list, and inline-list needs values\n- extend workflow-permissions regression fixtures to cover dependency gate failures without printing workflow contents or secrets\n\n## Validation\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-github-workflow-permissions-regression.py\n- python scripts\\check-python-script-compile.py\n- git diff --check\n\nFixes #651

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces required job dependencies in `release.yml` and updates the workflow parser to read needs defined as a string, block list, or inline list. Adds regression checks that fail when critical release gates are missing.

- **New Features**
  - Enforced release gates via job needs: packages, production-readiness -> release-preflight; build -> packages + production-readiness; github-release -> build; linux-repository-pages and custom-linux-repository-publish -> github-release; linux-repository-publication -> github-release + linux-repository-pages + custom-linux-repository-publish; npm-publish -> github-release + linux-repository-publication.
  - Parser now supports needs in scalar, block-list, and inline-list formats.
  - Regression tests flag missing gates without printing workflow contents or secrets.

<sup>Written for commit cdff28c63cc810f29ce5c1830c7802663e18fc73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Require the release jobs to follow the intended publication order**

### What Changed
- The release workflow now checks that each publish job waits for the right earlier jobs, including preflight, build, repository publication, and npm publish steps
- Workflow checks now accept `needs` written as a single value, a block list, or an inline list, so release gating rules are read correctly in all supported formats
- Regression coverage now fails when key release dependencies are missing, while keeping workflow contents and secrets out of the failure output

### Impact
`✅ Fewer broken release runs`
`✅ Safer release publication order`
`✅ Clearer missing-gate failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
