### PR TITLE
Redact Rust SDK receive error debug output

### DIFF
--- a/crates/conu-sdk/src/lib.rs
+++ b/crates/conu-sdk/src/lib.rs
@@ -491,7 +491,6 @@ pub struct ProcessReport {
 }
 
 /// Errors returned by the SDK.
-#[derive(Debug)]
 pub enum SdkError {
     State(state::StateError),
     Security(security::SecurityError),
@@ -513,6 +512,39 @@ pub enum SdkError {
         agent_id: String,
         envelope_id: String,
     },
+}
+
+impl fmt::Debug for SdkError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(error) => formatter.debug_tuple("State").field(error).finish(),
+            Self::Security(error) => formatter.debug_tuple("Security").field(error).finish(),
+            Self::Agent(error) => formatter.debug_tuple("Agent").field(error).finish(),
+            Self::Message(error) => formatter.debug_tuple("Message").field(error).finish(),
+            Self::Policy(error) => formatter.debug_tuple("Policy").field(error).finish(),
+            Self::Runtime(error) => formatter.debug_tuple("Runtime").field(error).finish(),
+            Self::Route(error) => formatter.debug_tuple("Route").field(error).finish(),
+            Self::RelayDelivery(error) => {
+                formatter.debug_tuple("RelayDelivery").field(error).finish()
+            }
+            Self::Room(error) => formatter.debug_tuple("Room").field(error).finish(),
+            Self::Session(error) => formatter.debug_tuple("Session").field(error).finish(),
+            Self::Stream(error) => formatter.debug_tuple("Stream").field(error).finish(),
+            Self::Trust(error) => formatter.debug_tuple("Trust").field(error).finish(),
+            Self::EnvelopeNotFound { .. } => formatter
+                .debug_struct("EnvelopeNotFound")
+                .field("agent_id", &"[redacted]")
+                .field("envelope_id", &"[redacted]")
+                .field("contents_displayed", &false)
+                .finish(),
+            Self::UnauthorizedReceive { .. } => formatter
+                .debug_struct("UnauthorizedReceive")
+                .field("agent_id", &"[redacted]")
+                .field("envelope_id", &"[redacted]")
+                .field("contents_displayed", &false)
+                .finish(),
+        }
+    }
 }
 
 impl fmt::Display for SdkError {
@@ -690,7 +722,7 @@ mod tests {
     }
 
     #[test]
-    fn sdk_receive_error_display_redacts_identifiers() {
+    fn sdk_receive_error_formatting_redacts_identifiers() {
         let missing = SdkError::EnvelopeNotFound {
             agent_id: "agent.secret-token".to_string(),
             envelope_id: "env.secret-token".to_string(),
@@ -700,11 +732,19 @@ mod tests {
             envelope_id: "env.secret-token".to_string(),
         };
 
-        for rendered in [missing.to_string(), unauthorized.to_string()] {
+        for rendered in [
+            missing.to_string(),
+            format!("{missing:?}"),
+            unauthorized.to_string(),
+            format!("{unauthorized:?}"),
+        ] {
             assert!(!rendered.contains("agent.secret-token"));
             assert!(!rendered.contains("env.secret-token"));
             assert!(!rendered.contains("secret-token"));
-            assert!(rendered.contains("contentsDisplayed=false"));
+            assert!(
+                rendered.contains("contentsDisplayed=false")
+                    || rendered.contains("contents_displayed: false")
+            );
         }
     }
 


### PR DESCRIPTION
## **User description**
Closes #742

## Summary
- Replaces derived Rust SDK SdkError debug output with an explicit formatter.
- Redacts addressed-agent and envelope identifiers for receive-boundary errors in Debug, matching the existing Display privacy behavior.
- Expands the receive-error formatting regression to cover both Display and Debug.

## Validation
- cargo fmt --all -- --check
- git diff --check
- python scripts\\check-python-script-compile.py
- python scripts\\check-python-sdk-error-redaction.py
- 
pm run check --prefix sdk/typescript
- 
pm run check --prefix packaging/npm/conu-cli
- python scripts\\verify-npm-package-contents.py
- python scripts\\verify-npm-package-contents-regression.py
- python scripts\\check-npm-publish-preflight.py
- python scripts\\check-npm-publish-preflight-regression.py
- python scripts\\verify-release-versions.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-actions-permissions-regression.py
- python scripts\\check-tagged-release-readiness-regression.py
- python scripts\\check-release-secret-env-preflight-regression.py
- python scripts\\check-github-release-secret-readiness-regression.py
- python scripts\\check-platform-signing-secrets-preflight-regression.py
- python scripts\\check-linux-signing-secrets-preflight-regression.py
- python scripts\\set-github-release-secrets-regression.py

Local Rust execution is blocked on this workstation: GNU test target is missing dlltool.exe, and MSVC check is missing link.exe. CI should cover Rust on the configured matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts agent_id and envelope_id in `Debug` output for Rust SDK receive errors, matching existing `Display` redaction. Prevents sensitive identifiers from appearing in logs for `EnvelopeNotFound` and `UnauthorizedReceive` in `conu-sdk`.

- **Bug Fixes**
  - Implement explicit `fmt::Debug` for `SdkError` and remove `derive(Debug)`.
  - Redact identifiers and align the contentsDisplayed flag in `Debug` with `Display`.
  - Update tests to verify redaction for both `Display` and `Debug`.

<sup>Written for commit ca79765690b1a3faf13287209462039f16b53f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact receive error details in both display and debug output**

### What Changed
- Receive errors no longer expose agent or envelope identifiers when shown in logs or debug output.
- The same redaction now applies to both the plain error message and the debug view, so sensitive receive-boundary details stay hidden in all common outputs.
- The redaction coverage now includes both missing-envelope and unauthorized-receive cases.

### Impact
`✅ Safer error logs`
`✅ Less exposure of sensitive identifiers`
`✅ Consistent redaction across user-visible error output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now redact sensitive identifiers to enhance privacy and security during error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->