### PR TITLE
Verify local release asset set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -523,6 +523,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python scripts/check-github-release-clobber-preflight.py --repo "$GITHUB_REPOSITORY" --tag "$GITHUB_REF_NAME"
+      - name: Verify local GitHub Release asset set
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: python scripts/check-github-release-assets-published.py --tag "$TAG_NAME" --dist-dir dist
       - name: Publish release assets
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/check-github-release-assets-published-regression.py
+++ b/scripts/check-github-release-assets-published-regression.py
@@ -209,6 +209,74 @@ def run_audit_tests(module) -> None:
     assert_raises(lambda: module.validate_tag("vlatest"), "semver")
 
 
+def run_dist_tests(module) -> None:
+    with tempfile.TemporaryDirectory(prefix="conu-release-dist-assets-") as temp_dir:
+        dist = Path(temp_dir) / "dist"
+        dist.mkdir()
+        for name in module.expected_release_asset_names(TEST_VERSION):
+            (dist / name).write_bytes(b"asset\n")
+
+        payload = module.load_dist_metadata(TEST_TAG, dist)
+        report = module.audit_release_assets("local/dist", TEST_TAG, payload)
+        if not report.ready:
+            raise AssertionError(f"expected local dist report to pass, got {report.issues!r}")
+
+        unexpected = dist / "conu-0.1.0-extra.txt"
+        unexpected.write_text(SENSITIVE_SENTINEL, encoding="utf-8")
+        unexpected_report = module.audit_release_assets(
+            "local/dist",
+            TEST_TAG,
+            module.load_dist_metadata(TEST_TAG, dist),
+        )
+        assert_not_ready(unexpected_report, "unexpectedAssets")
+        rendered = json.dumps(unexpected_report.as_json())
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("local dist report leaked unexpected file contents")
+        unexpected.unlink()
+
+        empty_asset = dist / "conu.rb"
+        empty_asset.write_bytes(b"")
+        assert_not_ready(
+            module.audit_release_assets(
+                "local/dist",
+                TEST_TAG,
+                module.load_dist_metadata(TEST_TAG, dist),
+            ),
+            "size must be greater than zero",
+        )
+        empty_asset.write_bytes(b"asset\n")
+
+        package_asset = dist / "conu.json"
+        package_asset.unlink()
+        package_asset.mkdir()
+        assert_not_ready(
+            module.audit_release_assets(
+                "local/dist",
+                TEST_TAG,
+                module.load_dist_metadata(TEST_TAG, dist),
+            ),
+            "local asset must be a regular file",
+        )
+        package_asset.rmdir()
+        package_asset.write_bytes(b"asset\n")
+
+        symlink_asset = dist / "conu.spec"
+        symlink_asset.unlink()
+        try:
+            symlink_asset.symlink_to(dist / "conu.rb")
+        except OSError:
+            symlink_asset.write_bytes(b"asset\n")
+        else:
+            assert_not_ready(
+                module.audit_release_assets(
+                    "local/dist",
+                    TEST_TAG,
+                    module.load_dist_metadata(TEST_TAG, dist),
+                ),
+                "local asset must not be a symlink",
+            )
+
+
 def run_loader_tests(module) -> None:
     original_run_gh_json = module.run_gh_json
 
@@ -284,11 +352,37 @@ def run_main_tests(module) -> None:
     if SENSITIVE_SENTINEL in rendered:
         raise AssertionError("main() output leaked unrelated release metadata")
 
+    with tempfile.TemporaryDirectory(prefix="conu-release-dist-main-") as temp_dir:
+        dist = Path(temp_dir) / "dist"
+        dist.mkdir()
+        for name in module.expected_release_asset_names(TEST_VERSION):
+            (dist / name).write_bytes(b"asset\n")
+
+        original_argv = sys.argv
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        sys.argv = [
+            "check-github-release-assets-published.py",
+            "--tag",
+            TEST_TAG,
+            "--dist-dir",
+            str(dist),
+        ]
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                exit_code = module.main()
+        finally:
+            sys.argv = original_argv
+
+    if exit_code != 0:
+        raise AssertionError(f"expected dist main() to pass, got {exit_code}: {stderr.getvalue()}")
+
 
 def main() -> int:
     module = load_module()
     run_expected_name_tests(module)
     run_audit_tests(module)
