### PR TITLE
Select Windows readiness Rust fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg openssl
       - name: Python script compile
         run: python scripts/check-python-script-compile.py
+      - name: Production readiness toolchain regression
+        run: python scripts/check-production-readiness-toolchain.py
       - name: Smoke output privacy regression
         run: python scripts/check-smoke-output-privacy.py
       - name: Release version consistency

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg openssl
       - name: Python script compile
         run: python scripts/check-python-script-compile.py
+      - name: Production readiness toolchain regression
+        run: python scripts/check-production-readiness-toolchain.py
       - name: Smoke output privacy regression
         run: python scripts/check-smoke-output-privacy.py
       - name: Release version consistency

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -177,6 +177,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg openssl
       - name: Python script compile
         run: python scripts/check-python-script-compile.py
+      - name: Production readiness toolchain regression
+        run: python scripts/check-production-readiness-toolchain.py
       - name: Smoke output privacy regression
         run: python scripts/check-smoke-output-privacy.py
       - name: Release version consistency
@@ -1209,6 +1211,24 @@ def run_required_package_checks_job_tests(module) -> None:
         "package tool install command"
     ) not in json.dumps(assert_safe_report(report)):
         raise AssertionError("weakened package tool install was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: python scripts/check-production-readiness-toolchain.py\n",
+            "        run: echo skipped-production-readiness-toolchain\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing production readiness toolchain regression should fail")
+    if (
+        "release.yml:packages run production readiness toolchain regression is "
+        "missing production readiness toolchain command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError(
+            "missing production readiness toolchain regression was not reported"
+        )
 
     report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -429,6 +429,16 @@ PACKAGES_REQUIRED_STEPS: tuple[
         (("Python compile command", "python scripts/check-python-script-compile.py"),),
     ),
     (
+        "Production readiness toolchain regression",
+        "run production readiness toolchain regression",
+        (
+            (
+                "production readiness toolchain command",
+                "python scripts/check-production-readiness-toolchain.py",
+            ),
+        ),
+    ),
+    (
         "Smoke output privacy regression",
         "run smoke output privacy regression",
         (("smoke privacy command", "python scripts/check-smoke-output-privacy.py"),),

--- a/scripts/check-production-readiness-toolchain.py
+++ b/scripts/check-production-readiness-toolchain.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Regression checks for production-readiness Rust toolchain selection."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+HELPER = Path(__file__).with_name("production-readiness-toolchain.ps1")
+
+
+def powershell_executable() -> str:
+    for name in ("pwsh", "powershell"):
+        path = shutil.which(name)
+        if path:
+            return path
+    raise RuntimeError("PowerShell executable was not found")
+
+
+def run_powershell(script: str) -> None:
+    exe = powershell_executable()
+    args = [exe, "-NoProfile"]
+    if Path(exe).name.lower().startswith("powershell"):
+        args.extend(["-ExecutionPolicy", "Bypass"])
+    args.extend(["-Command", script])
+    completed = subprocess.run(
+        args,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "production-readiness toolchain regression failed: "
+            f"exit={completed.returncode}\nstdout={completed.stdout}\nstderr={completed.stderr}"
+        )
+
+
+def main() -> int:
+    helper = str(HELPER.resolve()).replace("'", "''")
+    script = f"""
+$ErrorActionPreference = "Stop"
+. '{helper}'
+
+$explicit = Resolve-ConuReadinessRustToolchain `
+    -ExplicitToolchain "stable-custom" `
+    -IsWindowsHost $true `
+    -LinkExePath "" `
+    -InstalledToolchains @("stable-x86_64-pc-windows-gnu") `
+    -DefaultToolchain "stable-x86_64-pc-windows-msvc"
+if ($explicit -ne "stable-custom") {{
+    throw "explicit toolchain was not preserved: $explicit"
+}}
+
+$fallback = Resolve-ConuReadinessRustToolchain `
+    -ExplicitToolchain "" `
+    -IsWindowsHost $true `
+    -LinkExePath "" `
+    -InstalledToolchains @("stable-x86_64-pc-windows-gnu", "stable-x86_64-pc-windows-msvc") `
+    -DefaultToolchain "stable-x86_64-pc-windows-msvc"
+if ($fallback -ne "stable-x86_64-pc-windows-gnu") {{
+    throw "GNU fallback was not selected: $fallback"
+}}
+
+$defaultGnu = Resolve-ConuReadinessRustToolchain `
+    -ExplicitToolchain "" `
+    -IsWindowsHost $true `
+    -LinkExePath "" `
+    -InstalledToolchains @("custom-x86_64-pc-windows-gnu") `
+    -DefaultToolchain "custom-x86_64-pc-windows-gnu"
+if ($defaultGnu -ne "") {{
+    throw "default GNU toolchain should not be overridden: $defaultGnu"
+}}
+
+$nonWindows = Resolve-ConuReadinessRustToolchain `
+    -ExplicitToolchain "" `
+    -IsWindowsHost $false `
+    -LinkExePath "" `
+    -InstalledToolchains @() `
+    -DefaultToolchain "stable-x86_64-unknown-linux-gnu"
+if ($nonWindows -ne "") {{
+    throw "non-Windows host should not select a Windows fallback: $nonWindows"
+}}
+
+$linkPresent = Resolve-ConuReadinessRustToolchain `
+    -ExplicitToolchain "" `
+    -IsWindowsHost $true `
+    -LinkExePath "C:\\\\BuildTools\\\\VC\\\\Tools\\\\MSVC\\\\link.exe" `
+    -InstalledToolchains @("stable-x86_64-pc-windows-gnu") `
+    -DefaultToolchain "stable-x86_64-pc-windows-msvc"
+if ($linkPresent -ne "") {{
+    throw "available MSVC linker should not select fallback: $linkPresent"
+}}
+
+if (-not (Test-ConuGnuLinkerToolsAvailable -AvailableCommands @("dlltool.exe", "gcc.exe"))) {{
+    throw "GNU linker tool availability was not detected"
+}}
+
+try {{
+    Assert-ConuGnuLinkerToolsAvailable -AvailableCommands @("dlltool.exe")
+    throw "missing GNU gcc.exe did not fail"
+}} catch {{
+    $message = $_.Exception.Message
+    if (-not $message.Contains("dlltool.exe") -or -not $message.Contains("gcc.exe")) {{
+        throw "GNU linker tool error was not actionable: $message"
+    }}
+}}
+
+try {{
+    Resolve-ConuReadinessRustToolchain `
+        -ExplicitToolchain "" `
+        -IsWindowsHost $true `
+        -LinkExePath "" `
+        -InstalledToolchains @("stable-x86_64-pc-windows-msvc") `
+        -DefaultToolchain "stable-x86_64-pc-windows-msvc" | Out-Null
+    throw "missing fallback did not fail"
+}} catch {{
+    $message = $_.Exception.Message
+    if (-not $message.Contains("link.exe") -or -not $message.Contains("stable-x86_64-pc-windows-gnu")) {{
+        throw "missing fallback error was not actionable: $message"
+    }}
+}}
+"""
+    run_powershell(script)
+    print("Production readiness toolchain regression checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/production-readiness-toolchain.ps1
+++ b/scripts/production-readiness-toolchain.ps1
@@ -1,0 +1,110 @@
+function Test-ConuWindowsHost {
+    return ($IsWindows -or $env:OS -eq "Windows_NT")
+}
+
+function Get-ConuInstalledRustToolchains {
+    $output = & rustup toolchain list 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+
+    $toolchains = @()
+    foreach ($line in $output) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) {
+            continue
+        }
+        $toolchains += ($trimmed -split "\s+")[0]
+    }
+    return $toolchains
+}
+
+function Get-ConuDefaultRustToolchain {
+    $output = & rustup default 2>$null
+    if ($LASTEXITCODE -ne 0 -or $null -eq $output) {
+        return ""
+    }
+    $firstLine = ($output | Select-Object -First 1)
+    if ($null -eq $firstLine) {
+        return ""
+    }
+    return (($firstLine.ToString().Trim()) -split "\s+")[0]
+}
+
+function Resolve-ConuReadinessRustToolchain {
+    param(
+        [string]$ExplicitToolchain = "",
+        [bool]$IsWindowsHost = (Test-ConuWindowsHost),
+        [string]$LinkExePath = "",
+        [string[]]$InstalledToolchains = @(),
+        [string]$DefaultToolchain = "",
+        [string]$FallbackGnuToolchain = "stable-x86_64-pc-windows-gnu"
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitToolchain)) {
+        return $ExplicitToolchain.Trim()
+    }
+
+    if (-not $IsWindowsHost) {
+        return ""
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($LinkExePath)) {
+        return ""
+    }
+
+    if ($DefaultToolchain -like "*windows-gnu*") {
+        return ""
+    }
+
+    if ($InstalledToolchains -contains $FallbackGnuToolchain) {
+        return $FallbackGnuToolchain
+    }
+
+    throw (
+        "MSVC linker link.exe was not found and fallback Rust toolchain " +
+        "$FallbackGnuToolchain is not installed. Install Visual C++ Build Tools " +
+        "or run: rustup toolchain install $FallbackGnuToolchain"
+    )
+}
+
+function Resolve-ConuReadinessRustToolchainForHost {
+    param([string]$ExplicitToolchain = "")
+
+    $link = Get-Command link.exe -ErrorAction SilentlyContinue
+    $linkPath = if ($null -ne $link) { $link.Source } else { "" }
+    return Resolve-ConuReadinessRustToolchain `
+        -ExplicitToolchain $ExplicitToolchain `
+        -IsWindowsHost (Test-ConuWindowsHost) `
+        -LinkExePath $linkPath `
+        -InstalledToolchains (Get-ConuInstalledRustToolchains) `
+        -DefaultToolchain (Get-ConuDefaultRustToolchain)
+}
+
+function Test-ConuGnuLinkerToolsAvailable {
+    param([object[]]$AvailableCommands = $null)
+
+    if ($null -ne $AvailableCommands) {
+        return (
+            ($AvailableCommands -contains "dlltool.exe") -and
+            ($AvailableCommands -contains "gcc.exe")
+        )
+    }
+
+    return (
+        (Get-Command dlltool.exe -ErrorAction SilentlyContinue) -and
+        (Get-Command gcc.exe -ErrorAction SilentlyContinue)
+    )
+}
+
+function Assert-ConuGnuLinkerToolsAvailable {
+    param([object[]]$AvailableCommands = $null)
+
+    if (-not (Test-ConuGnuLinkerToolsAvailable -AvailableCommands $AvailableCommands)) {
+        throw (
+            "GNU Rust toolchain selected but MinGW linker tools dlltool.exe and gcc.exe " +
+            "were not found on PATH. Install MinGW-w64 binutils/GCC or use an MSVC " +
+            "toolchain with Visual C++ Build Tools available."
+        )
+    }
+}

--- a/scripts/verify-production-readiness.ps1
+++ b/scripts/verify-production-readiness.ps1
@@ -33,6 +33,26 @@ $ErrorActionPreference = "Stop"
 
 $repo = Resolve-Path (Join-Path $PSScriptRoot "..")
 $tempRoot = $null
+. (Join-Path $PSScriptRoot "production-readiness-toolchain.ps1")
+$EffectiveToolchain = ""
+if (-not $SkipRust) {
+    $EffectiveToolchain = Resolve-ConuReadinessRustToolchainForHost -ExplicitToolchain $Toolchain
+    if (
+        [string]::IsNullOrWhiteSpace($Toolchain) -and
+        -not [string]::IsNullOrWhiteSpace($EffectiveToolchain)
+    ) {
+        Write-Host "Using Rust toolchain $EffectiveToolchain for production readiness"
+    }
+}
+if (-not $SkipRust -and (Test-ConuWindowsHost)) {
+    $rustPrereqToolchain = $EffectiveToolchain
+    if ([string]::IsNullOrWhiteSpace($rustPrereqToolchain)) {
+        $rustPrereqToolchain = Get-ConuDefaultRustToolchain
+    }
+    if ($rustPrereqToolchain -like "*windows-gnu*") {
+        Assert-ConuGnuLinkerToolsAvailable
+    }
+}
 
 function Invoke-ReadinessStep {
     param(
@@ -54,8 +74,8 @@ function Invoke-CargoStep {
     )
 
     Invoke-ReadinessStep $Name {
-        if (-not [string]::IsNullOrWhiteSpace($Toolchain)) {
-            & cargo "+$Toolchain" @CargoArgs
+        if (-not [string]::IsNullOrWhiteSpace($EffectiveToolchain)) {
+            & cargo "+$EffectiveToolchain" @CargoArgs
         } else {
             & cargo @CargoArgs
         }
@@ -82,8 +102,8 @@ function Get-BinaryPath {
 }
 
 function Get-EffectiveSmokeToolchain {
-    if (-not [string]::IsNullOrWhiteSpace($Toolchain)) {
-        return $Toolchain
+    if (-not [string]::IsNullOrWhiteSpace($EffectiveToolchain)) {
+        return $EffectiveToolchain
     }
     return "stable"
 }
@@ -270,6 +290,9 @@ try {
     if (-not $SmokeOnly -and -not $SkipPackages) {
         Invoke-ReadinessStep "python compile" {
             & python scripts/check-python-script-compile.py
+        }
+        Invoke-ReadinessStep "production readiness toolchain regression" {
+            & python scripts/check-production-readiness-toolchain.py
         }
         Invoke-ReadinessStep "smoke output privacy regression" {
             & python scripts/check-smoke-output-privacy.py


### PR DESCRIPTION
## **User description**
Closes #696.

Changes:
- add a production-readiness Rust toolchain helper for Windows linker fallback selection
- auto-select `stable-x86_64-pc-windows-gnu` when the default MSVC path lacks `link.exe`
- fail early with an actionable MinGW/binutils prerequisite when GNU linker tools are missing
- add regression coverage and require it in CI/release package checks

Validation:
- python scripts/check-production-readiness-toolchain.py
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

Local Rust note:
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions now fails before cargo with the expected local prerequisite message because this workstation has neither `dlltool.exe` nor `gcc.exe` on PATH. PR CI should cover the configured Windows runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Windows production-readiness Rust toolchain helper that auto-selects a GNU fallback when the MSVC linker is missing, and wires regression checks into CI and release. The verify script now resolves an effective toolchain and enforces MinGW prerequisites on Windows.

- **New Features**
  - New PowerShell helper resolves the effective toolchain and selects `stable-x86_64-pc-windows-gnu` when `link.exe` is not found; explicit toolchains and default GNU toolchains are preserved.
  - Enforces MinGW prerequisites for GNU toolchains (`dlltool.exe`, `gcc.exe`) with clear, early failure messages.
  - Adds a regression test (`scripts/check-production-readiness-toolchain.py`) and runs it in CI and release workflows; `verify-production-readiness.ps1` uses the resolved toolchain.

<sup>Written for commit 85b1f78f063acbb945da8edeeb66a5e9bc21ba03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Use a Windows Rust fallback when the MSVC linker is missing**

### What Changed
- On Windows, production readiness now switches to the GNU Rust toolchain when `link.exe` is not available.
- If the GNU toolchain is selected, the check now stops early with a clear message when required MinGW tools are missing.
- The new toolchain behavior is covered by a regression check, and that check now runs in CI, release checks, and the production readiness verifier.

### Impact
`✅ Fewer Windows readiness failures`
`✅ Clearer setup errors on Windows`
`✅ Safer CI and release checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
