### PR TITLE
Redact SDK failure command details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg openssl
       - name: Python script compile
         run: python scripts/check-python-script-compile.py
+      - name: Python SDK error redaction regression
+        run: python scripts/check-python-sdk-error-redaction.py
       - name: Production readiness toolchain regression
         run: python scripts/check-production-readiness-toolchain.py
       - name: Smoke output privacy regression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm createrepo-c gnupg openssl
       - name: Python script compile
         run: python scripts/check-python-script-compile.py
+      - name: Python SDK error redaction regression
+        run: python scripts/check-python-sdk-error-redaction.py
       - name: Production readiness toolchain regression
         run: python scripts/check-production-readiness-toolchain.py
       - name: Smoke output privacy regression

--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Regression checks for Python SDK command failure redaction."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SDK = ROOT / "sdk" / "python" / "conu_sdk" / "__init__.py"
+SENSITIVE_ENDPOINT = "wss://user:secret@relay.example.com/conu?token=private#fragment"
+SENSITIVE_STDOUT = "stdout with private fixture"
+SENSITIVE_STDERR = f"stderr with {SENSITIVE_ENDPOINT}"
+
+
+class Completed:
+    stdout = SENSITIVE_STDOUT.encode("utf-8")
+    stderr = SENSITIVE_STDERR.encode("utf-8")
+    returncode = 2
+
+
+def load_sdk():
+    spec = importlib.util.spec_from_file_location("conu_sdk_regression", SDK)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load Python SDK module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_redacted(rendered: str) -> None:
+    for forbidden in (
+        "secret",
+        "token=private",
+        "relay.example.com",
+        "private fixture",
+        SENSITIVE_ENDPOINT,
+    ):
+        if forbidden in rendered:
+            raise AssertionError(f"Python SDK error leaked sensitive text: {forbidden}")
+
+
+def run_failed_command_redaction_test(module) -> None:
+    captured: dict[str, tuple[str, ...]] = {}
+
+    def fake_run(argv, **_kwargs):
+        captured["argv"] = tuple(argv)
+        return Completed()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.trust_peer(
+            "node.peer",
+            "Peer",
+            "aa",
+            relay_endpoint=SENSITIVE_ENDPOINT,
+        )
+    except module.ConuError as exc:
+        rendered = str(exc)
+    else:
+        raise AssertionError("expected Python SDK command failure")
+
+    if SENSITIVE_ENDPOINT not in captured.get("argv", ()):
+        raise AssertionError("test did not pass the sensitive endpoint through argv")
+    assert_redacted(rendered)
+    if "conu-test.exe [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK error should retain only safe executable metadata")
+
+
+def run_spawn_error_redaction_test(module) -> None:
+    def fake_run(_argv, **_kwargs):
+        raise OSError(f"cannot execute {SENSITIVE_ENDPOINT}")
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin=SENSITIVE_ENDPOINT)
+    try:
+        client.status()
+    except module.ConuError as exc:
+        rendered = str(exc)
+    else:
+        raise AssertionError("expected Python SDK spawn failure")
+
+    assert_redacted(rendered)
+    if "conu [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK spawn error should use a generic safe binary label")
+
+
+def main() -> int:
+    module = load_sdk()
+    run_failed_command_redaction_test(module)
+    run_spawn_error_redaction_test(module)
+    print("Python SDK error redaction regression checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -423,21 +423,46 @@ class ConuClient:
         input_bytes: bytes | None = None,
     ) -> CommandResult:
         argv = (binary, *args)
-        completed = subprocess.run(
-            argv,
-            input=input_bytes,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=self.cwd,
-            env=self.env,
-            check=False,
-        )
+        try:
+            completed = subprocess.run(
+                argv,
+                input=input_bytes,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=self.cwd,
+                env=self.env,
+                check=False,
+            )
+        except OSError:
+            raise ConuError(
+                f"conU command failed before execution: {_safe_command_for_error(binary)}"
+            ) from None
         stdout = completed.stdout.decode("utf-8", errors="replace")
         stderr = completed.stderr.decode("utf-8", errors="replace")
         result = CommandResult(argv, stdout, stderr, completed.returncode)
         if completed.returncode != 0:
-            raise ConuError(f"conU command failed ({completed.returncode}): {' '.join(argv)}")
+            raise ConuError(
+                f"conU command failed ({completed.returncode}): {_safe_command_for_error(binary)}"
+            )
         return result
