### PR TITLE
Audit GitHub Release publication safety gates

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -121,7 +121,50 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - run: echo release
+      - name: Re-check GitHub Release tag is unpublished
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/check-github-release-clobber-preflight.py --repo "$GITHUB_REPOSITORY" --tag "$GITHUB_REF_NAME"
+      - name: Publish release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "::error::GitHub Release $TAG_NAME already exists; refusing to overwrite release assets."
+            exit 1
+          fi
+          gh release create "$TAG_NAME" dist/* --verify-tag --title "conU $TAG_NAME" --notes-file release-notes.md
+      - name: Verify published release update policy and artifact with CLI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: |
+          set -eu
+          VERSION="${TAG_NAME#v}"
+          POLICY_URL="https://github.com/${GH_REPO}/releases/download/${TAG_NAME}/conu-${VERSION}-update-policy.json"
+          KEY_DIR="$RUNNER_TEMP/conu-release-key"
+          GNUPG_HOME="$RUNNER_TEMP/conu-release-gnupg"
+          DOWNLOAD_DIR="$RUNNER_TEMP/conu-update-download"
+          APPLY_INSTALL_DIR="$RUNNER_TEMP/conu-update-apply-bin"
+          mkdir -p "$KEY_DIR" "$GNUPG_HOME"
+          chmod 700 "$GNUPG_HOME"
+          gh release download "$TAG_NAME" --repo "$GH_REPO" --pattern conu-linux-gpg-key.asc --dir "$KEY_DIR"
+          export GNUPGHOME="$GNUPG_HOME"
+          gpg --batch --yes --import "$KEY_DIR/conu-linux-gpg-key.asc"
+          EXPECTED_FINGERPRINT="$(printf '%s' "$CONU_LINUX_GPG_KEY_FINGERPRINT" | tr -d '[:space:]:' | sed 's/^0[xX]//' | tr '[:lower:]' '[:upper:]')"
+          ACTUAL_FINGERPRINT="$(gpg --batch --with-colons --fingerprint --list-keys | awk -F: '$1 == "fpr" { print toupper($10); exit }')"
+          if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then
+            echo "::error::Published Linux GPG public key fingerprint mismatch"
+            exit 1
+          fi
+          cargo run -p conu-cli -- update check --policy-url "$POLICY_URL" --gpg-verify --json
+          cargo run -p conu-cli -- update download --policy-url "$POLICY_URL" --output-dir "$DOWNLOAD_DIR" --target linux-x64 --gpg-verify --json
+          cargo run -p conu-cli -- update apply --policy-url "$POLICY_URL" --artifact-file "$DOWNLOAD_DIR/conu-${VERSION}-linux-x64.tar.gz" --install-dir "$APPLY_INSTALL_DIR" --target linux-x64 --gpg-verify --dry-run --json
   linux-repository-pages:
     needs: github-release
     permissions:
@@ -471,6 +514,91 @@ def run_required_release_job_needs_tests(module) -> None:
         raise AssertionError("missing package preflight dependency was not reported")
 
 
+def run_required_github_release_gate_tests(module) -> None:
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Re-check GitHub Release tag is unpublished\n"
+            "        env:\n"
+            "          GH_TOKEN: ${{ github.token }}\n"
+            '        run: python scripts/check-github-release-clobber-preflight.py --repo "$GITHUB_REPOSITORY" --tag "$GITHUB_REF_NAME"\n',
+            "",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing late GitHub Release clobber preflight should fail")
+    if (
+        "release.yml:github-release must re-check GitHub Release tag is unpublished"
+        not in json.dumps(assert_safe_report(report))
+    ):
+        raise AssertionError("missing late GitHub Release clobber preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '          gh release create "$TAG_NAME" dist/* --verify-tag --title "conU $TAG_NAME" --notes-file release-notes.md\n',
+            '          gh release create "$TAG_NAME" dist/* --title "conU $TAG_NAME" --notes-file release-notes.md\n',
+        ),
+    )
+    if report.ready:
+        raise AssertionError("GitHub Release creation without --verify-tag should fail")
+    if (
+        "release.yml:github-release publish release assets without clobber "
+        "is missing release create command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing GitHub Release --verify-tag issue was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '          gh release create "$TAG_NAME" dist/* --verify-tag --title "conU $TAG_NAME" --notes-file release-notes.md\n',
+            '          gh release create "$TAG_NAME" dist/* --verify-tag --title "conU $TAG_NAME" --notes-file release-notes.md --clobber\n',
+        ),
+    )
+    if report.ready:
+        raise AssertionError("GitHub Release clobber publication should fail")
+    if (
+        "release.yml:github-release publish release assets must not use "
+        "gh release upload/create clobber"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("GitHub Release clobber issue was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '          cargo run -p conu-cli -- update apply --policy-url "$POLICY_URL" --artifact-file "$DOWNLOAD_DIR/conu-${VERSION}-linux-x64.tar.gz" --install-dir "$APPLY_INSTALL_DIR" --target linux-x64 --gpg-verify --dry-run --json\n',
+            '          cargo run -p conu-cli -- update apply --policy-url "$POLICY_URL" --artifact-file "$DOWNLOAD_DIR/conu-${VERSION}-linux-x64.tar.gz" --install-dir "$APPLY_INSTALL_DIR" --target linux-x64 --gpg-verify --json\n',
+        ),
+    )
+    if report.ready:
+        raise AssertionError("published update apply without dry-run should fail")
+    if (
+        "release.yml:github-release verify published release update policy "
+        "and artifact with CLI is missing update apply dry-run command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing published update apply dry-run issue was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '          if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then\n',
+            '          if [ "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT" ]; then\n',
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing published GPG fingerprint mismatch gate should fail")
+    if (
+        "release.yml:github-release verify published release update policy "
+        "and artifact with CLI is missing fingerprint comparison"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing published GPG fingerprint comparison was not reported")
+
+
 def run_required_npm_publication_gate_tests(module) -> None:
     report = with_fixture(
         module,
@@ -621,6 +749,7 @@ def main() -> int:
     run_expected_job_permission_tests(module)
     run_required_release_preflight_tests(module)
     run_required_release_job_needs_tests(module)
+    run_required_github_release_gate_tests(module)
     run_required_npm_publication_gate_tests(module)
     run_required_release_publication_gate_tests(module)
     run_unsafe_environment_file_write_tests(module)

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -214,6 +214,76 @@ NPM_PUBLISH_REQUIRED_STEPS: tuple[
         ),
     ),
 )
+GITHUB_RELEASE_REQUIRED_STEPS: tuple[
+    tuple[str, str, tuple[tuple[str, str], ...]],
+    ...,
+] = (
+    (
+        "Re-check GitHub Release tag is unpublished",
+        "re-check GitHub Release tag is unpublished",
+        (
+            ("GitHub token env", "GH_TOKEN: ${{ github.token }}"),
+            (
+                "clobber preflight command",
+                'python scripts/check-github-release-clobber-preflight.py --repo '
+                '"$GITHUB_REPOSITORY" --tag "$GITHUB_REF_NAME"',
+            ),
+        ),
+    ),
+    (
+        "Publish release assets",
+        "publish release assets without clobber",
+        (
+            ("GitHub token env", "GH_TOKEN: ${{ github.token }}"),
+            ("release repository env", "GH_REPO: ${{ github.repository }}"),
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            ("existing release guard", 'gh release view "$TAG_NAME"'),
+            (
+                "release create command",
+                'gh release create "$TAG_NAME" dist/* --verify-tag --title '
+                '"conU $TAG_NAME" --notes-file release-notes.md',
+            ),
+        ),
+    ),
+    (
+        "Verify published release update policy and artifact with CLI",
+        "verify published release update policy and artifact with CLI",
+        (
+            ("GitHub token env", "GH_TOKEN: ${{ github.token }}"),
+            (
+                "Linux fingerprint env",
+                "CONU_LINUX_GPG_KEY_FINGERPRINT: "
+                "${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}",
+            ),
+            (
+                "public key download",
+                'gh release download "$TAG_NAME" --repo "$GH_REPO" --pattern '
+                'conu-linux-gpg-key.asc --dir "$KEY_DIR"',
+            ),
+            (
+                "fingerprint comparison",
+                'if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then',
+            ),
+            (
+                "update check command",
+                'cargo run -p conu-cli -- update check --policy-url "$POLICY_URL" '
+                "--gpg-verify --json",
+            ),
+            (
+                "update download command",
+                'cargo run -p conu-cli -- update download --policy-url "$POLICY_URL" '
+                '--output-dir "$DOWNLOAD_DIR" --target linux-x64 --gpg-verify --json',
+            ),
+            (
+                "update apply dry-run command",
+                'cargo run -p conu-cli -- update apply --policy-url "$POLICY_URL" '
+                '--artifact-file "$DOWNLOAD_DIR/conu-${VERSION}-linux-x64.tar.gz" '
+                '--install-dir "$APPLY_INSTALL_DIR" --target linux-x64 --gpg-verify '
+                "--dry-run --json",
+            ),
+        ),
+    ),
+)
 EXPECTED_JOB_PERMISSIONS: dict[tuple[str, str], dict[str, str]] = {
     ("release.yml", "release-preflight"): {
         "actions": "read",
@@ -564,6 +634,37 @@ def audit_required_npm_publication_gate(path: Path) -> tuple[str, ...]:
     return tuple(issues)
 
 
+def audit_required_github_release_gate(path: Path) -> tuple[str, ...]:
+    if path.name != "release.yml":
+        return ()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
+
+    block = extract_job_block(text, "github-release")
+    issues: list[str] = []
+    if not block:
+        return ("release.yml must define github-release job",)
+
+    for step_name, description, required_snippets in GITHUB_RELEASE_REQUIRED_STEPS:
+        step = extract_named_step_block(block, step_name)
+        if not step:
+            issues.append(f"release.yml:github-release must {description}")
+            continue
+        if step_name == "Publish release assets" and "--clobber" in step:
+            issues.append(
+                "release.yml:github-release publish release assets must not use "
+                "gh release upload/create clobber"
+            )
+        for label, snippet in required_snippets:
+            if snippet not in step:
+                issues.append(
+                    f"release.yml:github-release {description} is missing {label}"
+                )
+    return tuple(issues)
+
+
 def is_secret_like_env_name(name: str) -> bool:
     return any(token in name for token in SECRET_LIKE_ENV_TOKENS)
 
@@ -698,6 +799,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
             unsafe_env_writes.append(finding)
             issues.append(finding)
         issues.extend(audit_required_release_preflight_steps(path))
+        issues.extend(audit_required_github_release_gate(path))
         issues.extend(audit_required_release_publication_gate(path))
         issues.extend(audit_required_npm_publication_gate(path))
 


### PR DESCRIPTION
## **User description**
Adds workflow-permissions audit coverage for the tagged GitHub Release publication job so late tag clobber checks, non-clobber release creation, published Linux GPG public-key fingerprint verification, and public update check/download/apply dry-run verification cannot be removed silently.

Validation:
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-tagged-release-readiness-regression.py
- git diff --check

Fixes #661

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add audit checks that enforce safety gates in the GitHub Release publication job so they can’t be removed silently. Prevents tag clobber, requires verified tags, verifies the published Linux GPG key, and dry‑runs update apply, fixing #661.

- **New Features**
  - Enforce late tag clobber preflight via `scripts/check-github-release-clobber-preflight.py`.
  - Require non‑clobber `gh release create` with `--verify-tag` and an existing‑release guard.
  - Verify published key by downloading `conu-linux-gpg-key.asc` and comparing to `CONU_LINUX_GPG_KEY_FINGERPRINT`.
  - Require `conu-cli` update gates: `update check`, `update download` (linux‑x64), and `update apply --dry-run`.
  - Add `audit_required_github_release_gate` in `scripts/check-github-workflow-permissions.py` with regression tests in `scripts/check-github-workflow-permissions-regression.py`.

<sup>Written for commit 64576d6a23ffd4dff459ccc10051ee8344c230a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Tighten GitHub Release publication checks so release assets and update verification cannot be skipped or altered silently**

### What Changed
- The release workflow must now re-check that the tag is still unpublished before publishing assets.
- Release creation now has to refuse overwriting an existing release and must verify the tag before publishing.
- The published Linux GPG key is now downloaded and compared against the expected fingerprint before update checks run.
- The release job now has to run update check, update download for linux-x64, and a dry-run update apply against the published release.

### Impact
`✅ Fewer release overwrites`
`✅ Safer tag-based releases`
`✅ Clearer release verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
