### PR TITLE
Redact stored route session endpoints

### DIFF
--- a/crates/conu-core/src/relay_endpoint.rs
+++ b/crates/conu-core/src/relay_endpoint.rs
@@ -35,6 +35,20 @@ pub(crate) fn validate_relay_endpoint(value: String) -> Result<String, RelayEndp
     Ok(value)
 }
 
+pub(crate) fn metadata_relay_endpoint(value: &str) -> Result<String, RelayEndpointError> {
+    let value = validate_relay_endpoint(value.to_string())?;
+    let (scheme, rest) = value
+        .strip_prefix("ws://")
+        .map(|rest| ("ws://", rest))
+        .or_else(|| value.strip_prefix("wss://").map(|rest| ("wss://", rest)))
+        .ok_or(RelayEndpointError::Scheme)?;
+    if let Some((authority, _path)) = rest.split_once('/') {
+        Ok(format!("{scheme}{authority}"))
+    } else {
+        Ok(value)
+    }
+}
+
 fn validate_authority(authority: &str) -> Result<(), RelayEndpointError> {
     if authority.is_empty() {
         return Err(RelayEndpointError::Invalid);
@@ -108,7 +122,7 @@ fn validate_path(path: &str) -> Result<(), RelayEndpointError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{RelayEndpointError, validate_relay_endpoint};
+    use super::{RelayEndpointError, metadata_relay_endpoint, validate_relay_endpoint};
 
     #[test]
     fn relay_endpoint_validation_accepts_supported_shapes() {
@@ -151,6 +165,26 @@ mod tests {
         assert_eq!(
             validate_relay_endpoint("https://relay.example.com".to_string()),
             Err(RelayEndpointError::Scheme)
+        );
+    }
+
+    #[test]
+    fn relay_endpoint_metadata_hides_path_segments() {
+        assert_eq!(
+            metadata_relay_endpoint("wss://relay.example.com/conu/private-token").as_deref(),
+            Ok("wss://relay.example.com")
+        );
+        assert_eq!(
+            metadata_relay_endpoint("ws://[::1]:8787/relay").as_deref(),
+            Ok("ws://[::1]:8787")
+        );
+        assert_eq!(
+            metadata_relay_endpoint("wss://relay.example.com/").as_deref(),
+            Ok("wss://relay.example.com")
+        );
+        assert_eq!(
+            metadata_relay_endpoint("ws://127.0.0.1:8787").as_deref(),
+            Ok("ws://127.0.0.1:8787")
         );
     }
 }

--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -404,16 +404,17 @@ fn relay_route_candidate(
     nat_profile: NatProfile,
     now: u64,
 ) -> Result<RouteRecord, RouteError> {
+    let endpoint = metadata_route_endpoint(endpoint.to_string(), RouteTransport::RelayWebSocket)?;
     Ok(RouteRecord {
         route_id: route_id(
             &peer.peer_node_id,
             RouteTransport::RelayWebSocket,
-            Some(endpoint),
+            Some(endpoint.as_str()),
         ),
         peer_node_id: peer.peer_node_id.clone(),
         display_name: peer.display_name.clone(),
         transport: RouteTransport::RelayWebSocket,
-        endpoint: validate_endpoint(endpoint.to_string())?,
+        endpoint,
         state: RouteState::Candidate,
         score: 70,
         latency_ms: Some(RELAY_WEBSOCKET_LATENCY_MS),
@@ -648,6 +649,7 @@ fn write_routes(paths: &StatePaths, routes: &[RouteRecord]) -> Result<(), RouteE
     let mut contents = format!("# conU route registry\nversion = \"{}\"\n", ROUTE_VERSION);
 
     for route in sorted {
+        let endpoint = metadata_route_endpoint(route.endpoint.clone(), route.transport)?;
         contents.push_str("\n[[route]]\n");
         contents.push_str(&format!(
             "route_id = \"{}\"\n",
@@ -664,7 +666,7 @@ fn write_routes(paths: &StatePaths, routes: &[RouteRecord]) -> Result<(), RouteE
         contents.push_str(&format!("transport = \"{}\"\n", route.transport.as_str()));
         contents.push_str(&format!(
             "endpoint = \"{}\"\n",
-            escape_file_value(&route.endpoint)
+            escape_file_value(&endpoint)
         ));
         contents.push_str(&format!("state = \"{}\"\n", route.state.as_str()));
         contents.push_str(&format!("score = {}\n", route.score));
@@ -720,13 +722,14 @@ fn append_probes(paths: &StatePaths, probes: &[RouteProbe]) -> Result<(), RouteE
     .unwrap_or_else(|| format!("# conU route probes\nversion = \"{}\"\n", ROUTE_VERSION));
 
     for probe in probes {
+        let endpoint = metadata_route_endpoint(probe.endpoint.clone(), probe.transport)?;
         contents.push_str(&format!(
             "\n[[probe]]\nprobe_id = \"{}\"\nroute_id = \"{}\"\npeer_node_id = \"{}\"\ntransport = \"{}\"\nendpoint = \"{}\"\noutcome = \"{}\"\nscore = {}\nlatency_ms = {}\ncandidate_source = \"{}\"\ncandidate_kind = \"{}\"\nrendezvous_state = \"{}\"\ncreated_at_unix = {}\npayload_displayed = false\n",
             escape_file_value(&probe.probe_id),
             escape_file_value(&probe.route_id),
             escape_file_value(&probe.peer_node_id),
             probe.transport.as_str(),
-            escape_file_value(&probe.endpoint),
+            escape_file_value(&endpoint),
             escape_file_value(&probe.outcome),
             probe.score,
             probe.latency_ms.unwrap_or(0),
@@ -862,7 +865,7 @@ fn route_from_values(values: &HashMap<String, String>) -> Result<RouteRecord, Ro
     let latency_ms = parse_u64(&required(values, "latency_ms")?)?;
     let failure_reason = optional_clean(values.get("failure_reason"));
     let transport = RouteTransport::from_str(&required(values, "transport")?);
-    let endpoint = validate_route_endpoint(required(values, "endpoint")?, transport)?;
+    let endpoint = metadata_route_endpoint(required(values, "endpoint")?, transport)?;
     Ok(RouteRecord {
         route_id: validate_identifier(required(values, "route_id")?, "route id")?,
         peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
@@ -896,7 +899,7 @@ fn route_from_values(values: &HashMap<String, String>) -> Result<RouteRecord, Ro
 fn probe_from_values(values: &HashMap<String, String>) -> Result<RouteProbe, RouteError> {
     let latency_ms = parse_u64(&required(values, "latency_ms")?)?;
     let transport = RouteTransport::from_str(&required(values, "transport")?);
-    let endpoint = validate_route_endpoint(required(values, "endpoint")?, transport)?;
+    let endpoint = metadata_route_endpoint(required(values, "endpoint")?, transport)?;
     Ok(RouteProbe {
         probe_id: validate_identifier(required(values, "probe_id")?, "probe id")?,
         route_id: validate_identifier(required(values, "route_id")?, "route id")?,
@@ -1039,6 +1042,24 @@ fn validate_route_endpoint(value: String, transport: RouteTransport) -> Result<S
             Ok(value)
         }
         RouteTransport::RelayWebSocket => validate_endpoint(value),
+    }
+}
+
+fn metadata_route_endpoint(value: String, transport: RouteTransport) -> Result<String, RouteError> {
+    match transport {
+        RouteTransport::DirectQuic => validate_route_endpoint(value, transport),
+        RouteTransport::RelayWebSocket => {
+            relay_endpoint::metadata_relay_endpoint(&value).map_err(|error| {
+                let reason = match error {
+                    RelayEndpointError::Empty => "endpoint cannot be empty",
+                    RelayEndpointError::Scheme => "relay endpoint must start with ws:// or wss://",
+                    RelayEndpointError::Invalid => "relay endpoint is invalid",
+                };
+                RouteError::InvalidRecord {
+                    reason: reason.to_string(),
+                }
+            })
+        }
     }
 }
 
@@ -1395,6 +1416,43 @@ mod tests {
         assert!(rendered.contains("endpoint is invalid"));
         assert!(!rendered.contains("secret"));
         assert!(!rendered.contains("token=private"));
+    }
+
+    #[test]
+    fn relay_route_metadata_hides_endpoint_path_segments() {
+        let home = test_home("relay-path-route-config");
+        let peer = trusted_peer(&home);
+        let relay_endpoint = "wss://relay.example.com/conu/private-token";
+        fs::write(
+            StatePaths::from_home(home.clone()).config,
+            format!("version = \"1\"\ndefault_relay = \"{relay_endpoint}\"\n"),
+        )
+        .expect("config writes");
+
+        let report = sync_routes(Some(home.clone())).expect("routes sync");
+        let routes = list_routes(Some(home.clone())).expect("routes read");
+        let selected =
+            selected_route_for_peer(Some(home.clone()), &peer.peer_node_id).expect("route lookup");
+        let paths = StatePaths::from_home(home);
+        let registry = fs::read_to_string(paths.route_registry).expect("routes read");
+        let probes = fs::read_to_string(paths.route_probes).expect("probes read");
+
+        assert_eq!(report.selected_relay, 1);
+        assert_eq!(
+            selected.expect("selected").endpoint,
+            "wss://relay.example.com"
+        );
+        assert!(
+            routes
+                .iter()
+                .any(|route| route.endpoint == "wss://relay.example.com")
+        );
+        for contents in [&registry, &probes] {
+            assert!(contents.contains("wss://relay.example.com"));
+            assert!(!contents.contains("private-token"));
+            assert!(!contents.contains("/conu"));
+            assert!(!contents.contains(relay_endpoint));
+        }
     }
 
     #[test]

--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -179,7 +179,7 @@ pub fn sync_remote_sessions_from_paths(
         .map(|session| (session.peer_node_id.clone(), session))
         .collect::<HashMap<_, _>>();
     let previous_remote_agents = signed_remote_agents_by_peer(paths)?;
-    let relay_endpoint = relay_endpoint(paths)?;
+    let relay_endpoint = session_metadata_endpoint(&relay_endpoint(paths)?, "relay-websocket")?;
     let now = current_unix_seconds();
     let mut sessions = Vec::new();
     let mut remote_agents = Vec::new();
@@ -472,6 +472,7 @@ fn write_sessions(paths: &StatePaths, sessions: &[RemoteSession]) -> Result<(), 
     );
 
     for session in sorted {
+        let relay_endpoint = session_metadata_endpoint(&session.relay_endpoint, &session.route)?;
         contents.push_str("\n[[session]]\n");
         contents.push_str(&format!(
             "peer_node_id = \"{}\"\n",
@@ -488,7 +489,7 @@ fn write_sessions(paths: &StatePaths, sessions: &[RemoteSession]) -> Result<(), 
         ));
         contents.push_str(&format!(
             "relay_endpoint = \"{}\"\n",
-            escape_file_value(&session.relay_endpoint)
+            escape_file_value(&relay_endpoint)
         ));
         contents.push_str(&format!(
             "reconnect_attempts = {}\n",
@@ -659,7 +660,7 @@ fn parse_remote_agents(contents: &str) -> Result<Vec<RemoteAgentRecord>, Session
 
 fn session_from_values(values: &HashMap<String, String>) -> Result<RemoteSession, SessionError> {
     let route = validate_identifier(required(values, "route")?, "route")?;
-    let relay_endpoint = validate_endpoint(required(values, "relay_endpoint")?, &route)?;
+    let relay_endpoint = session_metadata_endpoint(&required(values, "relay_endpoint")?, &route)?;
     Ok(RemoteSession {
         peer_node_id: validate_identifier(required(values, "peer_node_id")?, "peer node id")?,
         display_name: validate_display_name(required(values, "display_name")?)?,
@@ -961,6 +962,23 @@ fn validate_endpoint(value: String, route: &str) -> Result<String, SessionError>
     }
 }
 
+fn session_metadata_endpoint(value: &str, route: &str) -> Result<String, SessionError> {
+    let value = value.trim().to_string();
+    if route == "direct-quic" {
+        return validate_endpoint(value, route);
+    }
+    relay_endpoint::metadata_relay_endpoint(&value).map_err(|error| {
+        let reason = match error {
+            RelayEndpointError::Empty => "relay endpoint cannot be empty",
+            RelayEndpointError::Scheme => "relay endpoint must start with ws:// or wss://",
+            RelayEndpointError::Invalid => "relay endpoint is invalid",
+        };
+        SessionError::InvalidRecord {
+            reason: reason.to_string(),
+        }
+    })
+}
+
 fn parse_u64(value: &str) -> Result<u64, SessionError> {
     value
         .parse::<u64>()
@@ -1095,6 +1113,32 @@ mod tests {
         assert!(rendered.contains("relay endpoint is invalid"));
         assert!(!rendered.contains("secret"));
         assert!(!rendered.contains("token=private"));
+    }
+
+    #[test]
+    fn session_metadata_hides_relay_endpoint_path_segments() {
+        let home = test_home("session-relay-path-config");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let invite = trust::create_pairing_invite(Some(home.clone())).expect("invite creates");
+        trust::join_pairing_code(Some(home.clone()), &invite.code).expect("joins");
+        let relay_endpoint = "wss://relay.example.com/conu/private-token";
+        fs::write(
+            &init.paths.config,
+            format!("version = \"1\"\ndefault_relay = \"{relay_endpoint}\"\n"),
+        )
+        .expect("config writes");
+
+        let report = sync_remote_sessions(Some(home.clone())).expect("sync succeeds");
+        let sessions = list_remote_sessions(Some(home.clone())).expect("sessions read");
+        let registry =
+            fs::read_to_string(init.paths.session_registry).expect("session registry reads");
+
+        assert_eq!(report.connected, 1);
+        assert_eq!(sessions[0].relay_endpoint, "wss://relay.example.com");
+        assert!(registry.contains("wss://relay.example.com"));
+        assert!(!registry.contains("private-token"));
+        assert!(!registry.contains("/conu"));
+        assert!(!registry.contains(relay_endpoint));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #770.

Summary:
- Adds relay endpoint metadata normalization that validates the configured relay endpoint but stores only scheme plus authority when a path is present.
- Applies the metadata-safe endpoint to persisted route records, route probes, session registries, and route/session read paths.
- Adds regressions for relay endpoint metadata, route registry/probe storage, and session registry storage so path-like token segments are not persisted.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- Focused Rust tests were attempted locally, but this workstation cannot link Rust tests because `dlltool.exe` is missing (`error calling dlltool 'dlltool.exe': program not found`). PR CI should run executable tests on the hosted runners.

Security review:
- Payload opacity is unchanged; this change only reduces persisted relay route/session metadata.
- Actual relay delivery/config validation remains separate and continues to preserve the real configured relay endpoint for connections.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts relay endpoint paths from stored routes, probes, and session metadata. Endpoints are still validated and used at runtime; only scheme+authority are persisted to prevent saving token-like path segments.

- **Bug Fixes**
  - Persist only scheme+authority for `ws://`/`wss://` relay endpoints in route registry, route probes, and session registry.
  - Use the redacted endpoint when reading route/session records and when building relay route candidates.
  - Added tests to ensure path segments (e.g., tokens) are never persisted.

- **Refactors**
  - Introduced `metadata_relay_endpoint`, `metadata_route_endpoint`, and `session_metadata_endpoint` helpers with strict validation.
  - Applied helpers across route candidate generation, registry/probe writes, and session sync/parsing paths.

<sup>Written for commit b9238328415b4e7652c90997059d2c1e9a98c535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact stored relay paths from route and session data**

### What Changed
- Stored relay websocket endpoints now keep only the scheme and host, so path segments like tokens are no longer saved in route records, probe history, or session records.
- Existing route and session lookups still work with the redacted endpoint, and relay endpoints continue to be validated before use.
- Added checks to keep path-like relay details out of saved metadata.

### Impact
`✅ Fewer secret-like relay details in saved files`
`✅ Lower risk of exposing token segments in route/session data`
`✅ Cleaner route and session records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for relay endpoints by removing sensitive path segments and authentication tokens from stored routes and sessions, preserving only essential scheme and authority information.

* **Tests**
  * Added comprehensive tests validating relay endpoint metadata sanitization for WebSocket and QUIC transports, including IPv6 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->