### PR TITLE
Redact update failure paths

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -6336,7 +6336,7 @@ fn render_update_download(args: &[String]) -> CliOutput {
                 CliOutput::success(render_update_download_text(&report))
             }
         }
-        Err(error) => CliOutput::failure(1, format!("conU update download failed\n\n{error}")),
+        Err(error) => update_command_failure("download", &error),
     }
 }
 
@@ -6354,8 +6354,76 @@ fn render_update_apply(args: &[String]) -> CliOutput {
                 CliOutput::success(render_update_apply_text(&report))
             }
         }
-        Err(error) => CliOutput::failure(1, format!("conU update apply failed\n\n{error}")),
+        Err(error) => update_command_failure("apply", &error),
     }
+}
+
+fn update_command_failure(command: &str, error: &str) -> CliOutput {
+    CliOutput::failure(
+        1,
+        format!(
+            "conU update {command} failed\n\n{}\n\ncontentsDisplayed=false",
+            redact_update_failure_paths(error)
+        ),
+    )
+}
+
+fn redact_update_failure_paths(error: &str) -> String {
+    let mut output = String::with_capacity(error.len());
+    let mut token = String::new();
+
+    for ch in error.chars() {
+        if ch.is_whitespace() {
+            append_redacted_update_failure_token(&mut output, &token);
+            token.clear();
+            output.push(ch);
+        } else {
+            token.push(ch);
+        }
+    }
+    append_redacted_update_failure_token(&mut output, &token);
+
+    output
+}
+
+fn append_redacted_update_failure_token(output: &mut String, token: &str) {
+    if token.is_empty() {
+        return;
+    }
+
+    if is_update_local_path_token(token) {
+        output.push_str("local; pathDisplayed=false");
+    } else {
+        output.push_str(token);
+    }
+}
+
+fn is_update_local_path_token(token: &str) -> bool {
+    let trimmed = token.trim_matches(|ch: char| {
+        matches!(
+            ch,
+            '"' | '\'' | '`' | ',' | ';' | ':' | '!' | '?' | '(' | ')' | '[' | ']' | '{' | '}'
+        )
+    });
+    let lower = trimmed.to_ascii_lowercase();
+
+    if lower.contains("http://") || lower.contains("https://") {
+        return false;
+    }
+    if trimmed.starts_with("~/") || trimmed.starts_with("~\\") {
+        return true;
+    }
+
+    let bytes = trimmed.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+    {
+        return true;
+    }
+
+    trimmed.contains('\\') || trimmed.contains('/')
 }
 
 fn parse_update_check_args(args: &[String]) -> Result<UpdateCheckArgs, CliOutput> {
@@ -12178,6 +12246,29 @@ mod tests {
     }
 
     #[test]
+    fn update_failure_redacts_local_paths_without_hiding_public_urls() {
+        let error = concat!(
+            r#"release update install-dir is not a directory: C:\secret-local-path\bin"#,
+            "\n",
+            "downloaded https://github.com/imthegoodboy/conU/releases/download/v0.1.0/conu.zip ",
+            "into /tmp/secret-local-path/conu.tar.gz",
+            "\n",
+            "relative dist/secret-local-path/conu.zip failed"
+        );
+        let redacted = redact_update_failure_paths(error);
+
+        assert!(
+            redacted
+                .contains("https://github.com/imthegoodboy/conU/releases/download/v0.1.0/conu.zip")
+        );
+        assert!(redacted.contains("local; pathDisplayed=false"));
+        assert!(!redacted.contains("secret-local-path"));
+        assert!(!redacted.contains(r#"C:\"#));
+        assert!(!redacted.contains("/tmp/"));
+        assert!(!redacted.contains("dist/"));
+    }
+
+    #[test]
     fn update_apply_dry_run_validates_archive_without_installing() {
         let target = update_apply_test_target();
         let filename = update_archive_fixture_name(&target);
@@ -12237,6 +12328,44 @@ mod tests {
         assert!(!output.stdout.contains("BEGIN PGP SIGNATURE"));
         assert!(!text_output.stdout.contains("BEGIN PGP SIGNATURE"));
         assert!(!install_dir.exists());
+    }
+
+    #[test]
+    fn update_apply_failure_redacts_install_dir_path() {
+        let target = update_apply_test_target();
+        let filename = update_archive_fixture_name(&target);
+        let archive_bytes = update_archive_fixture_bytes(&target, false);
+        let archive_sha = sha256_hex(&archive_bytes);
+        let home = temp_home("update-apply-error-secret-local-path");
+        let policy =
+            write_update_policy_fixture_for_asset(&home, false, &archive_sha, &target, &filename);
+        let artifact = write_update_artifact_fixture(&home, &filename, &archive_bytes);
+        let install_dir = home.join("install-bin");
+        fs::write(&install_dir, b"not a directory").expect("install marker writes");
+        let local_path_text = home.display().to_string();
+
+        let output = run(vec![
+            "update".to_string(),
+            "apply".to_string(),
+            "--policy-file".to_string(),
+            policy.to_str().expect("policy path").to_string(),
+            "--artifact-file".to_string(),
+            artifact.to_str().expect("artifact path").to_string(),
+            "--install-dir".to_string(),
+            install_dir.to_str().expect("install path").to_string(),
+            "--dry-run".to_string(),
+            "--target".to_string(),
+            target,
+        ]);
+
+        assert_eq!(output.code, 1);
+        assert!(output.stderr.contains("install-dir is not a directory"));
+        assert!(output.stderr.contains("contentsDisplayed=false"));
+        assert!(output.stderr.contains("pathDisplayed=false"));
+        assert!(!output.stderr.contains(&local_path_text));
+        assert!(!output.stderr.contains("secret-local-path"));
+        assert!(!output.stderr.contains("fixture binary bytes"));
+        assert!(!output.stderr.contains("BEGIN PGP SIGNATURE"));
     }
 
     #[cfg(unix)]
@@ -13398,11 +13527,12 @@ mod tests {
         let filename = update_archive_fixture_name(&target);
         let archive_bytes = update_archive_fixture_bytes(&target, false);
         let expected_sha = sha256_hex(&archive_bytes);
-        let home = temp_home("update-apply-drift");
+        let home = temp_home("update-apply-drift-secret-local-path");
         let policy =
             write_update_policy_fixture_for_asset(&home, false, &expected_sha, &target, &filename);
         let artifact = write_update_artifact_fixture(&home, &filename, b"tampered archive bytes");
         let install_dir = home.join("install-bin");
+        let local_path_text = home.display().to_string();
 
         let output = run([
             "update",
@@ -13419,6 +13549,11 @@ mod tests {
 
         assert_eq!(output.code, 1);
         assert!(output.stderr.contains("SHA-256 did not match policy"));
+        assert!(output.stderr.contains("contentsDisplayed=false"));
+        assert!(!output.stderr.contains(&local_path_text));
+        assert!(!output.stderr.contains("secret-local-path"));
+        assert!(!output.stderr.contains("tampered archive bytes"));
+        assert!(!output.stderr.contains("BEGIN PGP SIGNATURE"));
         assert!(!install_dir.exists());
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- Redact local path-looking tokens in `conu update download` and `conu update apply` failure output.
- Preserve public HTTPS URLs and safe failure reasons while appending `contentsDisplayed=false`.
- Add regressions for the sanitizer, command-level apply path redaction, and checksum-drift failure content safety.

Closes #762

## Validation
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Local test note
- `cargo test -p conu-cli update_failure_redacts_local_paths_without_hiding_public_urls -- --exact` could not build locally because this workstation is missing MSVC `link.exe`.
- `cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_failure_redacts_local_paths_without_hiding_public_urls -- --exact` could not build locally because this workstation is missing `dlltool.exe`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts local filesystem paths from `conu update download` and `conu update apply` failure output to prevent leaking sensitive locations. Public HTTPS URLs remain visible; failures now end with `contentsDisplayed=false`.

- **Bug Fixes**
  - Centralize failure handling in `update_command_failure` and sanitize via `redact_update_failure_paths`.
  - Token-based redaction hides path-like tokens (Windows/Unix) while preserving `http://`/`https://` URLs.
  - Redacts `--install-dir` in apply errors; checksum-drift failures avoid echoing archive/signature contents.
  - Adds tests for the sanitizer, apply-path redaction, and checksum-drift safety.

<sup>Written for commit 0a0a5e34f0d9e5fd81ef7c267a0b60526d6cc7c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact local paths from update failure messages**

### What Changed
- `conu update download` and `conu update apply` now hide local filesystem paths in failure output instead of showing them directly.
- Public HTTPS links stay visible, while local path-like values are replaced with a redaction marker and the error ends with `contentsDisplayed=false`.
- Apply failures now also avoid echoing the install directory path, and checksum mismatch failures no longer expose archive or signature contents.

### Impact
`✅ Fewer leaked local paths in update errors`
`✅ Safer failure output for download and apply`
`✅ Clearer public link visibility in update failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
