### PR TITLE
Audit release preflight workflow gates

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -90,11 +90,74 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python scripts/check-github-repository-security.py --repo "$GITHUB_REPOSITORY"
+      - name: Check tagged release secrets
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          CONU_WINDOWS_SIGN_CERT_PFX_BASE64: ${{ secrets.CONU_WINDOWS_SIGN_CERT_PFX_BASE64 }}
+          CONU_WINDOWS_SIGN_CERT_PASSWORD: ${{ secrets.CONU_WINDOWS_SIGN_CERT_PASSWORD }}
+          CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD: ${{ secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD }}
+          CONU_MACOS_CODESIGN_IDENTITY: ${{ secrets.CONU_MACOS_CODESIGN_IDENTITY }}
+          CONU_MACOS_NOTARY_APPLE_ID: ${{ secrets.CONU_MACOS_NOTARY_APPLE_ID }}
+          CONU_MACOS_NOTARY_TEAM_ID: ${{ secrets.CONU_MACOS_NOTARY_TEAM_ID }}
+          CONU_MACOS_NOTARY_PASSWORD: ${{ secrets.CONU_MACOS_NOTARY_PASSWORD }}
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: python scripts/check-release-secret-env-preflight.py
       - name: Validate npm token authentication and registry availability
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: python scripts/check-npm-publish-preflight.py --registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check
+      - name: Install signing preflight tools
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gnupg openssl
+      - name: Validate platform signing secret values
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          CONU_WINDOWS_SIGN_CERT_PFX_BASE64: ${{ secrets.CONU_WINDOWS_SIGN_CERT_PFX_BASE64 }}
+          CONU_WINDOWS_SIGN_CERT_PASSWORD: ${{ secrets.CONU_WINDOWS_SIGN_CERT_PASSWORD }}
+          CONU_WINDOWS_TIMESTAMP_URL: ${{ secrets.CONU_WINDOWS_TIMESTAMP_URL }}
+          CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD: ${{ secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD }}
+          CONU_MACOS_CODESIGN_IDENTITY: ${{ secrets.CONU_MACOS_CODESIGN_IDENTITY }}
+          CONU_MACOS_NOTARY_APPLE_ID: ${{ secrets.CONU_MACOS_NOTARY_APPLE_ID }}
+          CONU_MACOS_NOTARY_TEAM_ID: ${{ secrets.CONU_MACOS_NOTARY_TEAM_ID }}
+          CONU_MACOS_NOTARY_PASSWORD: ${{ secrets.CONU_MACOS_NOTARY_PASSWORD }}
+        run: python scripts/check-platform-signing-secrets-preflight.py --require-openssl
+      - name: Validate Linux signing secrets
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/check-linux-signing-secrets-preflight.py
+      - name: Validate default GitHub Pages repository settings
+        if: startsWith(github.ref, 'refs/tags/v') && vars.CONU_LINUX_REPOSITORY_BASE_URL == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/check-github-pages-readiness.py --repo "$GITHUB_REPOSITORY"
+      - name: Validate GitHub Release tag is unpublished
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/check-github-release-clobber-preflight.py --repo "$GITHUB_REPOSITORY" --tag "$GITHUB_REF_NAME"
+      - name: Validate custom Linux repository publication config
+        if: startsWith(github.ref, 'refs/tags/v') && vars.CONU_LINUX_REPOSITORY_BASE_URL != ''
+        env:
+          CONU_LINUX_REPOSITORY_BASE_URL: ${{ vars.CONU_LINUX_REPOSITORY_BASE_URL }}
+          CONU_LINUX_REPOSITORY_S3_BUCKET: ${{ vars.CONU_LINUX_REPOSITORY_S3_BUCKET }}
+          CONU_LINUX_REPOSITORY_S3_PREFIX: ${{ vars.CONU_LINUX_REPOSITORY_S3_PREFIX }}
+          CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL: ${{ vars.CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL }}
+          CONU_LINUX_REPOSITORY_AWS_REGION: ${{ vars.CONU_LINUX_REPOSITORY_AWS_REGION }}
+          CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID: ${{ secrets.CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID }}
+          CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY: ${{ secrets.CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY }}
+          CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN: ${{ secrets.CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN }}
+        run: python scripts/check-custom-linux-repository-publication-preflight.py
   packages:
     needs: release-preflight
     runs-on: ubuntu-latest
