### PR TITLE
Include repository governance in tagged release readiness

### DIFF
--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -115,6 +115,43 @@ class WorkflowPermissionsFixture:
         }
 
 
+class GovernanceFixture:
+    def __init__(self, *, schema: str, ready: bool, issues: tuple[str, ...] = ()) -> None:
+        self.schema = schema
+        self.ready = ready
+        self.issues = issues
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "schema": self.schema,
+            "ready": self.ready,
+            "issues": list(self.issues),
+            "payloadDisplayed": False,
+            "tokenDisplayed": False,
+            "tokenHashDisplayed": False,
+            "keyMaterialDisplayed": False,
+            "contentsDisplayed": False,
+            "alertBodiesDisplayed": False,
+        }
+
+
+def ready_governance_kwargs() -> dict[str, GovernanceFixture]:
+    return {
+        "main_branch_protection": GovernanceFixture(
+            schema="conu.githubMainBranchProtection.v1",
+            ready=True,
+        ),
+        "actions_permissions": GovernanceFixture(
+            schema="conu.githubActionsPermissions.v1",
+            ready=True,
+        ),
+        "repository_security": GovernanceFixture(
+            schema="conu.githubRepositorySecurity.v1",
+            ready=True,
+        ),
+    }
+
+
 def run_ready_pages_tests(module) -> None:
     report = module.audit_tagged_release_readiness(
         repo="owner/repo",
@@ -125,6 +162,7 @@ def run_ready_pages_tests(module) -> None:
         pages_payload=pages_payload(),
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if not report.ready:
         raise AssertionError(f"expected default Pages readiness to pass: {report.issues!r}")
@@ -139,6 +177,12 @@ def run_ready_pages_tests(module) -> None:
         raise AssertionError("release branch check should be skipped by default")
     if parsed["workflowPermissions"]["ready"] is not True:
         raise AssertionError("workflow permissions should be included in tagged release readiness")
+    if parsed["mainBranchProtection"]["ready"] is not True:
+        raise AssertionError("main branch protection should be included in tagged release readiness")
+    if parsed["actionsPermissions"]["ready"] is not True:
+        raise AssertionError("Actions permissions should be included in tagged release readiness")
+    if parsed["repositorySecurity"]["ready"] is not True:
+        raise AssertionError("repository security should be included in tagged release readiness")
 
 
 def run_workflow_permissions_tests(module) -> None:
@@ -155,6 +199,7 @@ def run_workflow_permissions_tests(module) -> None:
             ready=False,
             issues=("release.yml must define release-preflight job",),
         ),
+        **ready_governance_kwargs(),
     )
     if report.ready:
         raise AssertionError("workflow permissions failure should fail tagged release readiness")
@@ -163,6 +208,46 @@ def run_workflow_permissions_tests(module) -> None:
         raise AssertionError("workflow permissions readiness should be reported as failed")
     if "workflow readiness: release.yml must define release-preflight job" not in json.dumps(parsed):
         raise AssertionError("workflow permissions issue was not included in top-level issues")
+
+
+def run_repository_governance_tests(module) -> None:
+    report = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        variable_values={},
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        workflow_permissions=WorkflowPermissionsFixture(ready=True),
+        main_branch_protection=GovernanceFixture(
+            schema="conu.githubMainBranchProtection.v1",
+            ready=False,
+            issues=("missing required status check: Packages",),
+        ),
+        actions_permissions=GovernanceFixture(
+            schema="conu.githubActionsPermissions.v1",
+            ready=False,
+            issues=("default workflow token permissions must be read-only",),
+        ),
+        repository_security=GovernanceFixture(
+            schema="conu.githubRepositorySecurity.v1",
+            ready=False,
+            issues=("secret scanning push protection must be enabled",),
+        ),
+    )
+    if report.ready:
+        raise AssertionError("repository governance failures should fail tagged release readiness")
+    parsed = assert_safe_report(report)
+    rendered = json.dumps(parsed)
+    for expected in (
+        "main branch protection readiness: missing required status check: Packages",
+        "GitHub Actions permissions readiness: default workflow token permissions must be read-only",
+        "GitHub repository security readiness: secret scanning push protection must be enabled",
+    ):
+        if expected not in rendered:
+            raise AssertionError(f"repository governance issue was not reported: {expected}")
 
 
 def run_ci_readiness_tests(module) -> None:
@@ -178,6 +263,7 @@ def run_ci_readiness_tests(module) -> None:
         ci_required=True,
         ci_head_sha="a" * 40,
         ci_runs_payload=ci_success_payload(module),
+        **ready_governance_kwargs(),
     )
     if not report.ready:
         raise AssertionError(f"expected CI readiness to pass: {report.issues!r}")
