### PR TITLE
Harden workflow env write audit

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -2344,6 +2344,48 @@ def run_unsafe_environment_file_write_tests(module) -> None:
     if not parsed["unsafeEnvironmentFileWrites"]:
         raise AssertionError("unsafe GITHUB_ENV write finding was not listed")
 
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Verify release artifact\n",
+            "      - name: Unsafe printf env write\n"
+            "        run: |\n"
+            "          printf 'CONU_MACOS_CODESIGN_IDENTITY=%s\\n' "
+            "\"$MACOS_CODESIGN_IDENTITY\" >> \"$GITHUB_ENV\"\n"
+            "      - name: Verify release artifact\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("unsafe GITHUB_ENV secret-derived printf should fail")
+    rendered = json.dumps(assert_safe_report(report))
+    if (
+        "writes secret-derived MACOS_CODESIGN_IDENTITY directly to GITHUB_ENV"
+        not in rendered
+    ):
+        raise AssertionError("unsafe GITHUB_ENV printf write issue was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Verify release artifact\n",
+            "      - name: Unsafe heredoc env write\n"
+            "        run: |\n"
+            "          cat <<EOF >> \"$GITHUB_ENV\"\n"
+            "          NODE_AUTH_TOKEN=$NODE_AUTH_TOKEN\n"
+            "          EOF\n"
+            "      - name: Verify release artifact\n",
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("unsafe GITHUB_ENV secret-derived heredoc should fail")
+    rendered = json.dumps(assert_safe_report(report))
+    if "writes secret-derived NODE_AUTH_TOKEN directly to GITHUB_ENV" not in rendered:
+        raise AssertionError("unsafe GITHUB_ENV heredoc write issue was not reported")
+
 
 def main() -> int:
     module = load_module()

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -43,6 +43,8 @@ SECRET_LIKE_ENV_TOKENS = (
 UNSAFE_GITHUB_ENV_ECHO_RE = re.compile(
     r"\becho\s+[\"']?([A-Z0-9_]+)=\$([A-Z0-9_]+)"
 )
+SHELL_VARIABLE_RE = re.compile(r"\$(?:\{)?([A-Za-z_][A-Za-z0-9_]*)(?:\})?")
+GITHUB_ENV_ASSIGNMENT_NAME_RE = re.compile(r"\b([A-Z][A-Z0-9_]*)\s*=")
 RELEASE_PREFLIGHT_NPM_AUTH_COMMAND = (
     "python scripts/check-npm-publish-preflight.py "
     "--registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check"
@@ -1740,17 +1742,45 @@ def audit_environment_file_writes(path: Path) -> tuple[str, ...]:
 
     findings: list[str] = []
     for index, line in enumerate(lines):
-        match = UNSAFE_GITHUB_ENV_ECHO_RE.search(line.strip())
-        if match is None:
-            continue
-        output_name, source_name = match.groups()
-        if not is_secret_like_env_name(output_name) and not is_secret_like_env_name(source_name):
+        stripped = line.strip()
+        if stripped.startswith("append_github_env "):
             continue
         if not has_nearby_github_env_redirect(lines, index):
             continue
-        findings.append(
-            f"{path.name}:line {index + 1} echoes secret-derived {source_name} directly to GITHUB_ENV"
+
+        match = UNSAFE_GITHUB_ENV_ECHO_RE.search(stripped)
+        if match is not None:
+            output_name, source_name = match.groups()
+            if not is_secret_like_env_name(output_name) and not is_secret_like_env_name(
+                source_name
+            ):
+                continue
+            findings.append(
+                f"{path.name}:line {index + 1} echoes secret-derived {source_name} directly to GITHUB_ENV"
+            )
+            continue
+
+        source_names = tuple(
+            name
+            for name in SHELL_VARIABLE_RE.findall(stripped)
+            if name != "GITHUB_ENV" and is_secret_like_env_name(name)
         )
+        if source_names:
+            for source_name in source_names:
+                findings.append(
+                    f"{path.name}:line {index + 1} writes secret-derived {source_name} directly to GITHUB_ENV"
+                )
+            continue
+
+        output_names = tuple(
+            name
+            for name in GITHUB_ENV_ASSIGNMENT_NAME_RE.findall(stripped)
+            if is_secret_like_env_name(name)
+        )
+        for output_name in output_names:
+            findings.append(
+                f"{path.name}:line {index + 1} writes secret-like {output_name} directly to GITHUB_ENV"
+            )
     return tuple(findings)
 
 


### PR DESCRIPTION
## **User description**
Closes #706.

This hardens the workflow permissions audit so unsafe release-secret writes to GITHUB_ENV are caught beyond the narrow echo NAME=\ form. It now catches secret-like shell variables and secret-like assignment names near direct GITHUB_ENV redirects while preserving the audited safe append_github_env helper.

Validation:
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the GitHub workflow audit to flag unsafe secret writes to GITHUB_ENV beyond the simple echo pattern. Detects printf, heredoc, and secret-like assignment names near redirects, while keeping the safe append_github_env helper allowed.

- **Bug Fixes**
  - Expanded detection beyond echo NAME=$VAR to cover printf and heredoc writes.
  - Flags secret-derived shell variables when writing near GITHUB_ENV redirects.
  - Flags secret-like assignment names written to GITHUB_ENV.
  - Added regression tests for printf and heredoc cases.

<sup>Written for commit ce7e4e730bc0add18a2cc48d7a720f7710a2ed7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Catch more unsafe secret writes in workflow environment files**

### What Changed
- Workflow checks now flag more ways of writing secret-like values directly into `GITHUB_ENV`, including `printf` output and heredoc writes
- Secret-like environment variable names written to `GITHUB_ENV` are now reported, not just simple `echo NAME=$VAR` cases
- The safe `append_github_env` helper remains allowed
- Regression coverage was added for the new unsafe write patterns

### Impact
`✅ Fewer secret leaks in release workflows`
`✅ Safer GitHub environment file writes`
`✅ Clearer detection of unsafe workflow commands`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection capabilities for unsafe environment variable writes in GitHub workflows, now identifying additional secret exfiltration patterns beyond previously supported detection methods.

* **Tests**
  * Regression test suite expanded to validate detection of multiple secret write scenarios to environment files, covering additional write patterns and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->