### PR TITLE
Redact update check failure paths

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -6318,7 +6318,7 @@ fn render_update_check(args: &[String]) -> CliOutput {
                 CliOutput::success(render_update_check_text(&report))
             }
         }
-        Err(error) => CliOutput::failure(1, format!("conU update check failed\n\n{error}")),
+        Err(error) => update_command_failure("check", &error),
     }
 }
 
@@ -11696,6 +11696,27 @@ mod tests {
         assert!(!text_output.stdout.contains("BEGIN PGP SIGNATURE"));
         assert!(!output.stdout.contains("private message contents"));
         assert!(!text_output.stdout.contains("private message contents"));
+    }
+
+    #[test]
+    fn update_check_failure_redacts_local_policy_path() {
+        let home = temp_home("update-check-error-secret-local-path");
+        let policy = home.join("conu-0.1.0-update-policy.json");
+        fs::create_dir_all(&policy).expect("policy marker dir creates");
+        let policy_path = policy.to_str().expect("policy path");
+        let local_path_text = home.display().to_string();
+
+        let output = run(["update", "check", "--policy-file", policy_path]);
+
+        assert_eq!(output.code, 1);
+        assert!(output.stderr.contains("path is not a regular file"));
+        assert!(output.stderr.contains("contentsDisplayed=false"));
+        assert!(output.stderr.contains("pathDisplayed=false"));
+        assert!(!output.stderr.contains(&local_path_text));
+        assert!(!output.stderr.contains("secret-local-path"));
+        assert!(!output.stderr.contains(policy_path));
+        assert!(!output.stderr.contains("BEGIN PGP SIGNATURE"));
+        assert!(!output.stderr.contains("private message contents"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary
- Route `conu update check` failures through the existing update failure redactor.
- Preserve safe failure reasons while redacting local path-looking tokens and appending `contentsDisplayed=false`.
- Add a command-level regression for a local policy path failure with a secret-looking temp path.

Closes #764

## Validation
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Local test note
- `cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_check_failure_redacts_local_policy_path -- --exact` could not build locally because this workstation is missing `dlltool.exe`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `conu update check` failures through the existing update failure redactor to prevent leaking local paths or secret-looking tokens while keeping clear error reasons. Adds a regression test to ensure redaction and context flags are applied.

- **Bug Fixes**
  - Use `update_command_failure("check", ...)` in `render_update_check`.
  - Redact local path-like tokens; append `contentsDisplayed=false` and `pathDisplayed=false`.
  - Add regression test for a local policy path failure to verify redaction and flags.

<sup>Written for commit 6abbeba897479a15d82f677d2780f69ca5552a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact local path details from `conu update check` failures**

### What Changed
- `conu update check` now hides local path-like details when it fails, instead of printing the raw error path.
- Failure messages keep the user-facing reason, and now include redaction markers showing that file contents and paths were not displayed.
- Added a regression test to cover a local policy file path failure and confirm secret-looking path text stays hidden.

### Impact
`✅ Fewer leaked local file paths`
`✅ Safer update check errors`
`✅ Clearer redacted failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