+
+
+def _safe_command_for_error(binary: str) -> str:
+    return f"{_safe_binary_name(binary)} [arguments redacted]"
+
+
+def _safe_binary_name(binary: str) -> str:
+    value = str(binary).strip()
+    if not value:
+        return "conu"
+    if "://" in value or any(marker in value for marker in ("@", "?", "#")):
+        return "conu"
+    base = value.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1] or "conu"
+    sanitized = "".join(
+        character if character.isascii() and (character.isalnum() or character in "._-") else "_"
+        for character in base
+    )
+    return sanitized or "conu"
 
 
 def _bool_arg(value: bool) -> str:

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -415,14 +415,23 @@ export class ConuClient {
     );
     const response = parseMcpResponse(result.stdout);
     if (response.error) {
-      throw new ConuError(`conU MCP tool failed: ${safeMcpError(response.error)}`, result);
+      throw new ConuError(
+        `conU MCP tool failed: ${safeMcpError(response.error)}`,
+        resultForError({ code: 1 }, this.mcpBin),
+      );
     }
     const toolResult = response.result;
     if (!isRecord(toolResult)) {
-      throw new ConuError("conU MCP response did not include a tool result", result);
+      throw new ConuError(
+        "conU MCP response did not include a tool result",
+        resultForError({ code: 1 }, this.mcpBin),
+      );
     }
     if (toolResult.isError === true) {
-      throw new ConuError(`conU MCP tool failed: ${toolText(toolResult)}`, result);
+      throw new ConuError(
+        "conU MCP tool failed: [details redacted]",
+        resultForError({ code: 1 }, this.mcpBin),
+      );
     }
     return JSON.parse(toolText(toolResult));
   }
@@ -436,7 +445,11 @@ export class ConuClient {
       env: this.env,
     });
     if (result.code !== 0) {
-      throw new ConuError(`conU command failed (${result.code}): ${binary} ${args.join(" ")}`, result);
+      const safeResult = resultForError(result, binary);
+      throw new ConuError(
+        `conU command failed (${safeResult.code}): ${safeCommandForError(binary)}`,
+        safeResult,
+      );
     }
     return result;
   }
