### PR TITLE
Add Python SDK receive helper

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -112,11 +113,171 @@ def run_invalid_json_redaction_test(module) -> None:
         raise AssertionError("Python SDK JSON parse error should retain only safe command metadata")
 
 
+def run_receive_message_helper_test(module) -> None:
+    captured_requests: list[dict] = []
+
+    class McpCompleted:
+        returncode = 0
+        stderr = b""
+
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout.encode("utf-8")
+
+    def fake_run(argv, input=None, **_kwargs):
+        if tuple(argv) != ("C:/tools/conu-mcp-test.exe",):
+            raise AssertionError(f"unexpected argv for MCP helper: {argv!r}")
+        request = json.loads(input.decode("utf-8"))
+        captured_requests.append(request)
+        include_payload = request["params"]["arguments"]["includePayload"] is True
+        body = {
+            "envelopeId": request["params"]["arguments"]["envelopeId"],
+            "fromAgentId": "agent.alpha",
+            "toAgentId": request["params"]["arguments"]["agentId"],
+            "payloadBytes": 13,
+            "payloadReturned": include_payload,
+            "contentsDisplayed": False,
+        }
+        if include_payload:
+            body["payloadHex"] = b"private bytes".hex()
+            body["payloadEncoding"] = "hex"
+        return McpCompleted(
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request["id"],
+                    "result": {
+                        "content": [{"type": "text", "text": json.dumps(body)}],
+                        "isError": False,
+                    },
+                }
+            )
+        )
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(mcp_bin="C:/tools/conu-mcp-test.exe")
+    metadata = client.receive_message("agent.beta", "env.local.1")
+    payload = client.receive_message_bytes("agent.beta", "env.local.1")
+
+    if metadata.get("payloadReturned") is not False:
+        raise AssertionError("Python SDK metadata receive should not return payload by default")
+    if payload != b"private bytes":
+        raise AssertionError("Python SDK receive_message_bytes should decode payloadHex")
+    if captured_requests[0]["params"]["name"] != "conu_receive_message":
+        raise AssertionError("Python SDK receive helper should call conu_receive_message")
+    if captured_requests[0]["params"]["arguments"]["includePayload"] is not False:
+        raise AssertionError("Python SDK receive_message should default includePayload to false")
+    if captured_requests[1]["params"]["arguments"]["includePayload"] is not True:
+        raise AssertionError("Python SDK receive_message_bytes should request payload explicitly")
+
+
+def run_mcp_shape_redaction_tests(module) -> None:
+    class McpCompleted:
+        stderr = SENSITIVE_STDERR.encode("utf-8")
+        returncode = 0
+
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout.encode("utf-8")
+
+    cases = (
+        (
+            "missing text",
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "content": [{"type": "resource", "text": f"text with {SENSITIVE_ENDPOINT}"}],
+                    "isError": False,
+                },
+            },
+            lambda client: client.receive_message("agent.beta", "env.local.1"),
+            "conU MCP tool response did not include text content: conu-mcp-test.exe [arguments redacted]",
+        ),
+        (
+            "missing payloadHex",
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {
+                                    "payloadReturned": True,
+                                    "note": f"private fixture with {SENSITIVE_ENDPOINT}",
+                                }
+                            ),
+                        }
+                    ],
+                    "isError": False,
+                },
+            },
+            lambda client: client.receive_message_bytes("agent.beta", "env.local.1"),
+            "conU receive response did not include payloadHex: conu-mcp-test.exe [arguments redacted]",
+        ),
+        (
+            "invalid payloadHex",
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {
+                                    "payloadHex": SENSITIVE_ENDPOINT,
+                                    "payloadReturned": True,
+                                }
+                            ),
+                        }
+                    ],
+                    "isError": False,
+                },
+            },
+            lambda client: client.receive_message_bytes("agent.beta", "env.local.1"),
+            "conU receive response included invalid payloadHex: conu-mcp-test.exe [arguments redacted]",
+        ),
+        (
+            "protocol error",
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32602,
+                    "message": f"protocol error with {SENSITIVE_ENDPOINT}",
+                },
+            },
+            lambda client: client.receive_message("agent.beta", "env.local.1"),
+            "conU MCP tool failed: code -32602: conu-mcp-test.exe [arguments redacted]",
+        ),
+    )
+
+    for _label, response, action, expected in cases:
+        def fake_run(_argv, **_kwargs):
+            return McpCompleted(json.dumps(response))
+
+        module.subprocess.run = fake_run
+        client = module.ConuClient(mcp_bin="C:/tools/conu-mcp-test.exe")
+        try:
+            action(client)
+        except module.ConuError as exc:
+            rendered = str(exc)
+        else:
+            raise AssertionError("expected Python SDK MCP shape failure")
+
+        assert_redacted(rendered)
+        if expected not in rendered:
+            raise AssertionError("Python SDK MCP error should retain only safe command metadata")
+
+
 def main() -> int:
     module = load_sdk()
     run_failed_command_redaction_test(module)
     run_spawn_error_redaction_test(module)
     run_invalid_json_redaction_test(module)
