### PR TITLE
Redact Python SDK subprocess boundary failures

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -155,6 +155,112 @@ def run_spawn_error_redaction_test(module) -> None:
         raise AssertionError("Python SDK spawn error should use a generic safe binary label")
 
 
+def run_subprocess_exception_redaction_test(module) -> None:
+    def fake_run(_argv, **_kwargs):
+        raise RuntimeError(f"custom runner exposed {SENSITIVE_ENDPOINT}")
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.status()
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 1)
+    else:
+        raise AssertionError("expected Python SDK subprocess runner failure")
+
+    assert_redacted(rendered)
+    if "conU command failed before execution: conu-test.exe [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK subprocess error should retain safe metadata only")
+
+
+def run_malformed_completed_stdio_redaction_test(module) -> None:
+    class MalformedCompleted:
+        stderr = b"safe stderr"
+        returncode = 0
+
+        @property
+        def stdout(self):
+            raise RuntimeError(f"stdout getter exposed {SENSITIVE_ENDPOINT}")
+
+    def fake_run(_argv, **_kwargs):
+        return MalformedCompleted()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.status()
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 1)
+    else:
+        raise AssertionError("expected Python SDK malformed stdio failure")
+
+    assert_redacted(rendered)
+    if (
+        "conU command returned malformed process result: "
+        "conu-test.exe [arguments redacted]"
+    ) not in rendered:
+        raise AssertionError("Python SDK malformed stdio error should retain safe metadata only")
+
+
+def run_malformed_completed_returncode_redaction_test(module) -> None:
+    class MalformedCompleted:
+        stdout = b"safe stdout"
+        stderr = b"safe stderr"
+
+        @property
+        def returncode(self):
+            raise RuntimeError(f"returncode getter exposed {SENSITIVE_ENDPOINT}")
+
+    def fake_run(_argv, **_kwargs):
+        return MalformedCompleted()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.status()
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 1)
+    else:
+        raise AssertionError("expected Python SDK malformed returncode failure")
+
+    assert_redacted(rendered)
+    if (
+        "conU command returned malformed process result: "
+        "conu-test.exe [arguments redacted]"
+    ) not in rendered:
+        raise AssertionError("Python SDK malformed returncode error should retain safe metadata only")
+
+
+def run_malformed_completed_returncode_type_redaction_test(module) -> None:
+    class MalformedCompleted:
+        stdout = b"safe stdout"
+        stderr = b"safe stderr"
+        returncode = "0"
+
+    def fake_run(_argv, **_kwargs):
+        return MalformedCompleted()
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.status()
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 1)
+    else:
+        raise AssertionError("expected Python SDK malformed returncode type failure")
+
+    assert_redacted(rendered)
+    if (
+        "conU command returned malformed process result: "
+        "conu-test.exe [arguments redacted]"
+    ) not in rendered:
+        raise AssertionError("Python SDK malformed returncode type should retain safe metadata only")
+
+
 def run_invalid_json_redaction_test(module) -> None:
     class JsonCompleted:
         stdout = f"not json with {SENSITIVE_ENDPOINT}".encode("utf-8")
@@ -587,6 +693,10 @@ def main() -> int:
     run_success_result_metadata_test(module)
     run_failed_command_redaction_test(module)
     run_spawn_error_redaction_test(module)
+    run_subprocess_exception_redaction_test(module)
+    run_malformed_completed_stdio_redaction_test(module)
+    run_malformed_completed_returncode_redaction_test(module)
+    run_malformed_completed_returncode_type_redaction_test(module)
     run_invalid_json_redaction_test(module)
     run_non_object_json_redaction_test(module)
     run_receive_message_helper_test(module)

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -596,19 +596,17 @@ class ConuClient:
                 env=self.env,
                 check=False,
             )
-        except OSError:
+        except Exception:
             safe_result = _result_for_error(1, binary)
             raise ConuError(
                 f"conU command failed before execution: {_safe_command_for_error(binary)}",
                 safe_result,
             ) from None
