### PR TITLE
Redact Python SDK argument encoding failures

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -711,6 +711,63 @@ def run_stdin_payload_encoding_redaction_test(module) -> None:
         raise AssertionError("Python SDK payload encoding error should retain safe metadata only")
 
 
+def run_command_argument_encoding_redaction_test(module) -> None:
+    class SecretArgument:
+        def __str__(self) -> str:
+            raise RuntimeError(f"argument conversion exposed {SENSITIVE_ENDPOINT}")
+
+    def fake_run(_argv, **_kwargs):
+        raise AssertionError("Python SDK should not execute subprocess for invalid argument")
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(conu_bin="C:/tools/conu-test.exe")
+    try:
+        client.trust_peer(
+            "node.peer",
+            "Peer",
+            "aa",
+            relay_endpoint=SecretArgument(),
+        )
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu-test.exe", 1)
+    else:
+        raise AssertionError("expected Python SDK command argument encoding failure")
+
+    assert_redacted(rendered)
+    if (
+        "conU command argument could not be encoded: "
+        "conu-test.exe [arguments redacted]"
+    ) not in rendered:
+        raise AssertionError("Python SDK command argument error should retain safe metadata only")
+
+
+def run_mcp_argument_encoding_redaction_test(module) -> None:
+    class SecretArgument:
+        def __str__(self) -> str:
+            raise RuntimeError(f"MCP argument conversion exposed {SENSITIVE_ENDPOINT}")
+
+    def fake_run(_argv, **_kwargs):
+        raise AssertionError("Python SDK should not execute MCP subprocess for invalid argument")
+
+    module.subprocess.run = fake_run
+    client = module.ConuClient(mcp_bin="C:/tools/conu-mcp-test.exe")
+    try:
+        client.receive_message(SecretArgument(), "env.local.1")
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu-mcp-test.exe", 1)
+    else:
+        raise AssertionError("expected Python SDK MCP argument encoding failure")
+
+    assert_redacted(rendered)
+    if (
+        "conU command argument could not be encoded: "
+        "conu-mcp-test.exe [arguments redacted]"
+    ) not in rendered:
+        raise AssertionError("Python SDK MCP argument error should retain safe metadata only")
+
+
 def main() -> int:
     module = load_sdk()
     run_success_result_metadata_test(module)
@@ -727,6 +784,8 @@ def main() -> int:
     run_command_surface_parity_test(module)
     run_stdin_secret_failure_redaction_test(module)
     run_stdin_payload_encoding_redaction_test(module)
+    run_command_argument_encoding_redaction_test(module)
+    run_mcp_argument_encoding_redaction_test(module)
     print("Python SDK error redaction regression checks passed")
     return 0
 

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -117,20 +117,20 @@ class ConuClient:
         args = [
             "agents",
             "trust",
-            str(card["agentId"]),
-            str(card["displayName"]),
+            _command_arg(card["agentId"], self.conu_bin),
+            _command_arg(card["displayName"], self.conu_bin),
             "--node",
-            str(card["nodeId"]),
+            _command_arg(card["nodeId"], self.conu_bin),
             "--kind",
-            str(card.get("kind", "remote-agent")),
+            _command_arg(card.get("kind", "remote-agent"), self.conu_bin),
             "--signing-key",
-            str(card["signingPublicKeyHex"]),
+            _command_arg(card["signingPublicKeyHex"], self.conu_bin),
             "--signature",
-            str(card["signatureHex"]),
+            _command_arg(card["signatureHex"], self.conu_bin),
             "--signature-key-id",
-            str(card["signatureKeyId"]),
+            _command_arg(card["signatureKeyId"], self.conu_bin),
             "--signature-algorithm",
-            str(card.get("signatureAlgorithm", "Ed25519")),
+            _command_arg(card.get("signatureAlgorithm", "Ed25519"), self.conu_bin),
             "--messages",
             _bool_arg(_card_bool(capabilities, "messages", True)),
             "--streams",
@@ -238,8 +238,8 @@ class ConuClient:
         return self._call_mcp_tool(
             "conu_receive_message",
             {
-                "agentId": str(agent_id),
-                "envelopeId": str(envelope_id),
+                "agentId": _command_arg(agent_id, self.mcp_bin),
+                "envelopeId": _command_arg(envelope_id, self.mcp_bin),
                 "includePayload": bool(include_payload),
             },
         )
@@ -436,7 +436,7 @@ class ConuClient:
             "relay",
             "sync",
             "--wait-ms",
-            str(wait_ms),
+            _command_arg(wait_ms, self.conu_bin),
             "--json",
         )
 
