### PR TITLE
Redact Rust SDK receive error display

### DIFF
--- a/crates/conu-sdk/src/lib.rs
+++ b/crates/conu-sdk/src/lib.rs
@@ -530,19 +530,13 @@ impl fmt::Display for SdkError {
             Self::Session(error) => write!(formatter, "{error}"),
             Self::Stream(error) => write!(formatter, "{error}"),
             Self::Trust(error) => write!(formatter, "{error}"),
-            Self::EnvelopeNotFound {
-                agent_id,
-                envelope_id,
-            } => write!(
+            Self::EnvelopeNotFound { .. } => write!(
                 formatter,
-                "message envelope {envelope_id} was not found in {agent_id}'s inbox"
+                "message envelope was not found in the addressed agent inbox; contentsDisplayed=false"
             ),
-            Self::UnauthorizedReceive {
-                agent_id,
-                envelope_id,
-            } => write!(
+            Self::UnauthorizedReceive { .. } => write!(
                 formatter,
-                "agent {agent_id} is not authorized to receive envelope {envelope_id}"
+                "agent is not authorized to receive the requested envelope; contentsDisplayed=false"
             ),
         }
     }
@@ -687,8 +681,31 @@ mod tests {
         let error = client
             .receive_message_bytes("agent.sender", &inbox[0].envelope_id)
             .expect_err("wrong local agent cannot receive");
+        let rendered = error.to_string();
 
         assert!(matches!(error, SdkError::EnvelopeNotFound { .. }));
+        assert!(!rendered.contains("agent.sender"));
+        assert!(!rendered.contains(&inbox[0].envelope_id));
+        assert!(rendered.contains("contentsDisplayed=false"));
+    }
+
+    #[test]
+    fn sdk_receive_error_display_redacts_identifiers() {
+        let missing = SdkError::EnvelopeNotFound {
+            agent_id: "agent.secret-token".to_string(),
+            envelope_id: "env.secret-token".to_string(),
+        };
+        let unauthorized = SdkError::UnauthorizedReceive {
+            agent_id: "agent.secret-token".to_string(),
+            envelope_id: "env.secret-token".to_string(),
+        };
+
+        for rendered in [missing.to_string(), unauthorized.to_string()] {
+            assert!(!rendered.contains("agent.secret-token"));
+            assert!(!rendered.contains("env.secret-token"));
+            assert!(!rendered.contains("secret-token"));
+            assert!(rendered.contains("contentsDisplayed=false"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #740.\n\n## What changed\n- Redacted SdkError::EnvelopeNotFound and SdkError::UnauthorizedReceive Display output so formatted SDK errors do not print caller-supplied agent or envelope ids.\n- Preserved the structured enum fields for programmatic matching.\n- Added regression coverage for receive-scope errors and explicit secret-bearing id formatting.\n\n## Validation\n- cargo fmt --all -- --check\n- git diff --check\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-python-sdk-error-redaction.py\n- npm run check --prefix sdk/typescript\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\verify-release-versions.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-github-workflow-permissions-regression.py\n- python scripts\\check-tagged-release-readiness-regression.py\n\n## Local Rust note\n- cargo +stable-x86_64-pc-windows-gnu test -p conu-sdk was attempted but this workstation is missing dlltool.exe.\n- cargo check -p conu-sdk was attempted but this workstation is missing MSVC link.exe.\n- GitHub CI is expected to cover Rust on hosted Ubuntu, macOS, and Windows runners.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts identifiers from `conu-sdk` receive error messages to prevent leaking agent and envelope IDs in logs. Messages now use generic text with contentsDisplayed=false, while enum fields remain intact for matching.

- **Bug Fixes**
  - Redacted Display for `SdkError::EnvelopeNotFound` and `SdkError::UnauthorizedReceive` (no agent_id or envelope_id shown).
  - Preserved structured fields for programmatic matching.
  - Added tests for receive-scope errors and secret-bearing ID formatting.

<sup>Written for commit 9dbb8bb01d8915635acbd8489ccf39f1c0430d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

