### PR TITLE
Gate npm token rotation before tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         run: python scripts/check-github-release-secret-readiness-regression.py
       - name: Release secret env preflight regression
         run: python scripts/check-release-secret-env-preflight-regression.py
+      - name: Release secret rotation gate regression
+        run: python scripts/check-release-secret-rotation-gate-regression.py
       - name: GitHub release secret setup regression
         run: python scripts/set-github-release-secrets-regression.py
       - name: GitHub main branch protection regression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,11 @@ jobs:
           CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: python scripts/check-release-secret-env-preflight.py
+      - name: Validate NPM token rotation marker
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          CONU_NPM_TOKEN_ROTATED_AFTER: ${{ vars.CONU_NPM_TOKEN_ROTATED_AFTER }}
+        run: python scripts/check-release-secret-rotation-gate.py --secret-name NPM_TOKEN --rotated-after-env CONU_NPM_TOKEN_ROTATED_AFTER --required-after 2026-06-03T00:00:00Z
       - name: Validate npm token authentication and registry availability
         if: startsWith(github.ref, 'refs/tags/v')
         env:
@@ -162,6 +167,8 @@ jobs:
         run: python scripts/check-github-release-secret-readiness-regression.py
       - name: Release secret env preflight regression
         run: python scripts/check-release-secret-env-preflight-regression.py
+      - name: Release secret rotation gate regression
+        run: python scripts/check-release-secret-rotation-gate-regression.py
       - name: GitHub release secret setup regression
         run: python scripts/set-github-release-secrets-regression.py
       - name: GitHub main branch protection regression

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -76,6 +76,8 @@ jobs:
         run: python scripts/check-github-release-secret-readiness-regression.py
       - name: Release secret env preflight regression
         run: python scripts/check-release-secret-env-preflight-regression.py
+      - name: Release secret rotation gate regression
+        run: python scripts/check-release-secret-rotation-gate-regression.py
       - name: GitHub release secret setup regression
         run: python scripts/set-github-release-secrets-regression.py
       - name: GitHub main branch protection regression
