### PR TITLE
Add Python SDK command parity

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -271,6 +271,207 @@ def run_mcp_shape_redaction_tests(module) -> None:
             raise AssertionError("Python SDK MCP error should retain only safe command metadata")
 
 
+def run_command_surface_parity_test(module) -> None:
+    captured: list[dict] = []
+
+    class JsonCompleted:
+        stderr = b""
+        returncode = 0
+
+        def __init__(self) -> None:
+            self.stdout = json.dumps(
+                {
+                    "ok": True,
+                    "contentsDisplayed": False,
+                }
+            ).encode("utf-8")
+
+    def fake_run(argv, input=None, **_kwargs):
+        captured.append({"argv": tuple(argv), "input": input})
+        return JsonCompleted()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+
+    calls = (
+        (
+            lambda: client.rotate_identity(),
+            (
+                "C:/tools/conu-test.exe",
+                "security",
+                "rotate",
+                "identity",
+                "--confirm-peer-refresh",
+                "--json",
+            ),
+            None,
+        ),
+        (
+            lambda: client.retire_identity_archives(),
+            (
+                "C:/tools/conu-test.exe",
+                "security",
+                "retire",
+                "identity",
+                "--confirm-peer-refresh-complete",
+                "--json",
+            ),
+            None,
+        ),
+        (
+            lambda: client.rotate_storage(),
+            (
+                "C:/tools/conu-test.exe",
+                "security",
+                "rotate",
+                "storage",
+                "--confirm",
+                "--json",
+            ),
+            None,
+        ),
+        (
+            lambda: client.retire_storage(),
+            (
+                "C:/tools/conu-test.exe",
+                "security",
+                "retire",
+                "storage",
+                "--confirm",
+                "--json",
+            ),
+            None,
+        ),
+        (
+            lambda: client.relay_credential_status(),
+            (
+                "C:/tools/conu-test.exe",
+                "relay",
+                "credential",
+                "status",
+                "--json",
+            ),
+            None,
+        ),
+        (
+            lambda: client.set_relay_credential("relay-token-fixture"),
+            (
+                "C:/tools/conu-test.exe",
+                "relay",
+                "credential",
+                "set",
+                "--stdin",
+                "--json",
+            ),
+            b"relay-token-fixture",
+        ),
+        (
+            lambda: client.clear_relay_credential(),
+            (
+                "C:/tools/conu-test.exe",
+                "relay",
+                "credential",
+                "clear",
+                "--json",
+            ),
+            None,
+        ),
+        (
+            lambda: client.telemetry_snapshot(),
+            (
+                "C:/tools/conu-test.exe",
+                "telemetry",
+                "snapshot",
+                "--json",
+            ),
+            None,
+        ),
+        (
+            lambda: client.rotate_logs(max_bytes=4096, keep=3),
+            (
+                "C:/tools/conu-test.exe",
+                "logs",
+                "rotate",
+                "--json",
+                "--max-bytes",
+                "4096",
+                "--keep",
+                "3",
+            ),
+            None,
+        ),
+        (
+            lambda: client.send_message("agent.alpha", "agent.beta", "payload fixture"),
+            (
+                "C:/tools/conu-test.exe",
+                "messages",
+                "send",
+                "agent.alpha",
+                "agent.beta",
+                "--stdin",
+                "--json",
+            ),
+            b"payload fixture",
+        ),
+        (
+            lambda: client.write_stream("stream.local.1", bytearray(b"stream fixture")),
+            (
+                "C:/tools/conu-test.exe",
+                "streams",
+                "write",
+                "stream.local.1",
+                "--stdin",
+                "--json",
+            ),
+            b"stream fixture",
+        ),
+    )
+
+    for action, expected_argv, expected_input in calls:
+        result = action()
+        if result.get("contentsDisplayed") is not False:
+            raise AssertionError("Python SDK command helper should preserve display guard results")
+        recorded = captured[-1]
+        if recorded["argv"] != expected_argv:
+            raise AssertionError(f"unexpected argv: {recorded['argv']!r}")
+        if recorded["input"] != expected_input:
+            raise AssertionError(f"unexpected stdin bytes for {expected_argv!r}")
+        if expected_input is not None:
+            rendered_argv = " ".join(recorded["argv"])
+            if expected_input.decode("utf-8") in rendered_argv:
+                raise AssertionError("Python SDK placed stdin-only secret/payload in argv")
+
+
+def run_stdin_secret_failure_redaction_test(module) -> None:
+    captured: dict[str, bytes | None] = {}
+    secret = b"relay-token-fixture-secret"
+
+    class FailedCompleted:
+        stdout = b"stdout relay-token-fixture-secret"
+        stderr = b"stderr relay-token-fixture-secret"
+        returncode = 9
+
+    def fake_run(_argv, input=None, **_kwargs):
+        captured["input"] = input
+        return FailedCompleted()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.set_relay_credential(secret)
+    except module.ConuError as exc:
+        rendered = str(exc)
+    else:
+        raise AssertionError("expected Python SDK relay credential failure")
+
+    if captured.get("input") != secret:
+        raise AssertionError("Python SDK relay credential token should pass through stdin")
+    if secret.decode("utf-8") in rendered:
+        raise AssertionError("Python SDK error leaked relay credential stdin")
+    if "conu-test.exe [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK stdin failure should retain only safe command metadata")
+
+
 def main() -> int:
     module = load_sdk()
     run_failed_command_redaction_test(module)
