### PR TITLE
Add release secret rotation readiness gate

### DIFF
--- a/scripts/check-github-release-secret-readiness-regression.py
+++ b/scripts/check-github-release-secret-readiness-regression.py
@@ -68,11 +68,17 @@ def run_gh_payload_tests(module) -> None:
     helper.subprocess.run = fake_secret_list
     try:
         names = module.load_secret_names("owner/repo", "gh")
+        metadata = helper.load_secret_metadata("owner/repo", "gh")
     finally:
         helper.subprocess.run = original_run
 
     if names != set(module.REQUIRED_RELEASE_SECRETS):
         raise AssertionError("loaded secret names did not match required names")
+    if set(metadata) != names:
+        raise AssertionError("loaded secret metadata did not match required names")
+    for record in metadata.values():
+        if record.updated_at != "":
+            raise AssertionError("unexpected updatedAt value in fake metadata payload")
     report = module.audit_secret_names("owner/repo", names)
     rendered = json.dumps(report.as_json())
     if SENSITIVE_SENTINEL in rendered:

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -74,6 +74,10 @@ def all_custom_secrets(module) -> set[str]:
     return set(module.REQUIRED_RELEASE_SECRETS) | set(module.CUSTOM_REPOSITORY_REQUIRED_SECRETS)
 
 
+def all_secret_update_times(module, updated_at: str = "2026-06-03T02:00:00Z") -> dict[str, str]:
+    return {name: updated_at for name in module.REQUIRED_RELEASE_SECRETS}
+
+
 def assert_safe_report(report) -> dict[str, object]:
     rendered = json.dumps(report.as_json(), sort_keys=True)
     if SENSITIVE_SENTINEL in rendered:
@@ -183,6 +187,8 @@ def run_ready_pages_tests(module) -> None:
         raise AssertionError("Actions permissions should be included in tagged release readiness")
     if parsed["repositorySecurity"]["ready"] is not True:
         raise AssertionError("repository security should be included in tagged release readiness")
+    if parsed["secretRotation"]["checked"] is not False:
+        raise AssertionError("secret rotation readiness should be skipped by default")
 
 
 def run_workflow_permissions_tests(module) -> None:
@@ -488,6 +494,101 @@ def run_missing_secret_tests(module) -> None:
         raise AssertionError("missing release secret name was not reported")
 
 
