### PR TITLE
Fail closed on TypeScript SDK constructor options object

### DIFF
--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -10,15 +10,16 @@ export class ConuError extends Error {
 
 export class ConuClient {
   constructor(options = {}) {
-    this.conuBin = constructorBinary(options.conuBin, "conu");
-    this.conudBin = constructorBinary(options.conudBin, "conud");
-    this.mcpBin = constructorBinary(options.mcpBin, "conu-mcp");
-    this.cwd = constructorStringOption(options.cwd, this.conuBin, "cwd", true);
-    this.env = constructorEnv(options.env, this.conuBin);
-    if (options.home !== undefined && options.home !== null) {
-      this.env.CONU_HOME = constructorStringOption(options.home, this.conuBin, "home", false);
+    const safeOptions = constructorOptions(options);
+    this.conuBin = constructorBinary(safeOptions.conuBin, "conu");
+    this.conudBin = constructorBinary(safeOptions.conudBin, "conud");
+    this.mcpBin = constructorBinary(safeOptions.mcpBin, "conu-mcp");
+    this.cwd = constructorStringOption(safeOptions.cwd, this.conuBin, "cwd", true);
+    this.env = constructorEnv(safeOptions.env, this.conuBin);
+    if (safeOptions.home !== undefined && safeOptions.home !== null) {
+      this.env.CONU_HOME = constructorStringOption(safeOptions.home, this.conuBin, "home", false);
     }
-    this.runner = options.runner ?? defaultRunner;
+    this.runner = safeOptions.runner ?? defaultRunner;
   }
 
   init() {
@@ -514,6 +515,28 @@ export class ConuClient {
       );
     }
     return result;
+  }
+}
+
+function constructorOptions(options) {
+  if (options === undefined) {
+    return {};
+  }
+  if (!isRecord(options)) {
+    throw constructorOptionError("options", "conu");
+  }
+  try {
+    return {
+      conuBin: options.conuBin,
+      conudBin: options.conudBin,
+      mcpBin: options.mcpBin,
+      cwd: options.cwd,
+      env: options.env,
+      home: options.home,
+      runner: options.runner,
+    };
+  } catch (_error) {
+    throw constructorOptionError("options", "conu");
   }
 }
 

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -492,6 +492,60 @@ assert.throws(
   },
 );
 
+const poisonedConstructorOptions = {};
+Object.defineProperty(poisonedConstructorOptions, "home", {
+  enumerable: true,
+  get() {
+    throw new Error(`constructor options getter leaked ${secretEndpoint}`);
+  },
+});
+
+assert.throws(
+  () => new ConuClient(poisonedConstructorOptions),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU constructor options could not be encoded: conu [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+
+assert.throws(
+  () => new ConuClient(null),
+  (error) => {
+    assert.ok(error instanceof ConuError);
+    const rendered = JSON.stringify({
+      message: error.message,
+      result: error.result,
+    });
+    assert.ok(!rendered.includes("secret"));
+    assert.ok(!rendered.includes("token=private"));
+    assert.ok(!rendered.includes("relay.example.com"));
+    assert.equal(
+      error.message,
+      "conU constructor options could not be encoded: conu [arguments redacted]",
+    );
+    assert.deepEqual(error.result.args, ["conu", "[arguments redacted]"]);
+    assert.equal(error.result.contentsDisplayed, false);
+    assert.equal(error.result.argsRedacted, true);
+    assert.equal(error.result.stdioRedacted, true);
+    return true;
+  },
+);
+
 const invalidConstructorOption = {
   toString() {
     throw new Error(`constructor option conversion leaked ${secretEndpoint}`);


### PR DESCRIPTION
## **User description**
Closes #752.\n\n## Summary\n- read TypeScript SDK constructor options through a redacted fail-closed boundary\n- reject non-object or poisoned options objects before runner execution\n- add smoke regressions for throwing option getters and null options\n\n## Validation\n- npm run check --prefix sdk/typescript\n- python scripts\\check-python-sdk-error-redaction.py\n- python scripts\\check-python-script-compile.py\n- git diff --check\n- python scripts\\verify-release-versions.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- cargo fmt --all -- --check\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\check-npm-publish-preflight.py\n- python scripts\\check-npm-publish-preflight-regression.py\n- python scripts\\check-github-workflow-permissions.py\n- python scripts\\check-tagged-release-readiness-regression.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed and redact errors when reading the TypeScript SDK constructor options. Prevents secret leakage and blocks invalid or poisoned options before any runner is used (addresses #752).

- **Bug Fixes**
  - Read constructor options via a safe `constructorOptions` boundary that copies only known fields and throws a redacted `ConuError` on failure.
  - Reject non-object inputs and objects with throwing getters before runner execution.
  - Added smoke tests covering null options and poisoned option getters to prevent regressions.

<sup>Written for commit e53acb83312d4e405c0384759a2ae26c9072ac69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject invalid TypeScript SDK constructor options before anything runs**

### What Changed
- The TypeScript client now checks its constructor options upfront and rejects non-object or poisoned inputs immediately.
- If an options getter throws, the error is redacted so secret values do not leak.
- Added smoke tests for null options and throwing option getters.

### Impact
`✅ Fewer startup failures from bad SDK options`
`✅ Clearer errors for invalid constructor input`
`✅ Lower risk of secret leakage in constructor errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation and error handling for constructor options initialization, ensuring consistent error reporting for invalid inputs.

* **Tests**
  * Added test coverage for constructor option encoding scenarios and error message redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->