+    run_receive_message_helper_test(module)
+    run_mcp_shape_redaction_tests(module)
     print("Python SDK error redaction regression checks passed")
     return 0
 

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -35,12 +35,14 @@ class ConuClient:
         self,
         conu_bin: str | Path = "conu",
         conud_bin: str | Path = "conud",
+        mcp_bin: str | Path = "conu-mcp",
         home: str | Path | None = None,
         env: dict[str, str] | None = None,
         cwd: str | Path | None = None,
     ) -> None:
         self.conu_bin = str(conu_bin)
         self.conud_bin = str(conud_bin)
+        self.mcp_bin = str(mcp_bin)
         self.cwd = None if cwd is None else str(cwd)
         self.env = os.environ.copy()
         if env:
@@ -179,6 +181,31 @@ class ConuClient:
 
     def inbox(self, agent_id: str) -> dict[str, Any]:
         return self._run_json(self.conu_bin, "messages", "inbox", agent_id, "--json")
+
+    def receive_message(
+        self,
+        agent_id: str,
+        envelope_id: str,
+        include_payload: bool = False,
+    ) -> dict[str, Any]:
+        return self._call_mcp_tool(
+            "conu_receive_message",
+            {
+                "agentId": str(agent_id),
+                "envelopeId": str(envelope_id),
+                "includePayload": bool(include_payload),
+            },
+        )
+
+    def receive_message_bytes(self, agent_id: str, envelope_id: str) -> bytes:
+        received = self.receive_message(agent_id, envelope_id, include_payload=True)
+        payload_hex = received.get("payloadHex")
+        if not isinstance(payload_hex, str):
+            raise ConuError(
+                f"conU receive response did not include payloadHex: "
+                f"{_safe_command_for_error(self.mcp_bin)}"
+            )
+        return _hex_to_bytes(payload_hex, self.mcp_bin)
 
     def receipts(self) -> dict[str, Any]:
         return self._run_json(self.conu_bin, "messages", "receipts", "--json")
@@ -421,6 +448,48 @@ class ConuClient:
                 f"conU command returned invalid JSON: {_safe_command_for_error(binary)}"
             ) from None
 
+    def _call_mcp_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": name,
+                "arguments": arguments or {},
+            },
+        }
+        result = self._run(
+            self.mcp_bin,
+            input_bytes=(json.dumps(request, separators=(",", ":")) + "\n").encode("utf-8"),
+        )
+        response = _parse_mcp_response(result.stdout, self.mcp_bin)
+        error = response.get("error")
+        if error is not None:
+            raise ConuError(
+                f"conU MCP tool failed: {_safe_mcp_error(error)}: "
+                f"{_safe_command_for_error(self.mcp_bin)}"
+            )
+        tool_result = response.get("result")
+        if not isinstance(tool_result, dict):
+            raise ConuError(
+                f"conU MCP response did not include a tool result: "
+                f"{_safe_command_for_error(self.mcp_bin)}"
+            )
+        if tool_result.get("isError") is True:
+            raise ConuError(
+                f"conU MCP tool failed: [details redacted]: "
+                f"{_safe_command_for_error(self.mcp_bin)}"
+            )
+        return _parse_json_for_sdk(
+            _tool_text(tool_result, self.mcp_bin),
+            self.mcp_bin,
+            "conU MCP tool returned invalid JSON",
+        )
+
     def _run(
         self,
         binary: str,
@@ -468,6 +537,53 @@ def _safe_binary_name(binary: str) -> str:
         for character in base
     )
     return sanitized or "conu"
