### PR TITLE
Redact local update check paths

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -9018,15 +9018,12 @@ fn default_update_target() -> Option<&'static str> {
 
 fn render_update_check_json(report: &UpdateCheckReport) -> String {
     let location_fields = match report.source {
-        UpdateCheckSource::Local => format!(
-            r#"
-  "policyFile": "{}",
-  "sha256File": "{}",
-  "signatureFile": "{}","#,
-            json_escape(&report.policy_location),
-            json_escape(&report.sha256_location),
-            json_escape(&report.signature_location)
-        ),
+        UpdateCheckSource::Local => r#"
+  "policyFile": "local",
+  "sha256File": "local",
+  "signatureFile": "local",
+  "pathDisplayed": false,"#
+            .to_string(),
         UpdateCheckSource::Remote => format!(
             r#"
   "policyUrl": "{}",
@@ -9089,9 +9086,9 @@ fn render_update_check_json(report: &UpdateCheckReport) -> String {
 }
 
 fn render_update_check_text(report: &UpdateCheckReport) -> String {
-    let location_label = match report.source {
-        UpdateCheckSource::Local => "file",
-        UpdateCheckSource::Remote => "url",
+    let (location_label, location_value) = match report.source {
+        UpdateCheckSource::Local => ("file", "local; pathDisplayed=false".to_string()),
+        UpdateCheckSource::Remote => ("url", report.policy_location.clone()),
     };
     format!(
         r"conU update check
@@ -9131,7 +9128,7 @@ privacy
         report.channel,
         report.release_base_url,
         location_label,
-        report.policy_location,
+        location_value,
         report.sha256,
         yes_no(report.gpg_verified),
         yes_no(report.auto_apply),
@@ -11602,18 +11599,15 @@ mod tests {
 
     #[test]
     fn update_check_validates_signed_policy_metadata_without_payloads() {
-        let home = temp_home("update-check");
+        let home = temp_home("update-check-secret-local-path");
         let policy = write_update_policy_fixture(&home, false);
+        let policy_path = policy.to_str().expect("policy path");
 
-        let output = run([
-            "update",
-            "check",
-            "--policy-file",
-            policy.to_str().expect("policy path"),
-            "--json",
-        ]);
+        let output = run(["update", "check", "--policy-file", policy_path, "--json"]);
+        let text_output = run(["update", "check", "--policy-file", policy_path]);
 
         assert_eq!(output.code, 0, "{}", output.stderr);
+        assert_eq!(text_output.code, 0, "{}", text_output.stderr);
         assert!(
             output
                 .stdout
@@ -11628,9 +11622,18 @@ mod tests {
                 .stdout
                 .contains("\"manualVerificationRequired\": true")
         );
+        assert!(output.stdout.contains("\"policyFile\": \"local\""));
+        assert!(output.stdout.contains("\"pathDisplayed\": false"));
+        assert!(text_output.stdout.contains("local; pathDisplayed=false"));
         assert!(output.stdout.contains("\"contentsDisplayed\": false"));
+        assert!(!output.stdout.contains(policy_path));
+        assert!(!text_output.stdout.contains(policy_path));
+        assert!(!output.stdout.contains("secret-local-path"));
+        assert!(!text_output.stdout.contains("secret-local-path"));
         assert!(!output.stdout.contains("BEGIN PGP SIGNATURE"));
+        assert!(!text_output.stdout.contains("BEGIN PGP SIGNATURE"));
         assert!(!output.stdout.contains("private message contents"));
+        assert!(!text_output.stdout.contains("private message contents"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #758.

Changes:
- Redacts successful local `conu update check --policy-file` JSON output so policy/checksum/signature fields no longer expose full local paths.
- Redacts successful local update-check text output with `pathDisplayed=false`.
- Keeps remote public URL reporting unchanged; update URL validation already rejects credentials, queries, fragments, non-public hosts, and unsafe paths.
- Extends the update-check regression to prove JSON and text output do not contain the local policy path or a secret-looking path marker.

Validation:
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- python scripts\check-python-script-compile.py
- python scripts\check-smoke-output-privacy.py
- python scripts\check-production-readiness-toolchain.py
- python scripts\verify-release-versions.py
- python scripts\check-tagged-release-readiness-regression.py
- python scripts\verify-npm-package-contents.py
- python scripts\verify-npm-package-contents-regression.py
- python scripts\check-npm-publish-preflight.py
- python scripts\check-npm-publish-preflight-regression.py
- python scripts\check-github-workflow-permissions.py
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript

Local focused Rust test attempted but blocked because this Windows host lacks MSVC link.exe; GitHub CI should validate Rust compile/test coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts local paths in `conu update check` output to prevent leaking file system details. JSON and text now show "local" with pathDisplayed=false; remote URL reporting is unchanged.

- **Bug Fixes**
  - JSON: `policyFile`, `sha256File`, `signatureFile` set to "local"; added `pathDisplayed=false`.
  - Text: shows "local; pathDisplayed=false" instead of the full local path.
  - Extended regression tests to ensure JSON/text never include the local policy path or secret-like markers; remote URL validation remains strict.

<sup>Written for commit 909c66b018897df5239115215842a73020ac8671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide local file paths in update check output**

### What Changed
- Local `update check` output no longer prints full file paths for policy, checksum, and signature files.
- The text output now shows that the path is hidden instead of revealing the local location.
- Remote update check output still shows public URLs as before.
- Tests now verify that local paths and secret-like markers do not appear in either JSON or text output.

### Impact
`✅ Fewer local file path leaks`
`✅ Safer update check output`
`✅ Clearer privacy behavior for local policy checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
