### PR TITLE
Disable persisted checkout credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -105,6 +107,8 @@ jobs:
         os: [ubuntu-latest, windows-2025-vs2026, macos-15]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          persist-credentials: false
       - name: Validate tag target CI and release branch
         if: startsWith(github.ref, 'refs/tags/v')
         env:
@@ -126,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -215,6 +219,8 @@ jobs:
     runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Production readiness smoke gate
         shell: pwsh
@@ -266,6 +272,8 @@ jobs:
       CONU_SIGNING_REQUIRED: ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Configure macOS signing keychain
         if: runner.os == 'macOS'
@@ -368,6 +376,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/download-artifact@v8.0.1
         with:
@@ -651,6 +661,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v8.0.1
         with:
           name: conu-hosted-linux-repository-pages
@@ -721,6 +733,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -68,6 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          persist-credentials: false
       - run: echo preflight
       - name: Validate tag target CI and release branch
         if: startsWith(github.ref, 'refs/tags/v')
@@ -165,6 +167,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -253,6 +257,8 @@ jobs:
     runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Production readiness smoke gate
         shell: pwsh
@@ -303,6 +309,8 @@ jobs:
       CONU_SIGNING_REQUIRED: ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Configure macOS signing keychain
         if: runner.os == 'macOS'
@@ -359,6 +367,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/download-artifact@v8.0.1
         with:
@@ -570,6 +580,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v8.0.1
         with:
           name: conu-hosted-linux-repository-pages
@@ -634,6 +646,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -812,6 +826,27 @@ def run_forbidden_event_tests(module) -> None:
         raise AssertionError("forbidden event issue was not reported")
 
 
+def run_checkout_credential_persistence_tests(module) -> None:
+    report = with_fixture(
+        module,
+        ready_ci().replace(
+            "    steps:\n",
+            "    steps:\n"
+            "      - uses: actions/checkout@v6\n",
+            1,
+        ),
+        None,
+    )
+    if report.ready:
+        raise AssertionError("checkout without persisted credential guard should fail")
+    rendered = json.dumps(assert_safe_report(report))
+    if (
+        "ci.yml:checkout step at line" not in rendered
+        or "must set persist-credentials=false" not in rendered
+    ):
+        raise AssertionError("checkout persisted credential issue was not reported")
+
+
 def run_unexpected_job_write_tests(module) -> None:
     report = with_fixture(
         module,
@@ -863,13 +898,19 @@ def run_required_release_preflight_tests(module) -> None:
         "missing release-preflight Ubuntu runner should fail",
     )
 
