### PR TITLE
Audit release build workflow gate

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -193,14 +193,99 @@ jobs:
         shell: pwsh
         run: ./scripts/verify-production-readiness.ps1 -SmokeOnly
   build:
+    name: Build ${{ matrix.name }}
     needs: [packages, production-readiness]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       id-token: write
       attestations: write
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows-x64
+            os: windows-2025-vs2026
+            script: powershell -ExecutionPolicy Bypass -File scripts/build-release.ps1 -PackageSuffix windows-x64
+            artifact: |
+              dist/*.zip
+              dist/*.zip.sha256
+          - name: linux-x64
+            os: ubuntu-latest
+            script: PACKAGE_SUFFIX=linux-x64 sh scripts/build-release.sh
+            artifact: |
+              dist/*.tar.gz
+              dist/*.tar.gz.sha256
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            script: PACKAGE_SUFFIX=linux-arm64 sh scripts/build-release.sh
+            artifact: |
+              dist/*.tar.gz
+              dist/*.tar.gz.sha256
+          - name: macos-arm64
+            os: macos-15
+            script: PACKAGE_SUFFIX=macos-arm64 sh scripts/build-release.sh
+            artifact: |
+              dist/*.zip
+              dist/*.zip.sha256
+          - name: macos-x64
+            os: macos-15-intel
+            script: PACKAGE_SUFFIX=macos-x64 sh scripts/build-release.sh
+            artifact: |
+              dist/*.zip
+              dist/*.zip.sha256
+    env:
+      CONU_SIGNING_REQUIRED: ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '0' }}
     steps:
-      - run: echo build
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Configure macOS signing keychain
+        if: runner.os == 'macOS'
+        env:
+          MACOS_P12_BASE64: ${{ secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          MACOS_P12_PASSWORD: ${{ secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD }}
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.CONU_MACOS_CODESIGN_IDENTITY }}
+          MACOS_NOTARY_APPLE_ID: ${{ secrets.CONU_MACOS_NOTARY_APPLE_ID }}
+          MACOS_NOTARY_TEAM_ID: ${{ secrets.CONU_MACOS_NOTARY_TEAM_ID }}
+          MACOS_NOTARY_PASSWORD: ${{ secrets.CONU_MACOS_NOTARY_PASSWORD }}
+        run: |
+          set -eu
+          append_github_env() {
+            name="$1"
+            value="$2"
+            printf '%s=%s\\n' "$name" "$value" >> "$GITHUB_ENV"
+          }
+          if [ "${CONU_SIGNING_REQUIRED:-0}" = "1" ]; then
+            echo "signing required"
+          fi
+          xcrun notarytool store-credentials conu-notary-profile
+          append_github_env CONU_MACOS_CODESIGN_IDENTITY "$MACOS_CODESIGN_IDENTITY"
+          append_github_env CONU_MACOS_KEYCHAIN "$keychain_path"
+          append_github_env CONU_MACOS_NOTARY_KEYCHAIN_PROFILE "conu-notary-profile"
+      - name: Build package
+        env:
+          CONU_WINDOWS_SIGN_CERT_PFX_BASE64: ${{ secrets.CONU_WINDOWS_SIGN_CERT_PFX_BASE64 }}
+          CONU_WINDOWS_SIGN_CERT_PASSWORD: ${{ secrets.CONU_WINDOWS_SIGN_CERT_PASSWORD }}
+          CONU_WINDOWS_TIMESTAMP_URL: ${{ secrets.CONU_WINDOWS_TIMESTAMP_URL }}
+        run: ${{ matrix.script }}
+      - name: Verify release artifact
+        run: python scripts/verify-release-artifacts.py dist
+      - name: Smoke release artifact install
+        run: python scripts/smoke-release-artifacts.py dist
+      - name: Smoke npm launcher local install
+        run: python scripts/smoke-npm-launcher-local.py dist
+      - name: Smoke npm launcher download install
+        run: python scripts/smoke-npm-launcher-download.py dist
+      - name: Attest release artifact provenance
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: ${{ matrix.artifact }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: conu-${{ matrix.name }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
   github-release:
     needs: build
     permissions:
@@ -766,6 +851,108 @@ def run_required_production_readiness_job_tests(module) -> None:
         raise AssertionError("missing production readiness Windows runner was not reported")
 
 
+def run_required_build_job_tests(module) -> None:
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "    runs-on: ${{ matrix.os }}\n",
+            "    runs-on: ubuntu-latest\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("build job without matrix runner should fail")
+    if "release.yml:build is missing matrix runner" not in json.dumps(
+        assert_safe_report(report)
+    ):
+        raise AssertionError("missing build matrix runner was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "          - name: linux-arm64\n",
+            "          - name: linux-aarch64\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("build job without Linux arm64 target should fail")
+    if "release.yml:build is missing Linux arm64 target" not in json.dumps(
+        assert_safe_report(report)
+    ):
+        raise AssertionError("missing Linux arm64 build target was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: python scripts/verify-release-artifacts.py dist\n",
+            "        run: echo skipped-artifact-verifier\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("build job without artifact verifier should fail")
+    if (
+        "release.yml:build verify release artifact is missing "
+        "release artifact verifier command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing build artifact verifier was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        uses: actions/attest@v4.1.0\n",
+            "        uses: actions/upload-artifact@v7.0.1\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("build job without artifact attestation should fail")
+    if (
+        "release.yml:build attest release artifact provenance is missing "
+        "artifact attestation action"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing build artifact attestation was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "          subject-path: ${{ matrix.artifact }}\n",
+            "          subject-path: dist/*\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("build job without matrix attestation subject should fail")
+    if (
+        "release.yml:build attest release artifact provenance is missing "
+        "attestation subject path"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing matrix attestation subject was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: ${{ matrix.script }}\n",
+            "        run: echo skipped-matrix-build\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("build job without matrix build command should fail")
+    if (
+        "release.yml:build build release package is missing matrix build command"
+        not in json.dumps(assert_safe_report(report))
+    ):
+        raise AssertionError("missing matrix build command was not reported")
+
+
 def run_required_github_release_gate_tests(module) -> None:
     report = with_fixture(
         module,
@@ -1059,11 +1246,14 @@ def run_unsafe_environment_file_write_tests(module) -> None:
         module,
         None,
         ready_release().replace(
-            "      - run: echo build\n",
-            "      - run: |\n"
+            "      - name: Verify release artifact\n",
+            "      - name: Unsafe env write\n"
+            "        run: |\n"
             "          {\n"
             "            echo \"CONU_MACOS_CODESIGN_IDENTITY=$MACOS_CODESIGN_IDENTITY\"\n"
-            "          } >> \"$GITHUB_ENV\"\n",
+            "          } >> \"$GITHUB_ENV\"\n"
+            "      - name: Verify release artifact\n",
+            1,
         ),
     )
     if report.ready:
@@ -1087,6 +1277,7 @@ def main() -> int:
     run_required_release_job_needs_tests(module)
     run_required_package_checks_job_tests(module)
     run_required_production_readiness_job_tests(module)
+    run_required_build_job_tests(module)
     run_required_github_release_gate_tests(module)
     run_required_linux_repository_publication_job_tests(module)
     run_required_npm_publication_gate_tests(module)

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -496,6 +496,174 @@ PACKAGES_REQUIRED_STEPS: tuple[
         ),
     ),
 )
+BUILD_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
+    ("matrix job name", "name: Build ${{ matrix.name }}"),
+    ("matrix runner", "runs-on: ${{ matrix.os }}"),
+    ("matrix fail-fast", "fail-fast: false"),
+    ("Windows x64 target", "name: windows-x64"),
+    ("Windows runner", "os: windows-2025-vs2026"),
+    (
+        "Windows build command",
+        "powershell -ExecutionPolicy Bypass -File scripts/build-release.ps1 "
+        "-PackageSuffix windows-x64",
+    ),
+    ("Linux x64 target", "name: linux-x64"),
+    ("Linux x64 runner", "os: ubuntu-latest"),
+    ("Linux x64 build command", "PACKAGE_SUFFIX=linux-x64 sh scripts/build-release.sh"),
+    ("Linux arm64 target", "name: linux-arm64"),
+    ("Linux arm64 runner", "os: ubuntu-24.04-arm"),
+    ("Linux arm64 build command", "PACKAGE_SUFFIX=linux-arm64 sh scripts/build-release.sh"),
+    ("macOS arm64 target", "name: macos-arm64"),
+    ("macOS arm64 runner", "os: macos-15"),
+    ("macOS arm64 build command", "PACKAGE_SUFFIX=macos-arm64 sh scripts/build-release.sh"),
+    ("macOS x64 target", "name: macos-x64"),
+    ("macOS x64 runner", "os: macos-15-intel"),
+    ("macOS x64 build command", "PACKAGE_SUFFIX=macos-x64 sh scripts/build-release.sh"),
+    ("zip artifact glob", "dist/*.zip"),
+    ("zip checksum glob", "dist/*.zip.sha256"),
+    ("tarball artifact glob", "dist/*.tar.gz"),
+    ("tarball checksum glob", "dist/*.tar.gz.sha256"),
+    (
+        "signing required env",
+        "CONU_SIGNING_REQUIRED: ${{ startsWith(github.ref, 'refs/tags/v') && "
+        "'1' || '0' }}",
+    ),
+    ("checkout action", "uses: actions/checkout@v6"),
+    ("Rust toolchain action", "uses: dtolnay/rust-toolchain@stable"),
+)
+BUILD_REQUIRED_STEPS: tuple[
+    tuple[str, str, tuple[tuple[str, str], ...]],
+    ...,
+] = (
+    (
+        "Configure macOS signing keychain",
+        "configure macOS signing keychain",
+        (
+            ("macOS runner gate", "if: runner.os == 'macOS'"),
+            (
+                "macOS P12 secret env",
+                "MACOS_P12_BASE64: ${{ "
+                "secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 }}",
+            ),
+            (
+                "macOS P12 password secret env",
+                "MACOS_P12_PASSWORD: ${{ "
+                "secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD }}",
+            ),
+            (
+                "macOS codesign identity secret env",
+                "MACOS_CODESIGN_IDENTITY: ${{ secrets.CONU_MACOS_CODESIGN_IDENTITY }}",
+            ),
+            (
+                "macOS notary Apple ID secret env",
+                "MACOS_NOTARY_APPLE_ID: ${{ secrets.CONU_MACOS_NOTARY_APPLE_ID }}",
+            ),
+            (
+                "macOS notary team secret env",
+                "MACOS_NOTARY_TEAM_ID: ${{ secrets.CONU_MACOS_NOTARY_TEAM_ID }}",
+            ),
+            (
+                "macOS notary password secret env",
+                "MACOS_NOTARY_PASSWORD: ${{ secrets.CONU_MACOS_NOTARY_PASSWORD }}",
+            ),
+            (
+                "tagged signing required gate",
+                'if [ "${CONU_SIGNING_REQUIRED:-0}" = "1" ]; then',
+            ),
+            (
+                "notary credential storage",
+                "xcrun notarytool store-credentials conu-notary-profile",
+            ),
+            ("safe GitHub env writer", "append_github_env() {"),
+            (
+                "codesign identity export",
+                'append_github_env CONU_MACOS_CODESIGN_IDENTITY "$MACOS_CODESIGN_IDENTITY"',
+            ),
+            (
+                "keychain export",
+                'append_github_env CONU_MACOS_KEYCHAIN "$keychain_path"',
+            ),
+            (
+                "notary profile export",
+                'append_github_env CONU_MACOS_NOTARY_KEYCHAIN_PROFILE "conu-notary-profile"',
+            ),
+        ),
+    ),
+    (
+        "Build package",
+        "build release package",
+        (
+            (
+                "Windows signing cert env",
+                "CONU_WINDOWS_SIGN_CERT_PFX_BASE64: ${{ "
+                "secrets.CONU_WINDOWS_SIGN_CERT_PFX_BASE64 }}",
+            ),
+            (
+                "Windows signing password env",
+                "CONU_WINDOWS_SIGN_CERT_PASSWORD: ${{ "
+                "secrets.CONU_WINDOWS_SIGN_CERT_PASSWORD }}",
+            ),
+            (
+                "Windows timestamp URL env",
+                "CONU_WINDOWS_TIMESTAMP_URL: ${{ secrets.CONU_WINDOWS_TIMESTAMP_URL }}",
+            ),
+            ("matrix build command", "run: ${{ matrix.script }}"),
+        ),
+    ),
+    (
+        "Verify release artifact",
+        "verify release artifact",
+        (
+            (
+                "release artifact verifier command",
+                "python scripts/verify-release-artifacts.py dist",
+            ),
+        ),
+    ),
+    (
+        "Smoke release artifact install",
+        "smoke release artifact install",
+        (("release artifact smoke command", "python scripts/smoke-release-artifacts.py dist"),),
+    ),
+    (
+        "Smoke npm launcher local install",
+        "smoke npm launcher local install",
+        (
+            (
+                "npm launcher local smoke command",
+                "python scripts/smoke-npm-launcher-local.py dist",
+            ),
+        ),
+    ),
+    (
+        "Smoke npm launcher download install",
+        "smoke npm launcher download install",
+        (
+            (
+                "npm launcher download smoke command",
+                "python scripts/smoke-npm-launcher-download.py dist",
+            ),
+        ),
+    ),
+    (
+        "Attest release artifact provenance",
+        "attest release artifact provenance",
+        (
+            ("artifact attestation action", "uses: actions/attest@v4.1.0"),
+            ("attestation subject path", "subject-path: ${{ matrix.artifact }}"),
+        ),
+    ),
+    (
+        "Upload artifact",
+        "upload release artifact",
+        (
+            ("artifact upload action", "uses: actions/upload-artifact@v7.0.1"),
+            ("matrix artifact name", "name: conu-${{ matrix.name }}"),
+            ("matrix artifact path", "path: ${{ matrix.artifact }}"),
+            ("missing artifact failure", "if-no-files-found: error"),
+        ),
+    ),
+)
 NPM_PUBLISH_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
     ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
     ("Node setup", "uses: actions/setup-node@v6"),
@@ -1101,6 +1269,34 @@ def audit_required_package_checks_job(path: Path) -> tuple[str, ...]:
     return tuple(issues)
 
 
+def audit_required_build_job(path: Path) -> tuple[str, ...]:
+    if path.name != "release.yml":
+        return ()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
+
+    block = extract_job_block(text, "build")
+    issues: list[str] = []
+    if not block:
+        return ("release.yml must define build job",)
+
+    for label, snippet in BUILD_JOB_SNIPPETS:
+        if snippet not in block:
+            issues.append(f"release.yml:build is missing {label}")
+
+    for step_name, description, required_snippets in BUILD_REQUIRED_STEPS:
+        step = extract_named_step_block(block, step_name)
+        if not step:
+            issues.append(f"release.yml:build must {description}")
+            continue
+        for label, snippet in required_snippets:
+            if snippet not in step:
+                issues.append(f"release.yml:build {description} is missing {label}")
+    return tuple(issues)
+
+
 def audit_required_github_release_gate(path: Path) -> tuple[str, ...]:
     if path.name != "release.yml":
         return ()
@@ -1349,6 +1545,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
         issues.extend(audit_required_release_preflight_steps(path))
         issues.extend(audit_required_package_checks_job(path))
         issues.extend(audit_required_production_readiness_job(path))
+        issues.extend(audit_required_build_job(path))
         issues.extend(audit_required_github_release_gate(path))
         issues.extend(audit_required_linux_repository_publication_jobs(path))
         issues.extend(audit_required_release_publication_gate(path))


### PR DESCRIPTION
## **User description**
Adds release build job audit coverage for the platform matrix, build command, artifact verifier/smokes, provenance attestation, and artifact upload gates.

Validation:
- python scripts\check-github-workflow-permissions.py
- python scripts\check-github-workflow-permissions-regression.py
- python scripts\check-python-script-compile.py
- python scripts\check-tagged-release-readiness-regression.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Fixes #669


___

## **CodeAnt-AI Description**
Audit the release build job for all target platforms and release checks

### What Changed
- The release workflow audit now verifies the build job includes the full platform matrix for Windows, Linux, and macOS releases
- It now checks that release builds run artifact verification, install smoke tests, npm launcher smoke tests, provenance attestation, and artifact upload for each build output
- The regression coverage was expanded so workflow changes that remove any of these release protections are caught automatically

### Impact
`✅ Fewer broken release builds`
`✅ Safer multi-platform releases`
`✅ Earlier detection of missing artifact checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for build job validation to verify proper matrix configuration, artifact verification, and attestation steps.

* **Chores**
  * Enhanced workflow auditing capabilities with additional checks for build job requirements, including signing configuration and artifact handling across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict audits for the release build job to enforce the full platform matrix, artifact checks, provenance attestation, and uploads. This prevents unsafe `release.yml` changes and keeps Windows, Linux, and macOS releases consistent.

- **New Features**
  - Audits `release.yml` build job for matrix targets: windows-x64, linux-x64, linux-arm64, macos-arm64, macos-x64 with correct runners.
  - Requires matrix build command, artifact verification + smoke tests, and upload via `actions/upload-artifact` (errors if files are missing).
  - Enforces provenance attestation via `actions/attest` with the matrix subject path.
  - Validates macOS signing keychain setup and safe env exports; checks `actions/checkout` and `dtolnay/rust-toolchain` steps.
  - Adds regression coverage to flag removal or changes to any of the above gates.

<sup>Written for commit 16110edc08e3cf09088b3cedf05dbbb9c16c8bfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

