### PR TITLE
Audit Linux repository publication result gate

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -117,9 +117,32 @@ jobs:
       - run: echo custom
   linux-repository-publication:
     needs: [github-release, linux-repository-pages, custom-linux-repository-publish]
+    if: always() && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - run: echo repository
+      - name: Check Linux repository publication result
+        env:
+          CONU_LINUX_REPOSITORY_BASE_URL: ${{ vars.CONU_LINUX_REPOSITORY_BASE_URL }}
+          GITHUB_RELEASE_RESULT: ${{ needs.github-release.result }}
+          PAGES_RESULT: ${{ needs.linux-repository-pages.result }}
+          CUSTOM_RESULT: ${{ needs.custom-linux-repository-publish.result }}
+        run: |
+          set -eu
+          if [ "$GITHUB_RELEASE_RESULT" != "success" ]; then
+            echo "::error::GitHub Release publication did not complete successfully: $GITHUB_RELEASE_RESULT"
+            exit 1
+          fi
+          if [ -z "${CONU_LINUX_REPOSITORY_BASE_URL:-}" ]; then
+            if [ "$PAGES_RESULT" != "success" ]; then
+              echo "::error::Default Linux repository Pages deployment did not complete successfully: $PAGES_RESULT"
+              exit 1
+            fi
+          else
+            if [ "$CUSTOM_RESULT" != "success" ]; then
+              echo "::error::Custom Linux repository S3 publication did not complete successfully: $CUSTOM_RESULT"
+              exit 1
+            fi
+          fi
   npm-publish:
     needs: [github-release, linux-repository-publication]
     permissions:
@@ -318,6 +341,56 @@ def run_required_release_job_needs_tests(module) -> None:
         raise AssertionError("missing package preflight dependency was not reported")
 
 