@@ -201,6 +287,7 @@ def run_ci_readiness_tests(module) -> None:
         ci_required=True,
         ci_head_sha="b" * 40,
         ci_runs_payload=ci_success_payload(module),
+        **ready_governance_kwargs(),
     )
     if missing.ready:
         raise AssertionError("missing CI run should fail readiness")
@@ -231,6 +318,7 @@ def run_ci_readiness_tests(module) -> None:
                 "url": f"https://example.invalid/{SENSITIVE_SENTINEL}",
             }
         ],
+        **ready_governance_kwargs(),
     )
     if failed.ready:
         raise AssertionError("failed CI run should fail readiness")
@@ -286,6 +374,7 @@ def run_release_branch_readiness_tests(module) -> None:
         release_branch="main",
         release_target_sha="a" * 40,
         release_branch_sha="a" * 40,
+        **ready_governance_kwargs(),
     )
     if not report.ready:
         raise AssertionError(f"expected release branch readiness to pass: {report.issues!r}")
@@ -310,6 +399,7 @@ def run_release_branch_readiness_tests(module) -> None:
         release_branch="main",
         release_target_sha="b" * 40,
         release_branch_sha="c" * 40,
+        **ready_governance_kwargs(),
     )
     if mismatch.ready:
         raise AssertionError("mismatched release target and branch head should fail")
@@ -352,6 +442,7 @@ def run_missing_secret_tests(module) -> None:
         pages_payload=pages_payload(),
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if report.ready:
         raise AssertionError("missing release secret should fail readiness")
@@ -376,6 +467,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if not report.ready:
         raise AssertionError(f"expected custom repository readiness to pass: {report.issues!r}")
@@ -394,6 +486,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if missing.ready:
         raise AssertionError("missing custom bucket/secrets should fail")
@@ -419,6 +512,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if invalid_optional.ready:
         raise AssertionError("invalid optional custom repository variables should fail")
@@ -447,6 +541,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if invalid_base_paths.ready:
         raise AssertionError("encoded custom repository base URL dot segment should fail")
@@ -472,6 +567,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if invalid_base_separator.ready:
         raise AssertionError("encoded custom repository base URL separator should fail")
@@ -497,6 +593,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if invalid_base_authority.ready:
         raise AssertionError("malformed custom repository base URL authority should fail")
@@ -522,6 +619,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if invalid_endpoint_paths.ready:
         raise AssertionError("encoded custom repository endpoint URL dot segment should fail")
@@ -547,6 +645,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if invalid_endpoint_separator.ready:
         raise AssertionError("encoded custom repository endpoint URL separator should fail")
@@ -572,6 +671,7 @@ def run_custom_repository_tests(module) -> None:
         pages_payload=None,
         release_payload=None,
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if invalid_endpoint_authority.ready:
         raise AssertionError("malformed custom repository endpoint URL authority should fail")
@@ -596,6 +696,7 @@ def run_safe_failure_tests(module) -> None:
         pages_payload=None,
         release_payload=release_payload(),
         npm_registry_check=False,
+        **ready_governance_kwargs(),
     )
     if invalid.ready:
         raise AssertionError("invalid custom repository plus existing release should fail")
@@ -647,6 +748,7 @@ def main() -> int:
     run_tag_validation_tests(module)
     run_ready_pages_tests(module)
     run_workflow_permissions_tests(module)
+    run_repository_governance_tests(module)
     run_ci_readiness_tests(module)
     run_release_branch_readiness_tests(module)
     run_missing_secret_tests(module)

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -156,6 +156,9 @@ class TaggedReleaseReadiness:
     ci: CiReadiness
     release_branch: ReleaseBranchReadiness
     workflow_permissions: Any
+    main_branch_protection: Any
+    actions_permissions: Any
+    repository_security: Any
     issues: tuple[str, ...]
 
     def as_json(self) -> dict[str, Any]:
@@ -172,6 +175,9 @@ class TaggedReleaseReadiness:
             "ci": self.ci.as_json(),
             "releaseBranch": self.release_branch.as_json(),
             "workflowPermissions": self.workflow_permissions.as_json(),
+            "mainBranchProtection": self.main_branch_protection.as_json(),
+            "actionsPermissions": self.actions_permissions.as_json(),
+            "repositorySecurity": self.repository_security.as_json(),
             "issues": list(self.issues),
             "payloadDisplayed": False,
             "tokenDisplayed": False,
@@ -727,6 +733,68 @@ def audit_workflow_permissions(workflow_dir: Path | None = None) -> Any:
     return workflow_module.audit_workflows(workflow_module.find_workflow_paths(target_dir))
 
 
