### PR TITLE
Verify release public key sidecar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -603,6 +603,8 @@ jobs:
           mkdir -p "$KEY_DIR" "$GNUPG_HOME"
           chmod 700 "$GNUPG_HOME"
           gh release download "$TAG_NAME" --repo "$GH_REPO" --pattern conu-linux-gpg-key.asc --dir "$KEY_DIR"
+          gh release download "$TAG_NAME" --repo "$GH_REPO" --pattern conu-linux-gpg-key.asc.sha256 --dir "$KEY_DIR"
+          (cd "$KEY_DIR" && sha256sum -c conu-linux-gpg-key.asc.sha256)
           export GNUPGHOME="$GNUPG_HOME"
           gpg --batch --yes --import "$KEY_DIR/conu-linux-gpg-key.asc"
           EXPECTED_FINGERPRINT="$(printf '%s' "$CONU_LINUX_GPG_KEY_FINGERPRINT" | tr -d '[:space:]:' | sed 's/^0[xX]//' | tr '[:lower:]' '[:upper:]')"

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -538,6 +538,8 @@ jobs:
           mkdir -p "$KEY_DIR" "$GNUPG_HOME"
           chmod 700 "$GNUPG_HOME"
           gh release download "$TAG_NAME" --repo "$GH_REPO" --pattern conu-linux-gpg-key.asc --dir "$KEY_DIR"
+          gh release download "$TAG_NAME" --repo "$GH_REPO" --pattern conu-linux-gpg-key.asc.sha256 --dir "$KEY_DIR"
+          (cd "$KEY_DIR" && sha256sum -c conu-linux-gpg-key.asc.sha256)
           export GNUPGHOME="$GNUPG_HOME"
           gpg --batch --yes --import "$KEY_DIR/conu-linux-gpg-key.asc"
           EXPECTED_FINGERPRINT="$(printf '%s' "$CONU_LINUX_GPG_KEY_FINGERPRINT" | tr -d '[:space:]:' | sed 's/^0[xX]//' | tr '[:lower:]' '[:upper:]')"
