### PR TITLE
Mark relay hash-token display guards

### DIFF
--- a/crates/conu-relay/src/main.rs
+++ b/crates/conu-relay/src/main.rs
@@ -1984,12 +1984,24 @@ fn readiness_contents_displayed(report: &HostedReadinessReport) -> bool {
 
 fn hash_token_from_stdin() -> Result<(), String> {
     let token = read_relay_token_from_reader(io::stdin())?;
-    let hash = relay_token_sha256_hex(&token).map_err(|error| error.to_string())?;
-
-    println!("token_sha256_hex = \"{hash}\"");
-    println!("token_length = {}", token.len());
-    println!("token_displayed = false");
+    print!("{}", render_hashed_relay_token(&token)?);
     Ok(())
+}
+
+fn render_hashed_relay_token(token: &str) -> Result<String, String> {
+    let hash = relay_token_sha256_hex(token).map_err(|error| error.to_string())?;
+    Ok(format!(
+        "token_sha256_hex = \"{hash}\"\n\
+token_length = {}\n\
+payload_displayed = false\n\
+token_displayed = false\n\
+token_hash_displayed = true\n\
+key_material_displayed = false\n\
+session_id_displayed = false\n\
+ciphertext_displayed = false\n\
+contents_displayed = false\n",
+        token.len()
+    ))
 }
 
 fn issue_credential_from_args(args: Vec<String>) -> Result<(), String> {
@@ -13708,6 +13720,24 @@ mod tests {
         assert!(admin_error.contains("relay admin token"));
         assert!(admin_error.contains("exceeds"));
         assert!(!admin_error.contains(secret));
+    }
+
+    #[test]
+    fn hash_token_output_marks_hash_display_without_printing_token() {
+        let token = "relay-token-1234567890abcdef";
+        let hash = relay_token_sha256_hex(token).expect("token hashes");
+        let output = render_hashed_relay_token(token).expect("hash token output renders");
+
+        assert!(output.contains(&format!("token_sha256_hex = \"{hash}\"")));
+        assert!(output.contains(&format!("token_length = {}", token.len())));
+        assert!(output.contains("payload_displayed = false"));
+        assert!(output.contains("token_displayed = false"));
+        assert!(output.contains("token_hash_displayed = true"));
+        assert!(output.contains("key_material_displayed = false"));
+        assert!(output.contains("session_id_displayed = false"));
+        assert!(output.contains("ciphertext_displayed = false"));
+        assert!(output.contains("contents_displayed = false"));
+        assert!(!output.contains(token));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #774.

Summary:
- Keeps `conu-relay --hash-token` raw token handling stdin-only.
- Keeps printing `token_sha256_hex` because that is the command purpose.
- Adds explicit display guards, including `token_hash_displayed = true` and false payload/token/key/session/ciphertext/content guards.
- Adds a regression for rendered hash-token output so the raw token is not printed and the hash-display guard is honest.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- Focused Rust test attempted locally, but this workstation cannot link Rust tests because `dlltool.exe` is missing (`error calling dlltool 'dlltool.exe': program not found`). Hosted CI should run executable tests.

Security review:
- Raw relay token exposure is unchanged and remains blocked.
- Token hash output is intentional and now explicitly marked with `token_hash_displayed = true`.
- No relay auth, storage, or network behavior changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `conu-relay --hash-token` to only print the SHA-256 hash and clearly mark what was displayed. Adds display guards and a regression test to prevent raw token leaks.

- **Bug Fixes**
  - Centralized output in `render_hashed_relay_token`, keeping raw token stdin-only.
  - Prints `token_sha256_hex` plus explicit flags (`token_hash_displayed = true`; others `*_displayed = false`).
  - Added test to ensure the raw token is never printed and flags are correct.

<sup>Written for commit e78893f07886d453481b61ffcd2cc6df419a4a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make hashed relay token output explicit and prevent raw token display**

### What Changed
- `conu-relay --hash-token` now renders its output in one place, always showing the SHA-256 hash and token length.
- The hash-token output now includes clear display markers for the token, payload, key material, session ID, ciphertext, and contents, with all raw data marked as not displayed.
- Added a regression test to confirm the raw token is never printed and the hash display marker is set correctly.

### Impact
`✅ No raw relay token in hash-token output`
`✅ Clearer token hash output`
`✅ Fewer accidental secret leaks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
