### PR TITLE
Fail closed on SDK constructor options

### DIFF
--- a/scripts/check-python-sdk-error-redaction.py
+++ b/scripts/check-python-sdk-error-redaction.py
@@ -189,6 +189,65 @@ def run_constructor_binary_redaction_test(module) -> None:
         raise AssertionError("Python SDK empty constructor binary error should retain safe metadata")
 
 
+def run_constructor_option_redaction_test(module) -> None:
+    class SecretPath:
+        def __fspath__(self) -> str:
+            raise RuntimeError(f"path conversion exposed {SENSITIVE_ENDPOINT}")
+
+    class SecretEnv(dict):
+        def items(self):
+            raise RuntimeError(f"environment override exposed {SENSITIVE_ENDPOINT}")
+
+    class SecretEnvValue:
+        def __str__(self) -> str:
+            raise RuntimeError(f"environment value exposed {SENSITIVE_ENDPOINT}")
+
+    def fake_run(_argv, **_kwargs):
+        raise AssertionError("Python SDK should not execute subprocess for invalid constructor option")
+
+    module.subprocess.run = fake_run
+
+    cases = (
+        (
+            lambda: module.ConuClient(conu_bin="C:/tools/conu-test.exe", home=SecretPath()),
+            "conU constructor home could not be encoded: conu-test.exe [arguments redacted]",
+        ),
+        (
+            lambda: module.ConuClient(conu_bin="C:/tools/conu-test.exe", cwd=SecretPath()),
+            "conU constructor cwd could not be encoded: conu-test.exe [arguments redacted]",
+        ),
+        (
+            lambda: module.ConuClient(
+                conu_bin="C:/tools/conu-test.exe",
+                env=SecretEnv(CONU_SECRET_FIXTURE="safe"),
+            ),
+            "conU constructor environment could not be encoded: "
+            "conu-test.exe [arguments redacted]",
+        ),
+        (
+            lambda: module.ConuClient(
+                conu_bin="C:/tools/conu-test.exe",
+                env={"CONU_SECRET_FIXTURE": SecretEnvValue()},
+            ),
+            "conU constructor environment could not be encoded: "
+            "conu-test.exe [arguments redacted]",
+        ),
+    )
+
+    for action, expected in cases:
+        try:
+            action()
+        except module.ConuError as exc:
+            rendered = str(exc)
+            assert_safe_error_result(exc, "conu-test.exe", 1)
+        else:
+            raise AssertionError("expected Python SDK constructor option failure")
+
+        assert_redacted(rendered)
+        if expected not in rendered:
+            raise AssertionError("Python SDK constructor option error should retain safe metadata")
+
+
 def run_subprocess_exception_redaction_test(module) -> None:
     def fake_run(_argv, **_kwargs):
         raise RuntimeError(f"custom runner exposed {SENSITIVE_ENDPOINT}")
@@ -808,6 +867,7 @@ def main() -> int:
     run_failed_command_redaction_test(module)
     run_spawn_error_redaction_test(module)
     run_constructor_binary_redaction_test(module)
+    run_constructor_option_redaction_test(module)
     run_subprocess_exception_redaction_test(module)
     run_malformed_completed_stdio_redaction_test(module)
     run_malformed_completed_returncode_redaction_test(module)

--- a/sdk/python/conu_sdk/__init__.py
+++ b/sdk/python/conu_sdk/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+from collections.abc import Mapping
 from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
@@ -51,12 +52,15 @@ class ConuClient:
         self.conu_bin = _normalize_command_binary(conu_bin)
         self.conud_bin = _normalize_command_binary(conud_bin)
         self.mcp_bin = _normalize_command_binary(mcp_bin)
-        self.cwd = None if cwd is None else str(cwd)
-        self.env = os.environ.copy()
-        if env:
-            self.env.update(env)
+        self.cwd = _normalize_constructor_path(cwd, self.conu_bin, "cwd", optional=True)
+        self.env = _normalize_constructor_env(env, self.conu_bin)
         if home is not None:
-            self.env["CONU_HOME"] = str(home)
+            self.env["CONU_HOME"] = _normalize_constructor_path(
+                home,
+                self.conu_bin,
+                "home",
+                optional=False,
+            )
 
     def init(self) -> CommandResult:
         return self._run_conu("init")
@@ -629,6 +633,54 @@ def _normalize_command_binary(binary: Any) -> str:
         f"conU command binary could not be encoded: {_safe_command_for_error(binary)}",
         _result_for_error(1, binary),
     ) from None