@@ -227,6 +229,11 @@ jobs:
           CONU_LINUX_GPG_KEY_FINGERPRINT: ${{ secrets.CONU_LINUX_GPG_KEY_FINGERPRINT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: python scripts/check-release-secret-env-preflight.py
+      - name: Validate NPM token rotation marker
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          CONU_NPM_TOKEN_ROTATED_AFTER: ${{ vars.CONU_NPM_TOKEN_ROTATED_AFTER }}
+        run: python scripts/check-release-secret-rotation-gate.py --secret-name NPM_TOKEN --rotated-after-env CONU_NPM_TOKEN_ROTATED_AFTER --required-after 2026-06-03T00:00:00Z
       - name: Validate npm token authentication and registry availability
         if: startsWith(github.ref, 'refs/tags/v')
         env:
@@ -315,6 +322,8 @@ jobs:
         run: python scripts/check-github-release-secret-readiness-regression.py
       - name: Release secret env preflight regression
         run: python scripts/check-release-secret-env-preflight-regression.py
+      - name: Release secret rotation gate regression
+        run: python scripts/check-release-secret-rotation-gate-regression.py
       - name: GitHub release secret setup regression
         run: python scripts/set-github-release-secrets-regression.py
       - name: GitHub main branch protection regression
@@ -1286,6 +1295,22 @@ def run_required_release_preflight_tests(module) -> None:
         "is missing release secret env command"
     ) not in json.dumps(assert_safe_report(report)):
         raise AssertionError("missing tagged release secret preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "        run: python scripts/check-release-secret-rotation-gate.py --secret-name NPM_TOKEN --rotated-after-env CONU_NPM_TOKEN_ROTATED_AFTER --required-after 2026-06-03T00:00:00Z\n",
+            "        run: echo skipped-npm-token-rotation-marker\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing NPM token rotation marker preflight should fail")
+    if (
+        "release.yml:release-preflight validate NPM token rotation marker "
+        "is missing rotation marker command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing NPM token rotation marker preflight was not reported")
 
     report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -198,6 +198,23 @@ RELEASE_PREFLIGHT_REQUIRED_STEPS: tuple[
         ),
     ),
     (
+        "Validate NPM token rotation marker",
+        "validate NPM token rotation marker",
+        (
+            ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
+            (
+                "rotation marker env",
+                "CONU_NPM_TOKEN_ROTATED_AFTER: ${{ vars.CONU_NPM_TOKEN_ROTATED_AFTER }}",
+            ),
+            (
+                "rotation marker command",
+                "python scripts/check-release-secret-rotation-gate.py --secret-name "
+                "NPM_TOKEN --rotated-after-env CONU_NPM_TOKEN_ROTATED_AFTER "
+                "--required-after 2026-06-03T00:00:00Z",
+            ),
+        ),
+    ),
+    (
         "Validate npm token authentication and registry availability",
         "validate npm token authentication and registry availability",
         (
@@ -534,6 +551,16 @@ PACKAGES_REQUIRED_STEPS: tuple[
             (
                 "release secret env command",
                 "python scripts/check-release-secret-env-preflight-regression.py",
+            ),
+        ),
+    ),
+    (
+        "Release secret rotation gate regression",
+        "run release secret rotation gate regression",
+        (
+            (
+                "release secret rotation gate command",
+                "python scripts/check-release-secret-rotation-gate-regression.py",
             ),
         ),
     ),

--- a/scripts/check-release-secret-rotation-gate-regression.py
+++ b/scripts/check-release-secret-rotation-gate-regression.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Regression checks for the release secret rotation marker gate."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check-release-secret-rotation-gate.py")
+SENSITIVE_SENTINEL = "do-not-print-this-token-value"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_release_secret_rotation_gate", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load release secret rotation gate module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_safe_report(report) -> dict[str, object]:
+    rendered = json.dumps(report.as_json(), sort_keys=True)
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("rotation gate report leaked the marker value")
+    parsed = json.loads(rendered)
+    for field in (
+        "payloadDisplayed",
+        "tokenDisplayed",
+        "tokenHashDisplayed",
+        "keyMaterialDisplayed",
+        "contentsDisplayed",
+        "secretValuesDisplayed",
+    ):
+        if parsed.get(field) is not False:
+            raise AssertionError(f"expected {field}=false")
+    return parsed
+
+
+def run_audit_tests(module) -> None:
+    ready = module.audit_rotation_marker(
+        secret_name="NPM_TOKEN",
+        marker_env="CONU_NPM_TOKEN_ROTATED_AFTER",
+        required_after="2026-06-03T00:00:00Z",
+        rotated_after="2026-06-03T00:00:01+00:00",
+    )
+    if not ready.ready:
+        raise AssertionError(f"expected fresh rotation marker to pass: {ready.issues!r}")
+    parsed_ready = assert_safe_report(ready)
+    if parsed_ready["rotatedAfter"] != "2026-06-03T00:00:01Z":
+        raise AssertionError("rotation marker timestamp was not normalized")
+
+    stale = module.audit_rotation_marker(
+        secret_name="NPM_TOKEN",
+        marker_env="CONU_NPM_TOKEN_ROTATED_AFTER",
+        required_after="2026-06-03T00:00:00Z",
+        rotated_after="2026-06-03T00:00:00Z",
+    )
+    if stale.ready:
+        raise AssertionError("stale rotation marker should fail")
+    parsed_stale = assert_safe_report(stale)
+    if "NPM_TOKEN rotation marker is not after required timestamp" not in json.dumps(parsed_stale):
+        raise AssertionError("stale rotation marker issue was not reported")
+
+    missing = module.audit_rotation_marker(
+        secret_name="NPM_TOKEN",
+        marker_env="CONU_NPM_TOKEN_ROTATED_AFTER",
+        required_after="2026-06-03T00:00:00Z",
+        rotated_after="",
+    )
+    if missing.ready:
+        raise AssertionError("missing rotation marker should fail")
+    parsed_missing = assert_safe_report(missing)
+    if "CONU_NPM_TOKEN_ROTATED_AFTER" not in json.dumps(parsed_missing):
+        raise AssertionError("missing marker env name was not reported")
+
+    invalid = module.audit_rotation_marker(
+        secret_name="NPM_TOKEN",
+        marker_env="CONU_NPM_TOKEN_ROTATED_AFTER",
+        required_after="2026-06-03T00:00:00Z",
+        rotated_after=SENSITIVE_SENTINEL,
+    )
+    if invalid.ready:
+        raise AssertionError("invalid rotation marker should fail")
+    parsed_invalid = assert_safe_report(invalid)
+    if parsed_invalid["rotatedAfter"] != "":
+        raise AssertionError("invalid marker value should not be echoed")
+    if "NPM_TOKEN rotation marker timestamp is invalid" not in json.dumps(parsed_invalid):
+        raise AssertionError("invalid rotation marker issue was not reported")
+
+
+def run_parse_tests(module) -> None:
+    for kwargs, expected in (
+        (
+            {
+                "secret_name": "UNKNOWN",
+                "marker_env": "CONU_NPM_TOKEN_ROTATED_AFTER",
+                "required_after": "2026-06-03T00:00:00Z",
+                "rotated_after": "2026-06-03T00:00:01Z",
+            },
+            "unknown required secret",
+        ),
+        (
+            {
+                "secret_name": "NPM_TOKEN",
+                "marker_env": "CONU_NPM_TOKEN_ROTATED_AFTER",
+                "required_after": "2026-06-03T00:00:00",
+                "rotated_after": "2026-06-03T00:00:01Z",
+            },
+            "must include a timezone",
+        ),
+    ):
+        try:
+            module.audit_rotation_marker(**kwargs)
+        except ValueError as exc:
+            if expected not in str(exc):
+                raise AssertionError(f"unexpected parse error: {exc}") from exc
+        else:
+            raise AssertionError("expected rotation marker parse failure")
+
+
+def run_cli_tests(module) -> None:
+    original_argv = sys.argv[:]
+    original_env = os.environ.get("CONU_NPM_TOKEN_ROTATED_AFTER")
+    try:
+        os.environ["CONU_NPM_TOKEN_ROTATED_AFTER"] = SENSITIVE_SENTINEL
+        sys.argv = [
+            "check-release-secret-rotation-gate.py",
+            "--secret-name",
+            "NPM_TOKEN",
+            "--rotated-after-env",
+            "CONU_NPM_TOKEN_ROTATED_AFTER",
+            "--required-after",
+            "2026-06-03T00:00:00Z",
+            "--json",
+        ]
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = module.main()
+        rendered = stdout.getvalue() + stderr.getvalue()
+        if exit_code != 1:
+            raise AssertionError("invalid CLI marker should fail")
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("invalid CLI marker leaked the marker value")
+
+        os.environ["CONU_NPM_TOKEN_ROTATED_AFTER"] = "2026-06-03T00:00:01Z"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = module.main()
+        if exit_code != 0:
+            raise AssertionError(f"valid CLI marker should pass: {stderr.getvalue()}")
+    finally:
+        sys.argv = original_argv
+        if original_env is None:
+            os.environ.pop("CONU_NPM_TOKEN_ROTATED_AFTER", None)
+        else:
+            os.environ["CONU_NPM_TOKEN_ROTATED_AFTER"] = original_env
+
+
+def main() -> int:
+    module = load_module()
+    run_audit_tests(module)
+    run_parse_tests(module)
+    run_cli_tests(module)
+    print("Release secret rotation gate regression checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-release-secret-rotation-gate.py
+++ b/scripts/check-release-secret-rotation-gate.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Fail release preflight when a required secret rotation marker is stale."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from github_release_secrets import REQUIRED_RELEASE_SECRETS
+
+
+@dataclass(frozen=True)
+class RotationGateReport:
+    secret_name: str
+    marker_env: str
+    required_after: str
+    rotated_after: str
+    ready: bool
+    issues: tuple[str, ...]
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "schema": "conu.releaseSecretRotationGate.v1",
+            "checked": True,
+            "ready": self.ready,
+            "secretName": self.secret_name,
+            "markerEnv": self.marker_env,
+            "requiredAfter": self.required_after,
+            "rotatedAfter": self.rotated_after,
+            "issues": list(self.issues),
+            "payloadDisplayed": False,
+            "tokenDisplayed": False,
+            "tokenHashDisplayed": False,
+            "keyMaterialDisplayed": False,
+            "contentsDisplayed": False,
+            "secretValuesDisplayed": False,
+        }
+
+
+def parse_utc_timestamp(value: str, label: str) -> datetime:
+    raw = value.strip()
+    if not raw:
+        raise ValueError(f"{label} timestamp must not be empty")
+    if raw.endswith("Z"):
+        raw = f"{raw[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(f"{label} timestamp must be ISO-8601 with a timezone") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{label} timestamp must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def render_utc_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def audit_rotation_marker(
+    *,
+    secret_name: str,
+    marker_env: str,
+    required_after: str,
+    rotated_after: str,
+) -> RotationGateReport:
+    normalized_secret = secret_name.strip()
+    if normalized_secret not in REQUIRED_RELEASE_SECRETS:
+        raise ValueError(
+            f"release secret rotation gate uses an unknown required secret: {normalized_secret}"
+        )
+    normalized_marker = marker_env.strip()
+    if not normalized_marker:
+        raise ValueError("release secret rotation marker env name is required")
+
+    required = parse_utc_timestamp(required_after, f"{normalized_secret} required rotation")
+    rendered_required = render_utc_timestamp(required)
+    observed_raw = rotated_after.strip()
+    if not observed_raw:
+        return RotationGateReport(
+            secret_name=normalized_secret,
+            marker_env=normalized_marker,
+            required_after=rendered_required,
+            rotated_after="",
+            ready=False,
+            issues=(f"{normalized_secret} rotation marker {normalized_marker} is missing",),
+        )
+
+    try:
+        observed = parse_utc_timestamp(observed_raw, f"{normalized_secret} rotation marker")
+    except ValueError:
+        return RotationGateReport(
+            secret_name=normalized_secret,
+            marker_env=normalized_marker,
+            required_after=rendered_required,
+            rotated_after="",
+            ready=False,
+            issues=(f"{normalized_secret} rotation marker timestamp is invalid",),
+        )
+
+    rendered_observed = render_utc_timestamp(observed)
+    if observed <= required:
+        return RotationGateReport(
+            secret_name=normalized_secret,
+            marker_env=normalized_marker,
+            required_after=rendered_required,
+            rotated_after=rendered_observed,
+            ready=False,
+            issues=(f"{normalized_secret} rotation marker is not after required timestamp",),
+        )
+
+    return RotationGateReport(
+        secret_name=normalized_secret,
+        marker_env=normalized_marker,
+        required_after=rendered_required,
+        rotated_after=rendered_observed,
+        ready=True,
+        issues=(),
+    )
+
+
+def print_text_report(report: RotationGateReport) -> None:
+    if report.ready:
+        print(
+            "Release secret rotation gate passed: "
+            f"{report.secret_name} marker {report.marker_env} is after {report.required_after}"
+        )
+        return
+    print("Release secret rotation gate failed", file=sys.stderr)
+    for issue in report.issues:
+        print(f"issue: {issue}", file=sys.stderr)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--secret-name", required=True, help="required release secret name")
+    parser.add_argument(
+        "--rotated-after-env",
+        required=True,
+        help="environment variable containing a non-secret rotation timestamp marker",
+    )
+    parser.add_argument(
+        "--required-after",
+        required=True,
+        help="minimum required rotation timestamp, as ISO-8601 with timezone",
+    )
+    parser.add_argument("--json", action="store_true", help="print a machine-readable report")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        marker_value = os.environ.get(args.rotated_after_env, "")
+        report = audit_rotation_marker(
+            secret_name=args.secret_name,
+            marker_env=args.rotated_after_env,
+            required_after=args.required_after,
+            rotated_after=marker_value,
+        )
+    except ValueError as exc:
+        print(f"Release secret rotation gate failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report.as_json(), indent=2, sort_keys=True))
+    else:
+        print_text_report(report)
+    return 0 if report.ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## **User description**
Closes #780.

## Summary
- Adds a payload-safe release secret rotation marker gate for `NPM_TOKEN`.
- Fails tagged release preflight before npm auth unless `vars.CONU_NPM_TOKEN_ROTATED_AFTER` is after `2026-06-03T00:00:00Z`.
- Adds regression coverage and workflow-permission audit requirements so the gate cannot be removed silently.

## Validation
- `python scripts/check-release-secret-rotation-gate-regression.py`
- `python scripts/check-github-workflow-permissions-regression.py`
- `python scripts/check-github-workflow-permissions.py`
- `python scripts/check-python-script-compile.py`
- `python scripts/check-tagged-release-readiness-regression.py`
- `python scripts/check-release-secret-env-preflight-regression.py`
- `python scripts/set-github-release-secrets-regression.py`
- `python scripts/verify-release-versions.py`
- `npm run check --prefix sdk/typescript`
- `npm run check --prefix packaging/npm/conu-cli`
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a release preflight gate that blocks tagged publishes until the `NPM_TOKEN` rotation marker is updated. This prevents releasing with a stale token and adds CI audits to keep the gate in place.

- **New Features**
  - Validate `vars.CONU_NPM_TOKEN_ROTATED_AFTER` on tagged releases; it must be after 2026-06-03T00:00:00Z before npm auth runs.
  - Add `scripts/check-release-secret-rotation-gate.py` with regression coverage; wire checks into `release.yml` and `ci.yml` and require them via workflow-permissions audit.

- **Migration**
  - After rotating `NPM_TOKEN`, set `CONU_NPM_TOKEN_ROTATED_AFTER` to the rotation time (ISO-8601 with timezone) later than 2026-06-03T00:00:00Z.
  - Tagged releases will fail preflight until this is set and newer than the required date.

<sup>Written for commit 57d6dc91ab69ff5fd433acb9cba826a19f9e397b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block tagged releases until the NPM token rotation date is current**

### What Changed
- Tagged releases now stop if the NPM token rotation marker is missing, invalid, or older than the required date
- Release checks now read a non-secret rotation timestamp and report the result without exposing token values
- CI and release workflows now include the new rotation check, and regression coverage now ensures the check stays in place

### Impact
`✅ Fewer releases blocked by stale NPM credentials`
`✅ Clearer tagged-release failures before publish`
`✅ Lower risk of using an unrotated npm token`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