@@ -451,13 +464,17 @@ function defaultRunner({ binary, args, input, cwd, env }) {
     windowsHide: true,
   });
   if (completed.error) {
-    const result = {
+    const result = resultForError({
       args: [binary, ...args],
       stdout: "",
-      stderr: completed.error.message,
+      stderr: "",
       code: typeof completed.status === "number" ? completed.status : 1,
-    };
-    throw new ConuError(`conU command failed: ${completed.error.message}`, result);
+    }, binary);
+    const reason = typeof completed.error.code === "string" ? completed.error.code : "spawn_error";
+    throw new ConuError(
+      `conU command failed before execution (${reason}): ${safeCommandForError(binary)}`,
+      result,
+    );
   }
   return {
     args: [binary, ...args],
@@ -524,10 +541,35 @@ function toolText(toolResult) {
 }
 
 function safeMcpError(error) {
-  if (isRecord(error) && typeof error.message === "string") {
-    return error.message;
+  if (isRecord(error) && typeof error.code === "number") {
+    return `code ${error.code}`;
   }
   return "unknown MCP error";
+}
+
+function resultForError(result, binary) {
+  return {
+    args: [safeBinaryName(binary), "[arguments redacted]"],
+    stdout: "",
+    stderr: "",
+    code: typeof result?.code === "number" ? result.code : 1,
+    contentsDisplayed: false,
+    argsRedacted: true,
+    stdioRedacted: true,
+  };
+}
+
+function safeCommandForError(binary) {
+  return `${safeBinaryName(binary)} [arguments redacted]`;
+}
+
+function safeBinaryName(binary) {
+  const value = String(binary ?? "conu").trim();
+  if (value.includes("://") || /[@?#]/.test(value)) {
+    return "conu";
+  }
+  const base = value.split(/[\\/]/).filter(Boolean).at(-1) ?? "conu";
+  return base.replace(/[^\w.-]/g, "_") || "conu";
 }
 
 function hexToBuffer(hex) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -195,3 +195,123 @@ const failing = new ConuClient({
   },
 });
 assert.throws(() => failing.status(), ConuError);
+
+const secretEndpoint = "wss://user:secret@relay.example.com/conu?token=private#fragment";
+const endpointFailing = new ConuClient({
+  conuBin: "C:/tools/conu-test.exe",
+  runner({ binary, args }) {
+    return {
+      args: [binary, ...args],
+      stdout: "stdout with private fixture",
+      stderr: `stderr with ${secretEndpoint}`,
+      code: 2,
+    };
+  },
+});
+
+assert.throws(
+  () =>
+    endpointFailing.trustPeer("node.peer", "Peer", "aa", {
+      relayEndpoint: secretEndpoint,
+    }),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+
+for (const mcpFailureMode of ["protocol", "tool"]) {
+  const mcpFailing = new ConuClient({
+    mcpBin: "conu-mcp-test",
+    runner({ binary }) {
+      const body =
+        mcpFailureMode === "protocol"
+          ? {
+              jsonrpc: "2.0",
+              id: 1,
+              error: {
+                code: -32602,
+                message: `MCP protocol error with ${secretEndpoint}`,
+              },
+            }
+          : {
+              jsonrpc: "2.0",
+              id: 1,
+              result: {
+                content: [{ type: "text", text: `MCP tool error with ${secretEndpoint}` }],
+                isError: true,
+              },
+            };
+      return {
+        args: [binary],
+        stdout: JSON.stringify(body),
+        stderr: "stderr with private fixture",
+        code: 0,
+      };
+    },
+  });
+
+  assert.throws(
+    () => mcpFailing.receiveMessage("agent.beta", "env.local.1"),
+    (error) => {
+      assert.ok(error instanceof ConuError);
+      const rendered = JSON.stringify({
+        message: error.message,
+        result: error.result,
+      });
+      assert.ok(!rendered.includes("secret"));
+      assert.ok(!rendered.includes("token=private"));
+      assert.ok(!rendered.includes("relay.example.com"));
+      assert.ok(!rendered.includes("private fixture"));
+      assert.deepEqual(error.result.args, ["conu-mcp-test", "[arguments redacted]"]);
+      assert.equal(error.result.contentsDisplayed, false);
+      return true;
+    },
+  );
+}
+
+const mcpMalformed = new ConuClient({
+  mcpBin: "conu-mcp-test",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: `malformed MCP result with ${secretEndpoint}`,
+      }),
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => mcpMalformed.receiveMessage("agent.beta", "env.local.1"),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.deepEqual(error.result.args, ["conu-mcp-test", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);


### PR DESCRIPTION
## **User description**
Closes #710.

Summary:
- Redact failed subprocess command args/stdout/stderr from TypeScript SDK ConuError results.
- Redact TypeScript SDK MCP error result surfaces for protocol, malformed-result, and tool-error paths.
- Redact Python SDK failed command messages and spawn failures.
- Add Python SDK redaction regression and run it in CI/release package checks.

Validation:
- npm run check --prefix sdk/typescript
- python scripts/check-python-sdk-error-redaction.py
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- npm run check --prefix packaging/npm/conu-cli
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- git diff --check

Note: local no-Rust production readiness script was attempted and timed out after five minutes; PR CI will run the full package and Rust matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts sensitive command arguments and stdio from `ConuError` in the TypeScript and Python SDKs, including MCP failure paths, to prevent secret leaks. Adds a Python redaction regression and runs it in CI and release workflows.

- **Bug Fixes**
  - TypeScript SDK: redacts args/stdout/stderr in `ConuError` results; sanitizes binary names; masks MCP protocol/malformed/tool errors; sets `argsRedacted`, `stdioRedacted`, and `contentsDisplayed=false`.
  - Python SDK: redacts command details in error messages; sanitizes binary names; handles spawn errors with a safe, generic label.
  - CI: adds `scripts/check-python-sdk-error-redaction.py` and runs it in `.github/workflows/ci.yml` and `release.yml`.

<sup>Written for commit d7ceafa5b4483af852e35e2c9b29b573db997fdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact command details from SDK failures**

### What Changed
- Error messages from the Python and TypeScript SDKs now hide command arguments and output when a command fails.
- Failed MCP calls now show a redacted error instead of exposing raw tool error text or response contents.
- If a command cannot start, the Python SDK now reports a safe generic binary name instead of the original sensitive command.
- Added a Python regression check for redaction, and it now runs in CI and release validation.

### Impact
`✅ Fewer secret leaks in SDK errors`
`✅ Safer command failure messages`
`✅ Clearer privacy checks in CI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Error messages in Python and TypeScript SDKs now redact sensitive credential and endpoint information to prevent accidental data leaks in command execution and MCP tool call failures.

* **Tests**
  * Added regression tests to ensure error messages properly redact sensitive data across multiple failure scenarios in both SDKs.

* **Chores**
  * Enhanced CI and release workflows with automated error redaction validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->