### PR TITLE
Fail closed on SDK constructor binaries

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -155,6 +155,40 @@ def run_spawn_error_redaction_test(module) -> None:
         raise AssertionError("Python SDK spawn error should use a generic safe binary label")
 
 
+def run_constructor_binary_redaction_test(module) -> None:
+    class SecretBinary:
+        def __str__(self) -> str:
+            raise RuntimeError(f"binary conversion exposed {SENSITIVE_ENDPOINT}")
+
+    def fake_run(_argv, **_kwargs):
+        raise AssertionError("Python SDK should not execute subprocess for invalid binary")
+
+    module.subprocess.run = fake_run
+    try:
+        module.ConuClient(conu_bin=SecretBinary())
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu", 1)
+    else:
+        raise AssertionError("expected Python SDK constructor binary failure")
+
+    assert_redacted(rendered)
+    if "conU command binary could not be encoded: conu [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK constructor binary error should retain safe metadata only")
+
+    try:
+        module.ConuClient(mcp_bin="")
+    except module.ConuError as exc:
+        rendered = str(exc)
+        assert_safe_error_result(exc, "conu", 1)
+    else:
+        raise AssertionError("expected Python SDK empty constructor binary failure")
+
+    assert_redacted(rendered)
+    if "conU command binary could not be encoded: conu [arguments redacted]" not in rendered:
+        raise AssertionError("Python SDK empty constructor binary error should retain safe metadata")
+
+
 def run_subprocess_exception_redaction_test(module) -> None:
     def fake_run(_argv, **_kwargs):
         raise RuntimeError(f"custom runner exposed {SENSITIVE_ENDPOINT}")
@@ -773,6 +807,7 @@ def main() -> int:
     run_success_result_metadata_test(module)
     run_failed_command_redaction_test(module)
     run_spawn_error_redaction_test(module)
+    run_constructor_binary_redaction_test(module)
     run_subprocess_exception_redaction_test(module)
     run_malformed_completed_stdio_redaction_test(module)
     run_malformed_completed_returncode_redaction_test(module)

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -10,6 +10,7 @@ import json
 import os
 import subprocess
 from dataclasses import dataclass
+from os import PathLike
 from pathlib import Path
 from typing import Any
 
@@ -47,9 +48,9 @@ class ConuClient:
         env: dict[str, str] | None = None,
         cwd: str | Path | None = None,
     ) -> None:
-        self.conu_bin = str(conu_bin)
-        self.conud_bin = str(conud_bin)
-        self.mcp_bin = str(mcp_bin)
+        self.conu_bin = _normalize_command_binary(conu_bin)
+        self.conud_bin = _normalize_command_binary(conud_bin)
+        self.mcp_bin = _normalize_command_binary(mcp_bin)
         self.cwd = None if cwd is None else str(cwd)
         self.env = os.environ.copy()
         if env:
@@ -614,11 +615,27 @@ class ConuClient:
         return result
 
 
-def _safe_command_for_error(binary: str) -> str:
+def _normalize_command_binary(binary: Any) -> str:
+    try:
+        if isinstance(binary, PathLike):
+            binary = os.fspath(binary)
+        if isinstance(binary, bytes):
+            binary = os.fsdecode(binary)
+        if isinstance(binary, str) and binary.strip():
+            return binary
+    except Exception:
+        pass
+    raise ConuError(
+        f"conU command binary could not be encoded: {_safe_command_for_error(binary)}",
+        _result_for_error(1, binary),
+    ) from None
+
+
+def _safe_command_for_error(binary: Any) -> str:
     return f"{_safe_binary_name(binary)} [arguments redacted]"
 
 
-def _result_for_error(returncode: int, binary: str) -> CommandResult:
+def _result_for_error(returncode: int, binary: Any) -> CommandResult:
     return CommandResult(
         (_safe_binary_name(binary), "[arguments redacted]"),
         "",
@@ -630,7 +647,7 @@ def _result_for_error(returncode: int, binary: str) -> CommandResult:
     )
 
 
-def _completed_process_result(completed: Any, argv: tuple[str, ...], binary: str) -> CommandResult:
+def _completed_process_result(completed: Any, argv: tuple[str, ...], binary: Any) -> CommandResult:
     try:
         stdout = _decode_completed_stdio(completed.stdout)
         stderr = _decode_completed_stdio(completed.stderr)
