### PR TITLE
Audit Linux repository deployment runners

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1604,6 +1604,18 @@ def run_required_github_release_gate_tests(module) -> None:
 
 
 def run_required_linux_repository_publication_job_tests(module) -> None:
+    assert_release_gate_issue(
+        module,
+        replace_job_text(
+            ready_release(),
+            "linux-repository-pages",
+            "    runs-on: ubuntu-latest\n",
+            "",
+        ),
+        "release.yml:linux-repository-pages is missing Ubuntu runner",
+        "missing Linux repository Pages Ubuntu runner should fail",
+    )
+
     report = with_fixture(
         module,
         None,
@@ -1637,6 +1649,18 @@ def run_required_linux_repository_publication_job_tests(module) -> None:
         not in json.dumps(assert_safe_report(report))
     ):
         raise AssertionError("missing Pages deploy action was not reported")
+
+    assert_release_gate_issue(
+        module,
+        replace_job_text(
+            ready_release(),
+            "custom-linux-repository-publish",
+            "    runs-on: ubuntu-latest\n",
+            "",
+        ),
+        "release.yml:custom-linux-repository-publish is missing Ubuntu runner",
+        "missing custom Linux repository publication Ubuntu runner should fail",
+    )
 
     report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -1327,6 +1327,7 @@ GITHUB_RELEASE_REQUIRED_STEPS: tuple[
     ),
 )
 LINUX_REPOSITORY_PAGES_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
+    ("Ubuntu runner", "runs-on: ubuntu-latest"),
     (
         "default repository tag/base URL gate",
         "if: startsWith(github.ref, 'refs/tags/v') && "
@@ -1342,6 +1343,7 @@ LINUX_REPOSITORY_PAGES_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
     ("deploy Pages action", "uses: actions/deploy-pages@v5"),
 )
 CUSTOM_LINUX_REPOSITORY_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
+    ("Ubuntu runner", "runs-on: ubuntu-latest"),
     (
         "custom repository tag/base URL gate",
         "if: startsWith(github.ref, 'refs/tags/v') && "


### PR DESCRIPTION
## **User description**
Closes #681

## Summary
- Require the Linux repository Pages deployment job to stay on ubuntu-latest in the workflow permissions audit.
- Require the custom Linux repository publication job to stay on ubuntu-latest in the same audit.
- Add focused regressions for runner removal in both jobs.

## Validation
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-tagged-release-readiness-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Local production wrapper skipped GPG/OpenSSL/RPM-dependent signing regressions because those tools are unavailable on this workstation; the wrapper completed successfully otherwise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `runs-on: ubuntu-latest` for the Linux Pages deployment and custom publication jobs in our workflow permissions audit. Adds regression checks to fail fast if these runners are removed.

- **New Features**
  - Require `ubuntu-latest` in `linux-repository-pages` and `custom-linux-repository-publish` via `scripts/check-github-workflow-permissions.py`.
  - Add regression tests in `scripts/check-github-workflow-permissions-regression.py` to catch missing Ubuntu runners.

<sup>Written for commit 883089cc1245dfe66519e452c393cad5e53e9502. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Require Ubuntu runners for Linux repository deployment jobs

### What Changed
- The Linux repository Pages deployment job must keep using an Ubuntu runner
- The custom Linux repository publication job must also keep using an Ubuntu runner
- Added regression checks so these jobs fail if the Ubuntu runner is removed

### Impact
`✅ Safer Linux repository deployments`
`✅ Fewer broken release workflows`
`✅ Earlier detection of runner changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