-        stdout = completed.stdout.decode("utf-8", errors="replace")
-        stderr = completed.stderr.decode("utf-8", errors="replace")
-        result = CommandResult(argv, stdout, stderr, completed.returncode)
-        if completed.returncode != 0:
-            safe_result = _result_for_error(completed.returncode, binary)
+        result = _completed_process_result(completed, argv, binary)
+        if result.returncode != 0:
+            safe_result = _result_for_error(result.returncode, binary)
             raise ConuError(
-                f"conU command failed ({completed.returncode}): "
+                f"conU command failed ({result.returncode}): "
                 f"{_safe_command_for_error(binary)}",
                 safe_result,
             )
@@ -629,6 +627,32 @@ def _result_for_error(returncode: int, binary: str) -> CommandResult:
         args_redacted=True,
         stdio_redacted=True,
     )
+
+
+def _completed_process_result(completed: Any, argv: tuple[str, ...], binary: str) -> CommandResult:
+    try:
+        stdout = _decode_completed_stdio(completed.stdout)
+        stderr = _decode_completed_stdio(completed.stderr)
+        returncode = completed.returncode
+    except Exception:
+        raise ConuError(
+            f"conU command returned malformed process result: {_safe_command_for_error(binary)}",
+            _result_for_error(1, binary),
+        ) from None
+    if not isinstance(returncode, int) or isinstance(returncode, bool):
+        raise ConuError(
+            f"conU command returned malformed process result: {_safe_command_for_error(binary)}",
+            _result_for_error(1, binary),
+        )
+    return CommandResult(argv, stdout, stderr, returncode)
+
+
+def _decode_completed_stdio(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return bytes(value).decode("utf-8", errors="replace")
+    raise TypeError("unsupported completed process stream type")
 
 
 def _safe_binary_name(binary: str) -> str:


### PR DESCRIPTION
## **User description**
Closes #732.\n\n## What changed\n- Catch Python SDK subprocess runner exceptions at the command boundary and raise redacted ConuError metadata.\n- Normalize completed-process stdout, stderr, and returncode before use so malformed custom runner results fail closed.\n- Added regressions for non-OSError runner exceptions, unsafe stdio getters, unsafe returncode getters, and invalid returncode types.\n\n## Validation\n- python scripts\\check-python-sdk-error-redaction.py\n- python -m py_compile sdk\\python\\conu_sdk\\__init__.py scripts\\check-python-sdk-error-redaction.py examples\\python\\local_agent_pair.py\n- python scripts\\check-python-script-compile.py\n- npm run check --prefix sdk/typescript\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\verify-release-versions.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-github-workflow-permissions-regression.py\n- python scripts\\check-tagged-release-readiness-regression.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Python SDK subprocess boundary to redact sensitive data and fail closed. Runner errors and malformed process results now return only safe `ConuError` metadata.

- **Bug Fixes**
  - Catch all runner exceptions at the command boundary; raise a redacted `ConuError` with safe binary metadata.
  - Normalize and validate `CompletedProcess` stdout/stderr and returncode; malformed or non-int returncodes now fail closed.
  - Added regression tests for non-`OSError` exceptions, unsafe stdio/returncode getters, and invalid returncode types.

<sup>Written for commit 42e118d45251a2ac63a5818fb8e386d1ee452bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact Python SDK failures from the subprocess boundary**

### What Changed
- Python SDK command calls now hide sensitive details when the runner itself fails, instead of exposing raw exception data.
- If the subprocess result is missing, unreadable, or has an invalid return code, the SDK now fails closed with a safe error message and redacted command info.
- Regression checks were added for runner exceptions, broken output access, broken return-code access, and invalid return-code types.

### Impact
`✅ Clearer Python SDK failure messages`
`✅ Fewer secret leaks in command errors`
`✅ Safer handling of malformed subprocess results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
