### PR TITLE
Constrain GitHub Release artifact downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,6 +372,7 @@ jobs:
       - uses: actions/download-artifact@v8.0.1
         with:
           path: dist
+          pattern: conu-*
           merge-multiple: true
       - name: Install package tools
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -363,6 +363,7 @@ jobs:
       - uses: actions/download-artifact@v8.0.1
         with:
           path: dist
+          pattern: conu-*
           merge-multiple: true
       - name: Install package tools
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg
@@ -1374,6 +1375,17 @@ def run_required_github_release_gate_tests(module) -> None:
         ),
         "release.yml:github-release is missing artifact download action",
         "missing GitHub Release artifact download should fail",
+    )
+
+    assert_release_gate_issue(
+        module,
+        ready_release().replace(
+            "          pattern: conu-*\n",
+            "",
+            1,
+        ),
+        "release.yml:github-release is missing release artifact download pattern",
+        "missing GitHub Release artifact download pattern should fail",
     )
 
     assert_release_gate_issue(

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -994,6 +994,7 @@ GITHUB_RELEASE_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
     ("Rust toolchain action", "uses: dtolnay/rust-toolchain@stable"),
     ("artifact download action", "uses: actions/download-artifact@v8.0.1"),
     ("merged artifact download path", "path: dist"),
+    ("release artifact download pattern", "pattern: conu-*"),
     ("merged artifact download flag", "merge-multiple: true"),
 )
 GITHUB_RELEASE_LINUX_GPG_ENV_SNIPPETS: tuple[tuple[str, str], ...] = (


### PR DESCRIPTION
## **User description**
Closes #683

## Summary
- Limit the GitHub Release job artifact download to conu-* build artifacts before merging into dist.
- Require that artifact download pattern in the workflow permissions audit.
- Add a regression that fails if the pattern is removed.

## Validation
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-tagged-release-readiness-regression.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

I also confirmed from the primary ctions/download-artifact@v8.0.1 action metadata that pattern is a supported input. Local production wrapper skipped GPG/OpenSSL/RPM-dependent signing regressions because those tools are unavailable on this workstation; the wrapper completed successfully otherwise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrain GitHub Release artifact downloads to only `conu-*` artifacts to avoid pulling unintended files into `dist`. CI now enforces this with a workflow audit and a regression check that fail if the `actions/download-artifact@v8.0.1` pattern is removed.

<sup>Written for commit 6d739aab0beede01499d8381544c107e72365430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Limit GitHub release uploads to the intended build artifacts**

### What Changed
- GitHub release packaging now only pulls `conu-*` artifacts into `dist`, so unrelated build files are no longer included in release assets.
- Workflow checks now enforce that this release download filter stays in place.
- A regression test was added to fail if the release artifact pattern is removed.

### Impact
`✅ Cleaner release bundles`
`✅ Fewer accidental files in published assets`
`✅ Safer release checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now filters downloaded artifacts by a specific pattern before packaging, signing, and publishing, improving consistency and safety of release assets.

* **Tests**
  * Added a regression check to ensure the release workflow requires the artifact download pattern, preventing unintended files from being included in releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->