@@ -683,6 +746,121 @@ def run_required_release_preflight_tests(module) -> None:
     ) not in json.dumps(assert_safe_report(report)):
         raise AssertionError("missing early npm auth/registry preflight issue was not reported")
 
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: python scripts/check-release-secret-env-preflight.py\n",
+            "        run: echo skipped-release-secret-env-preflight\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing tagged release secret preflight should fail")
+    if (
+        "release.yml:release-preflight check tagged release secrets "
+        "is missing release secret env command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing tagged release secret preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gnupg openssl\n",
+            "        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gnupg\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing signing preflight OpenSSL install should fail")
+    if (
+        "release.yml:release-preflight install signing preflight tools is missing "
+        "signing preflight tool install command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing signing preflight tool install was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: python scripts/check-platform-signing-secrets-preflight.py --require-openssl\n",
+            "        run: python scripts/check-platform-signing-secrets-preflight.py\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("weakened platform signing value preflight should fail")
+    if (
+        "release.yml:release-preflight validate platform signing secret values "
+        "is missing platform signing secret value command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("weakened platform signing value preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: python scripts/check-linux-signing-secrets-preflight.py\n",
+            "        run: echo skipped-linux-signing-secret-preflight\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing Linux signing secret preflight should fail")
+    if (
+        "release.yml:release-preflight validate Linux signing secrets "
+        "is missing Linux signing secret command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing Linux signing secret preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        if: startsWith(github.ref, 'refs/tags/v') && vars.CONU_LINUX_REPOSITORY_BASE_URL == ''\n",
+            "        if: startsWith(github.ref, 'refs/tags/v')\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("default Pages preflight without mode gate should fail")
+    if (
+        "release.yml:release-preflight validate default GitHub Pages "
+        "repository settings is missing default repository mode gate"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing default Pages preflight mode gate was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '        run: python scripts/check-github-release-clobber-preflight.py --repo "$GITHUB_REPOSITORY" --tag "$GITHUB_REF_NAME"\n',
+            "        run: echo skipped-release-clobber-preflight\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing release clobber preflight should fail")
+    if (
+        "release.yml:release-preflight validate GitHub Release tag is unpublished "
+        "is missing release clobber preflight command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing release clobber preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: python scripts/check-custom-linux-repository-publication-preflight.py\n",
+            "        run: echo skipped-custom-repository-preflight\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing custom repository publication preflight should fail")
+    if (
+        "release.yml:release-preflight validate custom Linux repository "
+        "publication config is missing custom repository preflight command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing custom repository preflight was not reported")
+
 
 def run_required_release_job_needs_tests(module) -> None:
     report = with_fixture(
@@ -1043,8 +1221,8 @@ def run_required_linux_repository_publication_job_tests(module) -> None:
         module,
         None,
         ready_release().replace(
-            "    if: startsWith(github.ref, 'refs/tags/v') && vars.CONU_LINUX_REPOSITORY_BASE_URL == ''\n",
-            "",
+            "\n    if: startsWith(github.ref, 'refs/tags/v') && vars.CONU_LINUX_REPOSITORY_BASE_URL == ''\n",
+            "\n",
             1,
         ),
     )
@@ -1077,8 +1255,9 @@ def run_required_linux_repository_publication_job_tests(module) -> None:
         module,
         None,
         ready_release().replace(
-            "    if: startsWith(github.ref, 'refs/tags/v') && vars.CONU_LINUX_REPOSITORY_BASE_URL != ''\n",
-            "",
+            "\n    if: startsWith(github.ref, 'refs/tags/v') && vars.CONU_LINUX_REPOSITORY_BASE_URL != ''\n",
+            "\n",
+            1,
         ),
     )
     if report.ready:

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -113,12 +113,254 @@ RELEASE_PREFLIGHT_REQUIRED_STEPS: tuple[
         ),
     ),
     (
+        "Check tagged release secrets",
+        "check tagged release secrets",
+        (
+            ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
+            (
+                "Windows signing cert env",
+                "CONU_WINDOWS_SIGN_CERT_PFX_BASE64: ${{ "
+                "secrets.CONU_WINDOWS_SIGN_CERT_PFX_BASE64 }}",
+            ),
+            (
+                "Windows signing password env",
+                "CONU_WINDOWS_SIGN_CERT_PASSWORD: ${{ "
+                "secrets.CONU_WINDOWS_SIGN_CERT_PASSWORD }}",
+            ),
+            (
+                "macOS P12 secret env",
+                "CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ "
+                "secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 }}",
+            ),
+            (
+                "macOS P12 password env",
+                "CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD: ${{ "
+                "secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD }}",
+            ),
+            (
+                "macOS codesign identity env",
+                "CONU_MACOS_CODESIGN_IDENTITY: ${{ secrets.CONU_MACOS_CODESIGN_IDENTITY }}",
+            ),
+            (
+                "macOS notary Apple ID env",
+                "CONU_MACOS_NOTARY_APPLE_ID: ${{ secrets.CONU_MACOS_NOTARY_APPLE_ID }}",
+            ),
+            (
+                "macOS notary team env",
+                "CONU_MACOS_NOTARY_TEAM_ID: ${{ secrets.CONU_MACOS_NOTARY_TEAM_ID }}",
+            ),
+            (
+                "macOS notary password env",
+                "CONU_MACOS_NOTARY_PASSWORD: ${{ secrets.CONU_MACOS_NOTARY_PASSWORD }}",
+            ),
+            (
+                "Linux GPG private key env",
+                "CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ "
+                "secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}",
+            ),
+            (
+                "Linux GPG passphrase env",
+                "CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}",
+            ),
+            (
+                "Linux GPG key id env",
+                "CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}",
+            ),
+            (
+                "Linux GPG fingerprint env",
+                "CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ "
+                "secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}",
+            ),
+            ("NPM token env", "NPM_TOKEN: ${{ secrets.NPM_TOKEN }}"),
+            (
+                "release secret env command",
+                "python scripts/check-release-secret-env-preflight.py",
+            ),
+        ),
+    ),
+    (
         "Validate npm token authentication and registry availability",
         "validate npm token authentication and registry availability",
         (
             ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
             ("NPM token env", "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}"),
             ("npm auth/registry command", RELEASE_PREFLIGHT_NPM_AUTH_COMMAND),
+        ),
+    ),
+    (
+        "Install signing preflight tools",
+        "install signing preflight tools",
+        (
+            ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
+            (
+                "signing preflight tool install command",
+                "sudo apt-get update && sudo apt-get install -y "
+                "--no-install-recommends gnupg openssl",
+            ),
+        ),
+    ),
+    (
+        "Validate platform signing secret values",
+        "validate platform signing secret values",
+        (
+            ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
+            (
+                "Windows signing cert env",
+                "CONU_WINDOWS_SIGN_CERT_PFX_BASE64: ${{ "
+                "secrets.CONU_WINDOWS_SIGN_CERT_PFX_BASE64 }}",
+            ),
+            (
+                "Windows signing password env",
+                "CONU_WINDOWS_SIGN_CERT_PASSWORD: ${{ "
+                "secrets.CONU_WINDOWS_SIGN_CERT_PASSWORD }}",
+            ),
+            (
+                "Windows timestamp URL env",
+                "CONU_WINDOWS_TIMESTAMP_URL: ${{ secrets.CONU_WINDOWS_TIMESTAMP_URL }}",
+            ),
+            (
+                "macOS P12 secret env",
+                "CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ "
+                "secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 }}",
+            ),
+            (
+                "macOS P12 password env",
+                "CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD: ${{ "
+                "secrets.CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD }}",
+            ),
+            (
+                "macOS codesign identity env",
+                "CONU_MACOS_CODESIGN_IDENTITY: ${{ secrets.CONU_MACOS_CODESIGN_IDENTITY }}",
+            ),
+            (
+                "macOS notary Apple ID env",
+                "CONU_MACOS_NOTARY_APPLE_ID: ${{ secrets.CONU_MACOS_NOTARY_APPLE_ID }}",
+            ),
+            (
+                "macOS notary team env",
+                "CONU_MACOS_NOTARY_TEAM_ID: ${{ secrets.CONU_MACOS_NOTARY_TEAM_ID }}",
+            ),
+            (
+                "macOS notary password env",
+                "CONU_MACOS_NOTARY_PASSWORD: ${{ secrets.CONU_MACOS_NOTARY_PASSWORD }}",
+            ),
+            (
+                "platform signing secret value command",
+                "python scripts/check-platform-signing-secrets-preflight.py "
+                "--require-openssl",
+            ),
+        ),
+    ),
+    (
+        "Validate Linux signing secrets",
+        "validate Linux signing secrets",
+        (
+            ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
+            (
+                "Linux GPG private key env",
+                "CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ "
+                "secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}",
+            ),
+            (
+                "Linux GPG passphrase env",
+                "CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}",
+            ),
+            (
+                "Linux GPG key id env",
+                "CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}",
+            ),
+            (
+                "Linux GPG fingerprint env",
+                "CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ "
+                "secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}",
+            ),
+            (
+                "Linux signing secret command",
+                "python scripts/check-linux-signing-secrets-preflight.py",
+            ),
+        ),
+    ),
+    (
+        "Validate default GitHub Pages repository settings",
+        "validate default GitHub Pages repository settings",
+        (
+            (
+                "default repository mode gate",
+                "if: startsWith(github.ref, 'refs/tags/v') && "
+                "vars.CONU_LINUX_REPOSITORY_BASE_URL == ''",
+            ),
+            ("GitHub token env", "GH_TOKEN: ${{ github.token }}"),
+            (
+                "GitHub Pages readiness command",
+                'python scripts/check-github-pages-readiness.py --repo "$GITHUB_REPOSITORY"',
+            ),
+        ),
+    ),
+    (
+        "Validate GitHub Release tag is unpublished",
+        "validate GitHub Release tag is unpublished",
+        (
+            ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
+            ("GitHub token env", "GH_TOKEN: ${{ github.token }}"),
+            (
+                "release clobber preflight command",
+                'python scripts/check-github-release-clobber-preflight.py --repo '
+                '"$GITHUB_REPOSITORY" --tag "$GITHUB_REF_NAME"',
+            ),
+        ),
+    ),
+    (
+        "Validate custom Linux repository publication config",
+        "validate custom Linux repository publication config",
+        (
+            (
+                "custom repository mode gate",
+                "if: startsWith(github.ref, 'refs/tags/v') && "
+                "vars.CONU_LINUX_REPOSITORY_BASE_URL != ''",
+            ),
+            (
+                "custom repository base URL env",
+                "CONU_LINUX_REPOSITORY_BASE_URL: ${{ vars.CONU_LINUX_REPOSITORY_BASE_URL }}",
+            ),
+            (
+                "custom repository bucket env",
+                "CONU_LINUX_REPOSITORY_S3_BUCKET: ${{ "
+                "vars.CONU_LINUX_REPOSITORY_S3_BUCKET }}",
+            ),
+            (
+                "custom repository prefix env",
+                "CONU_LINUX_REPOSITORY_S3_PREFIX: ${{ "
+                "vars.CONU_LINUX_REPOSITORY_S3_PREFIX }}",
+            ),
+            (
+                "custom repository endpoint env",
+                "CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL: ${{ "
+                "vars.CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL }}",
+            ),
+            (
+                "custom repository region env",
+                "CONU_LINUX_REPOSITORY_AWS_REGION: ${{ "
+                "vars.CONU_LINUX_REPOSITORY_AWS_REGION }}",
+            ),
+            (
+                "custom repository access key env",
+                "CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID: ${{ "
+                "secrets.CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID }}",
+            ),
+            (
+                "custom repository secret key env",
+                "CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY: ${{ "
+                "secrets.CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY }}",
+            ),
+            (
+                "custom repository session token env",
+                "CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN: ${{ "
+                "secrets.CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN }}",
+            ),
+            (
+                "custom repository preflight command",
+                "python scripts/check-custom-linux-repository-publication-preflight.py",
+            ),
         ),
     ),
 )


