### PR TITLE
Redact TypeScript SDK runner exceptions

### DIFF
--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -444,13 +444,21 @@ export class ConuClient {
   }
 
   run(binary, args = [], input) {
-    const result = this.runner({
-      binary,
-      args,
-      input,
-      cwd: this.cwd,
-      env: this.env,
-    });
+    let result;
+    try {
+      result = this.runner({
+        binary,
+        args,
+        input,
+        cwd: this.cwd,
+        env: this.env,
+      });
+    } catch (_error) {
+      throw new ConuError(
+        `conU command failed before execution: ${safeCommandForError(binary)}`,
+        resultForError({ code: 1 }, binary),
+      );
+    }
     if (result.code !== 0) {
       const safeResult = resultForError(result, binary);
       throw new ConuError(

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -241,6 +241,39 @@ assert.throws(
   },
 );
 
+const throwingRunner = new ConuClient({
+  conuBin: "C:/tools/conu-test.exe",
+  runner({ binary, args, input }) {
+    throw new Error(
+      `runner leaked ${binary} ${args.join(" ")} ${input?.toString("utf8")} ${secretEndpoint}`,
+    );
+  },
+});
+
+assert.throws(
+  () => throwingRunner.sendMessage("agent.alpha", "agent.beta", "private bytes"),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.ok(!rendered.includes("private bytes"));
+    assert.equal(error.message, "conU command failed before execution: conu-test.exe [arguments redacted]");
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.stdout, "");
+    assert.equal(error.result.stderr, "");
+    assert.equal(error.result.code, 1);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+
 for (const mcpFailureMode of ["protocol", "tool"]) {
   const mcpFailing = new ConuClient({
     mcpBin: "conu-mcp-test",


### PR DESCRIPTION
## **User description**
Closes #728\n\n## Summary\n- wrap TypeScript SDK runner exceptions in redacted ConuError metadata\n- add smoke coverage proving thrown runner errors cannot expose endpoint secrets or payload bytes\n\n## Validation\n- npm run check --prefix sdk/typescript\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\verify-release-versions.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-github-workflow-permissions-regression.py\n- python scripts\\check-tagged-release-readiness-regression.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts TypeScript SDK runner exceptions to prevent leaking secrets. Wraps pre-execution runner errors in ConuError with sanitized message and result.

- **Bug Fixes**
  - Catch synchronous runner throws in ConuClient.run() and rethrow a ConuError with redacted args and stdio (code 1).
  - Added smoke tests to ensure endpoint secrets and payload bytes are never exposed and redaction flags are enforced.

<sup>Written for commit 109ca237cafcc84531a482e91a24050311c1847a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error handling now properly catches and reports failures that occur before command execution begins, providing appropriate error codes and messages
  * Error messages now automatically redact sensitive information including endpoint strings and private values from error payloads and displayed messages to prevent accidental exposure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Redact errors when the TypeScript SDK runner fails before execution**

### What Changed
- If the SDK runner throws before a command starts, the error is now wrapped in a safe ConuError instead of exposing the original failure details
- The error shown to users now says the command failed before execution and includes only a redacted command name
- Smoke coverage now checks that thrown runner errors do not reveal secrets, payload bytes, or raw command data, and that redaction is applied in the returned error result

### Impact
`✅ Fewer secret leaks in SDK errors`
`✅ Safer failure messages during command startup`
`✅ Clearer privacy checks for runner failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