@@ -278,6 +479,8 @@ def main() -> int:
     run_invalid_json_redaction_test(module)
     run_receive_message_helper_test(module)
     run_mcp_shape_redaction_tests(module)
+    run_command_surface_parity_test(module)
+    run_stdin_secret_failure_redaction_test(module)
     print("Python SDK error redaction regression checks passed")
     return 0
 

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -56,6 +56,46 @@ class ConuClient:
     def security_audit(self) -> dict[str, Any]:
         return self._run_json(self.conu_bin, "security", "audit", "--json")
 
+    def rotate_identity(self) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "security",
+            "rotate",
+            "identity",
+            "--confirm-peer-refresh",
+            "--json",
+        )
+
+    def retire_identity_archives(self) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "security",
+            "retire",
+            "identity",
+            "--confirm-peer-refresh-complete",
+            "--json",
+        )
+
+    def rotate_storage(self) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "security",
+            "rotate",
+            "storage",
+            "--confirm",
+            "--json",
+        )
+
+    def retire_storage(self) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "security",
+            "retire",
+            "storage",
+            "--confirm",
+            "--json",
+        )
+
     def status(self) -> dict[str, Any]:
         return self._run_json(self.conu_bin, "status", "--json")
 
@@ -257,7 +297,7 @@ class ConuClient:
         self,
         from_agent_id: str,
         to_agent_id: str,
-        payload: bytes,
+        payload: bytes | bytearray | memoryview | str,
     ) -> dict[str, Any]:
         return self._run_json(
             self.conu_bin,
@@ -267,7 +307,7 @@ class ConuClient:
             to_agent_id,
             "--stdin",
             "--json",
-            input_bytes=payload,
+            input_bytes=_to_bytes(payload),
         )
 
     def send_remote_message(
@@ -275,7 +315,7 @@ class ConuClient:
         from_agent_id: str,
         to_agent_id: str,
         peer_node_id: str,
-        payload: bytes,
+        payload: bytes | bytearray | memoryview | str,
     ) -> dict[str, Any]:
         return self._run_json(
             self.conu_bin,
@@ -287,7 +327,7 @@ class ConuClient:
             peer_node_id,
             "--stdin",
             "--json",
-            input_bytes=payload,
+            input_bytes=_to_bytes(payload),
         )
 
     def create_room(
@@ -322,7 +362,7 @@ class ConuClient:
         room_id: str,
         from_agent_id: str,
         topic: str,
-        payload: bytes,
+        payload: bytes | bytearray | memoryview | str,
     ) -> dict[str, Any]:
         return self._run_json(
             self.conu_bin,
@@ -333,7 +373,7 @@ class ConuClient:
             topic,
             "--stdin",
             "--json",
-            input_bytes=payload,
+            input_bytes=_to_bytes(payload),
         )
 
     def room_topic_policies(self) -> dict[str, Any]:
@@ -391,6 +431,26 @@ class ConuClient:
             "--json",
         )
 
+    def relay_credential_status(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "relay", "credential", "status", "--json")
+
+    def set_relay_credential(
+        self,
+        token: bytes | bytearray | memoryview | str,
+    ) -> dict[str, Any]:
+        return self._run_json(
+            self.conu_bin,
+            "relay",
+            "credential",
+            "set",
+            "--stdin",
+            "--json",
+            input_bytes=_to_bytes(token),
+        )
+
+    def clear_relay_credential(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "relay", "credential", "clear", "--json")
+
     def open_stream(
         self,
         from_agent_id: str,
@@ -408,7 +468,11 @@ class ConuClient:
             "--json",
         )
 
