### PR TITLE
Fail closed on malformed TypeScript runner results

### DIFF
--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -459,6 +459,7 @@ export class ConuClient {
         resultForError({ code: 1 }, binary),
       );
     }
+    result = normalizeRunnerResult(result, binary);
     if (result.code !== 0) {
       const safeResult = resultForError(result, binary);
       throw new ConuError(
@@ -529,6 +530,28 @@ function pushOptionalBool(args, flag, value) {
 function cardBool(values, key, defaultValue) {
   const value = values[key];
   return typeof value === "boolean" ? value : defaultValue;
+}
+
+function normalizeRunnerResult(result, binary) {
+  if (!isRecord(result)) {
+    throw new ConuError(
+      `conU command returned invalid runner result: ${safeCommandForError(binary)}`,
+      resultForError({ code: 1 }, binary),
+    );
+  }
+  try {
+    return {
+      args: Array.isArray(result.args) ? result.args.map((value) => String(value)) : [],
+      stdout: typeof result.stdout === "string" ? result.stdout : decode(result.stdout),
+      stderr: typeof result.stderr === "string" ? result.stderr : decode(result.stderr),
+      code: typeof result.code === "number" ? result.code : 1,
+    };
+  } catch (_error) {
+    throw new ConuError(
+      `conU command returned invalid runner result: ${safeCommandForError(binary)}`,
+      resultForError({ code: 1 }, binary),
+    );
+  }
 }
 
 function isRecord(value) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -274,6 +274,50 @@ assert.throws(
   },
 );
 
+for (const runner of [
+  () => null,
+  () => ({
+    args: ["conu-test", "status", secretEndpoint],
+    stdout: "stdout with private fixture",
+    stderr: "stderr with private fixture",
+    get code() {
+      throw new Error(`runner result leaked ${secretEndpoint}`);
+    },
+  }),
+]) {
+  const malformedRunner = new ConuClient({
+    conuBin: "C:/tools/conu-test.exe",
+    runner,
+  });
+
+  assert.throws(
+    () => malformedRunner.status(),
+    (error) => {
+      assert.ok(error instanceof ConuError);
+      const rendered = JSON.stringify({
+        message: error.message,
+        result: error.result,
+      });
+      assert.ok(!rendered.includes("secret"));
+      assert.ok(!rendered.includes("token=private"));
+      assert.ok(!rendered.includes("relay.example.com"));
+      assert.ok(!rendered.includes("private fixture"));
+      assert.equal(
+        error.message,
+        "conU command returned invalid runner result: conu-test.exe [arguments redacted]",
+      );
+      assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+      assert.equal(error.result.stdout, "");
+      assert.equal(error.result.stderr, "");
+      assert.equal(error.result.code, 1);
+      assert.equal(error.result.contentsDisplayed, false);
+      assert.equal(error.result.argsRedacted, true);
+      assert.equal(error.result.stdioRedacted, true);
+      return true;
+    },
+  );
+}
+
 for (const mcpFailureMode of ["protocol", "tool"]) {
   const mcpFailing = new ConuClient({
     mcpBin: "conu-mcp-test",


### PR DESCRIPTION
## **User description**
Closes #730\n\n## Summary\n- normalize TypeScript SDK runner results before reading command fields\n- fail closed with redacted ConuError metadata for null or getter-failing runner results\n- add smoke coverage proving malformed runner results do not expose endpoint secrets or payload-like output\n\n## Validation\n- npm run check --prefix sdk/typescript\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\verify-release-versions.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-github-workflow-permissions-regression.py\n- python scripts\\check-tagged-release-readiness-regression.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed on malformed TypeScript runner results by normalizing the runner output before use and throwing a redacted error on invalid shapes. Adds smoke tests to confirm no secrets or payload-like data leak.

- **Bug Fixes**
  - Normalize runner result (`args`, `stdout`, `stderr`, `code`) before reading.
  - Throw redacted `ConuError` when result is not a plain object or property access fails; default `code` to 1.
  - Add smoke tests for null and getter-throwing results to ensure args/stdio are redacted and secrets stay private.

<sup>Written for commit f23656904202c5de6f8025e06fd2b92ff8228c53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fail closed when the TypeScript runner returns an invalid result**

### What Changed
- If the runner returns nothing or an unexpected value, conU now stops with a redacted error instead of continuing
- If reading the runner result fails, conU also treats it as an invalid result and hides secrets, arguments, and output
- Added smoke coverage for null and getter-failing results to confirm private data does not appear in errors

### Impact
`✅ Fewer crashes from malformed runner results`
`✅ Clearer errors when command output is unusable`
`✅ Reduced risk of secret leakage in failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
