### PR TITLE
Restrict workflow env helper exception

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -2386,6 +2386,25 @@ def run_unsafe_environment_file_write_tests(module) -> None:
     if "writes secret-derived NODE_AUTH_TOKEN directly to GITHUB_ENV" not in rendered:
         raise AssertionError("unsafe GITHUB_ENV heredoc write issue was not reported")
 
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '          append_github_env CONU_MACOS_NOTARY_KEYCHAIN_PROFILE "conu-notary-profile"\n',
+            '          append_github_env CONU_MACOS_NOTARY_KEYCHAIN_PROFILE "conu-notary-profile"\n'
+            '          append_github_env NODE_AUTH_TOKEN "$NODE_AUTH_TOKEN"\n',
+            1,
+        ),
+    )
+    if report.ready:
+        raise AssertionError("extra secret-like append_github_env call should fail")
+    rendered = json.dumps(assert_safe_report(report))
+    if (
+        "uses unapproved append_github_env helper call for secret-like NODE_AUTH_TOKEN"
+        not in rendered
+    ):
+        raise AssertionError("extra append_github_env helper call issue was not reported")
+
 
 def main() -> int:
     module = load_module()

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -45,6 +45,14 @@ UNSAFE_GITHUB_ENV_ECHO_RE = re.compile(
 )
 SHELL_VARIABLE_RE = re.compile(r"\$(?:\{)?([A-Za-z_][A-Za-z0-9_]*)(?:\})?")
 GITHUB_ENV_ASSIGNMENT_NAME_RE = re.compile(r"\b([A-Z][A-Z0-9_]*)\s*=")
+GITHUB_ENV_HELPER_CALL_RE = re.compile(
+    r"^append_github_env\s+([A-Z][A-Z0-9_]*)\b(.*)$"
+)
+SAFE_GITHUB_ENV_HELPER_CALLS = (
+    'append_github_env CONU_MACOS_CODESIGN_IDENTITY "$MACOS_CODESIGN_IDENTITY"',
+    'append_github_env CONU_MACOS_KEYCHAIN "$keychain_path"',
+    'append_github_env CONU_MACOS_NOTARY_KEYCHAIN_PROFILE "conu-notary-profile"',
+)
 RELEASE_PREFLIGHT_NPM_AUTH_COMMAND = (
     "python scripts/check-npm-publish-preflight.py "
     "--registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check"
@@ -1743,7 +1751,22 @@ def audit_environment_file_writes(path: Path) -> tuple[str, ...]:
     findings: list[str] = []
     for index, line in enumerate(lines):
         stripped = line.strip()
-        if stripped.startswith("append_github_env "):
+        helper_match = GITHUB_ENV_HELPER_CALL_RE.search(stripped)
+        if helper_match is not None:
+            if stripped in SAFE_GITHUB_ENV_HELPER_CALLS:
+                continue
+            output_name, helper_args = helper_match.groups()
+            source_names = tuple(
+                name
+                for name in SHELL_VARIABLE_RE.findall(helper_args)
+                if is_secret_like_env_name(name)
+            )
+            if is_secret_like_env_name(output_name) or source_names:
+                finding_name = source_names[0] if source_names else output_name
+                findings.append(
+                    f"{path.name}:line {index + 1} uses unapproved "
+                    f"append_github_env helper call for secret-like {finding_name}"
+                )
             continue
         if not has_nearby_github_env_redirect(lines, index):
             continue


### PR DESCRIPTION
Closes #708.

This tightens the workflow permissions audit so append_github_env is exempt only for the exact safe macOS helper calls already required by the release workflow audit. Extra helper calls carrying token/key/secret-like names now fail the audit even when they are not adjacent to the helper's GITHUB_ENV redirect.

Validation:
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- powershell -ExecutionPolicy Bypass -File scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the workflow permissions audit so `append_github_env` is exempt only for the three known-safe macOS helper calls; all other uses that touch secret-like names are now reported even when not adjacent to a `GITHUB_ENV` redirect. Closes #708.

- **Bug Fixes**
  - Parse `append_github_env` with a dedicated regex and allow only: `CONU_MACOS_CODESIGN_IDENTITY`, `CONU_MACOS_KEYCHAIN`, `CONU_MACOS_NOTARY_KEYCHAIN_PROFILE`.
  - Flag helper calls when the output name or any argument is secret-like; include the offending name in the message.
  - Add regression test to fail on `append_github_env NODE_AUTH_TOKEN "$NODE_AUTH_TOKEN"`.

<sup>Written for commit 7f9ec8100fdfb3d716b3a92892c7bcad7fca70ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