@@ -511,9 +511,9 @@ class ConuClient:
     ) -> dict[str, Any]:
         args = ["logs", "rotate", "--json"]
         if max_bytes is not None:
-            args.extend(["--max-bytes", str(max_bytes)])
+            args.extend(["--max-bytes", _command_arg(max_bytes, self.conu_bin)])
         if keep is not None:
-            args.extend(["--keep", str(keep)])
+            args.extend(["--keep", _command_arg(keep, self.conu_bin)])
         return self._run_json(self.conu_bin, *args)
 
     def process_queued(self) -> CommandResult:
@@ -585,7 +585,8 @@ class ConuClient:
         *args: str,
         input_bytes: bytes | None = None,
     ) -> CommandResult:
-        argv = (binary, *args)
+        safe_binary = _command_arg(binary, binary)
+        argv = (safe_binary, *(_command_arg(arg, safe_binary) for arg in args))
         try:
             completed = subprocess.run(
                 argv,
@@ -656,7 +657,7 @@ def _decode_completed_stdio(value: Any) -> str:
 
 
 def _safe_binary_name(binary: str) -> str:
-    value = str(binary).strip()
+    value = binary.strip() if isinstance(binary, str) else ""
     if not value:
         return "conu"
     if "://" in value or any(marker in value for marker in ("@", "?", "#")):
@@ -714,6 +715,22 @@ def _safe_mcp_error(error: Any) -> str:
     if isinstance(error, dict) and isinstance(error.get("code"), int):
         return f"code {error['code']}"
     return "unknown MCP error"
+
+
+def _command_arg(value: Any, binary: Any) -> str:
+    try:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+    except Exception:
+        pass
+    raise ConuError(
+        f"conU command argument could not be encoded: {_safe_command_for_error(binary)}",
+        _result_for_error(1, binary),
+    ) from None
 
 
 def _to_bytes(value: Any, binary: str) -> bytes:


### PR DESCRIPTION
Closes #738.\n\n## What changed\n- Centralized Python SDK command argument encoding before subprocess execution.\n- Route MCP receive helper arguments through the same redacted encoding boundary.\n- Avoid arbitrary binary string conversion while building safe error labels.\n- Added regressions for invalid secret-bearing command and MCP arguments that prove subprocess execution is not reached.\n\n## Validation\n- python scripts\\check-python-sdk-error-redaction.py\n- python -m py_compile sdk\\python\\conu_sdk\\__init__.py scripts\\check-python-sdk-error-redaction.py examples\\python\\local_agent_pair.py\n- git diff --check\n- python scripts\\check-python-script-compile.py\n- npm run check --prefix sdk/typescript\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\verify-release-versions.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-github-workflow-permissions-regression.py\n- python scripts\\check-tagged-release-readiness-regression.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened argument encoding and error redaction in the Python `conu_sdk` so invalid or secret-bearing args never reach subprocesses, and error messages remain safely redacted. Addresses #738 by applying the same protections to both `conu` commands and MCP helpers.

- **Bug Fixes**
  - Centralized argument encoding via `_command_arg` (supports str/bool/number); raises `ConuError` with redacted command on failure.
  - Applied encoder to `_run` and command builders: `trust_agent_card`, `receive_message`, `relay_sync --wait-ms`, and `logs rotate --max-bytes/--keep`.
  - Routed MCP receive arguments through the same redacted boundary.
  - Tightened safe binary labeling in errors (no arbitrary string coercion of paths/URLs).
  - Added regression tests to ensure subprocesses don’t execute on bad args and that errors keep only safe metadata.

<sup>Written for commit fc8e54782098e63855aa0bfa497d0f931d29370a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now properly redact sensitive command and MCP arguments when encoding fails, preventing accidental exposure in logs and output.

* **Tests**
  * Added regression tests to verify argument redaction behavior in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->