### PR TITLE
Fail closed on TypeScript SDK low-level binaries

### DIFF
--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -488,11 +488,12 @@ export class ConuClient {
   }
 
   run(binary, args = [], input) {
-    const safeArgs = normalizeCommandArgs(args, binary);
+    const safeBinary = normalizeCommandBinary(binary);
+    const safeArgs = normalizeCommandArgs(args, safeBinary);
     let result;
     try {
       result = this.runner({
-        binary,
+        binary: safeBinary,
         args: safeArgs,
         input,
         cwd: this.cwd,
@@ -500,20 +501,30 @@ export class ConuClient {
       });
     } catch (_error) {
       throw new ConuError(
-        `conU command failed before execution: ${safeCommandForError(binary)}`,
-        resultForError({ code: 1 }, binary),
+        `conU command failed before execution: ${safeCommandForError(safeBinary)}`,
+        resultForError({ code: 1 }, safeBinary),
       );
     }
-    result = normalizeRunnerResult(result, binary);
+    result = normalizeRunnerResult(result, safeBinary);
     if (result.code !== 0) {
-      const safeResult = resultForError(result, binary);
+      const safeResult = resultForError(result, safeBinary);
       throw new ConuError(
-        `conU command failed (${safeResult.code}): ${safeCommandForError(binary)}`,
+        `conU command failed (${safeResult.code}): ${safeCommandForError(safeBinary)}`,
         safeResult,
       );
     }
     return result;
   }
+}
+
+function normalizeCommandBinary(binary) {
+  if (typeof binary === "string" && binary.trim().length > 0) {
+    return binary;
+  }
+  throw new ConuError(
+    `conU command binary could not be encoded: ${safeCommandForError(binary)}`,
+    resultForError({ code: 1 }, binary),
+  );
 }
 
 function normalizeCommandArgs(args, binary) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -421,6 +421,75 @@ assert.throws(
 );
 assert.equal(poisonedLowLevelArgumentRunnerCalled, false);
 
+let invalidLowLevelBinaryRunnerCalled = false;
+const invalidLowLevelBinaryClient = new ConuClient({
+  runner() {
+    invalidLowLevelBinaryRunnerCalled = true;
+    throw new Error("runner should not execute for invalid low-level command binary");
+  },
+});
+const invalidBinary = {
+  toString() {
+    throw new Error(`binary conversion leaked ${secretEndpoint}`);
+  },
+};
+
+assert.throws(
+  () => invalidLowLevelBinaryClient.run(invalidBinary, ["status"]),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU command binary could not be encoded: conu [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+assert.equal(invalidLowLevelBinaryRunnerCalled, false);
+
+let emptyLowLevelBinaryRunnerCalled = false;
+const emptyLowLevelBinaryClient = new ConuClient({
+  runner() {
+    emptyLowLevelBinaryRunnerCalled = true;
+    throw new Error("runner should not execute for empty low-level command binary");
+  },
+});
+
+assert.throws(
+  () => emptyLowLevelBinaryClient.run("", ["status"]),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU command binary could not be encoded: conu [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+assert.equal(emptyLowLevelBinaryRunnerCalled, false);
+
 let invalidPayloadRunnerCalled = false;
 const invalidPayloadClient = new ConuClient({
   conuBin: "C:/tools/conu-test.exe",


### PR DESCRIPTION
## **User description**
Closes #746

## Summary
- Normalizes public TypeScript SDK un() binary values before runner dispatch.
- Rejects non-string and empty binary values with redacted command/result metadata.
- Adds smoke regressions proving invalid and poisoned binary inputs do not invoke the runner or leak sensitive text.

## Validation
- 
pm run check --prefix sdk/typescript
- git diff --check
- cargo fmt --all -- --check
- python scripts\\check-python-script-compile.py
- python scripts\\check-python-sdk-error-redaction.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\verify-release-versions.py
- python scripts\\check-production-readiness-toolchain.py
- 
pm run check --prefix packaging/npm/conu-cli
- python scripts\\verify-npm-package-contents.py
- python scripts\\verify-npm-package-contents-regression.py
- python scripts\\check-npm-publish-preflight.py
- python scripts\\check-npm-publish-preflight-regression.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-actions-permissions-regression.py
- python scripts\\check-tagged-release-readiness-regression.py
- python scripts\\check-release-secret-env-preflight-regression.py
- python scripts\\check-github-release-secret-readiness-regression.py
- python scripts\\check-platform-signing-secrets-preflight-regression.py
- python scripts\\check-linux-signing-secrets-preflight-regression.py
- python scripts\\set-github-release-secrets-regression.py

Notes: local OpenSSL/GPG-dependent signing fixture branches were skipped by their regression scripts because openssl/gpg are unavailable on this workstation; CI covers the standard matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fail-closed validation for low-level command binaries in the TypeScript SDK. Invalid or empty binaries now throw with redacted details and never reach the runner, preventing data leaks.

- **Bug Fixes**
  - Require the binary to be a non-empty string via normalizeCommandBinary; reject others with redacted error/result.
  - Route all arg/result/error formatting through the validated binary to ensure consistent redaction.
  - Add smoke tests for invalid and empty binaries to confirm the runner is not invoked and no sensitive text is exposed.

<sup>Written for commit 6cb810a46b513f06dc3ec37a1d53a6a1aad0751a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Reject invalid low-level command binaries before execution

### What Changed
- Command runs now stop immediately when the binary is missing, empty, or not a usable string
- Failed binary validation now returns a redacted error instead of passing the value to the runner
- Added smoke coverage for invalid and empty binary inputs to confirm the runner is not called and sensitive text stays hidden

### Impact
`✅ Fewer command launch failures`
`✅ Clearer low-level binary errors`
`✅ Less risk of leaking sensitive command details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