+
+
+def _parse_mcp_response(stdout: str, binary: str) -> dict[str, Any]:
+    line = next((value.strip() for value in stdout.splitlines() if value.strip()), None)
+    if line is None:
+        raise ConuError(f"conU MCP response was empty: {_safe_command_for_error(binary)}")
+    return _parse_json_for_sdk(line, binary, "conU MCP response was invalid JSON")
+
+
+def _parse_json_for_sdk(text: str, binary: str, message: str) -> dict[str, Any]:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        raise ConuError(f"{message}: {_safe_command_for_error(binary)}") from None
+    if not isinstance(value, dict):
+        raise ConuError(f"{message}: {_safe_command_for_error(binary)}")
+    return value
+
+
+def _tool_text(tool_result: dict[str, Any], binary: str) -> str:
+    content = tool_result.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text")
+                if isinstance(text, str):
+                    return text
+    raise ConuError(
+        f"conU MCP tool response did not include text content: {_safe_command_for_error(binary)}"
+    )
+
+
+def _safe_mcp_error(error: Any) -> str:
+    if isinstance(error, dict) and isinstance(error.get("code"), int):
+        return f"code {error['code']}"
+    return "unknown MCP error"
+
+
+def _hex_to_bytes(payload_hex: str, binary: str) -> bytes:
+    if len(payload_hex) % 2 != 0 or any(
+        character not in "0123456789abcdefABCDEF" for character in payload_hex
+    ):
+        raise ConuError(
+            f"conU receive response included invalid payloadHex: "
+            f"{_safe_command_for_error(binary)}"
+        )
+    return bytes.fromhex(payload_hex)
 
 
 def _bool_arg(value: bool) -> str:


### PR DESCRIPTION
## **User description**
Closes #716

Adds explicit Python SDK receive_message and receive_message_bytes helpers through the MCP conu_receive_message path so Python agents can retrieve addressed inbox payloads without parsing CLI output. The helper keeps payload retrieval explicit, validates payloadHex, and normalizes malformed MCP failures to redacted ConuError messages with safe command metadata.

Local validation:
- python scripts/check-python-sdk-error-redaction.py
- python scripts/check-python-script-compile.py
- python -m py_compile sdk/python/conu_sdk/__init__.py scripts/check-python-sdk-error-redaction.py examples/python/local_agent_pair.py
- git diff --check
- npm run check --prefix sdk/typescript
- npm run check --prefix packaging/npm/conu-cli
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- python scripts/check-npm-publish-preflight.py
- python scripts/check-npm-publish-preflight-regression.py
- python scripts/check-production-readiness-toolchain.py
- python scripts/check-smoke-output-privacy.py
- python scripts/verify-release-versions.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-github-actions-permissions-regression.py
- python scripts/check-github-repository-security-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- cargo fmt --all -- --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Python SDK helpers `receive_message` and `receive_message_bytes` to fetch inbox metadata or raw payloads via MCP tool `conu_receive_message`, removing the need to parse CLI output. Validates `payloadHex` and converts MCP errors into redacted `ConuError`s.

- **New Features**
  - `ConuClient.receive_message(agent_id, envelope_id, include_payload=False)` and `ConuClient.receive_message_bytes(agent_id, envelope_id)` using MCP `conu_receive_message`.
  - Validates and decodes `payloadHex`; raises `ConuError` on missing/invalid payload or MCP errors (redacted).
  - Adds `mcp_bin` option on `ConuClient` and internal `_call_mcp_tool` for request/response handling.
  - Extends `scripts/check-python-sdk-error-redaction.py` with tests for receive behavior and MCP shape/redaction.

<sup>Written for commit 00fd03209b691f8201a13c414047056ea2ce33b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add a Python SDK helper for receiving inbox messages and raw payloads**

### What Changed
- Python apps can now fetch a message directly by agent and envelope ID without parsing CLI output
- Message fetches can return either message details only or the full payload
- A new helper returns the payload as bytes when it is requested
- Invalid payload data and MCP failures now produce clear, redacted error messages instead of exposing sensitive command details
- Regression checks were added for successful receive calls and for the new error cases

### Impact
`✅ Direct message retrieval from Python`
`✅ Easier access to raw inbox payloads`
`✅ Clearer receive errors with less sensitive data exposed`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
