### PR TITLE
Redact unknown CLI argument output

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -64,6 +64,24 @@ impl CliOutput {
     }
 }
 
+fn unknown_command_error() -> CliOutput {
+    CliOutput::failure(
+        2,
+        format!(
+            "unknown command; contentsDisplayed=false\n\n{}",
+            render_help()
+        ),
+    )
+}
+
+fn unknown_option_error() -> CliOutput {
+    CliOutput::failure(2, "unknown option; contentsDisplayed=false")
+}
+
+fn unexpected_argument_error() -> CliOutput {
+    CliOutput::failure(2, "unexpected argument; contentsDisplayed=false")
+}
+
 /// Dispatch a conU CLI invocation.
 pub fn run<I, S>(args: I) -> CliOutput
 where
@@ -142,10 +160,7 @@ where
         "stop" => render_stop(&args[1..], home_override),
         "--help" | "-h" | "help" => CliOutput::success(render_help()),
         "--version" | "-V" => CliOutput::success(format!("conu {}", env!("CARGO_PKG_VERSION"))),
-        unknown => CliOutput::failure(
-            2,
-            format!("unknown command: {unknown}\n\n{}", render_help()),
-        ),
+        _unknown => unknown_command_error(),
     }
 }
 
@@ -860,7 +875,7 @@ fn parse_agent_export_args(args: &[String]) -> Result<AgentExportArgs, CliOutput
         match arg.as_str() {
             "--json" => json = true,
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -963,7 +978,7 @@ fn parse_agent_trust_args(args: &[String]) -> Result<AgentTrustArgs, CliOutput> 
                 index += 2;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => {
                 positional.push(value.to_string());
@@ -1123,7 +1138,7 @@ fn parse_register_args(args: &[String]) -> Result<RegisterArgs, CliOutput> {
                 index += 2;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => {
                 positional.push(value.to_string());
@@ -1209,7 +1224,7 @@ fn parse_heartbeat_args(args: &[String]) -> Result<HeartbeatArgs, CliOutput> {
                 index += 2;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => {
                 if agent_id.is_some() {
@@ -1770,7 +1785,7 @@ fn parse_message_send_args(args: &[String]) -> Result<MessageSendArgs, CliOutput
                 index += 1;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -1798,7 +1813,7 @@ fn parse_message_inbox_args(args: &[String]) -> Result<MessageInboxArgs, CliOutp
         match arg.as_str() {
             "--json" => json = true,
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => {
                 if agent_id.is_some() {
@@ -2133,7 +2148,7 @@ fn parse_stream_open_args(args: &[String]) -> Result<StreamOpenArgs, CliOutput> 
                 kind = value.clone();
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -2162,7 +2177,7 @@ fn parse_stream_io_args(args: &[String], command: &'static str) -> Result<Stream
             "--json" => json = true,
             "--stdin" => stdin = true,
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => {
                 if stream_id.is_some() {
@@ -2856,7 +2871,7 @@ fn parse_room_create_args(args: &[String]) -> Result<RoomCreateArgs, CliOutput> 
                 index += 1;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -2886,7 +2901,7 @@ fn parse_room_join_args(args: &[String]) -> Result<RoomJoinArgs, CliOutput> {
         match arg.as_str() {
             "--json" => json = true,
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -2913,7 +2928,7 @@ fn parse_room_publish_args(args: &[String]) -> Result<RoomPublishArgs, CliOutput
             "--json" => json = true,
             "--stdin" => stdin = true,
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -2961,7 +2976,7 @@ fn parse_room_policy_args(args: &[String]) -> Result<RoomPolicyArgs, CliOutput> 
                 index += 2;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => {
                 positional.push(value.to_string());
@@ -3766,7 +3781,7 @@ fn parse_relay_sync_args(args: &[String]) -> Result<RelaySyncArgs, CliOutput> {
                 index += 1;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             _ => return Err(CliOutput::failure(2, render_relay_usage())),
         }
@@ -3785,7 +3800,7 @@ fn parse_relay_credential_set_args(args: &[String]) -> Result<RelayCredentialSet
             "--stdin" => stdin = true,
             "--json" => json = true,
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             _ => return Err(CliOutput::failure(2, render_relay_usage())),
         }
@@ -4936,7 +4951,7 @@ fn parse_peer_policy_args(args: &[String]) -> Result<PeerPolicyArgs, CliOutput> 
                 index += 2;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => {
                 positional.push(value.to_string());
@@ -5032,7 +5047,7 @@ fn parse_peer_trust_args(args: &[String]) -> Result<PeerTrustArgs, CliOutput> {
                 index += 1;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -5077,7 +5092,7 @@ fn parse_peer_revoke_args(args: &[String]) -> Result<(String, bool), CliOutput> 
         match arg.as_str() {
             "--json" => json = true,
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => {
                 if peer.is_some() {
@@ -5429,7 +5444,7 @@ fn parse_connect_local_args(args: &[String]) -> Result<ConnectLocalArgs, CliOutp
                 index += 1;
             }
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -5456,7 +5471,7 @@ fn parse_connect_room_args(args: &[String]) -> Result<ConnectRoomArgs, CliOutput
         match arg.as_str() {
             "--json" => json = true,
             value if value.starts_with("--") => {
-                return Err(CliOutput::failure(2, format!("unknown option: {value}")));
+                return Err(unknown_option_error());
             }
             value => positional.push(value.to_string()),
         }
@@ -11496,7 +11511,7 @@ fn json_flag(args: &[String]) -> Result<bool, CliOutput> {
         if arg == "--json" {
             json = true;
         } else {
-            return Err(CliOutput::failure(2, format!("unknown option: {arg}")));
+            return Err(unknown_option_error());
         }
     }
     Ok(json)
@@ -11521,8 +11536,7 @@ fn join_code(args: &[String]) -> Result<&str, CliOutput> {
 }
 
 fn reject_args(args: &[String]) -> Option<CliOutput> {
-    args.first()
-        .map(|arg| CliOutput::failure(2, format!("unexpected argument: {arg}")))
+    args.first().map(|_arg| unexpected_argument_error())
 }
 
 fn finish(mut output: String) -> String {
@@ -14817,6 +14831,25 @@ mod tests {
         assert_eq!(output.code, 2);
         assert!(output.stderr.contains("unknown command"));
         assert!(output.stderr.contains("Usage:"));
+    }
+
+    #[test]
+    fn unknown_cli_arguments_do_not_echo_secret_like_values() {
+        let secret_command = "secret-relay-token";
+        let secret_option = "--secret-relay-token";
+        let secret_argument = "secret-extra-argument";
+
+        let command = run([secret_command]);
+        let option = run(["agents", "export", secret_option]);
+        let argument = run(["dashboard", secret_argument]);
+
+        for output in [command, option, argument] {
+            assert_eq!(output.code, 2);
+            assert!(output.stderr.contains("contentsDisplayed=false"));
+            assert!(!output.stderr.contains(secret_command));
+            assert!(!output.stderr.contains(secret_option));
+            assert!(!output.stderr.contains(secret_argument));
+        }
     }
 
     fn temp_home(label: &str) -> PathBuf {

--- a/crates/conu-relay/src/main.rs
+++ b/crates/conu-relay/src/main.rs
@@ -477,8 +477,8 @@ fn main() -> ExitCode {
             println!("conu-relay {}", env!("CARGO_PKG_VERSION"));
             ExitCode::SUCCESS
         }
-        Some(unknown) => {
-            eprintln!("unknown option: {unknown}");
+        Some(_unknown) => {
+            eprintln!("{}", unknown_option_error());
             print_help();
             ExitCode::from(2)
         }
@@ -488,6 +488,10 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
     }
+}
+
+fn unknown_option_error() -> String {
+    "unknown option; contentsDisplayed=false".to_string()
 }
 
 fn print_help() {
@@ -693,7 +697,7 @@ fn parse_admin_token_audit_args(args: Vec<String>) -> Result<AdminTokenAuditArgs
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_token_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(admin_token_audit_usage()),
         }
         index += 1;
@@ -1097,7 +1101,7 @@ fn parse_hosted_readiness_args(args: Vec<String>) -> Result<HostedReadinessArgs,
                 };
                 parse_abuse_threshold_option(&mut cli_thresholds, value, limit)?;
             }
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(hosted_readiness_usage()),
         }
         index += 1;
@@ -2070,7 +2074,7 @@ fn parse_issue_credential_args(args: Vec<String>) -> Result<IssueCredentialArgs,
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(issue_credential_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -2219,7 +2223,7 @@ fn parse_revoke_credential_args(args: Vec<String>) -> Result<RevokeCredentialArg
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(revoke_credential_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -2419,7 +2423,7 @@ fn parse_admin_credential_args(
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(mode.usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -2501,7 +2505,7 @@ fn parse_admin_revoke_args(args: Vec<String>) -> Result<AdminRevokeArgs, String>
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_revoke_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -2584,7 +2588,7 @@ fn parse_admin_audit_args(args: Vec<String>) -> Result<AdminAuditArgs, String> {
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(admin_audit_usage()),
         }
         index += 1;
@@ -2677,7 +2681,7 @@ fn parse_admin_dashboard_args(args: Vec<String>) -> Result<AdminDashboardArgs, S
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_dashboard_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(admin_dashboard_usage()),
         }
         index += 1;
@@ -2764,7 +2768,7 @@ fn parse_admin_session_audit_args(args: Vec<String>) -> Result<AdminSessionAudit
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_session_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(admin_session_audit_usage()),
         }
         index += 1;
@@ -2920,7 +2924,7 @@ fn parse_admin_abuse_threshold_report_args(
                 };
                 parse_abuse_threshold_option(&mut cli_thresholds, value, limit)?;
             }
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(admin_abuse_threshold_report_usage()),
         }
         index += 1;
@@ -3054,7 +3058,7 @@ fn parse_admin_tenant_account_args(
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(mode.usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -3195,7 +3199,7 @@ fn parse_admin_tenant_node_upsert_args(
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_tenant_node_upsert_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -3281,7 +3285,7 @@ fn parse_admin_tenant_node_revoke_args(
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_tenant_node_revoke_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -3364,7 +3368,7 @@ fn parse_admin_tenant_audit_args(args: Vec<String>) -> Result<AdminTenantAuditAr
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_tenant_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(admin_tenant_audit_usage()),
         }
         index += 1;
@@ -3443,7 +3447,7 @@ fn parse_admin_account_suspend_args(args: Vec<String>) -> Result<AdminAccountSus
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_account_suspend_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -3558,7 +3562,7 @@ fn parse_admin_mailbox_audit_args(args: Vec<String>) -> Result<AdminMailboxAudit
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_mailbox_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(admin_mailbox_audit_usage()),
         }
         index += 1;
@@ -3681,7 +3685,7 @@ fn parse_admin_mailbox_purge_args(args: Vec<String>) -> Result<AdminMailboxPurge
             "--admin-token-stdin" => admin_token_stdin = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(admin_mailbox_purge_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(admin_mailbox_purge_usage()),
         }
         index += 1;
@@ -4494,7 +4498,7 @@ fn parse_tenant_account_args(
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(tenant_account_usage(command)),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -4617,7 +4621,7 @@ fn parse_tenant_node_upsert_args(args: Vec<String>) -> Result<TenantNodeUpsertAr
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(tenant_node_upsert_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -4682,7 +4686,7 @@ fn parse_tenant_node_revoke_args(args: Vec<String>) -> Result<TenantNodeRevokeAr
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(tenant_node_revoke_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -4750,7 +4754,7 @@ fn parse_tenant_audit_args(args: Vec<String>) -> Result<TenantAuditArgs, String>
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(tenant_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(tenant_audit_usage()),
         }
         index += 1;
@@ -4823,7 +4827,7 @@ fn parse_hosted_account_suspend_args(
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(hosted_account_suspend_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -5005,7 +5009,7 @@ fn parse_hosted_fleet_account_audit_args(
             "--json" => json = true,
             "--fail-on-warning" => fail_on_warning = true,
             "--help" | "-h" => return Err(hosted_fleet_account_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -5351,7 +5355,7 @@ fn parse_hosted_fleet_account_suspend_args(
             "--confirm" => confirm = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(hosted_fleet_account_suspend_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -5688,7 +5692,7 @@ fn parse_hosted_fleet_credential_revoke_args(
             "--confirm" => confirm = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(hosted_fleet_credential_revoke_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -6033,7 +6037,7 @@ fn parse_hosted_fleet_tenant_account_lifecycle_args(
             "--confirm" => confirm = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(mode.usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -6412,7 +6416,7 @@ fn parse_hosted_fleet_tenant_node_lifecycle_args(
             "--confirm" => confirm = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(mode.usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             value => positional.push(value.to_string()),
         }
         index += 1;
@@ -6667,7 +6671,7 @@ fn parse_session_audit_args(args: Vec<String>) -> Result<SessionAuditArgs, Strin
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(session_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(session_audit_usage()),
         }
         index += 1;
@@ -6733,7 +6737,7 @@ fn parse_abuse_audit_args(args: Vec<String>) -> Result<AbuseAuditArgs, String> {
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(abuse_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(abuse_audit_usage()),
         }
         index += 1;
@@ -6931,7 +6935,7 @@ fn parse_abuse_threshold_report_args(
                 };
                 parse_abuse_threshold_option(&mut cli_thresholds, value, limit)?;
             }
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(abuse_threshold_report_usage()),
         }
         index += 1;
@@ -7397,7 +7401,7 @@ fn parse_mailbox_audit_args(args: Vec<String>) -> Result<MailboxAuditArgs, Strin
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(mailbox_audit_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(mailbox_audit_usage()),
         }
         index += 1;
@@ -7661,7 +7665,7 @@ fn parse_mailbox_purge_args(args: Vec<String>) -> Result<MailboxPurgeArgs, Strin
             "--confirm" => confirm = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(mailbox_purge_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(mailbox_purge_usage()),
         }
         index += 1;
@@ -7838,7 +7842,7 @@ fn parse_hosted_fleet_mailbox_purge_args(
             "--confirm" => confirm = true,
             "--json" => json = true,
             "--help" | "-h" => return Err(hosted_fleet_mailbox_purge_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(hosted_fleet_mailbox_purge_usage()),
         }
         index += 1;
@@ -8123,7 +8127,7 @@ fn parse_hosted_fleet_abuse_response_plan_args(
                 };
                 parse_abuse_threshold_option(&mut cli_thresholds, value, limit)?;
             }
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(hosted_fleet_abuse_response_plan_usage()),
         }
         index += 1;
@@ -8880,7 +8884,7 @@ fn parse_hosted_fleet_dashboard_args(
                 };
                 parse_abuse_threshold_option(&mut cli_thresholds, value, limit)?;
             }
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(hosted_fleet_dashboard_usage()),
         }
         index += 1;
@@ -9277,7 +9281,7 @@ fn parse_hosted_dashboard_args(args: Vec<String>) -> Result<HostedDashboardArgs,
             }
             "--json" => json = true,
             "--help" | "-h" => return Err(hosted_dashboard_usage()),
-            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value if value.starts_with("--") => return Err(unknown_option_error()),
             _ => return Err(hosted_dashboard_usage()),
         }
         index += 1;
@@ -13342,6 +13346,16 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TEST_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn unknown_option_error_redacts_argument_contents() {
+        let secret_marker = "--relay-secret-token";
+        let error = unknown_option_error();
+
+        assert!(error.contains("unknown option"));
+        assert!(error.contains("contentsDisplayed=false"));
+        assert!(!error.contains(secret_marker));
+    }
 
     fn abuse_threshold_policy_contents(thresholds: &str) -> String {
         format!(

--- a/crates/conud/src/main.rs
+++ b/crates/conud/src/main.rs
@@ -21,12 +21,16 @@ fn main() -> ExitCode {
             println!("conud {}", env!("CARGO_PKG_VERSION"));
             ExitCode::SUCCESS
         }
-        Some(unknown) => {
-            eprintln!("unknown option: {unknown}");
+        Some(_unknown) => {
+            eprintln!("{}", unknown_option_message());
             print_help();
             ExitCode::from(2)
         }
     }
+}
+
+fn unknown_option_message() -> &'static str {
+    "unknown option; contentsDisplayed=false"
 }
 
 fn serve_runtime() -> ExitCode {
@@ -196,4 +200,19 @@ Usage:
   conud --help
   conud --version"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_option_message_redacts_argument_contents() {
+        let secret_marker = "--relay-secret-token";
+        let message = unknown_option_message();
+
+        assert!(message.contains("unknown option"));
+        assert!(message.contains("contentsDisplayed=false"));
+        assert!(!message.contains(secret_marker));
+    }
 }


### PR DESCRIPTION
## **User description**
Closes #756.

Changes:
- Redacts unknown command output in the conu CLI so secret-like command text is not echoed.
- Redacts unknown option output across conu, conud, and conu-relay parsers.
- Redacts unexpected extra-argument output from shared conu argument rejection.
- Adds focused redaction tests for conu, conud, and conu-relay unknown argument helpers.

Validation:
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- rg -n "unknown option:|unknown command:|unexpected argument:" crates\conu-cli\src crates\conud\src crates\conu-relay\src (no matches)
- python scripts\check-python-script-compile.py
- python scripts\check-smoke-output-privacy.py
- python scripts\check-production-readiness-toolchain.py
- python scripts\verify-release-versions.py
- python scripts\check-tagged-release-readiness-regression.py
- python scripts\verify-npm-package-contents.py
- python scripts\verify-npm-package-contents-regression.py
- python scripts\check-npm-publish-preflight.py
- python scripts\check-npm-publish-preflight-regression.py
- python scripts\check-github-workflow-permissions.py
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript

Local Rust focused tests attempted but blocked because this Windows host lacks MSVC link.exe; GitHub CI should validate Rust compile/test coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts unknown CLI argument output across `conu`, `conud`, and `conu-relay` to prevent echoing secret-like values. Errors keep exit code 2 and show help where relevant.

- **Bug Fixes**
  - Replace unknown command/option/extra-argument errors with redacted messages that include "contentsDisplayed=false" and never echo user input.
  - Apply redaction across all argument parsers and shared rejection paths in `conu`, plus equivalent helpers in `conu-relay` and `conud`.
  - Add focused tests to verify redaction behavior in all three CLIs.

<sup>Written for commit fb1cec93decf9eb37c6007c7352ad1a22748b67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide user input in unknown CLI errors**

### What Changed
- Unknown commands, options, and extra arguments now show a redacted error instead of echoing the value back to the terminal
- The CLI still returns exit code 2 and shows help where it did before
- Added tests to confirm secret-like command text and arguments are not printed in these error cases

### Impact
`✅ Fewer secrets exposed in terminal errors`
`✅ Safer CLI use with pasted tokens or sensitive arguments`
`✅ Clearer failure output without revealing input`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