+def run_required_release_publication_gate_tests(module) -> None:
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "    if: always() && startsWith(github.ref, 'refs/tags/v')\n",
+            "",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing Linux repository publication always/tag gate should fail")
+    if (
+        "release.yml:linux-repository-publication must be tag-gated "
+        "and always evaluate upstream results"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing Linux repository always/tag gate issue was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "          PAGES_RESULT: ${{ needs.linux-repository-pages.result }}\n",
+            "",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing Pages result env should fail")
+    if (
+        "release.yml:linux-repository-publication gate is missing Pages result"
+        not in json.dumps(assert_safe_report(report))
+    ):
+        raise AssertionError("missing Pages result issue was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '            if [ "$CUSTOM_RESULT" != "success" ]; then\n',
+            '            if [ "$CUSTOM_RESULT" != "failure" ]; then\n',
+        ),
+    )
+    if report.ready:
+        raise AssertionError("weakened custom repository result check should fail")
+    if (
+        "release.yml:linux-repository-publication gate is missing "
+        "custom repository success check"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("weakened custom repository result check issue was not reported")
+
+
 def run_unsafe_environment_file_write_tests(module) -> None:
     report = with_fixture(
         module,
@@ -349,6 +422,7 @@ def main() -> int:
     run_expected_job_permission_tests(module)
     run_required_release_preflight_tests(module)
     run_required_release_job_needs_tests(module)
+    run_required_release_publication_gate_tests(module)
     run_unsafe_environment_file_write_tests(module)
     print("GitHub workflow permissions regression checks passed")
     return 0

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -47,6 +47,32 @@ RELEASE_PREFLIGHT_NPM_AUTH_COMMAND = (
     "python scripts/check-npm-publish-preflight.py "
     "--registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check"
 )
+RELEASE_PUBLICATION_GATE_STEP = "Check Linux repository publication result"
+RELEASE_PUBLICATION_GATE_SNIPPETS: tuple[tuple[str, str], ...] = (
+    (
+        "base URL mode selector",
+        "CONU_LINUX_REPOSITORY_BASE_URL: ${{ vars.CONU_LINUX_REPOSITORY_BASE_URL }}",
+    ),
+    (
+        "GitHub Release result",
+        "GITHUB_RELEASE_RESULT: ${{ needs.github-release.result }}",
+    ),
+    ("Pages result", "PAGES_RESULT: ${{ needs.linux-repository-pages.result }}"),
+    (
+        "custom repository result",
+        "CUSTOM_RESULT: ${{ needs.custom-linux-repository-publish.result }}",
+    ),
+    (
+        "GitHub Release success check",
+        'if [ "$GITHUB_RELEASE_RESULT" != "success" ]; then',
+    ),
+    (
+        "default repository mode check",
+        'if [ -z "${CONU_LINUX_REPOSITORY_BASE_URL:-}" ]; then',
+    ),
+    ("Pages success check", 'if [ "$PAGES_RESULT" != "success" ]; then'),
+    ("custom repository success check", 'if [ "$CUSTOM_RESULT" != "success" ]; then'),
+)
 EXPECTED_JOB_PERMISSIONS: dict[tuple[str, str], dict[str, str]] = {
     ("release.yml", "release-preflight"): {
         "actions": "read",
@@ -346,6 +372,37 @@ def audit_required_release_preflight_steps(path: Path) -> tuple[str, ...]:
     return tuple(issues)
 
 
+def audit_required_release_publication_gate(path: Path) -> tuple[str, ...]:
+    if path.name != "release.yml":
+        return ()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
+
+    block = extract_job_block(text, "linux-repository-publication")
+    issues: list[str] = []
+    if not block:
+        return ("release.yml must define linux-repository-publication job",)
+    if "if: always() && startsWith(github.ref, 'refs/tags/v')" not in block:
+        issues.append(
+            "release.yml:linux-repository-publication must be tag-gated "
+            "and always evaluate upstream results"
+        )
+
+    step = extract_named_step_block(block, RELEASE_PUBLICATION_GATE_STEP)
+    if not step:
+        issues.append(
+            "release.yml:linux-repository-publication must check "
+            "Linux repository publication results"
+        )
+        return tuple(issues)
+    for label, snippet in RELEASE_PUBLICATION_GATE_SNIPPETS:
+        if snippet not in step:
+            issues.append(f"release.yml:linux-repository-publication gate is missing {label}")
+    return tuple(issues)
+
+
 def is_secret_like_env_name(name: str) -> bool:
     return any(token in name for token in SECRET_LIKE_ENV_TOKENS)
 
@@ -480,6 +537,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
             unsafe_env_writes.append(finding)
             issues.append(finding)
         issues.extend(audit_required_release_preflight_steps(path))
+        issues.extend(audit_required_release_publication_gate(path))
 
         events = event_names(workflow_trigger(payload))
         for event in events:


### PR DESCRIPTION
## **User description**
Summary:
- Audit the release Linux repository publication job's always/tag gate and result-check step.
- Require the GitHub Release, Pages, and custom repository result env wiring and success checks.
- Add regression cases for missing/weak publication gates.

Validation:
- python scripts\check-github-workflow-permissions.py
- python scripts\check-github-workflow-permissions-regression.py
- python scripts\check-python-script-compile.py
- git diff --check
- python scripts\check-tagged-release-readiness-regression.py

Fixes #655

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audit the Linux repository publication gate in `release.yml` to require tag-gating and strict upstream result checks. Adds regression tests to catch missing env wiring and weakened success checks.

- **New Features**
  - Enforce `linux-repository-publication` has `if: always() && startsWith(github.ref, 'refs/tags/v')`.
  - Require a step named "Check Linux repository publication result" with envs for `vars.CONU_LINUX_REPOSITORY_BASE_URL`, `needs.github-release.result`, `needs.linux-repository-pages.result`, `needs.custom-linux-repository-publish.result`, and success checks for each mode.

<sup>Written for commit 1a0159e53902a9a16882c05ed9a939e196fc3054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Tighten Linux repository publication checks during tagged releases**

### What Changed
- The Linux repository publication job now runs only for version tags and always checks upstream release results before continuing.
- The release flow now fails if GitHub Release does not succeed, and it verifies either the default Pages publish or the custom repository publish path based on the configured base URL.
- The workflow audit scripts now enforce these checks and include regression coverage for missing tag gating, missing result inputs, and weakened success checks.

### Impact
`✅ Safer tagged releases`
`✅ Fewer broken Linux repository publishes`
`✅ Earlier failure when release publication steps do not complete successfully`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