+    release_preflight_checkout = (
+        "      - uses: actions/checkout@v6\n"
+        "        if: startsWith(github.ref, 'refs/tags/v')\n"
+        "        with:\n"
+        "          persist-credentials: false\n"
+    )
+
     assert_release_gate_issue(
         module,
         replace_job_text(
             ready_release(),
             "release-preflight",
-            "      - uses: actions/checkout@v6\n"
-            "        if: startsWith(github.ref, 'refs/tags/v')\n",
+            release_preflight_checkout,
             "",
         ),
         "release.yml:release-preflight is missing tag-gated checkout action",
@@ -881,9 +922,10 @@ def run_required_release_preflight_tests(module) -> None:
         replace_job_text(
             ready_release(),
             "release-preflight",
+            release_preflight_checkout,
             "      - uses: actions/checkout@v6\n"
-            "        if: startsWith(github.ref, 'refs/tags/v')\n",
-            "      - uses: actions/checkout@v6\n",
+            "        with:\n"
+            "          persist-credentials: false\n",
         ),
         "release.yml:release-preflight is missing tag-gated checkout action",
         "untagged release-preflight checkout should fail",
@@ -1204,6 +1246,8 @@ def run_required_production_readiness_job_tests(module) -> None:
             "    runs-on: windows-2025-vs2026\n"
             "    steps:\n"
             "      - uses: actions/checkout@v6\n"
+            "        with:\n"
+            "          persist-credentials: false\n"
             "      - uses: dtolnay/rust-toolchain@stable\n"
             "      - name: Production readiness smoke gate\n"
             "        shell: pwsh\n"
@@ -1808,7 +1852,9 @@ def run_required_npm_publication_gate_tests(module) -> None:
         replace_job_text(
             ready_release(),
             "npm-publish",
-            "      - uses: actions/checkout@v6\n",
+            "      - uses: actions/checkout@v6\n"
+            "        with:\n"
+            "          persist-credentials: false\n",
             "",
         ),
         "release.yml:npm-publish is missing checkout action",
@@ -1975,6 +2021,7 @@ def main() -> int:
     run_ready_tests(module)
     run_top_level_permission_tests(module)
     run_forbidden_event_tests(module)
+    run_checkout_credential_persistence_tests(module)
     run_unexpected_job_write_tests(module)
     run_expected_job_permission_tests(module)
     run_required_release_preflight_tests(module)

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -1690,6 +1690,40 @@ def extract_named_step_block(job_block: str, step_name: str) -> str:
     return "\n".join(block)
 
 
+def extract_uses_step_blocks(text: str, action: str) -> tuple[tuple[int, str], ...]:
+    lines = text.splitlines()
+    blocks: list[tuple[int, str]] = []
+    for index, line in enumerate(lines):
+        if line.strip() != f"- uses: {action}":
+            continue
+        base_indent = len(line) - len(line.lstrip(" "))
+        block = [line]
+        for next_line in lines[index + 1 :]:
+            stripped = next_line.lstrip(" ")
+            next_indent = len(next_line) - len(stripped)
+            if next_indent == base_indent and stripped.startswith("- "):
+                break
+            block.append(next_line)
+        blocks.append((index + 1, "\n".join(block)))
+    return tuple(blocks)
+
+
+def audit_checkout_credential_persistence(path: Path) -> tuple[str, ...]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
+
+    issues: list[str] = []
+    for line_number, block in extract_uses_step_blocks(text, "actions/checkout@v6"):
+        if "persist-credentials: false" not in block:
+            issues.append(
+                f"{path.name}:checkout step at line {line_number} must set "
+                "persist-credentials=false"
+            )
+    return tuple(issues)
+
+
 def audit_required_release_preflight_steps(path: Path) -> tuple[str, ...]:
     if path.name != "release.yml":
         return ()
@@ -2085,6 +2119,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
         for finding in audit_environment_file_writes(path):
             unsafe_env_writes.append(finding)
             issues.append(finding)
+        issues.extend(audit_checkout_credential_persistence(path))
         issues.extend(audit_required_release_preflight_steps(path))
         issues.extend(audit_required_package_checks_job(path))
         issues.extend(audit_required_production_readiness_job(path))


### PR DESCRIPTION
## **User description**
Closes #689

## Summary
- set persist-credentials: false on CI and release workflow checkout steps
- add a generic workflow audit for checkout credential persistence
- add regression coverage for checkout steps that omit the guard

## Validation
- git diff --check
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- powershell -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables credential persistence for all `actions/checkout@v6` steps in CI and release, and adds a workflow audit to prevent regressions. Reduces risk of token exposure during builds.

- **New Features**
  - Set `persist-credentials: false` on all `actions/checkout@v6` steps in `ci.yml` and `release.yml`.
  - Added audit in `scripts/check-github-workflow-permissions.py` to flag checkout steps missing `persist-credentials: false` (with line numbers).
  - Added regression tests in `scripts/check-github-workflow-permissions-regression.py` to ensure the guard is enforced.

<sup>Written for commit 41e7b2ce5add3418cbd20b0da930a82d82128c7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Disable saved checkout credentials in CI and release workflows

### What Changed
- Checkout steps in CI and release no longer keep GitHub credentials after cloning
- The workflow audit now flags any checkout step that still leaves credentials enabled
- Regression coverage was added to catch missing credential protection in future workflow changes

### Impact
`✅ Lower risk of token exposure during builds`
`✅ Safer CI and release runs`
`✅ Fewer workflow security regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD security by disabling Git credential persistence across build and release workflows.

* **Tests**
  * Added regression tests to verify credential persistence is disabled in checkout actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->