### PR TITLE
Normalize TypeScript SDK MCP shape errors

### DIFF
--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -202,9 +202,12 @@ export class ConuClient {
   receiveMessageBytes(agentId, envelopeId) {
     const received = this.receiveMessage(agentId, envelopeId, { includePayload: true });
     if (typeof received.payloadHex !== "string") {
-      throw new Error("conU receive response did not include payloadHex");
+      throw new ConuError(
+        "conU receive response did not include payloadHex",
+        resultForError({ code: 1 }, this.mcpBin),
+      );
     }
-    return hexToBuffer(received.payloadHex);
+    return hexToBuffer(received.payloadHex, this.mcpBin);
   }
 
   receipts() {
@@ -434,7 +437,7 @@ export class ConuClient {
       );
     }
     return parseJsonForSdk(
-      toolText(toolResult),
+      toolText(toolResult, this.mcpBin),
       this.mcpBin,
       "conU MCP tool returned invalid JSON",
     );
@@ -538,11 +541,14 @@ function parseMcpResponse(stdout, binary) {
   return parseJsonForSdk(line, binary, "conU MCP response was invalid JSON");
 }
 
-function toolText(toolResult) {
+function toolText(toolResult, binary) {
   const content = Array.isArray(toolResult.content) ? toolResult.content : [];
   const text = content.find((item) => isRecord(item) && item.type === "text")?.text;
   if (typeof text !== "string") {
-    throw new Error("conU MCP tool response did not include text content");
+    throw new ConuError(
+      "conU MCP tool response did not include text content",
+      resultForError({ code: 1 }, binary),
+    );
   }
   return text;
 }
@@ -587,9 +593,12 @@ function safeBinaryName(binary) {
   return base.replace(/[^\w.-]/g, "_") || "conu";
 }
 
-function hexToBuffer(hex) {
+function hexToBuffer(hex, binary) {
   if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(hex)) {
-    throw new Error("conU receive response included invalid payloadHex");
+    throw new ConuError(
+      "conU receive response included invalid payloadHex",
+      resultForError({ code: 1 }, binary),
+    );
   }
   return Buffer.from(hex, "hex");
 }

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -316,6 +316,136 @@ assert.throws(
   },
 );
 
+const mcpMissingText = new ConuClient({
+  mcpBin: "conu-mcp-test",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          content: [{ type: "resource", text: `MCP content with ${secretEndpoint}` }],
+          isError: false,
+        },
+      }),
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => mcpMissingText.receiveMessage("agent.beta", "env.local.1"),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.equal(error.message, "conU MCP tool response did not include text content");
+    assert.deepEqual(error.result.args, ["conu-mcp-test", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);
+
+const receiveMissingPayloadHex = new ConuClient({
+  mcpBin: "conu-mcp-test",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                payloadReturned: true,
+                note: `private fixture with ${secretEndpoint}`,
+              }),
+            },
+          ],
+          isError: false,
+        },
+      }),
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => receiveMissingPayloadHex.receiveMessageBytes("agent.beta", "env.local.1"),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.equal(error.message, "conU receive response did not include payloadHex");
+    assert.deepEqual(error.result.args, ["conu-mcp-test", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);
+
+const receiveInvalidPayloadHex = new ConuClient({
+  mcpBin: "conu-mcp-test",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                payloadHex: secretEndpoint,
+                payloadReturned: true,
+              }),
+            },
+          ],
+          isError: false,
+        },
+      }),
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => receiveInvalidPayloadHex.receiveMessageBytes("agent.beta", "env.local.1"),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.equal(error.message, "conU receive response included invalid payloadHex");
+    assert.deepEqual(error.result.args, ["conu-mcp-test", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);
+
 const commandJsonMalformed = new ConuClient({
   conuBin: "C:/tools/conu-test.exe",
   runner({ binary }) {


### PR DESCRIPTION
## **User description**
Closes #714

This normalizes malformed MCP response-shape failures in the TypeScript SDK to redacted ConuError objects with safe command metadata. It covers missing MCP text content, missing payloadHex, and invalid payloadHex after payload-bearing MCP responses.

Local validation:
- npm run check --prefix sdk/typescript
- git diff --check
- python scripts/check-python-script-compile.py
- python scripts/check-python-sdk-error-redaction.py
- npm run check --prefix packaging/npm/conu-cli
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- python scripts/check-npm-publish-preflight.py
- python scripts/check-npm-publish-preflight-regression.py
- cargo fmt --all -- --check
- python scripts/check-production-readiness-toolchain.py
- python scripts/check-smoke-output-privacy.py
- python scripts/verify-release-versions.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes MCP response-shape errors in the TypeScript SDK by throwing redacted ConuError objects with safe command metadata. Adds tests to ensure secrets never leak and error messages stay consistent.

- **Bug Fixes**
  - Use ConuError (with redacted result) for malformed MCP responses.
  - Cover: missing tool text content, missing payloadHex, invalid payloadHex.
  - Pass mcpBin into toolText and hexToBuffer to generate safe error context.
  - Add smoke tests verifying redaction and expected error messages.

<sup>Written for commit b74a43790127fdc0d63c9b6147098d05c31c1af9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact malformed MCP response errors in the TypeScript SDK**

### What Changed
- Malformed MCP responses now fail with redacted SDK errors instead of plain errors, so command details stay hidden
- `receiveMessageBytes` now reports missing or invalid payload data through the same safe error path
- Added smoke tests for missing text content, missing payload data, and invalid payload hex to confirm secrets do not leak

### Impact
`✅ Fewer secret leaks in SDK errors`
`✅ Clearer MCP response failures`
`✅ Safer byte-message handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
