### PR TITLE
Expose TypeScript SDK redaction result types

### DIFF
--- a/sdk/typescript/src/index.d.ts
+++ b/sdk/typescript/src/index.d.ts
@@ -13,6 +13,9 @@ export interface CommandResult {
   stdout: string;
   stderr: string;
   code: number;
+  contentsDisplayed?: boolean;
+  argsRedacted?: boolean;
+  stdioRedacted?: boolean;
 }
 
 export interface RunnerInput {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { ConuClient, ConuError } from "../src/index.js";
 import {
   BrowserUnsupportedError,
@@ -18,6 +19,14 @@ assert.deepEqual(browserSupport, {
 assert.throws(() => new BrowserConuClient(), BrowserUnsupportedError);
 assert.ok(!browserSupport.reason.includes("token"));
 assert.ok(!browserSupport.reason.includes("payload"));
+
+const nodeDeclarations = readFileSync(new URL("../src/index.d.ts", import.meta.url), "utf8");
+for (const field of ["contentsDisplayed", "argsRedacted", "stdioRedacted"]) {
+  assert.ok(
+    nodeDeclarations.includes(`${field}?: boolean;`),
+    `TypeScript declarations should expose CommandResult.${field}`,
+  );
+}
 
 const calls = [];
 const client = new ConuClient({


### PR DESCRIPTION
## **User description**
Closes #726\n\n## Summary\n- expose TypeScript SDK CommandResult redaction flags in the published declarations\n- add SDK smoke coverage that keeps the declaration surface aligned with runtime ConuError.result metadata\n\n## Validation\n- npm run check --prefix sdk/typescript\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\verify-release-versions.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-github-workflow-permissions-regression.py\n- python scripts\\check-tagged-release-readiness-regression.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `CommandResult` redaction flags in the TypeScript SDK declarations so consumers can access redaction state in a type-safe way. Adds a smoke test to ensure `index.d.ts` includes `contentsDisplayed`, `argsRedacted`, and `stdioRedacted`, keeping declarations aligned with runtime `ConuError.result` metadata.

<sup>Written for commit 012762b3a08e0ef6e2d04337504e3fb816a0018e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Expose redaction status in the TypeScript SDK result types**

### What Changed
- TypeScript consumers can now see whether command output, arguments, or displayed contents were redacted in the returned command result
- Added a smoke check that fails if the published declarations stop including these fields

### Impact
`✅ Safer SDK integrations`
`✅ Clearer redaction handling in TypeScript`
`✅ Fewer declaration/runtime mismatches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
