### PR TITLE
Add Python SDK error result metadata

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -44,6 +44,22 @@ def assert_redacted(rendered: str) -> None:
             raise AssertionError(f"Python SDK error leaked sensitive text: {forbidden}")
 
 
+def assert_safe_error_result(exc, expected_binary: str, expected_returncode: int) -> None:
+    result = getattr(exc, "result", None)
+    if result is None:
+        raise AssertionError("Python SDK error should include redacted result metadata")
+    rendered = repr((result.args, result.stdout, result.stderr, result.returncode))
+    assert_redacted(rendered)
+    if result.args != (expected_binary, "[arguments redacted]"):
+        raise AssertionError(f"Python SDK error result kept unsafe args: {result.args!r}")
+    if result.stdout != "" or result.stderr != "":
+        raise AssertionError("Python SDK error result should redact stdout and stderr")
+    if result.returncode != expected_returncode:
+        raise AssertionError(
+            f"Python SDK error result returncode mismatch: {result.returncode!r}"
+        )
+
+
 def run_failed_command_redaction_test(module) -> None:
     captured: dict[str, tuple[str, ...]] = {}
 
@@ -62,6 +78,7 @@ def run_failed_command_redaction_test(module) -> None:
         )
     except module.ConuError as exc:
         rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 2)
     else:
         raise AssertionError("expected Python SDK command failure")
 
@@ -82,6 +99,7 @@ def run_spawn_error_redaction_test(module) -> None:
         client.status()
     except module.ConuError as exc:
         rendered = str(exc)
+        assert_safe_error_result(exc, "conu", 1)
     else:
         raise AssertionError("expected Python SDK spawn failure")
 
@@ -105,6 +123,7 @@ def run_invalid_json_redaction_test(module) -> None:
         client.status()
     except module.ConuError as exc:
         rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 1)
     else:
         raise AssertionError("expected Python SDK JSON parse failure")
 
@@ -263,6 +282,7 @@ def run_mcp_shape_redaction_tests(module) -> None:
             action(client)
         except module.ConuError as exc:
             rendered = str(exc)
+            assert_safe_error_result(exc, "conu-mcp-test.exe", 1)
         else:
             raise AssertionError("expected Python SDK MCP shape failure")
 
@@ -461,6 +481,7 @@ def run_stdin_secret_failure_redaction_test(module) -> None:
         client.set_relay_credential(secret)
     except module.ConuError as exc:
         rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 9)
     else:
         raise AssertionError("expected Python SDK relay credential failure")
 

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -14,10 +14,6 @@ from pathlib import Path
 from typing import Any
 
 
-class ConuError(RuntimeError):
-    """Raised when a conU command exits unsuccessfully."""
-
-
 @dataclass(frozen=True)
 class CommandResult:
     """Result of one conU subprocess call."""
@@ -26,6 +22,14 @@ class CommandResult:
     stdout: str
     stderr: str
     returncode: int
+
+
+class ConuError(RuntimeError):
+    """Raised when a conU command exits unsuccessfully."""
+
+    def __init__(self, message: str, result: CommandResult | None = None) -> None:
+        super().__init__(message)
+        self.result = result
 
 
 class ConuClient:
@@ -241,9 +245,11 @@ class ConuClient:
         received = self.receive_message(agent_id, envelope_id, include_payload=True)
         payload_hex = received.get("payloadHex")
         if not isinstance(payload_hex, str):
+            safe_result = _result_for_error(1, self.mcp_bin)
             raise ConuError(
                 f"conU receive response did not include payloadHex: "
-                f"{_safe_command_for_error(self.mcp_bin)}"
+                f"{_safe_command_for_error(self.mcp_bin)}",
+                safe_result,
             )
         return _hex_to_bytes(payload_hex, self.mcp_bin)
 
@@ -523,8 +529,10 @@ class ConuClient:
         try:
             return json.loads(result.stdout)
         except json.JSONDecodeError:
+            safe_result = _result_for_error(1, binary)
             raise ConuError(
-                f"conU command returned invalid JSON: {_safe_command_for_error(binary)}"
+                f"conU command returned invalid JSON: {_safe_command_for_error(binary)}",
+                safe_result,
             ) from None
 
     def _call_mcp_tool(
@@ -548,20 +556,26 @@ class ConuClient:
         response = _parse_mcp_response(result.stdout, self.mcp_bin)
         error = response.get("error")
         if error is not None:
+            safe_result = _result_for_error(1, self.mcp_bin)
             raise ConuError(
                 f"conU MCP tool failed: {_safe_mcp_error(error)}: "
-                f"{_safe_command_for_error(self.mcp_bin)}"
+                f"{_safe_command_for_error(self.mcp_bin)}",
+                safe_result,
             )
         tool_result = response.get("result")
         if not isinstance(tool_result, dict):
+            safe_result = _result_for_error(1, self.mcp_bin)
             raise ConuError(
                 f"conU MCP response did not include a tool result: "
-                f"{_safe_command_for_error(self.mcp_bin)}"
+                f"{_safe_command_for_error(self.mcp_bin)}",
+                safe_result,
             )
         if tool_result.get("isError") is True:
+            safe_result = _result_for_error(1, self.mcp_bin)
             raise ConuError(
                 f"conU MCP tool failed: [details redacted]: "
-                f"{_safe_command_for_error(self.mcp_bin)}"
+                f"{_safe_command_for_error(self.mcp_bin)}",
+                safe_result,
             )
         return _parse_json_for_sdk(
             _tool_text(tool_result, self.mcp_bin),
@@ -587,21 +601,35 @@ class ConuClient:
                 check=False,
             )
         except OSError:
+            safe_result = _result_for_error(1, binary)
             raise ConuError(
-                f"conU command failed before execution: {_safe_command_for_error(binary)}"
+                f"conU command failed before execution: {_safe_command_for_error(binary)}",
+                safe_result,
             ) from None
         stdout = completed.stdout.decode("utf-8", errors="replace")
         stderr = completed.stderr.decode("utf-8", errors="replace")
         result = CommandResult(argv, stdout, stderr, completed.returncode)
         if completed.returncode != 0:
+            safe_result = _result_for_error(completed.returncode, binary)
             raise ConuError(
-                f"conU command failed ({completed.returncode}): {_safe_command_for_error(binary)}"
+                f"conU command failed ({completed.returncode}): "
+                f"{_safe_command_for_error(binary)}",
+                safe_result,
             )
         return result
 
 
 def _safe_command_for_error(binary: str) -> str:
     return f"{_safe_binary_name(binary)} [arguments redacted]"
+
+
+def _result_for_error(returncode: int, binary: str) -> CommandResult:
+    return CommandResult(
+        (_safe_binary_name(binary), "[arguments redacted]"),
+        "",
+        "",
+        returncode,
+    )
 
 
 def _safe_binary_name(binary: str) -> str:
@@ -621,7 +649,10 @@ def _safe_binary_name(binary: str) -> str:
 def _parse_mcp_response(stdout: str, binary: str) -> dict[str, Any]:
     line = next((value.strip() for value in stdout.splitlines() if value.strip()), None)
     if line is None:
-        raise ConuError(f"conU MCP response was empty: {_safe_command_for_error(binary)}")
+        raise ConuError(
+            f"conU MCP response was empty: {_safe_command_for_error(binary)}",
+            _result_for_error(1, binary),
+        )
     return _parse_json_for_sdk(line, binary, "conU MCP response was invalid JSON")
 
 
@@ -629,9 +660,15 @@ def _parse_json_for_sdk(text: str, binary: str, message: str) -> dict[str, Any]:
     try:
         value = json.loads(text)
     except json.JSONDecodeError:
-        raise ConuError(f"{message}: {_safe_command_for_error(binary)}") from None
+        raise ConuError(
+            f"{message}: {_safe_command_for_error(binary)}",
+            _result_for_error(1, binary),
+        ) from None
     if not isinstance(value, dict):
-        raise ConuError(f"{message}: {_safe_command_for_error(binary)}")
+        raise ConuError(
+            f"{message}: {_safe_command_for_error(binary)}",
+            _result_for_error(1, binary),
+        )
     return value
 
 
@@ -644,7 +681,9 @@ def _tool_text(tool_result: dict[str, Any], binary: str) -> str:
                 if isinstance(text, str):
                     return text
     raise ConuError(
-        f"conU MCP tool response did not include text content: {_safe_command_for_error(binary)}"
+        f"conU MCP tool response did not include text content: "
+        f"{_safe_command_for_error(binary)}",
+        _result_for_error(1, binary),
     )
 
 
@@ -666,9 +705,11 @@ def _hex_to_bytes(payload_hex: str, binary: str) -> bytes:
     if len(payload_hex) % 2 != 0 or any(
         character not in "0123456789abcdefABCDEF" for character in payload_hex
     ):
+        safe_result = _result_for_error(1, binary)
         raise ConuError(
             f"conU receive response included invalid payloadHex: "
-            f"{_safe_command_for_error(binary)}"
+            f"{_safe_command_for_error(binary)}",
+            safe_result,
         )
     return bytes.fromhex(payload_hex)
 


### PR DESCRIPTION
## **User description**
## Summary
- attach redacted CommandResult metadata to Python ConuError failures
- redact command args, stdout, and stderr from structured failure results
- extend Python SDK regressions to inspect both exception messages and result metadata

## Validation
- python scripts\\check-python-sdk-error-redaction.py
- python scripts\\check-python-script-compile.py
- python -m py_compile sdk\\python\\conu_sdk\\__init__.py scripts\\check-python-sdk-error-redaction.py examples\\python\\local_agent_pair.py
- git diff --check
- npm run check --prefix sdk/typescript
- npm run check --prefix packaging/npm/conu-cli
- python scripts\\verify-npm-package-contents.py
- python scripts\\verify-npm-package-contents-regression.py
- python scripts\\check-npm-publish-preflight.py
- python scripts\\check-npm-publish-preflight-regression.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\verify-release-versions.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-actions-permissions-regression.py
- python scripts\\check-github-repository-security-regression.py
- python scripts\\check-tagged-release-readiness-regression.py
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Closes #720

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach redacted `CommandResult` metadata to `ConuError` so callers can read the binary and return code without leaking args, stdout, or stderr (closes #720). All error paths and regression checks now enforce this redaction.

- **New Features**
  - `ConuError` now includes `result: CommandResult` with redacted fields: `args` → (`<binary>`, "[arguments redacted]"), empty `stdout`/`stderr`, and the `returncode`.
  - Populated `result` across failures (non-zero exit, spawn errors, invalid JSON/MCP responses, invalid `payloadHex`) and extended `scripts/check-python-sdk-error-redaction.py` to assert the presence and safety of `result`.

<sup>Written for commit c690f5a302984b9e29adcb93fb42ff4d4abd91ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Include redacted command results on Python SDK errors**

### What Changed
- Python SDK failures now carry a safe result object with the command name, redacted arguments, empty output, and the exit code
- Error cases from failed commands, invalid JSON, MCP failures, and bad payload data now return the same redacted result details
- SDK error checks now verify both the error message and the attached safe result metadata

### Impact
`✅ Clearer Python SDK failure details`
`✅ Safer error diagnostics`
`✅ Consistent exit-code reporting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
