### PR TITLE
Redact npm launcher runtime failure output

### DIFF
--- a/packaging/npm/conu-cli/lib/run.js
+++ b/packaging/npm/conu-cli/lib/run.js
@@ -2,25 +2,21 @@
 
 const fs = require("node:fs");
 const { spawn } = require("node:child_process");
-const { binaryPath } = require("./platform");
+const { BINARIES, binaryPath } = require("./platform");
 
-const binaryName = process.env.CONU_BIN_NAME;
-const executable = binaryPath(binaryName);
+const binaryName = readBinaryName(process.env.CONU_BIN_NAME);
+const executable = resolveExecutable(binaryName);
 
 if (!fs.existsSync(executable)) {
-  console.error(`conU binary is missing: ${executable}`);
+  console.error(`conU binary is missing for ${binaryName}; pathDisplayed=false contentsDisplayed=false`);
   console.error("Run npm install again, or set CONU_NPM_BINARY_DIR during install.");
   process.exit(127);
 }
 
-const child = spawn(executable, process.argv.slice(2), {
-  stdio: "inherit",
-  env: process.env
-});
+const child = launchExecutable(binaryName, executable);
 
 child.on("error", (error) => {
-  console.error(`failed to launch ${binaryName}: ${error.message}`);
-  process.exit(1);
+  reportLaunchError(binaryName, error);
 });
 
 child.on("exit", (code, signal) => {
@@ -34,3 +30,59 @@ child.on("exit", (code, signal) => {
   }
   process.exit(code === null ? 1 : code);
 });
+
+function readBinaryName(name) {
+  if (BINARIES.includes(name)) {
+    return name;
+  }
+  console.error("conU binary selection is invalid; pathDisplayed=false contentsDisplayed=false");
+  process.exit(127);
+}
+
+function resolveExecutable(name) {
+  try {
+    return binaryPath(name);
+  } catch (error) {
+    console.error(
+      `conU binary is unavailable for this platform: ${platformErrorMessage(error)}; pathDisplayed=false contentsDisplayed=false`
+    );
+    process.exit(127);
+  }
+}
+
+function launchExecutable(name, executable) {
+  try {
+    return spawn(executable, process.argv.slice(2), {
+      stdio: "inherit",
+      env: process.env
+    });
+  } catch (error) {
+    reportLaunchError(name, error);
+  }
+}
+
+function reportLaunchError(name, error) {
+  console.error(
+    `failed to launch ${name}; errorCode=${runtimeErrorCode(error)} pathDisplayed=false contentsDisplayed=false`
+  );
+  process.exit(1);
+}
+
+function platformErrorMessage(error) {
+  const message = error && typeof error.message === "string" ? error.message : "";
+  if (message.startsWith("unsupported conU platform: ")) {
+    return message;
+  }
+  if (message === "the npm package currently ships Windows x64 binaries only") {
+    return message;
+  }
+  return "runtime configuration error";
+}
+
+function runtimeErrorCode(error) {
+  const code = error && typeof error.code === "string" ? error.code : "";
+  if (/^[A-Z0-9_]+$/.test(code)) {
+    return code;
+  }
+  return "UNKNOWN";
+}

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -5,7 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
-const { BINARIES, binarySuffix, vendorDir } = require("../lib/platform");
+const { BINARIES, binarySuffix, platformKey, vendorDir } = require("../lib/platform");
 
 const packageRoot = path.resolve(__dirname, "..");
 
@@ -37,16 +37,15 @@ function main() {
     expectIncludes(output, "sourcePathDisplayed=false", "local install source path guard");
   });
 
