### PR TITLE
Require hosted repository artifact digest failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -634,6 +634,7 @@ jobs:
         with:
           name: conu-hosted-linux-repository-pages
           path: linux-repository-site
+          digest-mismatch: error
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:
@@ -654,6 +655,7 @@ jobs:
         with:
           name: conu-hosted-linux-repository-pages
           path: linux-repository-site
+          digest-mismatch: error
       - name: Install AWS CLI
         run: |
           python -m pip install --user awscli

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -555,6 +555,7 @@ jobs:
         with:
           name: conu-hosted-linux-repository-pages
           path: linux-repository-site
+          digest-mismatch: error
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:
@@ -573,6 +574,7 @@ jobs:
         with:
           name: conu-hosted-linux-repository-pages
           path: linux-repository-site
+          digest-mismatch: error
       - name: Install AWS CLI
         run: |
           python -m pip install --user awscli
@@ -1674,6 +1676,26 @@ def run_required_linux_repository_publication_job_tests(module) -> None:
     ):
         raise AssertionError("missing Pages deploy action was not reported")
 
+    report = with_fixture(
+        module,
+        None,
+        replace_job_text(
+            ready_release(),
+            "linux-repository-pages",
+            "          digest-mismatch: error\n",
+            "",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing Pages artifact digest mismatch policy should fail")
+    if (
+        "release.yml:linux-repository-pages is missing hosted repository "
+        "artifact digest mismatch policy"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError(
+            "missing Pages artifact digest mismatch policy was not reported"
+        )
+
     assert_release_gate_issue(
         module,
         replace_job_text(
@@ -1702,6 +1724,26 @@ def run_required_linux_repository_publication_job_tests(module) -> None:
         "repository tag/base URL gate"
     ) not in json.dumps(assert_safe_report(report)):
         raise AssertionError("missing custom repository gate was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        replace_job_text(
+            ready_release(),
+            "custom-linux-repository-publish",
+            "          digest-mismatch: error\n",
+            "",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing custom artifact digest mismatch policy should fail")
+    if (
+        "release.yml:custom-linux-repository-publish is missing hosted "
+        "repository artifact digest mismatch policy"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError(
+            "missing custom artifact digest mismatch policy was not reported"
+        )
 
     report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -1340,6 +1340,7 @@ LINUX_REPOSITORY_PAGES_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
     ("hosted repository artifact download", "uses: actions/download-artifact@v8.0.1"),
     ("hosted repository artifact name", "name: conu-hosted-linux-repository-pages"),
     ("hosted repository artifact path", "path: linux-repository-site"),
+    ("hosted repository artifact digest mismatch policy", "digest-mismatch: error"),
     ("configure Pages action", "uses: actions/configure-pages@v6"),
     ("upload Pages artifact action", "uses: actions/upload-pages-artifact@v5"),
     ("deploy Pages action", "uses: actions/deploy-pages@v5"),
@@ -1355,6 +1356,7 @@ CUSTOM_LINUX_REPOSITORY_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
     ("hosted repository artifact download", "uses: actions/download-artifact@v8.0.1"),
     ("hosted repository artifact name", "name: conu-hosted-linux-repository-pages"),
     ("hosted repository artifact path", "path: linux-repository-site"),
+    ("hosted repository artifact digest mismatch policy", "digest-mismatch: error"),
     ("AWS CLI install", "python -m pip install --user awscli"),
 )
 CUSTOM_LINUX_REPOSITORY_PUBLISH_STEP = (


### PR DESCRIPTION
## **User description**
Closes #687

## Summary
- make hosted Linux repository Pages and custom S3 artifact downloads explicitly fail on digest mismatches
- require that setting in the workflow permissions audit
- add regression coverage for both publication paths

## Validation
- git diff --check
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce digest verification for hosted Linux repository artifacts in the release workflow. Pages and custom S3 publish jobs now fail on digest mismatches, with audit checks and tests to prevent regressions.

- **New Features**
  - Set `digest-mismatch: error` on `actions/download-artifact@v8.0.1` in `linux-repository-pages` and `custom-linux-repository-publish`.
  - Require this policy in `scripts/check-github-workflow-permissions.py`.
  - Add regression tests in `scripts/check-github-workflow-permissions-regression.py` for both publication paths.

<sup>Written for commit 609a5f4ef892b66af0abc19310eb4d7582447d36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fail release publishing if the hosted artifact does not match what was built**

### What Changed
- Release publishing now stops when the hosted Linux repository artifact digest does not match, instead of continuing with a potentially altered download
- This protection applies to both the GitHub Pages publish path and the custom S3 publish path
- Workflow checks now require this digest failure setting, with regression coverage to catch it if removed later

### Impact
`✅ Safer release publishing`
`✅ Fewer corrupted artifact deployments`
`✅ Clearer release integrity checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