+    run_dist_tests(module)
     run_loader_tests(module)
     run_main_tests(module)
     print("GitHub Release asset publication preflight regression checks passed")

--- a/scripts/check-github-release-assets-published.py
+++ b/scripts/check-github-release-assets-published.py
@@ -202,6 +202,15 @@ def asset_state_issue(asset: dict[str, Any], name: str) -> str | None:
     return None
 
 
+def asset_local_issue(asset: dict[str, Any], name: str) -> str | None:
+    value = asset.get("localInvalidReason")
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        return f"{name}: local invalid reason must be a non-empty string"
+    return f"{name}: {value.strip()}"
+
+
 def forbidden_asset_marker(name: str) -> str | None:
     lower = name.lower()
     if "/" in name or "\\" in name or name in {".", ".."} or ".." in name.split("."):
@@ -245,6 +254,9 @@ def audit_release_assets(
         state_issue = asset_state_issue(asset, name)
         if state_issue:
             invalid.append(state_issue)
+        local_issue = asset_local_issue(asset, name)
+        if local_issue:
+            invalid.append(local_issue)
 
         marker = forbidden_asset_marker(name)
         if marker:
@@ -356,6 +368,41 @@ def load_release_json(path: Path) -> dict[str, Any]:
     return payload
 
 
+def load_dist_metadata(tag: str, dist_dir: Path) -> dict[str, Any]:
+    tag, version = validate_tag(tag)
+    dist = dist_dir.expanduser()
+    if dist.is_symlink():
+        raise ValueError(f"release dist directory must not be a symlink: {dist}")
+    if not dist.exists() or not dist.is_dir():
+        raise ValueError(f"release dist directory does not exist: {dist}")
+
+    assets: list[dict[str, Any]] = []
+    for path in sorted(dist.iterdir(), key=lambda item: item.name):
+        name = path.name
+        asset: dict[str, Any] = {"name": name, "state": "uploaded"}
+        try:
+            stat_result = path.lstat()
+        except OSError as exc:
+            asset["size"] = 0
+            asset["localInvalidReason"] = f"local asset could not be statted: {exc}"
+            assets.append(asset)
+            continue
+
+        asset["size"] = stat_result.st_size
+        if path.is_symlink():
+            asset["localInvalidReason"] = "local asset must not be a symlink"
+        elif not path.is_file():
+            asset["localInvalidReason"] = "local asset must be a regular file"
+        assets.append(asset)
+
+    return {
+        "tag_name": tag,
+        "draft": False,
+        "prerelease": "-" in version,
+        "assets": assets,
+    }
+
+
 def print_text_report(report: ReleaseAssetReadiness) -> None:
     if report.ready:
         print(
@@ -409,6 +456,12 @@ def parse_args() -> argparse.Namespace:
         help="read GitHub Release metadata from a JSON fixture instead of gh api",
     )
     parser.add_argument(
+        "--dist-dir",
+        type=Path,
+        default=None,
+        help="read local release asset files from a dist directory instead of gh api",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="print a machine-readable readiness report",
@@ -430,15 +483,26 @@ def main() -> int:
         tag, _version = validate_tag(args.tag)
         gh = args.gh.strip()
         repo = args.repo.strip()
+        if args.release_json is not None and args.dist_dir is not None:
+            raise ValueError("--release-json and --dist-dir cannot be used together")
+
+        if args.dist_dir is not None:
+            repo = repo or "local/dist"
+            payload = load_dist_metadata(tag, args.dist_dir)
+        else:
+            if not repo:
+                gh = gh or find_gh()
+                repo = infer_repo(gh)
+
+            if args.release_json:
+                payload = load_release_json(args.release_json)
+            else:
+                gh = gh or find_gh()
+                payload = load_release_metadata(repo, tag, gh)
+
         if not repo:
             gh = gh or find_gh()
             repo = infer_repo(gh)
-
-        if args.release_json:
-            payload = load_release_json(args.release_json)
-        else:
-            gh = gh or find_gh()
-            payload = load_release_metadata(repo, tag, gh)
 
         report = audit_release_assets(repo, tag, payload)
     except (OSError, ValueError) as exc:

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -509,6 +509,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python scripts/check-github-release-clobber-preflight.py --repo "$GITHUB_REPOSITORY" --tag "$GITHUB_REF_NAME"
+      - name: Verify local GitHub Release asset set
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: python scripts/check-github-release-assets-published.py --tag "$TAG_NAME" --dist-dir dist
       - name: Publish release assets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1609,6 +1613,42 @@ def run_required_github_release_gate_tests(module) -> None:
         not in json.dumps(assert_safe_report(report))
     ):
         raise AssertionError("missing late GitHub Release clobber preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Verify local GitHub Release asset set\n"
+            "        env:\n"
+            "          TAG_NAME: ${{ github.ref_name }}\n"
+            '        run: python scripts/check-github-release-assets-published.py --tag "$TAG_NAME" --dist-dir dist\n',
+            "",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing local GitHub Release asset-set preflight should fail")
+    if (
+        "release.yml:github-release must verify local GitHub Release asset set"
+        not in json.dumps(assert_safe_report(report))
+    ):
+        raise AssertionError("missing local GitHub Release asset-set preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '        run: python scripts/check-github-release-assets-published.py --tag "$TAG_NAME" --dist-dir dist\n',
+            "        run: echo skipped-local-asset-check\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("weakened local GitHub Release asset-set preflight should fail")
+    if (
+        "release.yml:github-release verify local GitHub Release asset set "
+        "is missing local release asset preflight command"
+        not in json.dumps(assert_safe_report(report))
+    ):
+        raise AssertionError("weakened local GitHub Release asset-set preflight was not reported")
 
     report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -1275,6 +1275,18 @@ GITHUB_RELEASE_REQUIRED_STEPS: tuple[
         ),
     ),
     (
+        "Verify local GitHub Release asset set",
+        "verify local GitHub Release asset set",
+        (
+            ("tag name env", "TAG_NAME: ${{ github.ref_name }}"),
+            (
+                "local release asset preflight command",
+                'python scripts/check-github-release-assets-published.py --tag "$TAG_NAME" '
+                "--dist-dir dist",
+            ),
+        ),
+    ),
+    (
         "Publish release assets",
         "publish release assets without clobber",
         (


### PR DESCRIPTION
## **User description**
Closes #694.

Changes:
- add local dist asset-set mode to the GitHub Release asset preflight
- run that local preflight before gh release create dist/*
- require the pre-publish local asset gate in workflow audit coverage

Validation:
- git diff --check
- python scripts/check-github-release-assets-published-regression.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local `dist` asset preflight to the GitHub Release process so we fail fast on missing or invalid assets before publishing. Tightens workflow audits and tests to require this gate.

- **New Features**
  - `scripts/check-github-release-assets-published.py`: adds `--dist-dir` to audit local `dist` files; enforces regular file, no symlinks, size > 0; reports `localInvalidReason`.
  - `.github/workflows/release.yml`: new “Verify local GitHub Release asset set” step runs the local preflight for the current tag before publishing.
  - Workflow permission audits and regression tests updated to require this step and detect weakened or missing checks.

<sup>Written for commit 17b695697385f9fa012a7537505584c44a19c8dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Check local release assets before publishing**

### What Changed
- Release publishing now checks the files in `dist/` before creating the GitHub release, so missing, empty, non-file, or symlinked assets fail fast.
- The asset check now reports local file problems as part of the release readiness result.
- Workflow and audit checks now require this local asset gate before release assets are published.

### Impact
`✅ Fewer release publish failures`
`✅ Earlier detection of broken release assets`
`✅ Safer release publishing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release process with local asset verification before publishing to ensure quality and consistency of release artifacts.
  * Expanded regression test coverage for release asset validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->