### PR DESCRIPTION
## **User description**
Adds workflow audit coverage for tagged release preflight gates: release-secret env checks, signing tool installation, platform signing value checks, Linux GPG signing checks, default GitHub Pages readiness, GitHub Release clobber preflight, and custom Linux repository publication config preflight.

Validation:
- python scripts\check-github-workflow-permissions.py
- python scripts\check-github-workflow-permissions-regression.py
- python scripts\check-python-script-compile.py
- python scripts\check-tagged-release-readiness-regression.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Fixes #671

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands our release preflight audit to cover all tagged-release gates so misconfigurations are caught early. Aligns with #671 by enforcing checks for secrets, signing tools, Pages settings, and release tag state.

- **New Features**
  - Audits tagged-release secret envs (Windows/macOS/Linux signing and `NPM_TOKEN`) and requires `check-release-secret-env-preflight.py`.
  - Requires signing tools install (`gnupg` and `openssl`) and validates platform signing values with `--require-openssl`.
  - Adds Linux GPG signing checks for key, passphrase, ID, and fingerprint.
  - Verifies default GitHub Pages readiness (when `CONU_LINUX_REPOSITORY_BASE_URL` is empty) and that the GitHub Release tag is unpublished.
  - Validates custom Linux repository publication config (base URL, S3 settings, region, and AWS creds) via preflight command.
  - Extends regression tests to flag missing or weakened gates and report clear, actionable errors.

<sup>Written for commit 03f8c31ff5255320e47fc22bd4cf3cb5a03ad82a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add release preflight checks for signing, publishing, and release safety**

### What Changed
- Tagged releases now fail early if required signing secrets, npm access, or repository publishing settings are missing
- Release checks now verify both Windows and macOS signing values, Linux GPG signing secrets, and the tools needed to validate them
- Tagged releases now check whether the GitHub release tag is still unpublished before publishing starts
- Linux package publishing now follows the default GitHub Pages path when no custom repository URL is set, or validates the custom publication settings when it is set
- Coverage was expanded so these release gates are enforced by regression tests

### Impact
`✅ Fewer broken tagged releases`
`✅ Clearer release setup errors`
`✅ Safer package publication`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
