### PR TITLE
Audit Linux repository publication runner gate

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1794,6 +1794,18 @@ def run_required_npm_publication_gate_tests(module) -> None:
 
 
 def run_required_release_publication_gate_tests(module) -> None:
+    assert_release_gate_issue(
+        module,
+        replace_job_text(
+            ready_release(),
+            "linux-repository-publication",
+            "    runs-on: ubuntu-latest\n",
+            "",
+        ),
+        "release.yml:linux-repository-publication is missing Ubuntu runner",
+        "missing Linux repository publication Ubuntu runner should fail",
+    )
+
     report = with_fixture(
         module,
         None,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -373,6 +373,9 @@ RELEASE_PREFLIGHT_REQUIRED_STEPS: tuple[
     ),
 )
 RELEASE_PUBLICATION_GATE_STEP = "Check Linux repository publication result"
+RELEASE_PUBLICATION_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
+    ("Ubuntu runner", "runs-on: ubuntu-latest"),
+)
 RELEASE_PUBLICATION_GATE_SNIPPETS: tuple[tuple[str, str], ...] = (
     (
         "base URL mode selector",
@@ -1728,6 +1731,9 @@ def audit_required_release_publication_gate(path: Path) -> tuple[str, ...]:
             "release.yml:linux-repository-publication must be tag-gated "
             "and always evaluate upstream results"
         )
+    for label, snippet in RELEASE_PUBLICATION_JOB_SNIPPETS:
+        if snippet not in block:
+            issues.append(f"release.yml:linux-repository-publication is missing {label}")
 
     step = extract_named_step_block(block, RELEASE_PUBLICATION_GATE_STEP)
     if not step:


### PR DESCRIPTION
## **User description**
Closes #679

## Summary
- Require the linux-repository-publication gate job to keep its Ubuntu runner in the workflow permissions audit.
- Add a regression that removes the runner from only that job and expects the audit to fail.

## Validation
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-tagged-release-readiness-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Local production wrapper skipped GPG/OpenSSL/RPM-dependent signing regressions because those tools are unavailable on this workstation; the wrapper completed successfully otherwise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an audit rule that requires the `linux-repository-publication` job to run on `ubuntu-latest`, plus a regression test that fails if the runner is removed. This prevents release gate misconfigurations.

- **New Features**
  - Audit verifies `release.yml:linux-repository-publication` includes the "Ubuntu runner" snippet (`runs-on: ubuntu-latest`), raising "is missing Ubuntu runner" if absent.
  - Regression test removes the runner from that job and expects the audit to fail.

<sup>Written for commit e227775d959b31d97cc258cbe73887ef763cdf5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Require the Linux publication gate to run on Ubuntu**

### What Changed
- The release workflow audit now checks that the `linux-repository-publication` job uses an Ubuntu runner.
- If that job loses its Ubuntu runner, the audit reports the missing requirement.
- Added a regression check that removes the runner from that job and expects the audit to fail.

### Impact
`✅ Fewer release gate misconfigurations`
`✅ Safer Linux repository publication`
`✅ Earlier detection of broken release workflows`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
