### PR TITLE
Fail closed on SDK stdin payload encoding

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -688,6 +688,29 @@ def run_stdin_secret_failure_redaction_test(module) -> None:
         raise AssertionError("Python SDK stdin failure should retain only safe command metadata")
 
 
+def run_stdin_payload_encoding_redaction_test(module) -> None:
+    class SecretPayload:
+        def __str__(self) -> str:
+            raise RuntimeError(f"payload conversion exposed {SENSITIVE_ENDPOINT}")
+
+    def fake_run(_argv, **_kwargs):
+        raise AssertionError("Python SDK should not execute subprocess for invalid payload")
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.send_message("agent.alpha", "agent.beta", SecretPayload())
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 1)
+    else:
+        raise AssertionError("expected Python SDK stdin payload encoding failure")
+
+    assert_redacted(rendered)
+    if "conU stdin payload could not be encoded: conu-test.exe [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK payload encoding error should retain safe metadata only")
+
+
 def main() -> int:
     module = load_sdk()
     run_success_result_metadata_test(module)
@@ -703,6 +726,7 @@ def main() -> int:
     run_mcp_shape_redaction_tests(module)
     run_command_surface_parity_test(module)
     run_stdin_secret_failure_redaction_test(module)
+    run_stdin_payload_encoding_redaction_test(module)
     print("Python SDK error redaction regression checks passed")
     return 0
 

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -316,7 +316,7 @@ class ConuClient:
             to_agent_id,
             "--stdin",
             "--json",
-            input_bytes=_to_bytes(payload),
+            input_bytes=_to_bytes(payload, self.conu_bin),
         )
 
     def send_remote_message(
@@ -336,7 +336,7 @@ class ConuClient:
             peer_node_id,
             "--stdin",
             "--json",
-            input_bytes=_to_bytes(payload),
+            input_bytes=_to_bytes(payload, self.conu_bin),
         )
 
     def create_room(
@@ -382,7 +382,7 @@ class ConuClient:
             topic,
             "--stdin",
             "--json",
-            input_bytes=_to_bytes(payload),
+            input_bytes=_to_bytes(payload, self.conu_bin),
         )
 
     def room_topic_policies(self) -> dict[str, Any]:
@@ -454,7 +454,7 @@ class ConuClient:
             "set",
             "--stdin",
             "--json",
-            input_bytes=_to_bytes(token),
+            input_bytes=_to_bytes(token, self.conu_bin),
         )
 
     def clear_relay_credential(self) -> dict[str, Any]:
@@ -489,7 +489,7 @@ class ConuClient:
             stream_id,
             "--stdin",
             "--json",
-            input_bytes=_to_bytes(payload),
+            input_bytes=_to_bytes(payload, self.conu_bin),
         )
 
     def close_stream(self, stream_id: str) -> dict[str, Any]:
@@ -716,12 +716,20 @@ def _safe_mcp_error(error: Any) -> str:
     return "unknown MCP error"
 
 
-def _to_bytes(value: bytes | bytearray | memoryview | str) -> bytes:
-    if isinstance(value, bytes):
-        return value
-    if isinstance(value, (bytearray, memoryview)):
-        return bytes(value)
-    return str(value).encode("utf-8")
+def _to_bytes(value: Any, binary: str) -> bytes:
+    try:
+        if isinstance(value, bytes):
+            return value
+        if isinstance(value, (bytearray, memoryview)):
+            return bytes(value)
+        if isinstance(value, str):
+            return value.encode("utf-8")
+    except Exception:
+        pass
+    raise ConuError(
+        f"conU stdin payload could not be encoded: {_safe_command_for_error(binary)}",
+        _result_for_error(1, binary),
+    ) from None
 
 
 def _hex_to_bytes(payload_hex: str, binary: str) -> bytes:

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -251,7 +251,7 @@ export class ConuClient {
     return this.runJson(
       this.conuBin,
       ["messages", "send", fromAgentId, toAgentId, "--stdin", "--json"],
-      toBuffer(payload),
+      toBuffer(payload, this.conuBin),
     );
   }
 
@@ -268,7 +268,7 @@ export class ConuClient {
         "--stdin",
         "--json",
       ],
-      toBuffer(payload),
+      toBuffer(payload, this.conuBin),
     );
   }
 
@@ -292,7 +292,7 @@ export class ConuClient {
     return this.runJson(
       this.conuBin,
       ["rooms", "publish", roomId, fromAgentId, topic, "--stdin", "--json"],
-      toBuffer(payload),
+      toBuffer(payload, this.conuBin),
     );
   }
 
