### PR TITLE
Audit GitHub Release asset preparation gates

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -351,10 +351,146 @@ jobs:
           if-no-files-found: error
   github-release:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Install package tools
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg
+      - name: Verify downloaded release assets
+        run: python scripts/verify-release-artifacts.py dist
+      - name: Generate package-manager manifests
+        env:
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          VERSION="${TAG_NAME#v}"
+          python scripts/generate-package-manager-manifests.py dist --output-dir dist --repo "$GH_REPO" --version "$VERSION" --tag "$TAG_NAME" --build-rpm-packages --build-apt-repository-metadata
+      - name: Sign RPM packages
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/sign-rpm-packages.py dist
+      - name: Generate RPM repository metadata
+        env:
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          VERSION="${TAG_NAME#v}"
+          python scripts/generate-package-manager-manifests.py dist --output-dir dist --repo "$GH_REPO" --version "$VERSION" --tag "$TAG_NAME" --build-rpm-repository-metadata
+      - name: Export Linux GPG public key
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/export-linux-gpg-public-key.py dist
+      - name: Sign Linux repository metadata
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/sign-linux-repository-metadata.py dist
+      - name: Sign Linux release assets
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/sign-linux-release-assets.py dist
+      - name: Prepare package-manager submission bundle
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          VERSION="${TAG_NAME#v}"
+          python scripts/prepare-package-manager-submissions.py dist --output-dir dist --version "$VERSION" --require-rpm-assets --require-repository-metadata --require-linux-signatures
+      - name: Sign package-manager submission bundle
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/sign-linux-release-assets.py dist --only-package-manager-submissions
+      - name: Generate hosted Linux repositories
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          VERSION="${TAG_NAME#v}"
+          python scripts/generate-hosted-linux-repositories.py dist --output-dir dist --version "$VERSION"
+      - name: Sign hosted Linux repository bundle
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/sign-linux-release-assets.py dist --only-hosted-repository-bundles
+      - name: Generate hosted Linux repository site
+        env:
+          GH_REPO: ${{ github.repository }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          TAG_NAME: ${{ github.ref_name }}
+          CONU_LINUX_REPOSITORY_BASE_URL: ${{ vars.CONU_LINUX_REPOSITORY_BASE_URL }}
+        run: |
+          set -eu
+          VERSION="${TAG_NAME#v}"
+          BASE_URL="${CONU_LINUX_REPOSITORY_BASE_URL:-}"
+          if [ -z "$BASE_URL" ]; then
+            REPO_NAME="${GH_REPO#*/}"
+            BASE_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPO_NAME}"
+          fi
+          python scripts/generate-hosted-linux-repository-site.py dist --output-dir dist --version "$VERSION" --base-url "$BASE_URL"
+      - name: Sign hosted Linux repository site
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/sign-linux-release-assets.py dist --only-hosted-repository-sites
+      - name: Generate release update policy
+        env:
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          VERSION="${TAG_NAME#v}"
+          python scripts/generate-release-update-policy.py dist --output-dir dist --version "$VERSION" --tag "$TAG_NAME" --repo "$GH_REPO"
+      - name: Sign release update policy
+        env:
+          CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}
+          CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}
+          CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
+        run: python scripts/sign-linux-release-assets.py dist --only-update-policies
+      - name: Check release update policy with CLI
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          VERSION="${TAG_NAME#v}"
+          cargo run -p conu-cli -- update check --policy-file "dist/conu-${VERSION}-update-policy.json" --json
+      - name: Prepare hosted Linux repository Pages artifact
+        run: python scripts/prepare-hosted-linux-repository-pages.py dist --output-dir linux-repository-site
+      - name: Upload hosted Linux repository Pages artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: conu-hosted-linux-repository-pages
+          path: linux-repository-site
+          if-no-files-found: error
+          retention-days: 14
       - name: Re-check GitHub Release tag is unpublished
         env:
           GH_TOKEN: ${{ github.token }}
@@ -565,6 +701,31 @@ def with_fixture(module, ci_text: str | None, release_text: str | None):
         return audit(module, root)
     finally:
         shutil.rmtree(root)
