### PR TITLE
Add Python SDK redaction flags

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -48,7 +48,17 @@ def assert_safe_error_result(exc, expected_binary: str, expected_returncode: int
     result = getattr(exc, "result", None)
     if result is None:
         raise AssertionError("Python SDK error should include redacted result metadata")
-    rendered = repr((result.args, result.stdout, result.stderr, result.returncode))
+    rendered = repr(
+        (
+            result.args,
+            result.stdout,
+            result.stderr,
+            result.returncode,
+            result.contents_displayed,
+            result.args_redacted,
+            result.stdio_redacted,
+        )
+    )
     assert_redacted(rendered)
     if result.args != (expected_binary, "[arguments redacted]"):
         raise AssertionError(f"Python SDK error result kept unsafe args: {result.args!r}")
@@ -58,6 +68,43 @@ def assert_safe_error_result(exc, expected_binary: str, expected_returncode: int
         raise AssertionError(
             f"Python SDK error result returncode mismatch: {result.returncode!r}"
         )
+    if result.contents_displayed is not False:
+        raise AssertionError("Python SDK error result should mark contents_displayed false")
+    if result.args_redacted is not True:
+        raise AssertionError("Python SDK error result should mark args_redacted true")
+    if result.stdio_redacted is not True:
+        raise AssertionError("Python SDK error result should mark stdio_redacted true")
+
+
+def assert_success_result_defaults(result) -> None:
+    if result.contents_displayed is not True:
+        raise AssertionError("Python SDK successful result should keep contents_displayed true")
+    if result.args_redacted is not False:
+        raise AssertionError("Python SDK successful result should not mark args redacted")
+    if result.stdio_redacted is not False:
+        raise AssertionError("Python SDK successful result should not mark stdio redacted")
+
+
+def run_success_result_metadata_test(module) -> None:
+    class SuccessCompleted:
+        stdout = b"safe stdout"
+        stderr = b"safe stderr"
+        returncode = 0
+
+    def fake_run(argv, **_kwargs):
+        return SuccessCompleted()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    result = client.init()
+
+    if result.args != ("C:/tools/conu-test.exe", "init"):
+        raise AssertionError("Python SDK successful result should keep actual argv")
+    if result.stdout != "safe stdout" or result.stderr != "safe stderr":
+        raise AssertionError("Python SDK successful result should keep command output")
+    if result.returncode != 0:
+        raise AssertionError("Python SDK successful result should keep returncode")
+    assert_success_result_defaults(result)
 
 
 def run_failed_command_redaction_test(module) -> None:
@@ -495,6 +542,7 @@ def run_stdin_secret_failure_redaction_test(module) -> None:
 
 def main() -> int:
     module = load_sdk()
+    run_success_result_metadata_test(module)
     run_failed_command_redaction_test(module)
     run_spawn_error_redaction_test(module)
     run_invalid_json_redaction_test(module)

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -22,6 +22,9 @@ class CommandResult:
     stdout: str
     stderr: str
     returncode: int
+    contents_displayed: bool = True
+    args_redacted: bool = False
+    stdio_redacted: bool = False
 
 
 class ConuError(RuntimeError):
@@ -629,6 +632,9 @@ def _result_for_error(returncode: int, binary: str) -> CommandResult:
         "",
         "",
         returncode,
+        contents_displayed=False,
+        args_redacted=True,
+        stdio_redacted=True,
     )
 
 


### PR DESCRIPTION
## **User description**
## Summary
- add explicit redaction/display guard fields to Python SDK CommandResult
- mark ConuError.result metadata as contents_displayed=false, args_redacted=true, and stdio_redacted=true
- expand Python SDK regressions for redacted failure flags and successful result defaults

## Validation
- python scripts\\check-python-sdk-error-redaction.py
- python scripts\\check-python-script-compile.py
- python -m py_compile sdk\\python\\conu_sdk\\__init__.py scripts\\check-python-sdk-error-redaction.py examples\\python\\local_agent_pair.py
- git diff --check
- npm run check --prefix sdk/typescript
- npm run check --prefix packaging/npm/conu-cli
- python scripts\\verify-npm-package-contents.py
- python scripts\\verify-npm-package-contents-regression.py
- python scripts\\check-npm-publish-preflight.py
- python scripts\\check-npm-publish-preflight-regression.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\verify-release-versions.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-actions-permissions-regression.py
- python scripts\\check-github-repository-security-regression.py
- python scripts\\check-tagged-release-readiness-regression.py
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Closes #722

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit redaction flags to the Python `conu_sdk` `CommandResult` and sets safe defaults on errors to improve output privacy and make redaction state clear. Addresses #722.

- **New Features**
  - Added `contents_displayed`, `args_redacted`, and `stdio_redacted` to `CommandResult` with success defaults: True, False, False.
  - Error results (`ConuError.result`) now set: `contents_displayed=False`, `args_redacted=True`, `stdio_redacted=True`.
  - Expanded `scripts/check-python-sdk-error-redaction.py` to verify error redaction flags and successful result defaults.

<sup>Written for commit baa33a7746fb67e2dadb1636bb53fb9a18f383ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add explicit redaction state to Python SDK results**

### What Changed
- Python SDK results now include clear flags showing whether command contents were displayed, and whether arguments or output were redacted
- Failed commands now mark their results as redacted and keep only safe command details
- Successful commands keep their real arguments and output, with redaction flags left off by default
- Added regression checks for both successful result defaults and redacted error results

### Impact
`✅ Clearer redaction status in Python SDK results`
`✅ Safer error details for failed commands`
`✅ Fewer privacy regressions in SDK output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