-    def write_stream(self, stream_id: str, payload: bytes) -> dict[str, Any]:
+    def write_stream(
+        self,
+        stream_id: str,
+        payload: bytes | bytearray | memoryview | str,
+    ) -> dict[str, Any]:
         return self._run_json(
             self.conu_bin,
             "streams",
@@ -416,7 +480,7 @@ class ConuClient:
             stream_id,
             "--stdin",
             "--json",
-            input_bytes=payload,
+            input_bytes=_to_bytes(payload),
         )
 
     def close_stream(self, stream_id: str) -> dict[str, Any]:
@@ -427,6 +491,21 @@ class ConuClient:
             stream_id,
             "--json",
         )
+
+    def telemetry_snapshot(self) -> dict[str, Any]:
+        return self._run_json(self.conu_bin, "telemetry", "snapshot", "--json")
+
+    def rotate_logs(
+        self,
+        max_bytes: int | None = None,
+        keep: int | None = None,
+    ) -> dict[str, Any]:
+        args = ["logs", "rotate", "--json"]
+        if max_bytes is not None:
+            args.extend(["--max-bytes", str(max_bytes)])
+        if keep is not None:
+            args.extend(["--keep", str(keep)])
+        return self._run_json(self.conu_bin, *args)
 
     def process_queued(self) -> CommandResult:
         return self._run(self.conud_bin, "--process-ipc")
@@ -573,6 +652,14 @@ def _safe_mcp_error(error: Any) -> str:
     if isinstance(error, dict) and isinstance(error.get("code"), int):
         return f"code {error['code']}"
     return "unknown MCP error"
+
+
+def _to_bytes(value: bytes | bytearray | memoryview | str) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, (bytearray, memoryview)):
+        return bytes(value)
+    return str(value).encode("utf-8")
 
 
 def _hex_to_bytes(payload_hex: str, binary: str) -> bytes:


### PR DESCRIPTION
## **User description**
## Summary
- add Python SDK helpers for security key rotation and retirement
- add relay credential status/set/clear helpers with stdin-only token handling
- add telemetry snapshot and log rotation helpers
- expand Python SDK regression coverage for command parity and stdin secret redaction

## Validation
- python scripts\\check-python-sdk-error-redaction.py
- python scripts\\check-python-script-compile.py
- python -m py_compile sdk\\python\\conu_sdk\\__init__.py scripts\\check-python-sdk-error-redaction.py examples\\python\\local_agent_pair.py
- git diff --check
- npm run check --prefix sdk/typescript
- npm run check --prefix packaging/npm/conu-cli
- python scripts\\verify-npm-package-contents.py
- python scripts\\verify-npm-package-contents-regression.py
- python scripts\\check-npm-publish-preflight.py
- python scripts\\check-npm-publish-preflight-regression.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\verify-release-versions.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-actions-permissions-regression.py
- python scripts\\check-github-repository-security-regression.py
- python scripts\\check-tagged-release-readiness-regression.py
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Closes #718

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the Python SDK to CLI command parity by adding security rotation/retirement, relay credential management, telemetry snapshot, and log rotation helpers. Also broadens payload types and adds regression tests for stdin-only handling and error redaction.

- **New Features**
  - `conu_sdk.ConuClient` security: `rotate_identity`, `retire_identity_archives`, `rotate_storage`, `retire_storage`.
  - Relay credential: `relay_credential_status`, `set_relay_credential` (stdin token), `clear_relay_credential`.
  - Telemetry & logs: `telemetry_snapshot`, `rotate_logs(max_bytes, keep)`.
  - Payload typing: `send_message`, `send_remote_message`, `publish_room_event`, `write_stream` now accept `bytes | bytearray | memoryview | str`.
  - Regression tests for command surface parity, stdin-only payloads, and failure redaction.

<sup>Written for commit 628efe1c978371100aadbd1e4921b8a42a89ed87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add Python SDK support for more CLI commands and safer stdin payload handling**

### What Changed
- Added Python SDK helpers for security key rotation and retirement, relay credential status/set/clear, telemetry snapshot, and log rotation
- Let message, stream, and room payloads be passed as text or binary data while still sending them through stdin
- Kept secrets and payloads out of command arguments in error cases, so failures now show safe command details without exposing stdin content
- Expanded regression checks to cover command parity and stdin secret redaction

### Impact
`✅ Easier access to security and relay management from Python`
`✅ Fewer accidental secret leaks in error messages`
`✅ Safer message and stream sends with text or binary payloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded payload handling across messaging and streaming methods to accept multiple input types beyond bytes.
  * Added identity and storage rotation methods for lifecycle management.
  * Extended relay credential management with status checking and credential setting capabilities.
  * Added telemetry snapshot and enhanced log rotation with configurable parameters.

* **Tests**
  * Added regression tests for error redaction and command surface parity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->