+
+
+def replace_named_step_text(text: str, step_name: str, old: str, new: str) -> str:
+    marker = f"      - name: {step_name}\n"
+    start = text.index(marker)
+    next_start = text.find("\n      - ", start + len(marker))
+    if next_start == -1:
+        next_start = len(text)
+    step = text[start:next_start]
+    if old not in step:
+        raise AssertionError(f"{step_name} fixture block did not contain expected text")
+    return text[:start] + step.replace(old, new, 1) + text[next_start:]
+
+
+def assert_release_gate_issue(
+    module,
+    release_text: str,
+    expected_issue: str,
+    ready_message: str,
+) -> None:
+    report = with_fixture(module, None, release_text)
+    if report.ready:
+        raise AssertionError(ready_message)
+    if expected_issue not in json.dumps(assert_safe_report(report)):
+        raise AssertionError(f"expected issue was not reported: {expected_issue}")
 
 
 def run_ready_tests(module) -> None:
@@ -1132,6 +1293,171 @@ def run_required_build_job_tests(module) -> None:
 
 
 def run_required_github_release_gate_tests(module) -> None:
+    assert_release_gate_issue(
+        module,
+        ready_release().replace(
+            "\n    if: startsWith(github.ref, 'refs/tags/v')\n",
+            "\n",
+            1,
+        ),
+        "release.yml:github-release is missing tag gate",
+        "missing GitHub Release tag gate should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        ready_release().replace(
+            "      - uses: actions/download-artifact@v8.0.1\n",
+            "      - uses: actions/upload-artifact@v7.0.1\n",
+            1,
+        ),
+        "release.yml:github-release is missing artifact download action",
+        "missing GitHub Release artifact download should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Verify downloaded release assets",
+            "        run: python scripts/verify-release-artifacts.py dist",
+            "        run: echo skipped-release-asset-verifier",
+        ),
+        "release.yml:github-release verify downloaded release assets "
+        "is missing release artifact verifier command",
+        "downloaded release asset verifier removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Generate package-manager manifests",
+            "--build-rpm-packages",
+            "--skip-rpm-packages",
+        ),
+        "release.yml:github-release generate package-manager manifests "
+        "is missing RPM package build flag",
+        "RPM package generation removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Sign RPM packages",
+            "        run: python scripts/sign-rpm-packages.py dist",
+            "        run: echo skipped-rpm-signing",
+        ),
+        "release.yml:github-release sign RPM packages is missing RPM signing command",
+        "RPM package signing removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Prepare package-manager submission bundle",
+            "--require-linux-signatures",
+            "--allow-unsigned-linux-assets",
+        ),
+        "release.yml:github-release prepare package-manager submission bundle "
+        "is missing Linux signature requirement",
+        "package-manager submission without Linux signatures should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Sign package-manager submission bundle",
+            "        run: python scripts/sign-linux-release-assets.py dist "
+            "--only-package-manager-submissions",
+            "        run: python scripts/sign-linux-release-assets.py dist",
+        ),
+        "release.yml:github-release sign package-manager submission bundle "
+        "is missing package-manager submission signing command",
+        "package-manager submission signing mode removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Generate hosted Linux repositories",
+            '          python scripts/generate-hosted-linux-repositories.py dist --output-dir dist --version "$VERSION"',
+            "          echo skipped-hosted-repository-generation",
+        ),
+        "release.yml:github-release generate hosted Linux repositories "
+        "is missing hosted repository generation command",
+        "hosted repository generation removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Generate hosted Linux repository site",
+            '            BASE_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPO_NAME}"',
+            '            BASE_URL="${CONU_LINUX_REPOSITORY_BASE_URL}"',
+        ),
+        "release.yml:github-release generate hosted Linux repository site "
+        "is missing default Pages base URL",
+        "default hosted repository site URL fallback removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Generate release update policy",
+            "python scripts/generate-release-update-policy.py dist",
+            "python scripts/generate-release-update-metadata.py dist",
+        ),
+        "release.yml:github-release generate release update policy "
+        "is missing release update policy generation command",
+        "release update policy generation removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Sign release update policy",
+            "        run: python scripts/sign-linux-release-assets.py dist --only-update-policies",
+            "        run: python scripts/sign-linux-release-assets.py dist",
+        ),
+        "release.yml:github-release sign release update policy "
+        "is missing release update policy signing command",
+        "release update policy signing mode removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Prepare hosted Linux repository Pages artifact",
+            "        run: python scripts/prepare-hosted-linux-repository-pages.py dist --output-dir linux-repository-site",
+            "        run: echo skipped-pages-artifact-prep",
+        ),
+        "release.yml:github-release prepare hosted Linux repository Pages artifact "
+        "is missing Pages artifact preparation command",
+        "hosted Linux repository Pages artifact preparation removal should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        replace_named_step_text(
+            ready_release(),
+            "Upload hosted Linux repository Pages artifact",
+            "          retention-days: 14",
+            "          retention-days: 1",
+        ),
+        "release.yml:github-release upload hosted Linux repository Pages artifact "
+        "is missing retention period",
+        "hosted Linux repository Pages artifact retention weakening should fail",
+    )
+
     report = with_fixture(
         module,
         None,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -972,10 +972,279 @@ NPM_PUBLISH_REQUIRED_STEPS: tuple[
         ),
     ),
 )
