### PR TITLE
Fail closed on non-object SDK JSON

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -179,6 +179,30 @@ def run_invalid_json_redaction_test(module) -> None:
         raise AssertionError("Python SDK JSON parse error should retain only safe command metadata")
 
 
+def run_non_object_json_redaction_test(module) -> None:
+    class JsonCompleted:
+        stdout = json.dumps([f"array item with {SENSITIVE_ENDPOINT}"]).encode("utf-8")
+        stderr = SENSITIVE_STDERR.encode("utf-8")
+        returncode = 0
+
+    def fake_run(argv, **_kwargs):
+        return JsonCompleted()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.status()
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 1)
+    else:
+        raise AssertionError("expected Python SDK non-object JSON failure")
+
+    assert_redacted(rendered)
+    if "conU command returned invalid JSON: conu-test.exe [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK non-object JSON error should retain safe metadata only")
+
+
 def run_receive_message_helper_test(module) -> None:
     captured_requests: list[dict] = []
 
@@ -316,6 +340,24 @@ def run_mcp_shape_redaction_tests(module) -> None:
             },
             lambda client: client.receive_message("agent.beta", "env.local.1"),
             "conU MCP tool failed: code -32602: conu-mcp-test.exe [arguments redacted]",
+        ),
+        (
+            "MCP text non-object JSON",
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps([f"array item with {SENSITIVE_ENDPOINT}"]),
+                        }
+                    ],
+                    "isError": False,
+                },
+            },
+            lambda client: client.receive_message("agent.beta", "env.local.1"),
+            "conU MCP tool returned invalid JSON: conu-mcp-test.exe [arguments redacted]",
         ),
     )
 
@@ -546,6 +588,7 @@ def main() -> int:
     run_failed_command_redaction_test(module)
     run_spawn_error_redaction_test(module)
     run_invalid_json_redaction_test(module)
+    run_non_object_json_redaction_test(module)
     run_receive_message_helper_test(module)
     run_mcp_shape_redaction_tests(module)
     run_command_surface_parity_test(module)

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -529,14 +529,7 @@ class ConuClient:
         input_bytes: bytes | None = None,
     ) -> dict[str, Any]:
         result = self._run(binary, *args, input_bytes=input_bytes)
-        try:
-            return json.loads(result.stdout)
-        except json.JSONDecodeError:
-            safe_result = _result_for_error(1, binary)
-            raise ConuError(
-                f"conU command returned invalid JSON: {_safe_command_for_error(binary)}",
-                safe_result,
-            ) from None
+        return _parse_json_for_sdk(result.stdout, binary, "conU command returned invalid JSON")
 
     def _call_mcp_tool(
         self,

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -561,11 +561,16 @@ function safeMcpError(error) {
 }
 
 function parseJsonForSdk(text, binary, message) {
+  let value;
   try {
-    return JSON.parse(text);
+    value = JSON.parse(text);
   } catch (_error) {
     throw new ConuError(message, resultForError({ code: 1 }, binary));
   }
+  if (!isRecord(value)) {
+    throw new ConuError(message, resultForError({ code: 1 }, binary));
+  }
+  return value;
 }
 
 function resultForError(result, binary) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -477,6 +477,37 @@ assert.throws(
   },
 );
 
+const commandJsonNonObject = new ConuClient({
+  conuBin: "C:/tools/conu-test.exe",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: JSON.stringify([`array item with ${secretEndpoint}`]),
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => commandJsonNonObject.status(),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.equal(error.message, "conU command returned invalid JSON");
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);
+
 const mcpJsonMalformed = new ConuClient({
   mcpBin: "conu-mcp-test",
   runner({ binary }) {
@@ -498,6 +529,49 @@ const mcpJsonMalformed = new ConuClient({
 
 assert.throws(
   () => mcpJsonMalformed.receiveMessage("agent.beta", "env.local.1"),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private fixture"));
+    assert.equal(error.message, "conU MCP tool returned invalid JSON");
+    assert.deepEqual(error.result.args, ["conu-mcp-test", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    return true;
+  },
+);
+
+const mcpJsonNonObject = new ConuClient({
+  mcpBin: "conu-mcp-test",
+  runner({ binary }) {
+    return {
+      args: [binary],
+      stdout: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify([`array item with ${secretEndpoint}`]),
+            },
+          ],
+          isError: false,
+        },
+      }),
+      stderr: "stderr with private fixture",
+      code: 0,
+    };
+  },
+});
+
+assert.throws(
+  () => mcpJsonNonObject.receiveMessage("agent.beta", "env.local.1"),
   (error) => {
     assert.ok(error instanceof ConuError);
     const rendered = JSON.stringify({


### PR DESCRIPTION
## **User description**
## Summary
- make Python SDK command JSON parsing require object-shaped responses
- make TypeScript SDK JSON parsing require object-shaped command and MCP tool responses
- add redaction regressions for direct command and MCP non-object JSON failures

## Validation
- python scripts\\check-python-sdk-error-redaction.py
- npm run check --prefix sdk/typescript
- python scripts\\check-python-script-compile.py
- python -m py_compile sdk\\python\\conu_sdk\\__init__.py scripts\\check-python-sdk-error-redaction.py examples\\python\\local_agent_pair.py
- git diff --check
- npm run check --prefix packaging/npm/conu-cli
- python scripts\\verify-npm-package-contents.py
- python scripts\\verify-npm-package-contents-regression.py
- python scripts\\check-npm-publish-preflight.py
- python scripts\\check-npm-publish-preflight-regression.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\verify-release-versions.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-actions-permissions-regression.py
- python scripts\\check-github-repository-security-regression.py
- python scripts\\check-tagged-release-readiness-regression.py
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings

Closes #724

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require object-shaped JSON for SDK command and MCP tool responses. Non-object JSON now fails closed with a clear error and redacted details to avoid leaking sensitive info.

- **Bug Fixes**
  - Python SDK: `_run_json` now uses `_parse_json_for_sdk` and requires object JSON; non-object responses raise "conU command returned invalid JSON" with redacted args.
  - TypeScript SDK: `parseJsonForSdk` rejects non-object values; MCP tool text content that decodes to non-object raises "conU MCP tool returned invalid JSON". Added smoke tests to verify redaction for both command and MCP cases.

- **Migration**
  - Update any command or MCP tool that returns arrays or primitives to return an object. The SDK will now error on non-object JSON.

<sup>Written for commit 1fa6a98c7afcc0516fb6cecbf99733f8a9f63e08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject non-object JSON from SDK commands and MCP tool replies**

### What Changed
- SDK command responses now fail when the JSON is not an object, instead of accepting arrays or other shapes
- MCP tool replies now also fail when their text JSON is not an object
- These failures keep the error message generic and hide command details and response contents

### Impact
`✅ Fewer crashes from unexpected SDK JSON`
`✅ Safer handling of malformed tool responses`
`✅ Clearer invalid-JSON errors without exposing private output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
