### PR TITLE
Redact Linux GPG fingerprint mismatch output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,7 +618,7 @@ jobs:
           EXPECTED_FINGERPRINT="$(printf '%s' "$CONU_LINUX_GPG_KEY_FINGERPRINT" | tr -d '[:space:]:' | sed 's/^0[xX]//' | tr '[:lower:]' '[:upper:]')"
           ACTUAL_FINGERPRINT="$(gpg --batch --with-colons --fingerprint --list-keys | awk -F: '$1 == "fpr" { print toupper($10); exit }')"
           if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then
-            echo "::error::Published Linux GPG public key fingerprint mismatch: expected $EXPECTED_FINGERPRINT, found $ACTUAL_FINGERPRINT"
+            echo "::error::Published Linux GPG public key fingerprint mismatch"
             exit 1
           fi
           for attempt in 1 2 3 4 5 6; do

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1987,6 +1987,25 @@ def run_required_github_release_gate_tests(module) -> None:
         module,
         None,
         ready_release().replace(
+            '            echo "::error::Published Linux GPG public key fingerprint mismatch"\n',
+            (
+                '            echo "::error::Published Linux GPG public key fingerprint '
+                'mismatch: expected $EXPECTED_FINGERPRINT, found $ACTUAL_FINGERPRINT"\n'
+            ),
+        ),
+    )
+    if report.ready:
+        raise AssertionError("value-bearing published GPG fingerprint mismatch output should fail")
+    if (
+        "release.yml:github-release verify published release update policy "
+        "and artifact with CLI is missing redacted fingerprint mismatch error"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("value-bearing published GPG fingerprint output was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
             '          (cd "$KEY_DIR" && sha256sum -c conu-linux-gpg-key.asc.sha256)\n',
             "",
         ),

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -1419,6 +1419,10 @@ GITHUB_RELEASE_REQUIRED_STEPS: tuple[
                 'if [ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then',
             ),
             (
+                "redacted fingerprint mismatch error",
+                'echo "::error::Published Linux GPG public key fingerprint mismatch"',
+            ),
+            (
                 "update check command",
                 'cargo run -p conu-cli -- update check --policy-url "$POLICY_URL" '
                 "--gpg-verify --json",

--- a/scripts/check-linux-signing-secrets-preflight-regression.py
+++ b/scripts/check-linux-signing-secrets-preflight-regression.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "scripts"
 PREFLIGHT = ROOT / "scripts" / "check-linux-signing-secrets-preflight.py"
 PASSPHRASE = "conu-linux-signing-preflight-regression-passphrase"
 USER_ID = "conU Linux Signing Preflight Regression <noreply@github.com>"
@@ -20,9 +21,14 @@ WRONG_FINGERPRINT = "F" * 40
 
 
 def main() -> int:
+    run_common_output_redaction_tests()
+
     gpg = shutil.which("gpg")
     if gpg is None:
-        print("Linux signing-secret preflight regression skipped: gpg is unavailable")
+        print(
+            "Linux signing-secret common redaction checks passed; "
+            "GPG integration regression skipped: gpg is unavailable"
+        )
         return 0
 
     with tempfile.TemporaryDirectory(prefix="conu-linux-signing-preflight-check-") as temp_text:
@@ -69,7 +75,11 @@ def main() -> int:
 
         mismatch_env = env.copy()
         mismatch_env["CONU_LINUX_GPG_KEY_FINGERPRINT"] = WRONG_FINGERPRINT
-        assert_failed(mismatch_env, "fingerprint mismatch")
+        assert_failed(
+            mismatch_env,
+            "fingerprint mismatch",
+            forbidden=(WRONG_FINGERPRINT, key_id),
+        )
 
         wrong_passphrase_env = env.copy()
         wrong_passphrase_env["CONU_LINUX_GPG_PASSPHRASE"] = "wrong-passphrase"
@@ -79,7 +89,78 @@ def main() -> int:
     return 0
 
 
-def assert_failed(env: dict[str, str], expected: str) -> None:
+def run_common_output_redaction_tests() -> None:
+    sys.path.insert(0, str(SCRIPT_DIR))
+    try:
+        import linux_gpg_common
+    finally:
+        try:
+            sys.path.remove(str(SCRIPT_DIR))
+        except ValueError:
+            pass
+
+    original_run_gpg_text = linux_gpg_common.run_gpg_text
+    actual = "A" * 40
+    other = "B" * 40
+    expected = WRONG_FINGERPRINT
+    try:
+        linux_gpg_common.run_gpg_text = (
+            lambda *_args, **_kwargs: f"sec:::::::::\nfpr:::::::::{actual}:\n"
+        )
+        assert_common_failed(
+            linux_gpg_common,
+            expected,
+            "fingerprint mismatch",
+            forbidden=(expected, actual),
+        )
+
+        linux_gpg_common.run_gpg_text = (
+            lambda *_args, **_kwargs: (
+                f"sec:::::::::\nfpr:::::::::{actual}:\n"
+                f"sec:::::::::\nfpr:::::::::{other}:\n"
+            )
+        )
+        assert_common_failed(
+            linux_gpg_common,
+            actual,
+            "found 2 primary secret key(s)",
+            forbidden=(actual, other),
+        )
+    finally:
+        linux_gpg_common.run_gpg_text = original_run_gpg_text
+
+
+def assert_common_failed(
+    linux_gpg_common,
+    expected_fingerprint: str,
+    expected_error: str,
+    *,
+    forbidden: tuple[str, ...],
+) -> None:
+    try:
+        linux_gpg_common.verify_imported_secret_key_fingerprint(
+            "gpg",
+            {},
+            "test-key",
+            expected_fingerprint,
+        )
+    except SystemExit as exc:
+        rendered = str(exc)
+    else:
+        raise AssertionError("Linux GPG common fingerprint check unexpectedly passed")
+    if expected_error not in rendered:
+        raise AssertionError(f"expected {expected_error!r} in failure output:\n{rendered}")
+    for value in forbidden:
+        if value and value in rendered:
+            raise AssertionError("Linux GPG common failure output leaked a fingerprint value")
+
+
+def assert_failed(
+    env: dict[str, str],
+    expected: str,
+    *,
+    forbidden: tuple[str, ...] = (),
+) -> None:
     failed = subprocess.run(
         [sys.executable, str(PREFLIGHT)],
         stdout=subprocess.PIPE,
@@ -91,6 +172,9 @@ def assert_failed(env: dict[str, str], expected: str) -> None:
         raise AssertionError("preflight unexpectedly succeeded")
     if expected not in failed.stdout:
         raise AssertionError(f"expected {expected!r} in failure output:\n{failed.stdout}")
+    for value in forbidden:
+        if value and value in failed.stdout:
+            raise AssertionError("failure output leaked a fingerprint value")
 
 
 def create_test_key(gpg: str, home: Path) -> str:

--- a/scripts/linux_gpg_common.py
+++ b/scripts/linux_gpg_common.py
@@ -48,17 +48,13 @@ def verify_imported_secret_key_fingerprint(
     )
     fingerprints = primary_secret_fingerprints(output)
     if len(fingerprints) != 1:
-        joined = ", ".join(fingerprints) if fingerprints else "none"
         raise SystemExit(
             "Linux GPG key id must resolve to exactly one primary secret key "
-            f"(found: {joined})"
+            f"(found {len(fingerprints)} primary secret key(s))"
         )
     actual = fingerprints[0]
     if actual != expected_fingerprint:
-        raise SystemExit(
-            "Linux GPG signing key fingerprint mismatch: "
-            f"expected {expected_fingerprint}, found {actual}"
-        )
+        raise SystemExit("Linux GPG signing key fingerprint mismatch")
 
 
 def primary_secret_fingerprints(colon_listing: str) -> list[str]:


### PR DESCRIPTION
## **User description**
Closes #776.\n\n## Summary\n- Redact Linux GPG fingerprint mismatch diagnostics in the shared signing helper.\n- Redact the post-release public-key verification mismatch message in the release workflow.\n- Add regressions that reject value-bearing fingerprint mismatch output.\n\n## Validation\n- python scripts/check-linux-signing-secrets-preflight-regression.py\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-github-workflow-permissions.py\n- python scripts/check-release-update-download-gate.py\n- python scripts/check-linux-gpg-public-key-export.py (GPG integration skipped locally; gpg unavailable)\n- python scripts/check-linux-release-signing.py (GPG integration skipped locally; gpg unavailable)\n- python scripts/check-python-script-compile.py\n- python scripts/check-release-secret-env-preflight-regression.py\n- python scripts/check-github-release-secret-readiness-regression.py\n- python scripts/check-linux-repository-signing.py (GPG integration skipped locally; gpg unavailable)\n- python scripts/check-rpm-package-signing.py (GPG/RPM integration skipped locally; tools unavailable)\n- python scripts/check-tagged-release-readiness-regression.py\n- cargo fmt --all -- --check\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts Linux GPG fingerprint values from mismatch messages to avoid leaking sensitive data in logs. Adds regression tests and workflow checks to enforce redacted output.

- **Bug Fixes**
  - `scripts/linux_gpg_common.py`: generic mismatch message; multi-key error shows only the count.
  - `.github/workflows/release.yml`: replaces value-bearing error with a redacted message.
  - Regression tests: reject any value-bearing fingerprint output and expect the redacted error in workflow checks.

<sup>Written for commit 80ec1bf66079d7e4ad23b89675a67adabc39010d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide Linux GPG fingerprint values in mismatch errors**

### What Changed
- Linux GPG fingerprint mismatch messages now stay generic instead of printing the expected or actual fingerprint values
- When a secret key lookup returns the wrong number of keys, the message now reports only the count
- Regression checks were added to fail if any fingerprint value appears in Linux signing or release verification errors

### Impact
`✅ Fewer secret values in build and release logs`
`✅ Safer fingerprint mismatch reporting`
`✅ Lower risk of leaking signing details during release checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