+GITHUB_RELEASE_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
+    ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
+    ("Ubuntu runner", "runs-on: ubuntu-latest"),
+    ("checkout action", "uses: actions/checkout@v6"),
+    ("Rust toolchain action", "uses: dtolnay/rust-toolchain@stable"),
+    ("artifact download action", "uses: actions/download-artifact@v8.0.1"),
+    ("merged artifact download path", "path: dist"),
+    ("merged artifact download flag", "merge-multiple: true"),
+)
+GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS: tuple[tuple[str, str], ...] = (
+    (
+        "Linux GPG private key env",
+        "CONU_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ "
+        "secrets.CONU_LINUX_GPG_PRIVATE_KEY_BASE64 }}",
+    ),
+    (
+        "Linux GPG passphrase env",
+        "CONU_LINUX_GPG_PASSPHRASE: ${{ secrets.CONU_LINUX_GPG_PASSPHRASE }}",
+    ),
+    (
+        "Linux GPG key id env",
+        "CONU_LINUX_GPG_KEY_ID: ${{ secrets.CONU_LINUX_GPG_KEY_ID }}",
+    ),
+    (
+        "Linux GPG fingerprint env",
+        "CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ "
+        "secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}",
+    ),
+)
 GITHUB_RELEASE_REQUIRED_STEPS: tuple[
     tuple[str, str, tuple[tuple[str, str], ...]],
     ...,
 ] = (
+    (
+        "Install package tools",
+        "install package tools",
+        (
+            (
+                "package tool install command",
+                "sudo apt-get update && sudo apt-get install -y "
+                "--no-install-recommends rpm createrepo-c gnupg",
+            ),
+        ),
+    ),
+    (
+        "Verify downloaded release assets",
+        "verify downloaded release assets",
+        (("release artifact verifier command", "python scripts/verify-release-artifacts.py dist"),),
+    ),
+    (
+        "Generate package-manager manifests",
+        "generate package-manager manifests",
+        (
+            ("GitHub repository env", "GH_REPO: ${{ github.repository }}"),
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            ("tag version derivation", 'VERSION="${TAG_NAME#v}"'),
+            (
+                "manifest generation command",
+                "python scripts/generate-package-manager-manifests.py dist",
+            ),
+            ("manifest output dir", "--output-dir dist"),
+            ("manifest repo flag", '--repo "$GH_REPO"'),
+            ("manifest version flag", '--version "$VERSION"'),
+            ("manifest tag flag", '--tag "$TAG_NAME"'),
+            ("RPM package build flag", "--build-rpm-packages"),
+            ("APT repository metadata flag", "--build-apt-repository-metadata"),
+        ),
+    ),
+    (
+        "Sign RPM packages",
+        "sign RPM packages",
+        (
+            *GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS,
+            ("RPM signing command", "python scripts/sign-rpm-packages.py dist"),
+        ),
+    ),
+    (
+        "Generate RPM repository metadata",
+        "generate RPM repository metadata",
+        (
+            ("GitHub repository env", "GH_REPO: ${{ github.repository }}"),
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            ("tag version derivation", 'VERSION="${TAG_NAME#v}"'),
+            (
+                "manifest generation command",
+                "python scripts/generate-package-manager-manifests.py dist",
+            ),
+            ("RPM repository metadata flag", "--build-rpm-repository-metadata"),
+        ),
+    ),
+    (
+        "Export Linux GPG public key",
+        "export Linux GPG public key",
+        (
+            *GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS,
+            ("Linux public-key export command", "python scripts/export-linux-gpg-public-key.py dist"),
+        ),
+    ),
+    (
+        "Sign Linux repository metadata",
+        "sign Linux repository metadata",
+        (
+            *GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS,
+            (
+                "Linux repository metadata signing command",
+                "python scripts/sign-linux-repository-metadata.py dist",
+            ),
+        ),
+    ),
+    (
+        "Sign Linux release assets",
+        "sign Linux release assets",
+        (
+            *GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS,
+            ("Linux release asset signing command", "python scripts/sign-linux-release-assets.py dist"),
+        ),
+    ),
+    (
+        "Prepare package-manager submission bundle",
+        "prepare package-manager submission bundle",
+        (
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            ("tag version derivation", 'VERSION="${TAG_NAME#v}"'),
+            (
+                "package-manager submission command",
+                "python scripts/prepare-package-manager-submissions.py dist",
+            ),
+            ("submission output dir", "--output-dir dist"),
+            ("submission version flag", '--version "$VERSION"'),
+            ("RPM asset requirement", "--require-rpm-assets"),
+            ("repository metadata requirement", "--require-repository-metadata"),
+            ("Linux signature requirement", "--require-linux-signatures"),
+        ),
+    ),
+    (
+        "Sign package-manager submission bundle",
+        "sign package-manager submission bundle",
+        (
+            *GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS,
+            (
+                "package-manager submission signing command",
+                "python scripts/sign-linux-release-assets.py dist "
+                "--only-package-manager-submissions",
+            ),
+        ),
+    ),
+    (
+        "Generate hosted Linux repositories",
+        "generate hosted Linux repositories",
+        (
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            ("tag version derivation", 'VERSION="${TAG_NAME#v}"'),
+            (
+                "hosted repository generation command",
+                "python scripts/generate-hosted-linux-repositories.py dist "
+                '--output-dir dist --version "$VERSION"',
+            ),
+        ),
+    ),
+    (
+        "Sign hosted Linux repository bundle",
+        "sign hosted Linux repository bundle",
+        (
+            *GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS,
+            (
+                "hosted repository bundle signing command",
+                "python scripts/sign-linux-release-assets.py dist "
+                "--only-hosted-repository-bundles",
+            ),
+        ),
+    ),
+    (
+        "Generate hosted Linux repository site",
+        "generate hosted Linux repository site",
+        (
+            ("GitHub repository env", "GH_REPO: ${{ github.repository }}"),
+            (
+                "GitHub repository owner env",
+                "GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}",
+            ),
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            (
+                "custom base URL env",
+                "CONU_LINUX_REPOSITORY_BASE_URL: "
+                "${{ vars.CONU_LINUX_REPOSITORY_BASE_URL }}",
+            ),
+            ("tag version derivation", 'VERSION="${TAG_NAME#v}"'),
+            ("base URL derivation", 'BASE_URL="${CONU_LINUX_REPOSITORY_BASE_URL:-}"'),
+            ("default Pages base URL", 'BASE_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPO_NAME}"'),
+            (
+                "hosted repository site generation command",
+                "python scripts/generate-hosted-linux-repository-site.py dist",
+            ),
+            ("site output dir", "--output-dir dist"),
+            ("site version flag", '--version "$VERSION"'),
+            ("site base URL flag", '--base-url "$BASE_URL"'),
+        ),
+    ),
+    (
+        "Sign hosted Linux repository site",
+        "sign hosted Linux repository site",
+        (
+            *GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS,
+            (
+                "hosted repository site signing command",
+                "python scripts/sign-linux-release-assets.py dist "
+                "--only-hosted-repository-sites",
+            ),
+        ),
+    ),
+    (
+        "Generate release update policy",
+        "generate release update policy",
+        (
+            ("GitHub repository env", "GH_REPO: ${{ github.repository }}"),
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            ("tag version derivation", 'VERSION="${TAG_NAME#v}"'),
+            (
+                "release update policy generation command",
+                "python scripts/generate-release-update-policy.py dist",
+            ),
+            ("update policy output dir", "--output-dir dist"),
+            ("update policy version flag", '--version "$VERSION"'),
+            ("update policy tag flag", '--tag "$TAG_NAME"'),
+            ("update policy repo flag", '--repo "$GH_REPO"'),
+        ),
+    ),
+    (
+        "Sign release update policy",
+        "sign release update policy",
+        (
+            *GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS,
+            (
+                "release update policy signing command",
+                "python scripts/sign-linux-release-assets.py dist --only-update-policies",
+            ),
+        ),
+    ),
+    (
+        "Check release update policy with CLI",
+        "check release update policy with CLI",
+        (
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            ("tag version derivation", 'VERSION="${TAG_NAME#v}"'),
+            (
+                "local update policy check command",
+                'cargo run -p conu-cli -- update check --policy-file '
+                '"dist/conu-${VERSION}-update-policy.json" --json',
+            ),
+        ),
+    ),
+    (
+        "Prepare hosted Linux repository Pages artifact",
+        "prepare hosted Linux repository Pages artifact",
+        (
+            (
+                "Pages artifact preparation command",
+                "python scripts/prepare-hosted-linux-repository-pages.py dist "
+                "--output-dir linux-repository-site",
+            ),
+        ),
+    ),
+    (
+        "Upload hosted Linux repository Pages artifact",
+        "upload hosted Linux repository Pages artifact",
+        (
+            ("artifact upload action", "uses: actions/upload-artifact@v7.0.1"),
+            ("hosted repository artifact name", "name: conu-hosted-linux-repository-pages"),
+            ("hosted repository artifact path", "path: linux-repository-site"),
+            ("missing artifact failure", "if-no-files-found: error"),
+            ("retention period", "retention-days: 14"),
+        ),
+    ),
     (
         "Re-check GitHub Release tag is unpublished",
         "re-check GitHub Release tag is unpublished",
@@ -1551,6 +1820,10 @@ def audit_required_github_release_gate(path: Path) -> tuple[str, ...]:
     issues: list[str] = []
     if not block:
         return ("release.yml must define github-release job",)
+
+    for label, snippet in GITHUB_RELEASE_JOB_SNIPPETS:
+        if snippet not in block:
+            issues.append(f"release.yml:github-release is missing {label}")
 
     for step_name, description, required_snippets in GITHUB_RELEASE_REQUIRED_STEPS:
         step = extract_named_step_block(block, step_name)


### PR DESCRIPTION
## **User description**
## Summary
- audit the GitHub Release job tag gate, checkout/toolchain/download-artifact setup, and merged artifact download settings
- require release asset verification, Linux signing, package-manager bundle, hosted repository, update policy, and Pages artifact preparation/signing steps before publication
- expand workflow-permissions regression coverage for missing or weakened release publication gates

## Validation
- python scripts\check-github-workflow-permissions.py
- python scripts\check-github-workflow-permissions-regression.py
- python scripts\check-python-script-compile.py
- python scripts\check-tagged-release-readiness-regression.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

Fixes #673

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the GitHub Release job by enforcing asset verification, Linux signing, package-manager bundles, hosted repo/site prep, and Pages artifacts before publishing. Adds regression checks to prevent missing or weakened gates. Fixes #673.

- **New Features**
  - Require tag gate, `ubuntu-latest` runner, `actions/checkout@v6`, `dtolnay/rust-toolchain@stable`, and merged `actions/download-artifact@v8.0.1` to `dist`.
  - Enforce asset verification, package-manifest generation (RPM + APT metadata), RPM signing, repository metadata generation/signing, and Linux asset signing.
  - Require hosted Linux repo/site generation, signing, and Pages artifact prep/upload with 14-day retention.
  - Require release update policy generation, signing, and local CLI check via `conu-cli`.
  - Add regression tests to flag missing commands, weakened flags, or reduced retention.

<sup>Written for commit ae134c75762e2d02bae16a5c556b0b6307f386fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Tighten GitHub Release checks so release assets are only published after all required preparation steps run**

### What Changed
- The release workflow now requires a tag-based trigger and checks that release assets are downloaded before publication.
- It now verifies and signs release artifacts, package-manager metadata, hosted Linux repository bundles, the repository site, and the release update policy before publishing.
- It also requires the Pages artifact to be prepared and kept long enough for publishing.
- The workflow permission audit now treats missing or weakened release-preparation steps as failures, with regression tests covering each required gate.

### Impact
`✅ Fewer incomplete GitHub releases`
`✅ Safer Linux package publication`
`✅ Fewer broken hosted repository pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced validation and testing for the release workflow pipeline to ensure quality and security checks during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->