@@ -341,7 +341,7 @@ export class ConuClient {
     return this.runJson(
       this.conuBin,
       ["relay", "credential", "set", "--stdin", "--json"],
-      toBuffer(token),
+      toBuffer(token, this.conuBin),
     );
   }
 
@@ -365,7 +365,7 @@ export class ConuClient {
     return this.runJson(
       this.conuBin,
       ["streams", "write", streamId, "--stdin", "--json"],
-      toBuffer(payload),
+      toBuffer(payload, this.conuBin),
     );
   }
 
@@ -507,14 +507,24 @@ function decode(value) {
   return Buffer.from(value).toString("utf8");
 }
 
-function toBuffer(value) {
-  if (Buffer.isBuffer(value)) {
-    return value;
+function toBuffer(value, binary) {
+  try {
+    if (Buffer.isBuffer(value)) {
+      return value;
+    }
+    if (value instanceof Uint8Array) {
+      return Buffer.from(value);
+    }
+    if (typeof value === "string") {
+      return Buffer.from(value, "utf8");
+    }
+  } catch (_error) {
+    // Fall through to the redacted SDK boundary error below.
   }
-  if (value instanceof Uint8Array) {
-    return Buffer.from(value);
-  }
-  return Buffer.from(String(value), "utf8");
+  throw new ConuError(
+    `conU stdin payload could not be encoded: ${safeCommandForError(binary)}`,
+    resultForError({ code: 1 }, binary),
+  );
 }
 
 function boolArg(value) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -274,6 +274,47 @@ assert.throws(
   },
 );
 
+let invalidPayloadRunnerCalled = false;
+const invalidPayloadClient = new ConuClient({
+  conuBin: "C:/tools/conu-test.exe",
+  runner() {
+    invalidPayloadRunnerCalled = true;
+    throw new Error("runner should not execute for invalid payload");
+  },
+});
+const invalidPayload = {
+  toString() {
+    throw new Error(`payload conversion leaked ${secretEndpoint}`);
+  },
+};
+
+assert.throws(
+  () => invalidPayloadClient.sendMessage("agent.alpha", "agent.beta", invalidPayload),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU stdin payload could not be encoded: conu-test.exe [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.stdout, "");
+    assert.equal(error.result.stderr, "");
+    assert.equal(error.result.code, 1);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+assert.equal(invalidPayloadRunnerCalled, false);
+
 for (const runner of [
   () => null,
   () => ({


### PR DESCRIPTION
Closes #734.\n\n## What changed\n- Python SDK stdin payload/token conversion now accepts only bytes, bytearray, memoryview, or string and raises redacted ConuError metadata for unsupported or failed conversions.\n- TypeScript SDK stdin payload/token conversion now accepts only Buffer, Uint8Array, or string and raises redacted ConuError metadata for unsupported or failed conversions.\n- Added regressions proving invalid secret-bearing payload objects are rejected before subprocess/runner execution.\n\n## Validation\n- python scripts\\check-python-sdk-error-redaction.py\n- npm run check --prefix sdk/typescript\n- python -m py_compile sdk\\python\\conu_sdk\\__init__.py scripts\\check-python-sdk-error-redaction.py examples\\python\\local_agent_pair.py\n- python scripts\\check-python-script-compile.py\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\verify-release-versions.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-github-workflow-permissions-regression.py\n- python scripts\\check-tagged-release-readiness-regression.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closed stdin payload encoding in the Python and TypeScript SDKs to prevent secret leaks. Only accept byte/string primitives; unsupported or failing conversions now raise a redacted `ConuError` and the runner never executes.

- **Bug Fixes**
  - Python: `_to_bytes` only accepts `bytes`, `bytearray`, `memoryview`, or `str`; otherwise raises a redacted `ConuError` (callers now pass `conu_bin` for safe error output).
  - TypeScript: `toBuffer` only accepts `Buffer`, `Uint8Array`, or `string`; otherwise throws a redacted `ConuError`.
  - Added regression tests to ensure invalid payload objects are rejected before any subprocess/runner execution and that errors are fully redacted.

- **Migration**
  - Ensure callers pass supported types for stdin payloads/tokens (Python: bytes/bytearray/memoryview/str; TypeScript: Buffer/Uint8Array/string).
  - Do not rely on implicit `.toString()` or custom objects for payload encoding.

<sup>Written for commit 9b909673c6b15259f23406d9087a5ac2b3b558a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