@@ -656,7 +673,7 @@ def _decode_completed_stdio(value: Any) -> str:
     raise TypeError("unsupported completed process stream type")
 
 
-def _safe_binary_name(binary: str) -> str:
+def _safe_binary_name(binary: Any) -> str:
     value = binary.strip() if isinstance(binary, str) else ""
     if not value:
         return "conu"

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -10,9 +10,9 @@ export class ConuError extends Error {
 
 export class ConuClient {
   constructor(options = {}) {
-    this.conuBin = String(options.conuBin ?? "conu");
-    this.conudBin = String(options.conudBin ?? "conud");
-    this.mcpBin = String(options.mcpBin ?? "conu-mcp");
+    this.conuBin = constructorBinary(options.conuBin, "conu");
+    this.conudBin = constructorBinary(options.conudBin, "conud");
+    this.mcpBin = constructorBinary(options.mcpBin, "conu-mcp");
     this.cwd = options.cwd === undefined ? undefined : String(options.cwd);
     this.env = { ...process.env, ...(options.env ?? {}) };
     if (options.home !== undefined && options.home !== null) {
@@ -515,6 +515,13 @@ export class ConuClient {
     }
     return result;
   }
+}
+
+function constructorBinary(binary, fallback) {
+  if (binary === undefined || binary === null) {
+    return fallback;
+  }
+  return normalizeCommandBinary(binary);
 }
 
 function normalizeCommandBinary(binary) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -435,6 +435,64 @@ const invalidBinary = {
 };
 
 assert.throws(
+  () =>
+    new ConuClient({
+      conuBin: invalidBinary,
+      runner() {
+        throw new Error("runner should not execute for invalid constructor binary");
+      },
+    }),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU command binary could not be encoded: conu [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+
+assert.throws(
+  () =>
+    new ConuClient({
+      mcpBin: "",
+      runner() {
+        throw new Error("runner should not execute for empty constructor binary");
+      },
+    }),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU command binary could not be encoded: conu [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+
+assert.throws(
   () => invalidLowLevelBinaryClient.run(invalidBinary, ["status"]),
   (error) => {
     assert.ok(error instanceof ConuError);


### PR DESCRIPTION
## **User description**
Closes #748.\n\n## Summary\n- harden TypeScript SDK constructor binary options so invalid values fail closed before runner execution\n- harden Python SDK constructor binary options while preserving normal string/Path inputs\n- add TypeScript and Python regressions for throwing and empty constructor binary values\n\n## Validation\n- npm run check --prefix sdk/typescript\n- python scripts\\check-python-sdk-error-redaction.py\n- python scripts\\check-python-script-compile.py\n- git diff --check\n- python scripts\\verify-release-versions.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- cargo fmt --all -- --check\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-tagged-release-readiness-regression.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fail-closed validation for SDK constructor binaries to prevent runner execution with invalid or empty values. Errors are fully redacted. Closes #748.

- **Bug Fixes**
  - TypeScript: Validate `conuBin`/`conudBin`/`mcpBin` in constructor; undefined/null use defaults, empty or non-string values throw `ConuError` with redacted metadata.
  - Python: New `_normalize_command_binary` accepts `str`/`PathLike`/`bytes`; otherwise raises `ConuError`. Error messages/results keep only safe metadata.
  - Tests: Added TS and Python regressions for invalid and empty constructor binaries; assert no runner/subprocess execution and full redaction.

- **Migration**
  - Pass non-empty strings or `PathLike` values for binaries; avoid custom objects that rely on implicit string conversion.
  - Use `undefined`/`None` for defaults (`conu`, `conud`, `conu-mcp`); do not pass empty strings.

<sup>Written for commit ef11580fdba61f82f8ba1472484b1a84a64c85bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject invalid SDK binary settings before any command runs**

### What Changed
- Invalid or empty binary values now fail immediately during SDK setup instead of reaching the command runner or subprocess call
- The error message keeps only safe, generic details and redacts sensitive input
- Default binary names are still used when binary settings are omitted

### Impact
`✅ Fewer crashes from bad SDK setup`
`✅ No command execution with empty binary values`
`✅ Clearer, redacted error messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