@@ -1671,6 +1673,24 @@ def run_required_github_release_gate_tests(module) -> None:
         "and artifact with CLI is missing fingerprint comparison"
     ) not in json.dumps(assert_safe_report(report)):
         raise AssertionError("missing published GPG fingerprint comparison was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '          (cd "$KEY_DIR" && sha256sum -c conu-linux-gpg-key.asc.sha256)\n',
+            "",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing published GPG public-key checksum verification should fail")
+    if (
+        "release.yml:github-release verify published release update policy "
+        "and artifact with CLI is missing public key checksum verification"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError(
+            "missing published GPG public-key checksum verification was not reported"
+        )
 
 
 def run_required_linux_repository_publication_job_tests(module) -> None:

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -1305,6 +1305,15 @@ GITHUB_RELEASE_REQUIRED_STEPS: tuple[
                 'conu-linux-gpg-key.asc --dir "$KEY_DIR"',
             ),
             (
+                "public key checksum download",
+                'gh release download "$TAG_NAME" --repo "$GH_REPO" --pattern '
+                'conu-linux-gpg-key.asc.sha256 --dir "$KEY_DIR"',
+            ),
+            (
+                "public key checksum verification",
+                '(cd "$KEY_DIR" && sha256sum -c conu-linux-gpg-key.asc.sha256)',
+            ),
+            (
                 "fingerprint comparison",
                 'if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then',
             ),

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -26,6 +26,9 @@ PREFIX = "public/conu"
 HOSTED_BUNDLE = f"conu-{VERSION}-hosted-linux-repositories.zip"
 SITE_BUNDLE = f"conu-{VERSION}-hosted-linux-repository-site.zip"
 SENSITIVE_SENTINEL = "do-not-print-this-secret-value"
+PUBLISHER_TIMEOUT_SECONDS = 300
+PREPARER_TIMEOUT_SECONDS = 60
+PREFLIGHT_TIMEOUT_SECONDS = 60
 
 
 def main() -> int:
@@ -344,6 +347,7 @@ def run_preparer(site: Path, output_dir: Path) -> str:
         text=True,
         encoding="utf-8",
         errors="replace",
+        timeout=PREPARER_TIMEOUT_SECONDS,
     ).stdout
 
 
@@ -383,6 +387,7 @@ def run_publisher_raw(
         encoding="utf-8",
         errors="replace",
         env=run_env,
+        timeout=PUBLISHER_TIMEOUT_SECONDS,
     )
 
 
@@ -414,8 +419,8 @@ def assert_publication_report(report: dict, *, published: bool) -> None:
         raise AssertionError(f"publication report cache classes were {cache_classes!r}")
 
 
-def write_fake_aws(temp: Path) -> Path:
-    fake_py = temp / "fake_aws.py"
+def write_fake_aws(temp: Path) -> str:
+    fake_py = temp / "fake aws.py"
     fake_py.write_text(
         "\n".join(
             [
@@ -450,22 +455,7 @@ def write_fake_aws(temp: Path) -> Path:
         encoding="ascii",
         newline="\n",
     )
-    if os.name == "nt":
-        fake_cmd = temp / "fake-aws.cmd"
-        fake_cmd.write_text(
-            f"@echo off\r\n\"{sys.executable}\" \"{fake_py}\" %*\r\n",
-            encoding="ascii",
-            newline="\r\n",
-        )
-        return fake_cmd
-    fake_sh = temp / "fake-aws"
-    fake_sh.write_text(
-        f"#!/bin/sh\nexec \"{sys.executable}\" \"{fake_py}\" \"$@\"\n",
-        encoding="ascii",
-        newline="\n",
-    )
-    fake_sh.chmod(0o755)
-    return fake_sh
+    return subprocess.list2cmdline([sys.executable, str(fake_py)])
 
 
 def assert_fake_aws_log(log: Path, expected_count: int) -> None:
@@ -587,6 +577,7 @@ def run_preflight_raw(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
         encoding="utf-8",
         errors="replace",
         env=run_env,
+        timeout=PREFLIGHT_TIMEOUT_SECONDS,
     )
 
 

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -815,9 +815,17 @@ def parse_aws_cli(raw: str) -> list[str]:
         parsed = shlex.split(command, posix=os.name != "nt")
     except ValueError as exc:
         raise PublicationError(f"AWS CLI command could not be parsed: {exc}") from exc
+    if os.name == "nt":
+        parsed = [strip_matching_quotes(item) for item in parsed]
     if not parsed:
         raise PublicationError("AWS CLI command must not be empty")
     return parsed
+
+
+def strip_matching_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
 
 
 def run_endpoint_check(plan: PublishPlan, args: argparse.Namespace) -> None:


### PR DESCRIPTION
## **User description**
Closes #691. Closes #692.

Changes:
- verify the published Linux GPG public key against its .sha256 sidecar before importing it in post-release CLI verification
- require that checksum verification in the workflow permissions audit and regression fixture
- fix the hosted S3 publication regression fake AWS command on Windows and add bounded subprocess timeouts so readiness validation does not hang

Validation:
- git diff --check
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- python scripts/check-hosted-linux-repository-s3-publication.py
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify the released Linux GPG public key against its `.sha256` sidecar before import, and enforce this in workflow permission checks. Also fix Windows S3 publication regression and add subprocess timeouts to prevent hangs.

- **New Features**
  - Verify `conu-linux-gpg-key.asc` with `conu-linux-gpg-key.asc.sha256` before `gpg --import`.
  - Require checksum download and verification in workflow permission audit and regression tests.

- **Bug Fixes**
  - Fix Windows S3 publication regression by returning a properly quoted fake AWS command and stripping matching quotes in CLI parsing.
  - Add timeouts to publisher, preparer, and preflight subprocesses to avoid hangs during readiness checks.

<sup>Written for commit bc894f7f20e1d2e76057082bb6e4def637fe9912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Verify the published release key before using it**

### What Changed
- Release verification now downloads the Linux public key checksum and checks it before importing the key
- Workflow checks now require the checksum step, so release verification fails if the key file is changed without updating its checksum
- Hosted Linux S3 publication checks now stop hanging by timing out long-running validation steps
- Windows AWS command handling now works with quoted command paths in the publication check

### Impact
`✅ Safer release key verification`
`✅ Fewer stalled publication checks`
`✅ More reliable Windows publication validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
