### PR TITLE
Fail closed on TypeScript SDK low-level arguments

### DIFF
--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -488,11 +488,12 @@ export class ConuClient {
   }
 
   run(binary, args = [], input) {
+    const safeArgs = normalizeCommandArgs(args, binary);
     let result;
     try {
       result = this.runner({
         binary,
-        args,
+        args: safeArgs,
         input,
         cwd: this.cwd,
         env: this.env,
@@ -513,6 +514,27 @@ export class ConuClient {
     }
     return result;
   }
+}
+
+function normalizeCommandArgs(args, binary) {
+  const safeArgs = [];
+  try {
+    if (!Array.isArray(args)) {
+      throw new TypeError("command arguments must be an array");
+    }
+    for (let index = 0; index < args.length; index += 1) {
+      safeArgs.push(commandArg(args[index], binary));
+    }
+  } catch (error) {
+    if (error instanceof ConuError) {
+      throw error;
+    }
+    throw new ConuError(
+      `conU command argument could not be encoded: ${safeCommandForError(binary)}`,
+      resultForError({ code: 1 }, binary),
+    );
+  }
+  return safeArgs;
 }
 
 function defaultRunner({ binary, args, input, cwd, env }) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -348,6 +348,79 @@ assert.throws(
 );
 assert.equal(invalidMcpArgumentRunnerCalled, false);
 
+let invalidLowLevelArgumentRunnerCalled = false;
+const invalidLowLevelArgumentClient = new ConuClient({
+  conuBin: "C:/tools/conu-test.exe",
+  runner() {
+    invalidLowLevelArgumentRunnerCalled = true;
+    throw new Error("runner should not execute for invalid low-level command argument");
+  },
+});
+
+assert.throws(
+  () => invalidLowLevelArgumentClient.run("C:/tools/conu-test.exe", ["status", invalidArgument]),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU command argument could not be encoded: conu-test.exe [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+assert.equal(invalidLowLevelArgumentRunnerCalled, false);
+
+let poisonedLowLevelArgumentRunnerCalled = false;
+const poisonedLowLevelArgumentClient = new ConuClient({
+  conuBin: "C:/tools/conu-test.exe",
+  runner() {
+    poisonedLowLevelArgumentRunnerCalled = true;
+    throw new Error("runner should not execute for poisoned low-level command arguments");
+  },
+});
+const poisonedLowLevelArgs = [];
+Object.defineProperty(poisonedLowLevelArgs, 0, {
+  get() {
+    throw new Error(`argument getter leaked ${secretEndpoint}`);
+  },
+});
+poisonedLowLevelArgs.length = 1;
+
+assert.throws(
+  () => poisonedLowLevelArgumentClient.run("C:/tools/conu-test.exe", poisonedLowLevelArgs),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU command argument could not be encoded: conu-test.exe [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+assert.equal(poisonedLowLevelArgumentRunnerCalled, false);
+
 let invalidPayloadRunnerCalled = false;
 const invalidPayloadClient = new ConuClient({
   conuBin: "C:/tools/conu-test.exe",


### PR DESCRIPTION
## **User description**
Closes #744

## Summary
- Normalizes public TypeScript SDK un() arguments before runner dispatch.
- Fails closed with redacted command/result metadata when low-level arguments are malformed.
- Adds smoke regressions proving invalid objects and poisoned argument getters do not invoke the runner or leak sensitive text.

## Validation
- 
pm run check --prefix sdk/typescript
- git diff --check
- cargo fmt --all -- --check
- python scripts\\check-python-script-compile.py
- python scripts\\check-python-sdk-error-redaction.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\verify-release-versions.py
- python scripts\\check-production-readiness-toolchain.py
- 
pm run check --prefix packaging/npm/conu-cli
- python scripts\\verify-npm-package-contents.py
- python scripts\\verify-npm-package-contents-regression.py
- python scripts\\check-npm-publish-preflight.py
- python scripts\\check-npm-publish-preflight-regression.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-actions-permissions-regression.py
- python scripts\\check-tagged-release-readiness-regression.py
- python scripts\\check-release-secret-env-preflight-regression.py
- python scripts\\check-github-release-secret-readiness-regression.py
- python scripts\\check-platform-signing-secrets-preflight-regression.py
- python scripts\\check-linux-signing-secrets-preflight-regression.py
- python scripts\\set-github-release-secrets-regression.py

Notes: local OpenSSL/GPG-dependent signing fixture branches were skipped by their regression scripts because openssl/gpg are unavailable on this workstation; CI covers the standard matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the TypeScript SDK so `ConuClient.run()` normalizes low‑level args and fails closed with redacted metadata when args are malformed. This prevents runner execution and avoids leaking sensitive data in errors.

- **Bug Fixes**
  - Normalize and validate `args` before dispatch; on malformed input, throw `ConuError` with redacted command/result.
  - Added smoke tests for invalid objects and poisoned argument getters to ensure the runner is not invoked and no secrets appear (args redacted, stdio redacted, contents not displayed).

<sup>Written for commit 08f8ad2d588471f33a63dc724d96ca554c1e6651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fail closed when low-level command arguments are invalid**

### What Changed
- Command arguments are now checked before the runner is called, so malformed or unsafe values are rejected immediately
- When argument encoding fails, the SDK returns a redacted error instead of passing the command through or exposing sensitive text
- Added smoke tests covering invalid arrays and poisoned argument getters to confirm the runner is not executed and no secrets appear in error output

### Impact
`✅ Fewer command crashes from bad arguments`
`✅ Lower risk of leaking secrets in error messages`
`✅ Safer TypeScript SDK command execution`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