+def run_secret_rotation_tests(module) -> None:
+    requirement = module.SecretRotationRequirement(
+        name="NPM_TOKEN",
+        updated_after="2026-06-03T00:00:00Z",
+    )
+    ready = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        secret_updated_at=all_secret_update_times(module, "2026-06-03T00:00:01Z"),
+        secret_rotation_requirements=(requirement,),
+        variable_values={},
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        **ready_governance_kwargs(),
+    )
+    if not ready.ready:
+        raise AssertionError(f"expected fresh secret rotation readiness to pass: {ready.issues!r}")
+    parsed_ready = assert_safe_report(ready)
+    if parsed_ready["secretRotation"]["checked"] is not True:
+        raise AssertionError("secret rotation readiness should be checked")
+    if parsed_ready["secretRotation"]["requirements"][0]["name"] != "NPM_TOKEN":
+        raise AssertionError("secret rotation report should identify the checked secret name")
+
+    stale = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        secret_updated_at=all_secret_update_times(module, "2026-06-02T23:59:59Z"),
+        secret_rotation_requirements=(requirement,),
+        variable_values={},
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        **ready_governance_kwargs(),
+    )
+    if stale.ready:
+        raise AssertionError("stale secret rotation should fail readiness")
+    parsed_stale = assert_safe_report(stale)
+    if (
+        "release secret rotation readiness: NPM_TOKEN was not rotated after required timestamp"
+        not in json.dumps(parsed_stale)
+    ):
+        raise AssertionError("stale secret rotation issue was not reported")
+
+    missing = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        secret_updated_at={},
+        secret_rotation_requirements=(requirement,),
+        variable_values={},
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        **ready_governance_kwargs(),
+    )
+    if missing.ready:
+        raise AssertionError("missing secret update timestamp should fail readiness")
+    parsed_missing = assert_safe_report(missing)
+    if "NPM_TOKEN update timestamp is missing" not in json.dumps(parsed_missing):
+        raise AssertionError("missing secret update timestamp issue was not reported")
+
+    invalid = module.audit_secret_rotation(
+        {"NPM_TOKEN": "not-a-timestamp"},
+        (requirement,),
+    )
+    if invalid.ready:
+        raise AssertionError("invalid secret update timestamp should fail readiness")
+    if "NPM_TOKEN update timestamp is invalid" not in json.dumps(invalid.as_json()):
+        raise AssertionError("invalid secret update timestamp issue was not reported")
+
+    parsed = module.parse_secret_rotation_requirement(
+        "NPM_TOKEN=2026-06-03T00:00:00+00:00"
+    )
+    if parsed.updated_after != "2026-06-03T00:00:00Z":
+        raise AssertionError("secret rotation requirement timestamp was not normalized")
+    for raw, expected in (
+        ("NPM_TOKEN", "NAME=ISO-8601_TIMESTAMP"),
+        ("UNKNOWN=2026-06-03T00:00:00Z", "unknown required secret"),
+        ("NPM_TOKEN=2026-06-03T00:00:00", "must include a timezone"),
+    ):
+        try:
+            module.parse_secret_rotation_requirement(raw)
+        except ValueError as exc:
+            if expected not in str(exc):
+                raise AssertionError(f"unexpected parse error for {raw!r}: {exc}") from exc
+        else:
+            raise AssertionError(f"expected secret rotation parse failure for {raw!r}")
+
+
 def run_custom_repository_tests(module) -> None:
     report = module.audit_tagged_release_readiness(
         repo="owner/repo",
@@ -790,6 +891,7 @@ def main() -> int:
     run_ci_readiness_tests(module)
     run_release_branch_readiness_tests(module)
     run_missing_secret_tests(module)
+    run_secret_rotation_tests(module)
     run_custom_repository_tests(module)
     run_safe_failure_tests(module)
     print("Tagged release readiness regression checks passed")

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, unquote, urlparse, urlunparse
@@ -20,6 +21,7 @@ from github_release_secrets import (
     audit_secret_names,
     find_gh,
     infer_repo,
+    load_secret_metadata,
     load_secret_names,
     run_gh_json,
 )
@@ -122,6 +124,34 @@ class CiReadiness:
 
 
 @dataclass(frozen=True)
+class SecretRotationRequirement:
+    name: str
+    updated_after: str
+
+
+@dataclass(frozen=True)
+class SecretRotationReadiness:
+    checked: bool
+    ready: bool
+    requirements: tuple[dict[str, Any], ...]
+    issues: tuple[str, ...]
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "checked": self.checked,
+            "ready": self.ready,
+            "requirements": list(self.requirements),
+            "issues": list(self.issues),
+            "payloadDisplayed": False,
+            "tokenDisplayed": False,
+            "tokenHashDisplayed": False,
+            "keyMaterialDisplayed": False,
+            "contentsDisplayed": False,
+            "secretValuesDisplayed": False,
+        }
+
+
+@dataclass(frozen=True)
 class ReleaseBranchReadiness:
     checked: bool
     required: bool
@@ -150,6 +180,7 @@ class TaggedReleaseReadiness:
     version: str
     ready: bool
     release_secrets: Any
+    secret_rotation: SecretRotationReadiness
     linux_repository: LinuxRepositoryReadiness
     release_clobber: Any
     npm_registry: NpmRegistryReadiness
@@ -169,6 +200,7 @@ class TaggedReleaseReadiness:
             "version": self.version,
             "ready": self.ready,
             "releaseSecrets": self.release_secrets.as_json(),
+            "secretRotation": self.secret_rotation.as_json(),
             "linuxRepository": self.linux_repository.as_json(),
             "releaseClobber": self.release_clobber.as_json(),
             "npmRegistry": self.npm_registry.as_json(),
@@ -253,6 +285,107 @@ def validate_tag_for_version(tag: str, version: str) -> str:
     if tag_version != version:
         raise ValueError(f"release tag {raw} does not match package version {version}")
     return raw