+def audit_main_branch_protection(repo: str, gh: str, branch: str) -> Any:
+    branch_module = load_script_module(
+        "check-github-main-protection.py",
+        "check_github_main_protection_for_tagged_release",
+    )
+    normalized_branch = branch.strip() or branch_module.DEFAULT_BRANCH
+    payload = branch_module.load_branch_protection(repo, normalized_branch, gh)
+    return branch_module.audit_branch_protection(
+        repo=repo,
+        branch=normalized_branch,
+        protection_payload=payload,
+        required_status_checks=branch_module.DEFAULT_REQUIRED_STATUS_CHECKS,
+    )
+
+
+def audit_actions_permissions(repo: str, gh: str) -> Any:
+    actions_module = load_script_module(
+        "check-github-actions-permissions.py",
+        "check_github_actions_permissions_for_tagged_release",
+    )
+    actions_payload = actions_module.load_actions_permissions(repo, gh)
+    workflow_payload = actions_module.load_workflow_permissions(repo, gh)
+    selected_actions_payload = None
+    if actions_payload.get("allowed_actions") == "selected":
+        selected_actions_payload = actions_module.load_selected_actions(repo, gh)
+    return actions_module.audit_actions_permissions(
+        repo=repo,
+        actions_payload=actions_payload,
+        workflow_payload=workflow_payload,
+        selected_actions_payload=selected_actions_payload,
+        required_patterns=actions_module.DEFAULT_REQUIRED_SELECTED_PATTERNS,
+    )
+
+
+def audit_repository_security(repo: str, gh: str) -> Any:
+    security_module = load_script_module(
+        "check-github-repository-security.py",
+        "check_github_repository_security_for_tagged_release",
+    )
+    repo_payload = security_module.load_repo_payload(repo, gh)
+    vulnerability_alerts_enabled = security_module.load_vulnerability_alert_status(repo, gh)
+    dependabot_alerts = security_module.load_alerts(
+        repo,
+        gh,
+        "dependabot/alerts",
+        "gh api Dependabot alerts",
+    )
+    secret_scanning_alerts = security_module.load_alerts(
+        repo,
+        gh,
+        "secret-scanning/alerts",
+        "gh api secret scanning alerts",
+    )
+    return security_module.audit_repository_security(
+        repo=repo,
+        repo_payload=repo_payload,
+        vulnerability_alerts_enabled=vulnerability_alerts_enabled,
+        dependabot_alerts=dependabot_alerts,
+        secret_scanning_alerts=secret_scanning_alerts,
+    )
+
+
 def combine_issues(
     release_secrets: Any,
     linux_repository: LinuxRepositoryReadiness,
@@ -735,6 +803,9 @@ def combine_issues(
     ci: CiReadiness,
     release_branch: ReleaseBranchReadiness,
     workflow_permissions: Any,
+    main_branch_protection: Any,
+    actions_permissions: Any,
+    repository_security: Any,
 ) -> tuple[str, ...]:
     issues: list[str] = []
     for name in release_secrets.missing:
@@ -755,6 +826,12 @@ def combine_issues(
         issues.append(f"release branch readiness: {issue}")
     for issue in workflow_permissions.issues:
         issues.append(f"workflow readiness: {issue}")
+    for issue in main_branch_protection.issues:
+        issues.append(f"main branch protection readiness: {issue}")
+    for issue in actions_permissions.issues:
+        issues.append(f"GitHub Actions permissions readiness: {issue}")
+    for issue in repository_security.issues:
+        issues.append(f"GitHub repository security readiness: {issue}")
     return tuple(issues)
 
 
@@ -779,6 +856,9 @@ def audit_tagged_release_readiness(
     release_branch_sha: str = "",
     workflow_permissions: Any | None = None,
     workflow_dir: Path | None = None,
+    main_branch_protection: Any | None = None,
+    actions_permissions: Any | None = None,
+    repository_security: Any | None = None,
 ) -> TaggedReleaseReadiness:
     release_secrets = audit_secret_names(repo, secret_names)
     linux_repository = audit_linux_repository(repo, variable_values, secret_names, pages_payload)
@@ -805,6 +885,12 @@ def audit_tagged_release_readiness(
         if workflow_permissions is not None
         else audit_workflow_permissions(workflow_dir)
     )
+    if main_branch_protection is None:
+        raise ValueError("main branch protection readiness report is required")
+    if actions_permissions is None:
+        raise ValueError("GitHub Actions permissions readiness report is required")
+    if repository_security is None:
+        raise ValueError("GitHub repository security readiness report is required")
     issues = combine_issues(
         release_secrets,
         linux_repository,
@@ -813,6 +899,9 @@ def audit_tagged_release_readiness(
         ci,
         branch_readiness,
         workflow_readiness,
+        main_branch_protection,
+        actions_permissions,
+        repository_security,
     )
     return TaggedReleaseReadiness(
         repo=repo,
@@ -826,6 +915,9 @@ def audit_tagged_release_readiness(
         ci=ci,
         release_branch=branch_readiness,
         workflow_permissions=workflow_readiness,
+        main_branch_protection=main_branch_protection,
+        actions_permissions=actions_permissions,
+        repository_security=repository_security,
         issues=issues,
     )
 
@@ -837,7 +929,7 @@ def print_text_report(report: TaggedReleaseReadiness) -> None:
         branch_note = " and release branch check" if report.release_branch.checked else ""
         print(
             "Tagged release readiness passed"
-            f"{npm_note}{ci_note}{branch_note} and workflow permissions check: "
+            f"{npm_note}{ci_note}{branch_note}, workflow permissions, and repository governance checks: "
             f"{report.repo}@{report.tag} ({report.linux_repository.mode})"
         )
         return
@@ -1012,6 +1104,10 @@ def main() -> int:
                 "check_github_pages_loader_for_tagged_release",
             )
             pages_payload = pages_module.load_pages_metadata(repo, gh)
+        governance_branch = args.release_branch.strip() or release_branch or load_default_branch(repo, gh)
+        main_branch_protection = audit_main_branch_protection(repo, gh, governance_branch)
+        actions_permissions = audit_actions_permissions(repo, gh)
+        repository_security = audit_repository_security(repo, gh)
         report = audit_tagged_release_readiness(
             repo=repo,
             tag=tag,
@@ -1030,6 +1126,9 @@ def main() -> int:
             release_branch=release_branch,
             release_target_sha=release_target_sha,
             release_branch_sha=release_branch_sha,
+            main_branch_protection=main_branch_protection,
+            actions_permissions=actions_permissions,
+            repository_security=repository_security,
         )
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"Tagged release readiness failed: {exc}", file=sys.stderr)


### PR DESCRIPTION
## **User description**
## Summary\n- include live main branch protection, GitHub Actions permissions, and repository security reports in tagged-release readiness JSON\n- fail tagged-release readiness when any repository governance report has issues\n- add hermetic regression fixtures proving governance failures are surfaced without leaking payloads, tokens, keys, workflow contents, or alert bodies\n\n## Validation\n- python scripts\\check-tagged-release-readiness-regression.py\n- python scripts\\check-python-script-compile.py\n- git diff --check\n- python scripts\\check-tagged-release-readiness.py --repo imthegoodboy/conU --tag v0.1.0 --npm-registry-check --require-ci --require-default-branch-head --json\n  - governance reports ready; failure remains only the known missing signing/notary/GPG secrets\n- python scripts\\check-github-main-protection.py --repo imthegoodboy/conU\n- python scripts\\check-github-actions-permissions.py --repo imthegoodboy/conU\n- python scripts\\check-github-repository-security.py --repo imthegoodboy/conU\n\nFixes #653

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repository governance checks to tagged-release readiness and fails the check when any governance issue is found. Also adds hermetic regression fixtures to surface failures without leaking sensitive data.

- **New Features**
  - Include main branch protection, Actions permissions, and repository security in readiness JSON and text output.
  - Fail readiness when any governance report has issues.
  - CLI loads these reports using the repo’s default or provided release branch.
  - Regression fixtures verify failures are reported without exposing payloads, tokens, keys, workflow contents, or alert bodies.

- **Migration**
  - If you call `audit_tagged_release_readiness` directly, pass `main_branch_protection`, `actions_permissions`, and `repository_security`. CLI users don’t need to change anything.

<sup>Written for commit 614c4562f0f72ee42df465acf3347efcf3139109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Include repository governance checks in tagged release readiness**

### What Changed
- Tagged release readiness now includes main branch protection, GitHub Actions permissions, and repository security checks in both the JSON output and pass/fail result
- The readiness check now fails when any of those governance areas has issues, and their problems are reported in the top-level summary
- The success message now says the release passed with repository governance checks included
- Regression coverage now verifies these failures are reported without exposing sensitive payloads or alert details

### Impact
`✅ Fewer releases from repos with missing branch protection`
`✅ Clearer release readiness failures`
`✅ Safer release checks without leaking sensitive data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded repository governance checks for tagged release readiness validation, now assessing main branch protection status, GitHub Actions permissions, and repository security configurations separately.

* **Tests**
  * Enhanced regression test suite to verify governance requirements are properly enforced during release readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->