### PR TITLE
Surface NPM rotation marker in tagged release readiness

### DIFF
--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -589,6 +589,98 @@ def run_secret_rotation_tests(module) -> None:
             raise AssertionError(f"expected secret rotation parse failure for {raw!r}")
 
 
+def run_secret_rotation_marker_tests(module) -> None:
+    requirement = module.default_secret_rotation_marker_requirements()[0]
+    ready = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        variable_values={
+            module.NPM_TOKEN_ROTATION_MARKER_VAR: "2026-06-03T00:00:01Z",
+        },
+        secret_rotation_marker_requirements=(requirement,),
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        **ready_governance_kwargs(),
+    )
+    if not ready.ready:
+        raise AssertionError(f"expected fresh rotation marker readiness to pass: {ready.issues!r}")
+    parsed_ready = assert_safe_report(ready)
+    marker_report = parsed_ready["secretRotationMarkers"]
+    if marker_report["checked"] is not True:
+        raise AssertionError("secret rotation marker readiness should be checked")
+    if marker_report["markers"][0]["markerEnv"] != module.NPM_TOKEN_ROTATION_MARKER_VAR:
+        raise AssertionError("secret rotation marker report should identify the marker variable")
+    if marker_report["markers"][0]["rotatedAfter"] != "2026-06-03T00:00:01Z":
+        raise AssertionError("secret rotation marker timestamp should be reported when valid")
+
+    missing = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        variable_values={},
+        secret_rotation_marker_requirements=(requirement,),
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        **ready_governance_kwargs(),
+    )
+    if missing.ready:
+        raise AssertionError("missing rotation marker should fail tagged release readiness")
+    parsed_missing = assert_safe_report(missing)
+    if (
+        "release secret rotation marker readiness: NPM_TOKEN rotation marker "
+        "CONU_NPM_TOKEN_ROTATED_AFTER is missing"
+        not in json.dumps(parsed_missing)
+    ):
+        raise AssertionError("missing rotation marker issue was not reported")
+
+    stale = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        variable_values={
+            module.NPM_TOKEN_ROTATION_MARKER_VAR: "2026-06-03T00:00:00Z",
+        },
+        secret_rotation_marker_requirements=(requirement,),
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        **ready_governance_kwargs(),
+    )
+    if stale.ready:
+        raise AssertionError("stale rotation marker should fail tagged release readiness")
+    parsed_stale = assert_safe_report(stale)
+    if "NPM_TOKEN rotation marker is not after required timestamp" not in json.dumps(parsed_stale):
+        raise AssertionError("stale rotation marker issue was not reported")
+
+    invalid = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_release_secrets(module),
+        variable_values={
+            module.NPM_TOKEN_ROTATION_MARKER_VAR: SENSITIVE_SENTINEL,
+        },
+        secret_rotation_marker_requirements=(requirement,),
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        **ready_governance_kwargs(),
+    )
+    if invalid.ready:
+        raise AssertionError("invalid rotation marker should fail tagged release readiness")
+    parsed_invalid = assert_safe_report(invalid)
+    if parsed_invalid["secretRotationMarkers"]["markers"][0]["rotatedAfter"] != "":
+        raise AssertionError("invalid rotation marker value should not be echoed")
+    if "NPM_TOKEN rotation marker timestamp is invalid" not in json.dumps(parsed_invalid):
+        raise AssertionError("invalid rotation marker issue was not reported")
+
+
 def run_custom_repository_tests(module) -> None:
     report = module.audit_tagged_release_readiness(
         repo="owner/repo",
@@ -892,6 +984,7 @@ def main() -> int:
     run_release_branch_readiness_tests(module)
     run_missing_secret_tests(module)
     run_secret_rotation_tests(module)
+    run_secret_rotation_marker_tests(module)
     run_custom_repository_tests(module)
     run_safe_failure_tests(module)
     print("Tagged release readiness regression checks passed")

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -55,6 +55,8 @@ NPM_MANIFESTS = (
 DEFAULT_CI_WORKFLOW = "CI"
 DEFAULT_RELEASE_BRANCH = "main"
 SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+NPM_TOKEN_ROTATION_MARKER_VAR = "CONU_NPM_TOKEN_ROTATED_AFTER"
+NPM_TOKEN_ROTATION_REQUIRED_AFTER = "2026-06-03T00:00:00Z"
 
 
 @dataclass(frozen=True)
@@ -130,6 +132,13 @@ class SecretRotationRequirement:
 
 
 @dataclass(frozen=True)
+class SecretRotationMarkerRequirement:
+    secret_name: str
+    marker_env: str
+    required_after: str
+
+
+@dataclass(frozen=True)
 class SecretRotationReadiness:
     checked: bool
     ready: bool
@@ -141,6 +150,28 @@ class SecretRotationReadiness:
             "checked": self.checked,
             "ready": self.ready,
             "requirements": list(self.requirements),
+            "issues": list(self.issues),
+            "payloadDisplayed": False,
+            "tokenDisplayed": False,
+            "tokenHashDisplayed": False,
+            "keyMaterialDisplayed": False,
+            "contentsDisplayed": False,
+            "secretValuesDisplayed": False,
+        }
+
+
+@dataclass(frozen=True)
+class SecretRotationMarkerReadiness:
+    checked: bool
+    ready: bool
+    markers: tuple[dict[str, Any], ...]
+    issues: tuple[str, ...]
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "checked": self.checked,
+            "ready": self.ready,
+            "markers": list(self.markers),
             "issues": list(self.issues),
             "payloadDisplayed": False,
             "tokenDisplayed": False,
@@ -181,6 +212,7 @@ class TaggedReleaseReadiness:
     ready: bool
     release_secrets: Any
     secret_rotation: SecretRotationReadiness
+    secret_rotation_markers: SecretRotationMarkerReadiness
     linux_repository: LinuxRepositoryReadiness
     release_clobber: Any
     npm_registry: NpmRegistryReadiness
@@ -201,6 +233,7 @@ class TaggedReleaseReadiness:
             "ready": self.ready,
             "releaseSecrets": self.release_secrets.as_json(),
             "secretRotation": self.secret_rotation.as_json(),
+            "secretRotationMarkers": self.secret_rotation_markers.as_json(),
             "linuxRepository": self.linux_repository.as_json(),
             "releaseClobber": self.release_clobber.as_json(),
             "npmRegistry": self.npm_registry.as_json(),
@@ -384,6 +417,60 @@ def audit_secret_rotation(
         checked=True,
         ready=not issues,
         requirements=tuple(rendered_requirements),
+        issues=tuple(issues),
+    )
+
+
+def default_secret_rotation_marker_requirements() -> tuple[SecretRotationMarkerRequirement, ...]:
+    return (
+        SecretRotationMarkerRequirement(
+            secret_name="NPM_TOKEN",
+            marker_env=NPM_TOKEN_ROTATION_MARKER_VAR,
+            required_after=NPM_TOKEN_ROTATION_REQUIRED_AFTER,
+        ),
+    )
+
+
+def audit_secret_rotation_markers(
+    variable_values: dict[str, str],
+    requirements: tuple[SecretRotationMarkerRequirement, ...],
+) -> SecretRotationMarkerReadiness:
+    if not requirements:
+        return SecretRotationMarkerReadiness(
+            checked=False,
+            ready=True,
+            markers=(),
+            issues=(),
+        )
+
+    gate_module = load_script_module(
+        "check-release-secret-rotation-gate.py",
+        "check_release_secret_rotation_gate_for_tagged_readiness",
+    )
+    markers: list[dict[str, Any]] = []
+    issues: list[str] = []
+    for requirement in requirements:
+        report = gate_module.audit_rotation_marker(
+            secret_name=requirement.secret_name,
+            marker_env=requirement.marker_env,
+            required_after=requirement.required_after,
+            rotated_after=variable_values.get(requirement.marker_env, ""),
+        )
+        markers.append(
+            {
+                "secretName": report.secret_name,
+                "markerEnv": report.marker_env,
+                "requiredAfter": report.required_after,
+                "rotatedAfter": report.rotated_after,
+                "ready": report.ready,
+            }
+        )
+        issues.extend(report.issues)
+
+    return SecretRotationMarkerReadiness(
+        checked=True,
+        ready=not issues,
+        markers=tuple(markers),
         issues=tuple(issues),
     )
 
@@ -932,6 +1019,7 @@ def audit_repository_security(repo: str, gh: str) -> Any:
 def combine_issues(
     release_secrets: Any,
     secret_rotation: SecretRotationReadiness,
+    secret_rotation_markers: SecretRotationMarkerReadiness,
     linux_repository: LinuxRepositoryReadiness,
     release_clobber: Any,
     npm_registry: NpmRegistryReadiness,
@@ -947,6 +1035,8 @@ def combine_issues(
         issues.append(f"missing release secret: {name}")
     for issue in secret_rotation.issues:
         issues.append(f"release secret rotation readiness: {issue}")
+    for issue in secret_rotation_markers.issues:
+        issues.append(f"release secret rotation marker readiness: {issue}")
     for name in linux_repository.missing_variables:
         issues.append(f"missing repository variable: {name}")
     for name in linux_repository.missing_secrets:
@@ -984,6 +1074,7 @@ def audit_tagged_release_readiness(
     npm_registry_check: bool,
     secret_updated_at: dict[str, str] | None = None,
     secret_rotation_requirements: tuple[SecretRotationRequirement, ...] = (),
+    secret_rotation_marker_requirements: tuple[SecretRotationMarkerRequirement, ...] = (),
     npm: str = "",
     ci_required: bool = False,
     ci_workflow: str = DEFAULT_CI_WORKFLOW,
@@ -1003,6 +1094,10 @@ def audit_tagged_release_readiness(
     secret_rotation = audit_secret_rotation(
         secret_updated_at or {},
         secret_rotation_requirements,
+    )
+    secret_rotation_markers = audit_secret_rotation_markers(
+        variable_values,
+        secret_rotation_marker_requirements,
     )
     linux_repository = audit_linux_repository(repo, variable_values, secret_names, pages_payload)
     clobber_module = load_script_module(
@@ -1037,6 +1132,7 @@ def audit_tagged_release_readiness(
     issues = combine_issues(
         release_secrets,
         secret_rotation,
+        secret_rotation_markers,
         linux_repository,
         release_clobber,
         npm_registry,
@@ -1054,6 +1150,7 @@ def audit_tagged_release_readiness(
         ready=not issues,
         release_secrets=release_secrets,
         secret_rotation=secret_rotation,
+        secret_rotation_markers=secret_rotation_markers,
         linux_repository=linux_repository,
         release_clobber=release_clobber,
         npm_registry=npm_registry,
@@ -1288,6 +1385,7 @@ def main() -> int:
             npm_registry_check=args.npm_registry_check,
             secret_updated_at=secret_updated_at,
             secret_rotation_requirements=secret_rotation_requirements,
+            secret_rotation_marker_requirements=default_secret_rotation_marker_requirements(),
             npm=args.npm,
             ci_required=args.require_ci,
             ci_workflow=args.ci_workflow,


### PR DESCRIPTION
## **User description**
Closes #782.

## Summary
- Adds `secretRotationMarkers` to tagged-release readiness output.
- Checks the non-secret `CONU_NPM_TOKEN_ROTATED_AFTER` repository variable against the same post-leak timestamp required by the release workflow.
- Adds regressions for fresh, missing, stale, and invalid marker values, including invalid-value redaction.

## Validation
- `python scripts/check-tagged-release-readiness-regression.py`
- `python scripts/check-release-secret-rotation-gate-regression.py`
- `python scripts/check-github-workflow-permissions.py`
- `python scripts/check-python-script-compile.py`
- `python scripts/verify-release-versions.py`
- `npm run check --prefix sdk/typescript`
- `npm run check --prefix packaging/npm/conu-cli`
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
- Live readiness smoke: reports missing `CONU_NPM_TOKEN_ROTATED_AFTER` in `secretRotationMarkers` without secret material.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an NPM token rotation-marker gate to tagged release readiness and surface its status in the readiness report. The check blocks releases when `CONU_NPM_TOKEN_ROTATED_AFTER` is missing, stale, or invalid.

- **New Features**
  - Exposes `secretRotationMarkers` in the readiness JSON with per-marker details and no secret material.
  - Enforces `CONU_NPM_TOKEN_ROTATED_AFTER` is after `2026-06-03T00:00:00Z`; missing/stale/invalid markers fail readiness, and invalid values are redacted.
  - Adds `default_secret_rotation_marker_requirements()` and integrates marker issues into combined readiness issues.
  - Adds regression tests for fresh, missing, stale, and invalid marker cases.

<sup>Written for commit 8b819ac77bcc4b07b6de36ac20a6291ec3c8ce84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Show NPM token rotation status in tagged release readiness**

### What Changed
- Tagged release readiness now includes a check for the NPM token rotation marker and reports whether it is present, current, stale, or invalid.
- The readiness report now shows this marker status separately, while keeping secret material hidden.
- A missing, outdated, or malformed marker now blocks release readiness with a clear issue message.
- Regression checks were added for valid, missing, stale, and invalid marker values.

### Impact
`✅ Clearer release readiness checks`
`✅ Fewer releases from stale NPM token markers`
`✅ Safer readiness reports without secret values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
