### PR TITLE
Redact relay pump debug endpoints

### DIFF
--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -247,12 +247,15 @@ impl fmt::Debug for RelayRuntimePump {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("RelayRuntimePump")
-            .field("endpoint", &self.endpoint)
+            .field("endpoint", &debug_relay_endpoint(&self.endpoint))
             .field(
                 "session_id",
                 &self.session_id.as_ref().map(|_| "<redacted>"),
             )
-            .field("resume_endpoint", &self.resume_endpoint)
+            .field(
+                "resume_endpoint",
+                &debug_relay_endpoint(&self.resume_endpoint),
+            )
             .field(
                 "resume_session_id",
                 &self.resume_session_id.as_ref().map(|_| "<redacted>"),
@@ -260,6 +263,13 @@ impl fmt::Debug for RelayRuntimePump {
             .field("client", &self.client.as_ref().map(|_| "<connected>"))
             .finish()
     }
+}
+
+fn debug_relay_endpoint(endpoint: &Option<String>) -> Option<String> {
+    endpoint.as_ref().map(|endpoint| {
+        relay_endpoint::metadata_relay_endpoint(endpoint)
+            .unwrap_or_else(|_| "endpointDisplayed=false".to_string())
+    })
 }
 
 impl RelayRuntimePump {
@@ -2067,6 +2077,33 @@ fn current_unix_nanos() -> u128 {
 mod tests {
     use super::*;
     use crate::agents::AgentRegistration;
+
+    #[test]
+    fn relay_runtime_pump_debug_hides_endpoint_paths_and_session_ids() {
+        let pump = RelayRuntimePump {
+            endpoint: Some("wss://relay.example.com/conu/private-token".to_string()),
+            session_id: Some("session-secret".to_string()),
+            resume_endpoint: Some("wss://resume.example.com/relay/resume-token".to_string()),
+            resume_session_id: Some("resume-session-secret".to_string()),
+            client: None,
+        };
+
+        let rendered = format!("{pump:?}");
+
+        assert!(rendered.contains("wss://relay.example.com"));
+        assert!(rendered.contains("wss://resume.example.com"));
+        assert!(rendered.contains("<redacted>"));
+        for hidden in [
+            "private-token",
+            "/conu",
+            "resume-token",
+            "resume.example.com/relay",
+            "session-secret",
+            "resume-session-secret",
+        ] {
+            assert!(!rendered.contains(hidden));
+        }
+    }
 
     #[test]
     fn remote_message_request_hides_literal_payload() {


### PR DESCRIPTION
## **User description**
Closes #772.

Summary:
- Redacts `RelayRuntimePump` debug endpoint rendering through the existing relay metadata endpoint helper.
- Keeps actual relay connection and resume endpoint state unchanged.
- Adds a regression proving relay path segments and session ids do not appear in `Debug` output.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- Focused Rust test attempted locally, but this workstation cannot link Rust tests because `dlltool.exe` is missing (`error calling dlltool 'dlltool.exe': program not found`). Hosted CI should run executable tests.

Security review:
- Payload opacity is unchanged.
- Trust/permission behavior is unchanged.
- Storage/network behavior is unchanged; this is debug rendering only.
- Debug output now avoids exposing relay endpoint path metadata or relay session ids.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts relay endpoint paths and session IDs from `Debug` output for `RelayRuntimePump`, preventing token/path leakage in logs. Keeps connection and resume behavior unchanged and aligns with #772.

- **Bug Fixes**
  - Debug renders endpoints via `relay_endpoint::metadata_relay_endpoint`.
  - `session_id` and `resume_session_id` show as "<redacted>".
  - Added a test to ensure path segments and session IDs never appear in `Debug` output.

<sup>Written for commit 2fc58ef07eb3879e82dc6ade49e557c1189eceb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide relay endpoint paths and session IDs in debug output**

### What Changed
- Relay debug output now shows endpoint metadata instead of full relay paths, so private tokens and path segments are not exposed.
- Session IDs and resume session IDs remain redacted in debug output.
- A regression test checks that debug output still shows the relay host while hiding secret path pieces and session values.

### Impact
`✅ Fewer secret leaks in logs`
`✅ Safer debug output for relay connections`
`✅ Less chance of exposing session IDs during troubleshooting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
