### PR TITLE
Require admin branch protection for releases

### DIFF
--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -250,6 +250,43 @@ def run_repository_governance_tests(module) -> None:
             raise AssertionError(f"repository governance issue was not reported: {expected}")
 
 
+def run_main_branch_protection_caller_tests(module) -> None:
+    original_loader = module.load_script_module
+    captured: dict[str, object] = {}
+
+    class BranchModuleFixture:
+        DEFAULT_BRANCH = "main"
+        DEFAULT_REQUIRED_STATUS_CHECKS = ("Packages",)
+
+        @staticmethod
+        def load_branch_protection(repo: str, branch: str, gh: str) -> dict[str, object]:
+            captured["repo"] = repo
+            captured["branch"] = branch
+            captured["gh"] = gh
+            return {}
+
+        @staticmethod
+        def audit_branch_protection(**kwargs):
+            captured.update(kwargs)
+            return GovernanceFixture(
+                schema="conu.githubMainBranchProtection.v1",
+                ready=True,
+            )
+
+    try:
+        module.load_script_module = lambda script, name: BranchModuleFixture
+        report = module.audit_main_branch_protection("owner/repo", "gh", "main")
+    finally:
+        module.load_script_module = original_loader
+
+    if report.ready is not True:
+        raise AssertionError("expected branch protection fixture to pass")
+    if captured.get("require_admin_enforcement") is not True:
+        raise AssertionError("tagged release readiness must require admin enforcement")
+    if captured.get("required_status_checks") != BranchModuleFixture.DEFAULT_REQUIRED_STATUS_CHECKS:
+        raise AssertionError("tagged release readiness must keep default required status checks")
+
+
 def run_ci_readiness_tests(module) -> None:
     report = module.audit_tagged_release_readiness(
         repo="owner/repo",
@@ -749,6 +786,7 @@ def main() -> int:
     run_ready_pages_tests(module)
     run_workflow_permissions_tests(module)
     run_repository_governance_tests(module)
+    run_main_branch_protection_caller_tests(module)
     run_ci_readiness_tests(module)
     run_release_branch_readiness_tests(module)
     run_missing_secret_tests(module)

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -745,6 +745,7 @@ def audit_main_branch_protection(repo: str, gh: str, branch: str) -> Any:
         branch=normalized_branch,
         protection_payload=payload,
         required_status_checks=branch_module.DEFAULT_REQUIRED_STATUS_CHECKS,
+        require_admin_enforcement=True,
     )
 
 


### PR DESCRIPTION
## **User description**
## Summary
- require admin-enforced main branch protection in tagged release readiness
- add a regression proving the tagged-release readiness caller requests admin enforcement
- enabled admin enforcement on the live main branch protection setting

## Validation
- python scripts/check-github-main-protection-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- python scripts/check-github-main-protection.py --repo imthegoodboy/conU --require-admin-enforcement --json
- python scripts/check-python-script-compile.py
- git diff --check
- live tagged-release readiness still fails only on known release signing/notary/GPG secrets

Closes #702

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require admin-enforced main branch protection for tagged release readiness. Adds a regression test to ensure the readiness check requests admin enforcement and preserves the default required status checks.

<sup>Written for commit f5bb0fe005e673ed36c4c61139ad0819c18d7007. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Require admin-enforced branch protection for tagged releases**

### What Changed
- Tagged release readiness now checks that the main branch uses admin-enforced protection before considering a release ready.
- A new regression test verifies the readiness check passes through admin enforcement while keeping the default required status checks.
- The release readiness regression suite now includes this branch-protection check.

### Impact
`✅ Safer release readiness checks`
`✅ Fewer releases approved without admin-protected main branch rules`
`✅ Clearer protection checks before tagged releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
