### PR TITLE
Redact SDK JSON parse failures

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -89,10 +89,34 @@ def run_spawn_error_redaction_test(module) -> None:
         raise AssertionError("Python SDK spawn error should use a generic safe binary label")
 
 
+def run_invalid_json_redaction_test(module) -> None:
+    class JsonCompleted:
+        stdout = f"not json with {SENSITIVE_ENDPOINT}".encode("utf-8")
+        stderr = SENSITIVE_STDERR.encode("utf-8")
+        returncode = 0
+
+    def fake_run(argv, **_kwargs):
+        return JsonCompleted()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.status()
+    except module.ConuError as exc:
+        rendered = str(exc)
+    else:
+        raise AssertionError("expected Python SDK JSON parse failure")
+
+    assert_redacted(rendered)
+    if "conU command returned invalid JSON: conu-test.exe [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK JSON parse error should retain only safe command metadata")
+
+
 def main() -> int:
     module = load_sdk()
     run_failed_command_redaction_test(module)
     run_spawn_error_redaction_test(module)
+    run_invalid_json_redaction_test(module)
     print("Python SDK error redaction regression checks passed")
     return 0
 

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -414,7 +414,12 @@ class ConuClient:
         input_bytes: bytes | None = None,
     ) -> dict[str, Any]:
         result = self._run(binary, *args, input_bytes=input_bytes)
-        return json.loads(result.stdout)
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError:
+            raise ConuError(
+                f"conU command returned invalid JSON: {_safe_command_for_error(binary)}"
+            ) from None
 
     def _run(
         self,

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -395,7 +395,7 @@ export class ConuClient {
 
   runJson(binary, args, input) {
     const result = this.run(binary, args, input);
-    return JSON.parse(result.stdout);
+    return parseJsonForSdk(result.stdout, binary, "conU command returned invalid JSON");
   }
 
   callMcpTool(name, argumentsValue = {}) {
@@ -413,7 +413,7 @@ export class ConuClient {
       [],
       Buffer.from(`${JSON.stringify(request)}\n`, "utf8"),
     );
-    const response = parseMcpResponse(result.stdout);
+    const response = parseMcpResponse(result.stdout, this.mcpBin);
     if (response.error) {
       throw new ConuError(
         `conU MCP tool failed: ${safeMcpError(response.error)}`,
@@ -433,7 +433,11 @@ export class ConuClient {
         resultForError({ code: 1 }, this.mcpBin),
       );
     }
-    return JSON.parse(toolText(toolResult));
+    return parseJsonForSdk(
+      toolText(toolResult),
+      this.mcpBin,
+      "conU MCP tool returned invalid JSON",
+    );
   }
 
   run(binary, args = [], input) {
@@ -520,15 +524,18 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseMcpResponse(stdout) {
+function parseMcpResponse(stdout, binary) {
   const line = String(stdout)
     .split(/\r?\n/)
     .map((value) => value.trim())
     .find((value) => value.length > 0);
   if (line === undefined) {
-    throw new Error("conU MCP response was empty");
+    throw new ConuError(
+      "conU MCP response was empty",
+      resultForError({ code: 1 }, binary),
+    );
   }
-  return JSON.parse(line);
+  return parseJsonForSdk(line, binary, "conU MCP response was invalid JSON");
 }
 
 function toolText(toolResult) {
@@ -545,6 +552,14 @@ function safeMcpError(error) {
     return `code ${error.code}`;
   }
   return "unknown MCP error";
+}
+
+function parseJsonForSdk(text, binary, message) {
+  try {
+    return JSON.parse(text);
+  } catch (_error) {
+    throw new ConuError(message, resultForError({ code: 1 }, binary));
+  }
 }
 
 function resultForError(result, binary) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -315,3 +315,103 @@ assert.throws(
     return true;
   },
 );
+
+const commandJsonMalformed = new ConuClient({
+  conuBin: "C:/tools/conu-test.exe",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: `not json with ${secretEndpoint}`,
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => commandJsonMalformed.status(),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.equal(error.message, "conU command returned invalid JSON");
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);
+
+const mcpJsonMalformed = new ConuClient({
+  mcpBin: "conu-mcp-test",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          content: [{ type: "text", text: `not json with ${secretEndpoint}` }],
+          isError: false,
+        },
+      }),
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => mcpJsonMalformed.receiveMessage("agent.beta", "env.local.1"),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.equal(error.message, "conU MCP tool returned invalid JSON");
+    assert.deepEqual(error.result.args, ["conu-mcp-test", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);
+
+const mcpProtocolJsonMalformed = new ConuClient({
+  mcpBin: "conu-mcp-test",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: `not json with ${secretEndpoint}`,
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => mcpProtocolJsonMalformed.receiveMessage("agent.beta", "env.local.1"),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.equal(error.message, "conU MCP response was invalid JSON");
+    assert.deepEqual(error.result.args, ["conu-mcp-test", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);


### PR DESCRIPTION
## **User description**
Closes #712

This hardens TypeScript and Python SDK JSON parsing so malformed CLI or MCP output raises safe ConuError messages with redacted command metadata instead of exposing raw parser failure surfaces.

Local validation:
- npm run check --prefix sdk/typescript
- python scripts/check-python-sdk-error-redaction.py
- git diff --check
- package, release, workflow, repository-security, hosted-repository, update-policy, and npm preflight regression checks

Local Rust note: cargo test --workspace --all-targets could not run in this shell because link.exe/MSVC linker is not installed; PR CI will cover Rust on GitHub-hosted runners.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened JSON parsing in the TypeScript and Python SDKs so malformed CLI/MCP output raises safe ConuError with redacted command metadata. Prevents leaking secrets and standardizes errors for invalid or empty JSON.

- **Bug Fixes**
  - TypeScript (`sdk/typescript`): added parseJsonForSdk; used in `runJson`, MCP response parsing, and MCP tool results. Empty/invalid MCP responses now throw ConuError with redacted `result`.
  - Python (`sdk/python/conu_sdk`): `_run_json` now catches JSONDecodeError and raises ConuError with a safe, redacted command label.
  - Tests: expanded `sdk/typescript/test/smoke.mjs` to cover malformed command/MCP JSON and protocol JSON; updated `scripts/check-python-sdk-error-redaction.py` to validate invalid JSON redaction.

<sup>Written for commit 57803548b05e83a729b6b123c88640e56efe47b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact invalid JSON errors from SDK commands and MCP responses**

### What Changed
- SDK commands now return a safe error when they produce invalid JSON instead of exposing a raw parse failure
- MCP tool calls now do the same for invalid tool output and empty or invalid MCP responses
- Python SDK JSON parsing now also reports a redacted command label when the output is not valid JSON
- Added regression checks to cover these redaction cases in both TypeScript and Python

### Impact
`✅ Safer SDK error messages`
`✅ Fewer secret leaks in parse failures`
`✅ Clearer invalid JSON failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