-  console.log("install output privacy check passed");
+  expectLauncherMissingBinaryIsRedacted();
+  expectLauncherInvalidBinaryIsRedacted();
+  expectLauncherSpawnFailureIsRedacted();
+
+  console.log("install and launcher output privacy check passed");
 }
 
 function runNode(args, envOverrides = {}) {
-  const env = { ...process.env, ...envOverrides };
-  for (const [name, value] of Object.entries(envOverrides)) {
-    if (value === "") {
-      delete env[name];
-    }
-  }
+  const env = buildEnv(envOverrides);
   const result = spawnSync(process.execPath, args, {
     cwd: packageRoot,
     env,
@@ -60,6 +59,78 @@ function runNode(args, envOverrides = {}) {
     throw new Error(`node command failed with ${result.status}: ${output}`);
   }
   return output;
+}
+
+function runNodeFailure(args, envOverrides = {}, cwd = packageRoot) {
+  const result = spawnSync(process.execPath, args, {
+    cwd,
+    env: buildEnv(envOverrides),
+    encoding: "utf8",
+    errors: "replace",
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  if (result.status === 0) {
+    throw new Error(`expected node command to fail, but it passed: ${output}`);
+  }
+  return output;
+}
+
+function buildEnv(envOverrides = {}) {
+  const env = { ...process.env, ...envOverrides };
+  for (const [name, value] of Object.entries(envOverrides)) {
+    if (value === "") {
+      delete env[name];
+    }
+  }
+  return env;
+}
+
+function expectLauncherMissingBinaryIsRedacted() {
+  withFixture((root) => {
+    const packageCopy = path.join(root, "package");
+    copyPackage(packageRoot, packageCopy);
+
+    const output = runNodeFailure([path.join(packageCopy, "bin", "conu.js")], {}, packageCopy);
+
+    expectNoLocalPath(output, root, "launcher missing temp root");
+    expectNoLocalPath(output, path.join(packageCopy, "vendor"), "launcher missing vendor dir");
+    expectIncludes(output, "pathDisplayed=false", "launcher missing path display guard");
+    expectIncludes(output, "contentsDisplayed=false", "launcher missing content display guard");
+  });
+}
+
+function expectLauncherInvalidBinaryIsRedacted() {
+  withFixture((root) => {
+    const packageCopy = path.join(root, "package");
+    const poisonedBinaryName = path.join(root, "env-secret-binary");
+    copyPackage(packageRoot, packageCopy);
+
+    const output = runNodeFailure([path.join(packageCopy, "lib", "run.js")], {
+      CONU_BIN_NAME: poisonedBinaryName
+    }, packageCopy);
+
+    expectNoLocalPath(output, root, "launcher invalid env temp root");
+    expectNotIncludes(output, poisonedBinaryName, "launcher invalid env value guard");
+    expectIncludes(output, "contentsDisplayed=false", "launcher invalid env content display guard");
+  });
+}
+
+function expectLauncherSpawnFailureIsRedacted() {
+  withFixture((root) => {
+    const packageCopy = path.join(root, "package");
+    copyPackage(packageRoot, packageCopy);
+
+    const executable = path.join(packageCopy, "vendor", platformKey(), `conu${binarySuffix()}`);
+    fs.mkdirSync(executable, { recursive: true });
+
+    const output = runNodeFailure([path.join(packageCopy, "bin", "conu.js")], {}, packageCopy);
+
+    expectNoLocalPath(output, root, "launcher spawn error temp root");
+    expectIncludes(output, "pathDisplayed=false", "launcher spawn path display guard");
+    expectIncludes(output, "contentsDisplayed=false", "launcher spawn content display guard");
+  });
 }
 
 function withFixture(callback) {


### PR DESCRIPTION
## **User description**
Closes #754.

Changes:
- Redacts npm launcher missing-binary output so local executable paths are not printed.
- Rejects invalid CONU_BIN_NAME values without echoing untrusted env contents.
- Redacts raw spawn failure messages while preserving a safe error code.
- Extends the npm privacy regression to cover missing binary, invalid env, and spawn failure paths.

Validation:
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript
- python scripts\check-python-script-compile.py
- python scripts\verify-release-versions.py
- python scripts\check-smoke-output-privacy.py
- python scripts\check-production-readiness-toolchain.py
- python scripts\verify-npm-package-contents.py
- python scripts\verify-npm-package-contents-regression.py
- python scripts\check-npm-publish-preflight.py
- python scripts\check-npm-publish-preflight-regression.py
- python scripts\check-github-workflow-permissions.py
- python scripts\check-tagged-release-readiness-regression.py
- cargo fmt --all -- --check
- git diff --check

Local Rust workspace tests: cargo test --workspace is blocked on this Windows host because link.exe from Visual C++ Build Tools is not installed; GitHub CI should cover the Rust compile/test gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts npm launcher runtime failure output to prevent leaking local paths and untrusted env values. Adds strict binary selection and regression tests to enforce privacy across error paths.

- **Bug Fixes**
  - Redact missing-binary messages; no executable paths printed.
  - Validate `CONU_BIN_NAME` against `BINARIES`; reject invalid values without echoing env contents.
  - Sanitize spawn failures; show only a safe `errorCode`, not raw error text.
  - Keep known-safe platform errors; otherwise show a generic message.
  - Add regression tests covering missing binary, invalid env, and spawn failures, asserting no local paths or contents are displayed.

<sup>Written for commit 74ab5387471812e86634ff214230380ab98c43da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact npm launcher failures so they no longer leak local paths or raw error details**

### What Changed
- When the npm launcher cannot find a binary, it now shows a redacted error instead of printing the full local path.
- If `CONU_BIN_NAME` is invalid, the launcher now rejects it without echoing the environment value.
- If startup fails while launching the binary, the message now shows a safe error code and hides the raw failure text.
- The privacy checks now cover missing binary, invalid environment value, and launch failure cases.

### Impact
`✅ Fewer local path leaks in npm errors`
`✅ Safer handling of invalid environment values`
`✅ Clearer launch failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