+
+
+def parse_utc_timestamp(value: str, label: str) -> datetime:
+    raw = value.strip()
+    if not raw:
+        raise ValueError(f"{label} timestamp must not be empty")
+    if raw.endswith("Z"):
+        raw = f"{raw[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(f"{label} timestamp must be ISO-8601 with a timezone") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{label} timestamp must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def render_utc_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_secret_rotation_requirement(raw: str) -> SecretRotationRequirement:
+    if "=" not in raw:
+        raise ValueError(
+            "--require-secret-updated-after must use NAME=ISO-8601_TIMESTAMP"
+        )
+    name, timestamp = raw.split("=", 1)
+    normalized_name = name.strip()
+    if normalized_name not in REQUIRED_RELEASE_SECRETS:
+        raise ValueError(
+            f"release secret rotation requirement uses an unknown required secret: {normalized_name}"
+        )
+    updated_after = render_utc_timestamp(
+        parse_utc_timestamp(timestamp, f"{normalized_name} rotation requirement")
+    )
+    return SecretRotationRequirement(name=normalized_name, updated_after=updated_after)
+
+
+def parse_secret_rotation_requirements(values: list[str]) -> tuple[SecretRotationRequirement, ...]:
+    requirements: list[SecretRotationRequirement] = []
+    seen: set[str] = set()
+    for value in values:
+        requirement = parse_secret_rotation_requirement(value)
+        if requirement.name in seen:
+            raise ValueError(
+                f"duplicate release secret rotation requirement: {requirement.name}"
+            )
+        seen.add(requirement.name)
+        requirements.append(requirement)
+    return tuple(requirements)
+
+
+def audit_secret_rotation(
+    secret_updated_at: dict[str, str],
+    requirements: tuple[SecretRotationRequirement, ...],
+) -> SecretRotationReadiness:
+    if not requirements:
+        return SecretRotationReadiness(
+            checked=False,
+            ready=True,
+            requirements=(),
+            issues=(),
+        )
+
+    rendered_requirements: list[dict[str, Any]] = []
+    issues: list[str] = []
+    for requirement in requirements:
+        updated_at = secret_updated_at.get(requirement.name, "")
+        entry: dict[str, Any] = {
+            "name": requirement.name,
+            "updatedAfter": requirement.updated_after,
+            "updatedAt": updated_at,
+            "ready": False,
+        }
+        if not updated_at:
+            issues.append(f"{requirement.name} update timestamp is missing")
+            rendered_requirements.append(entry)
+            continue
+        try:
+            observed = parse_utc_timestamp(updated_at, f"{requirement.name} updatedAt")
+            required = parse_utc_timestamp(
+                requirement.updated_after,
+                f"{requirement.name} rotation requirement",
+            )
+        except ValueError:
+            issues.append(f"{requirement.name} update timestamp is invalid")
+            rendered_requirements.append(entry)
+            continue
+        entry["updatedAt"] = render_utc_timestamp(observed)
+        if observed <= required:
+            issues.append(f"{requirement.name} was not rotated after required timestamp")
+        else:
+            entry["ready"] = True
+        rendered_requirements.append(entry)
+
+    return SecretRotationReadiness(
+        checked=True,
+        ready=not issues,
+        requirements=tuple(rendered_requirements),
+        issues=tuple(issues),
+    )
 
 
 def load_variable_values(repo: str, gh: str) -> dict[str, str]:
@@ -798,6 +931,7 @@ def audit_repository_security(repo: str, gh: str) -> Any:
 
 def combine_issues(
     release_secrets: Any,
+    secret_rotation: SecretRotationReadiness,
     linux_repository: LinuxRepositoryReadiness,
     release_clobber: Any,
     npm_registry: NpmRegistryReadiness,
@@ -811,6 +945,8 @@ def combine_issues(
     issues: list[str] = []
     for name in release_secrets.missing:
         issues.append(f"missing release secret: {name}")
+    for issue in secret_rotation.issues:
+        issues.append(f"release secret rotation readiness: {issue}")
     for name in linux_repository.missing_variables:
         issues.append(f"missing repository variable: {name}")
     for name in linux_repository.missing_secrets:
@@ -846,6 +982,8 @@ def audit_tagged_release_readiness(
     pages_payload: dict[str, Any] | None,
     release_payload: dict[str, Any] | None,
     npm_registry_check: bool,
+    secret_updated_at: dict[str, str] | None = None,
+    secret_rotation_requirements: tuple[SecretRotationRequirement, ...] = (),
     npm: str = "",
     ci_required: bool = False,
     ci_workflow: str = DEFAULT_CI_WORKFLOW,
@@ -862,6 +1000,10 @@ def audit_tagged_release_readiness(
     repository_security: Any | None = None,
 ) -> TaggedReleaseReadiness:
     release_secrets = audit_secret_names(repo, secret_names)
+    secret_rotation = audit_secret_rotation(
+        secret_updated_at or {},
+        secret_rotation_requirements,
+    )
     linux_repository = audit_linux_repository(repo, variable_values, secret_names, pages_payload)
     clobber_module = load_script_module(
         "check-github-release-clobber-preflight.py",
@@ -894,6 +1036,7 @@ def audit_tagged_release_readiness(
         raise ValueError("GitHub repository security readiness report is required")
     issues = combine_issues(
         release_secrets,
+        secret_rotation,
         linux_repository,
         release_clobber,
         npm_registry,
@@ -910,6 +1053,7 @@ def audit_tagged_release_readiness(
         version=version,
         ready=not issues,
         release_secrets=release_secrets,
+        secret_rotation=secret_rotation,
         linux_repository=linux_repository,
         release_clobber=release_clobber,
         npm_registry=npm_registry,
@@ -986,6 +1130,16 @@ def parse_args() -> argparse.Namespace:
         help="fail unless the release target commit matches the repository default branch head",
     )
     parser.add_argument(
+        "--require-secret-updated-after",
+        action="append",
+        default=[],
+        metavar="NAME=TIMESTAMP",
+        help=(
+            "fail unless a required release secret was updated after the given ISO-8601 "
+            "timestamp; may be repeated and reports only secret names plus update metadata"
+        ),
+    )
+    parser.add_argument(
         "--release-branch",
         default="",
         help="release branch name to compare against; defaults to the repository default branch",
@@ -1009,6 +1163,11 @@ def main() -> int:
         tag = validate_tag_for_version(args.tag or default_tag(version), version)
         gh = args.gh or find_gh()
         repo = args.repo.strip() or infer_repo(gh)
+        secret_rotation_requirements = parse_secret_rotation_requirements(
+            args.require_secret_updated_after
+        )
+        if args.ci_only and secret_rotation_requirements:
+            raise ValueError("--require-secret-updated-after cannot be used with --ci-only")
         if args.ci_only:
             release_target_sha = args.release_target_head.strip()
             ci_head_sha = args.ci_head.strip() or release_target_sha or resolve_git_head()
@@ -1068,7 +1227,16 @@ def main() -> int:
                     print(f"issue: {issue}", file=sys.stderr)
             return 0 if ready else 1
 
-        secret_names = load_secret_names(repo, gh)
+        secret_updated_at: dict[str, str] = {}
+        if secret_rotation_requirements:
+            secret_records = load_secret_metadata(repo, gh)
+            secret_names = set(secret_records)
+            secret_updated_at = {
+                name: record.updated_at
+                for name, record in secret_records.items()
+            }
+        else:
+            secret_names = load_secret_names(repo, gh)
         variable_values = load_variable_values(repo, gh)
         ci_head_sha = args.ci_head.strip()
         release_target_sha = args.release_target_head.strip()
@@ -1118,6 +1286,8 @@ def main() -> int:
             pages_payload=pages_payload,
             release_payload=release_payload,
             npm_registry_check=args.npm_registry_check,
+            secret_updated_at=secret_updated_at,
+            secret_rotation_requirements=secret_rotation_requirements,
             npm=args.npm,
             ci_required=args.require_ci,
             ci_workflow=args.ci_workflow,

--- a/scripts/github_release_secrets.py
+++ b/scripts/github_release_secrets.py
@@ -49,6 +49,12 @@ class SecretReadiness:
         }
 
 
+@dataclass(frozen=True)
+class SecretMetadata:
+    name: str
+    updated_at: str
+
+
 def find_gh() -> str:
     candidates = ("gh.exe", "gh") if sys.platform == "win32" else ("gh",)
     for candidate in candidates:
@@ -95,24 +101,35 @@ def infer_repo(gh: str) -> str:
     return repo.strip()
 
 
-def load_secret_names(repo: str, gh: str) -> set[str]:
+def load_secret_metadata(repo: str, gh: str) -> dict[str, SecretMetadata]:
     payload = run_gh_json(
         gh,
-        ["secret", "list", "--repo", repo, "--json", "name"],
+        ["secret", "list", "--repo", repo, "--json", "name,updatedAt"],
         "gh secret list",
     )
     if not isinstance(payload, list):
         raise ValueError("gh secret list returned an unexpected payload")
 
-    names: set[str] = set()
+    records: dict[str, SecretMetadata] = {}
     for item in payload:
         if not isinstance(item, dict):
             raise ValueError("gh secret list returned a non-object secret entry")
         name = item.get("name")
         if not isinstance(name, str) or not name.strip():
             raise ValueError("gh secret list returned a secret entry without a name")
-        names.add(name.strip())
-    return names
+        updated_at = item.get("updatedAt", "")
+        if updated_at is not None and not isinstance(updated_at, str):
+            raise ValueError("gh secret list returned a non-string updatedAt field")
+        normalized_name = name.strip()
+        records[normalized_name] = SecretMetadata(
+            name=normalized_name,
+            updated_at=(updated_at or "").strip(),
+        )
+    return records
+
+
+def load_secret_names(repo: str, gh: str) -> set[str]:
+    return set(load_secret_metadata(repo, gh))
 
 
 def audit_secret_names(repo: str, configured_names: set[str]) -> SecretReadiness:


### PR DESCRIPTION
Closes #778.

## Summary
- Add GitHub secret metadata loading for updatedAt without reading secret values.
- Add check-tagged-release-readiness.py --require-secret-updated-after NAME=TIMESTAMP.
- Report secret-rotation readiness with false display guards and only names/timestamps.
- Add regressions for fresh, stale, missing, invalid, and value-safe rotation checks.

## Validation
- python scripts/check-python-script-compile.py
- python scripts/check-tagged-release-readiness-regression.py
- python scripts/check-github-release-secret-readiness-regression.py
- python scripts/check-release-secret-env-preflight-regression.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-tagged-release-readiness.py --repo imthegoodboy/conU --require-ci --ci-head c475590090ced3ae3871cd0393fac76a0284a37e --require-default-branch-head --npm-registry-check --require-secret-updated-after NPM_TOKEN=2026-06-03T00:00:00Z --json (expected fail: NPM_TOKEN updatedAt precedes cutoff; no secret values displayed)
- python scripts/check-tagged-release-readiness.py --repo imthegoodboy/conU --require-ci --ci-head c475590090ced3ae3871cd0393fac76a0284a37e --require-default-branch-head --npm-registry-check --json (expected fail: missing platform signing/notary/GPG secrets)
- python scripts/check-github-release-secret-readiness.py --repo imthegoodboy/conU --json (expected fail: missing platform signing/notary/GPG secrets)
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a release secret rotation readiness gate to the tagged release check, using GitHub secret metadata (`updatedAt`) to verify required secrets were rotated after a given timestamp. Reports only names and timestamps, never secret values.

- **New Features**
  - New `--require-secret-updated-after NAME=TIMESTAMP` flag to enforce rotation cutoffs per secret.
  - Load secret metadata via `gh secret list --json name,updatedAt` without reading secret values.
  - Adds `secretRotation` to the readiness report with pass/fail per requirement.
  - Normalizes timestamps to UTC (`Z`) and validates ISO-8601 with timezone.
  - Skips rotation checks by default unless requirements are provided.

- **Migration**
  - Use `--require-secret-updated-after NPM_TOKEN=2026-06-03T00:00:00Z` (repeatable for multiple secrets).
  - Requires timestamps with a timezone; `Z` is supported and normalized.
  - Not compatible with `--ci-only`.
  - Failures surface as "release secret rotation readiness: ..." in the issue list.

<sup>Written for commit 9c877dc01d00150265a371ee29e9b1aa0421e819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added secret rotation readiness validation to release checks, enabling enforcement of minimum secret update timestamps.
  * System now loads and tracks secret metadata including last update timestamps to verify rotation compliance.

* **Tests**
  * Added comprehensive regression tests for secret rotation requirements and metadata loading functionality.

* **Refactor**
  * Optimized secret loading infrastructure to support metadata retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->