+
+
+def _normalize_constructor_path(
+    value: Any,
+    binary: Any,
+    name: str,
+    *,
+    optional: bool,
+) -> str | None:
+    if value is None:
+        if optional:
+            return None
+        raise _constructor_option_error(name, binary)
+    try:
+        if isinstance(value, PathLike):
+            value = os.fspath(value)
+        if isinstance(value, bytes):
+            value = os.fsdecode(value)
+        if isinstance(value, str) and value.strip():
+            return value
+    except Exception:
+        pass
+    raise _constructor_option_error(name, binary)
+
+
+def _normalize_constructor_env(env: Any, binary: Any) -> dict[str, str]:
+    safe_env = os.environ.copy()
+    if env is None:
+        return safe_env
+    try:
+        if not isinstance(env, Mapping):
+            raise TypeError("environment overrides must be a mapping")
+        for key, value in env.items():
+            if not isinstance(key, str) or not key or "=" in key or "\0" in key:
+                raise TypeError("environment variable name is invalid")
+            if not isinstance(value, str):
+                raise TypeError("environment variable value must be a string")
+            safe_env[key] = value
+        return safe_env
+    except Exception:
+        raise _constructor_option_error("environment", binary) from None
+
+
+def _constructor_option_error(name: str, binary: Any) -> ConuError:
+    return ConuError(
+        f"conU constructor {name} could not be encoded: {_safe_command_for_error(binary)}",
+        _result_for_error(1, binary),
+    )
 
 
 def _safe_command_for_error(binary: Any) -> str:

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -13,10 +13,10 @@ export class ConuClient {
     this.conuBin = constructorBinary(options.conuBin, "conu");
     this.conudBin = constructorBinary(options.conudBin, "conud");
     this.mcpBin = constructorBinary(options.mcpBin, "conu-mcp");
-    this.cwd = options.cwd === undefined ? undefined : String(options.cwd);
-    this.env = { ...process.env, ...(options.env ?? {}) };
+    this.cwd = constructorStringOption(options.cwd, this.conuBin, "cwd", true);
+    this.env = constructorEnv(options.env, this.conuBin);
     if (options.home !== undefined && options.home !== null) {
-      this.env.CONU_HOME = String(options.home);
+      this.env.CONU_HOME = constructorStringOption(options.home, this.conuBin, "home", false);
     }
     this.runner = options.runner ?? defaultRunner;
   }
@@ -522,6 +522,57 @@ function constructorBinary(binary, fallback) {
     return fallback;
   }
   return normalizeCommandBinary(binary);
+}
+
+function constructorStringOption(value, binary, name, optional) {
+  if (value === undefined || value === null) {
+    if (optional) {
+      return undefined;
+    }
+    throw constructorOptionError(name, binary);
+  }
+  try {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  } catch (_error) {
+    // Fall through to the redacted constructor option error below.
+  }
+  throw constructorOptionError(name, binary);
+}
+
+function constructorEnv(env, binary) {
+  const safeEnv = { ...process.env };
+  if (env === undefined || env === null) {
+    return safeEnv;
+  }
+  try {
+    if (!isRecord(env)) {
+      throw new TypeError("environment overrides must be an object");
+    }
+    for (const [key, value] of Object.entries(env)) {
+      if (key.length === 0 || key.includes("=") || key.includes("\0")) {
+        throw new TypeError("environment variable name is invalid");
+      }
+      if (value === undefined) {
+        safeEnv[key] = undefined;
+      } else if (typeof value === "string") {
+        safeEnv[key] = value;
+      } else {
+        throw new TypeError("environment variable value must be a string or undefined");
+      }
+    }
+    return safeEnv;
+  } catch (_error) {
+    throw constructorOptionError("environment", binary);
+  }
+}
+
+function constructorOptionError(name, binary) {
+  return new ConuError(
+    `conU constructor ${name} could not be encoded: ${safeCommandForError(binary)}`,
+    resultForError({ code: 1 }, binary),
+  );
 }
 
 function normalizeCommandBinary(binary) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -492,6 +492,119 @@ assert.throws(
   },
 );
 
