### PR TITLE
Require CI package workflow audit

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -41,9 +41,95 @@ permissions:
   contents: read
 jobs:
   packages:
+    name: Packages
     runs-on: ubuntu-latest
     steps:
-      - run: echo {SENSITIVE_SENTINEL}
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Install package tools
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg openssl
+      - name: Python script compile
+        run: python scripts/check-python-script-compile.py
+      - name: Production readiness toolchain regression
+        run: python scripts/check-production-readiness-toolchain.py
+      - name: Smoke output privacy regression
+        run: python scripts/check-smoke-output-privacy.py
+      - name: Release version consistency
+        run: python scripts/verify-release-versions.py
+      - name: Release artifact verifier regression
+        run: python scripts/check-release-artifact-verifier.py
+      - name: Release artifact smoke preflight regression
+        run: python scripts/check-release-artifact-smoke-preflight.py
+      - name: Package-manager manifest regression
+        run: python scripts/check-package-manager-manifests.py
+      - name: Package-manager submission bundle regression
+        run: python scripts/check-package-manager-submissions.py
+      - name: Linux signing secret preflight regression
+        run: python scripts/check-linux-signing-secrets-preflight-regression.py
+      - name: Platform signing secret value preflight regression
+        run: python scripts/check-platform-signing-secrets-preflight-regression.py
+      - name: GitHub release secret readiness regression
+        run: python scripts/check-github-release-secret-readiness-regression.py
+      - name: Release secret env preflight regression
+        run: python scripts/check-release-secret-env-preflight-regression.py
+      - name: GitHub release secret setup regression
+        run: python scripts/set-github-release-secrets-regression.py
+      - name: GitHub main branch protection regression
+        run: python scripts/check-github-main-protection-regression.py
+      - name: GitHub Actions permissions regression
+        run: python scripts/check-github-actions-permissions-regression.py
+      - name: GitHub workflow permissions regression
+        run: python scripts/check-github-workflow-permissions-regression.py
+      - name: GitHub repository security regression
+        run: python scripts/check-github-repository-security-regression.py
+      - name: GitHub Pages readiness regression
+        run: python scripts/check-github-pages-readiness-regression.py
+      - name: GitHub Release asset publication regression
+        run: python scripts/check-github-release-assets-published-regression.py
+      - name: GitHub Release clobber preflight regression
+        run: python scripts/check-github-release-clobber-preflight-regression.py
+      - name: Tagged release readiness regression
+        run: python scripts/check-tagged-release-readiness-regression.py
+      - name: RPM package signing regression
+        run: python scripts/check-rpm-package-signing.py
+      - name: Linux release signing regression
+        run: python scripts/check-linux-release-signing.py
+      - name: Linux repository signing regression
+        run: python scripts/check-linux-repository-signing.py
+      - name: Hosted Linux repository bundle regression
+        run: python scripts/check-hosted-linux-repositories.py
+      - name: Hosted Linux repository site regression
+        run: python scripts/check-hosted-linux-repository-site.py
+      - name: Hosted Linux repository Pages regression
+        run: python scripts/check-hosted-linux-repository-pages.py
+      - name: Hosted Linux repository endpoint regression
+        run: python scripts/check-hosted-linux-repository-endpoint-regression.py
+      - name: Hosted Linux repository S3 publication regression
+        run: python scripts/check-hosted-linux-repository-s3-publication.py
+      - name: Release update policy regression
+        run: python scripts/check-release-update-policy.py
+      - name: Release update download/apply gate regression
+        run: python scripts/check-release-update-download-gate.py
+      - name: Linux GPG public-key export regression
+        run: python scripts/check-linux-gpg-public-key-export.py
+      - name: TypeScript SDK check
+        run: npm run check --prefix sdk/typescript
+      - name: npm launcher check
+        run: npm run check --prefix packaging/npm/conu-cli
+      - name: npm launcher local smoke preflight regression
+        run: python scripts/check-npm-launcher-local-smoke-preflight.py
+      - name: Verify npm package contents
+        run: python scripts/verify-npm-package-contents.py
+      - name: npm package public metadata regression
+        run: python scripts/verify-npm-package-contents-regression.py
+      - name: npm publish preflight
+        run: python scripts/check-npm-publish-preflight.py
+      - name: npm publish preflight regression
+        run: python scripts/check-npm-publish-preflight-regression.py
 """
 
 
@@ -869,6 +955,42 @@ def run_unexpected_job_write_tests(module) -> None:
     rendered = json.dumps(assert_safe_report(report))
     if "ci.yml:packages must not request write permission for contents" not in rendered:
         raise AssertionError("unexpected write issue was not reported")
+
+
+def run_required_ci_package_checks_job_tests(module) -> None:
+    report = with_fixture(
+        module,
+        ready_ci().replace(
+            "          node-version: 24\n",
+            "          node-version: 22\n",
+            1,
+        ),
+        None,
+    )
+    if report.ready:
+        raise AssertionError("weakened CI package Node LTS setup should fail")
+    if "ci.yml:packages is missing Node version" not in json.dumps(
+        assert_safe_report(report)
+    ):
+        raise AssertionError("weakened CI package Node version was not reported")
+
+    report = with_fixture(
+        module,
+        ready_ci().replace(
+            "        run: python scripts/check-github-workflow-permissions-regression.py\n",
+            "        run: echo skipped-workflow-permissions-regression\n",
+        ),
+        None,
+    )
+    if report.ready:
+        raise AssertionError("missing CI workflow permissions regression should fail")
+    if (
+        "ci.yml:packages run GitHub workflow permissions regression is "
+        "missing workflow permissions regression command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError(
+            "missing CI workflow permissions regression was not reported"
+        )
 
 
 def run_expected_job_permission_tests(module) -> None:
@@ -2103,6 +2225,7 @@ def main() -> int:
     run_forbidden_event_tests(module)
     run_checkout_credential_persistence_tests(module)
     run_unexpected_job_write_tests(module)
+    run_required_ci_package_checks_job_tests(module)
     run_expected_job_permission_tests(module)
     run_required_release_preflight_tests(module)
     run_required_release_job_needs_tests(module)

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -401,11 +401,14 @@ RELEASE_PUBLICATION_GATE_SNIPPETS: tuple[tuple[str, str], ...] = (
     ("Pages success check", 'if [ "$PAGES_RESULT" != "success" ]; then'),
     ("custom repository success check", 'if [ "$CUSTOM_RESULT" != "success" ]; then'),
 )
-PACKAGES_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
+CI_PACKAGES_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
     ("Ubuntu runner", "runs-on: ubuntu-latest"),
     ("checkout action", "uses: actions/checkout@v6"),
     ("Node setup", "uses: actions/setup-node@v6"),
     ("Node version", "node-version: 24"),
+)
+PACKAGES_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
+    *CI_PACKAGES_JOB_SNIPPETS,
     ("npm registry URL", "registry-url: https://registry.npmjs.org"),
 )
 PACKAGES_REQUIRED_STEPS: tuple[
@@ -1847,7 +1850,11 @@ def audit_required_npm_publication_gate(path: Path) -> tuple[str, ...]:
 
 
 def audit_required_package_checks_job(path: Path) -> tuple[str, ...]:
-    if path.name != "release.yml":
+    if path.name == "release.yml":
+        required_job_snippets = PACKAGES_JOB_SNIPPETS
+    elif path.name == "ci.yml":
+        required_job_snippets = CI_PACKAGES_JOB_SNIPPETS
+    else:
         return ()
     try:
         text = path.read_text(encoding="utf-8")
@@ -1857,19 +1864,19 @@ def audit_required_package_checks_job(path: Path) -> tuple[str, ...]:
     block = extract_job_block(text, "packages")
     issues: list[str] = []
     if not block:
-        return ("release.yml must define packages job",)
-    for label, snippet in PACKAGES_JOB_SNIPPETS:
+        return (f"{path.name} must define packages job",)
+    for label, snippet in required_job_snippets:
         if snippet not in block:
-            issues.append(f"release.yml:packages is missing {label}")
+            issues.append(f"{path.name}:packages is missing {label}")
 
     for step_name, description, required_snippets in PACKAGES_REQUIRED_STEPS:
         step = extract_named_step_block(block, step_name)
         if not step:
-            issues.append(f"release.yml:packages must {description}")
+            issues.append(f"{path.name}:packages must {description}")
             continue
         for label, snippet in required_snippets:
             if snippet not in step:
-                issues.append(f"release.yml:packages {description} is missing {label}")
+                issues.append(f"{path.name}:packages {description} is missing {label}")
     return tuple(issues)
 
 


### PR DESCRIPTION
## **User description**
Closes #698.

Changes:
- make the workflow-permissions audit enforce required package/regression checks in `ci.yml:packages`
- keep release-only npm registry setup required only for `release.yml:packages`
- expand workflow-permissions regression coverage for CI package gate weakening

Validation:
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the workflow-permissions audit to enforce required package checks in `ci.yml:packages`, preventing CI gate weakening, while keeping npm registry setup checks limited to `release.yml:packages`.

- **Bug Fixes**
  - Audit `ci.yml:packages` for Ubuntu runner, `actions/checkout@v6`, `actions/setup-node@v6`, and Node `24`.
  - Keep npm registry URL requirement only in `release.yml:packages`.
  - Add regression tests for missing Node version and missing workflow-permissions regression step, with path-aware error messages.

<sup>Written for commit 057f44721d17512c0464cca047f3216831e24a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Require the CI package job to keep its full audit checks**

### What Changed
- The CI `packages` job now has to include the same core checks as the release package job, including the Linux runner, checkout, Node setup, and Node 24
- The release workflow still keeps the npm registry requirement, but CI no longer needs that release-only setup
- The regression coverage now fails if the CI package job weakens its Node version or drops the workflow-permissions regression check

### Impact
`✅ Fewer CI gate regressions`
`✅ Earlier detection of weakened package checks`
`✅ Clearer audit failures for CI workflow changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