+const invalidConstructorOption = {
+  toString() {
+    throw new Error(`constructor option conversion leaked ${secretEndpoint}`);
+  },
+};
+
+for (const [name, options, expectedMessage] of [
+  [
+    "home",
+    { conuBin: "C:/tools/conu-test.exe", home: invalidConstructorOption },
+    "conU constructor home could not be encoded: conu-test.exe [arguments redacted]",
+  ],
+  [
+    "cwd",
+    { conuBin: "C:/tools/conu-test.exe", cwd: invalidConstructorOption },
+    "conU constructor cwd could not be encoded: conu-test.exe [arguments redacted]",
+  ],
+]) {
+  assert.throws(
+    () =>
+      new ConuClient({
+        ...options,
+        runner() {
+          throw new Error(`runner should not execute for invalid constructor ${name}`);
+        },
+      }),
+    (error) => {
+      assert.ok(error instanceof ConuError);
+      const rendered = JSON.stringify({
+        message: error.message,
+        result: error.result,
+      });
+      assert.ok(!rendered.includes("secret"));
+      assert.ok(!rendered.includes("token=private"));
+      assert.ok(!rendered.includes("relay.example.com"));
+      assert.equal(error.message, expectedMessage);
+      assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+      assert.equal(error.result.contentsDisplayed, false);
+      assert.equal(error.result.argsRedacted, true);
+      assert.equal(error.result.stdioRedacted, true);
+      return true;
+    },
+  );
+}
+
+const poisonedConstructorEnv = {};
+Object.defineProperty(poisonedConstructorEnv, "CONU_SECRET_FIXTURE", {
+  enumerable: true,
+  get() {
+    throw new Error(`environment override getter leaked ${secretEndpoint}`);
+  },
+});
+
+assert.throws(
+  () =>
+    new ConuClient({
+      conuBin: "C:/tools/conu-test.exe",
+      env: poisonedConstructorEnv,
+      runner() {
+        throw new Error("runner should not execute for poisoned constructor environment");
+      },
+    }),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU constructor environment could not be encoded: conu-test.exe [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+
+assert.throws(
+  () =>
+    new ConuClient({
+      conuBin: "C:/tools/conu-test.exe",
+      env: { CONU_SECRET_FIXTURE: invalidConstructorOption },
+      runner() {
+        throw new Error("runner should not execute for invalid constructor environment");
+      },
+    }),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU constructor environment could not be encoded: conu-test.exe [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu-test.exe", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+
 assert.throws(
   () => invalidLowLevelBinaryClient.run(invalidBinary, ["status"]),
   (error) => {


### PR DESCRIPTION
## **User description**
Closes #750.\n\n## Summary\n- harden TypeScript SDK constructor home/cwd/env option normalization with redacted fail-closed errors\n- harden Python SDK constructor home/cwd/env option normalization with redacted fail-closed errors\n- add TypeScript and Python regressions for throwing path/env values and invalid env overrides\n\n## Validation\n- npm run check --prefix sdk/typescript\n- python scripts\\check-python-sdk-error-redaction.py\n- python scripts\\check-python-script-compile.py\n- git diff --check\n- python scripts\\verify-release-versions.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- cargo fmt --all -- --check\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-tagged-release-readiness-regression.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closed normalization for SDK constructor options in TypeScript and Python to prevent secret leakage and stop invalid configs early. Invalid home/cwd/env now throw redacted `ConuError` before any subprocess runs. Closes #750.

- **Bug Fixes**
  - Hardened parsing for `home`, `cwd`, and `env` in both SDKs with redacted, fail-closed errors that keep only safe metadata.
  - Prevented runner execution on invalid constructor options; errors include binary name and redacted args.
  - Added regression tests for path/env coercion, poisoned getters, and invalid env overrides.

- **Migration**
  - TypeScript: pass non-empty strings for `home`/`cwd`; `env` must be a plain object with string or undefined values.
  - Python: pass str/PathLike for `home`/`cwd`; `env` must be a mapping with string keys (no "=" or NUL) and string values.

<sup>Written for commit 13bf2cac24541b39691ca5534770e96a7bddcbc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fail closed when SDK constructor options are invalid**

### What Changed
- The Python and TypeScript SDKs now reject invalid `home`, `cwd`, and `env` values during client setup instead of continuing with a broken configuration
- These errors are redacted and only show safe command details, so sensitive path or environment values are not exposed
- The SDK no longer starts a command when constructor options cannot be encoded
- Added regression coverage for bad paths, poisoned environment values, and invalid environment overrides in both SDKs

### Impact
`✅ Fewer crashes from invalid SDK setup`
`✅ Clearer startup errors for bad constructor options`
`✅ Lower risk of leaking secret paths or environment values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
