### PR TITLE
Derive NPM marker from secret metadata

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -306,6 +306,55 @@ def run_rotation_marker_setup_tests(module) -> None:
         "--confirm-npm-token-rotated",
     )
 
+    original_loader = module.load_secret_metadata
+    try:
+        module.load_secret_metadata = lambda _repo, _gh: {
+            module.NPM_TOKEN_SECRET_NAME: SimpleNamespace(
+                updated_at="2026-06-03T00:00:04+00:00"
+            )
+        }
+        metadata_timestamp = module.load_npm_rotation_marker_timestamp_from_secret_metadata(
+            "owner/repo",
+            "gh",
+        )
+        if metadata_timestamp != "2026-06-03T00:00:04Z":
+            raise AssertionError("metadata-derived marker timestamp was not normalized")
+
+        module.load_secret_metadata = lambda _repo, _gh: {}
+        assert_raises(
+            lambda: module.load_npm_rotation_marker_timestamp_from_secret_metadata(
+                "owner/repo",
+                "gh",
+            ),
+            "secret metadata is missing",
+        )
+
+        module.load_secret_metadata = lambda _repo, _gh: {
+            module.NPM_TOKEN_SECRET_NAME: SimpleNamespace(
+                updated_at="2026-06-03T00:00:00Z"
+            )
+        }
+        assert_raises(
+            lambda: module.load_npm_rotation_marker_timestamp_from_secret_metadata(
+                "owner/repo",
+                "gh",
+            ),
+            "timestamp must be after",
+        )
+
+        module.load_secret_metadata = lambda _repo, _gh: {
+            module.NPM_TOKEN_SECRET_NAME: SimpleNamespace(updated_at=SENSITIVE_SENTINEL)
+        }
+        assert_raises(
+            lambda: module.load_npm_rotation_marker_timestamp_from_secret_metadata(
+                "owner/repo",
+                "gh",
+            ),
+            "ISO-8601",
+        )
+    finally:
+        module.load_secret_metadata = original_loader
+
     calls = []
 
     def fake_run(args, **kwargs):
@@ -715,6 +764,37 @@ def run_rotation_marker_main_tests(module) -> None:
         if SENSITIVE_SENTINEL in rendered:
             raise AssertionError("marker-only dry-run leaked a secret-like value")
 
+        original_loader = module.load_secret_metadata
+        try:
+            module.load_secret_metadata = lambda _repo, _gh: {
+                module.NPM_TOKEN_SECRET_NAME: SimpleNamespace(
+                    updated_at="2026-06-03T00:00:03+00:00"
+                )
+            }
+            exit_code, rendered = call_main(
+                module,
+                [
+                    "set-github-release-secrets.py",
+                    "--repo",
+                    "owner/repo",
+                    "--gh",
+                    "gh",
+                    "--set-npm-token-rotation-marker-from-secret-updated-at",
+                    "--confirm-npm-token-rotated",
+                    "--dry-run",
+                ],
+            )
+        finally:
+            module.load_secret_metadata = original_loader
+        if exit_code != 0:
+            raise AssertionError(f"expected metadata marker dry-run to pass: {rendered}")
+        if "2026-06-03T00:00:03Z" not in rendered:
+            raise AssertionError("metadata marker dry-run omitted normalized updatedAt")
+        if "missing local release secret values" in rendered:
+            raise AssertionError("metadata marker dry-run should not require signing secrets")
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("metadata marker dry-run leaked a secret-like value")
+
         exit_code, rendered = call_main(
             module,
             [
@@ -741,14 +821,53 @@ def run_rotation_marker_main_tests(module) -> None:
                 "owner/repo",
                 "--gh",
                 "gh",
+                "--set-npm-token-rotation-marker-from-secret-updated-at",
+                "--dry-run",
+            ],
+        )
+        if exit_code == 0 or "--confirm-npm-token-rotated" not in rendered:
+            raise AssertionError(
+                f"expected metadata marker setup without confirmation to fail: {rendered}"
+            )
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("metadata missing-confirm marker error leaked a secret-like value")
+
+        exit_code, rendered = call_main(
+            module,
+            [
+                "set-github-release-secrets.py",
+                "--repo",
+                "owner/repo",
+                "--gh",
+                "gh",
                 "--confirm-npm-token-rotated",
                 "--dry-run",
             ],
         )
-        if exit_code == 0 or "requires --set-npm-token-rotation-marker" not in rendered:
+        if exit_code == 0 or "requires a NPM token rotation marker setup option" not in rendered:
             raise AssertionError(f"expected confirmation without marker to fail: {rendered}")
         if SENSITIVE_SENTINEL in rendered:
             raise AssertionError("confirmation-only marker error leaked a secret-like value")
+
+        exit_code, rendered = call_main(
+            module,
+            [
+                "set-github-release-secrets.py",
+                "--repo",
+                "owner/repo",
+                "--gh",
+                "gh",
+                "--set-npm-token-rotation-marker",
+                "2026-06-03T00:00:01Z",
+                "--set-npm-token-rotation-marker-from-secret-updated-at",
+                "--confirm-npm-token-rotated",
+                "--dry-run",
+            ],
+        )
+        if exit_code == 0 or "mutually exclusive" not in rendered:
+            raise AssertionError(f"expected marker setup options to be mutually exclusive: {rendered}")
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("mutual-exclusion marker error leaked a secret-like value")
 
         exit_code, rendered = call_main(
             module,
@@ -787,6 +906,31 @@ def run_rotation_marker_main_tests(module) -> None:
             raise AssertionError(f"expected invalid marker setup to fail: {rendered}")
         if SENSITIVE_SENTINEL in rendered:
             raise AssertionError("invalid marker error leaked the provided marker value")
+
+        original_loader = module.load_secret_metadata
+        try:
+            module.load_secret_metadata = lambda _repo, _gh: {
+                module.NPM_TOKEN_SECRET_NAME: SimpleNamespace(updated_at=SENSITIVE_SENTINEL)
+            }
+            exit_code, rendered = call_main(
+                module,
+                [
+                    "set-github-release-secrets.py",
+                    "--repo",
+                    "owner/repo",
+                    "--gh",
+                    "gh",
+                    "--set-npm-token-rotation-marker-from-secret-updated-at",
+                    "--confirm-npm-token-rotated",
+                    "--dry-run",
+                ],
+            )
+        finally:
+            module.load_secret_metadata = original_loader
+        if exit_code == 0 or "ISO-8601" not in rendered:
+            raise AssertionError(f"expected invalid metadata marker setup to fail: {rendered}")
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("invalid metadata marker error leaked the updatedAt value")
 
         with tempfile.TemporaryDirectory() as temp_dir:
             env_file = Path(temp_dir) / ".env.release"

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -16,9 +16,11 @@ from typing import BinaryIO, Mapping
 from github_release_secrets import (
     NPM_TOKEN_ROTATION_MARKER_VAR,
     NPM_TOKEN_ROTATION_REQUIRED_AFTER,
+    NPM_TOKEN_SECRET_NAME,
     REQUIRED_RELEASE_SECRETS,
     find_gh,
     infer_repo,
+    load_secret_metadata,
 )
 
 
@@ -233,6 +235,18 @@ def normalize_npm_rotation_marker_timestamp(value: str) -> str:
     return render_utc_timestamp(observed)
 
 
+def load_npm_rotation_marker_timestamp_from_secret_metadata(repo: str, gh: str) -> str:
+    records = load_secret_metadata(repo, gh)
+    record = records.get(NPM_TOKEN_SECRET_NAME)
+    if record is None or not record.updated_at:
+        raise ValueError(
+            f"{NPM_TOKEN_SECRET_NAME} secret metadata is missing; "
+            f"rotate and upload {NPM_TOKEN_SECRET_NAME} before setting "
+            f"{NPM_TOKEN_ROTATION_MARKER_VAR}"
+        )
+    return normalize_npm_rotation_marker_timestamp(record.updated_at)
+
+
 def configure_npm_rotation_marker(
     repo: str,
     gh: str,
@@ -399,6 +413,15 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--set-npm-token-rotation-marker-from-secret-updated-at",
+        action="store_true",
+        help=(
+            "set non-secret GitHub variable "
+            f"{NPM_TOKEN_ROTATION_MARKER_VAR} from GitHub's "
+            f"{NPM_TOKEN_SECRET_NAME} updatedAt metadata after confirmed rotation"
+        ),
+    )
+    parser.add_argument(
         "--gh",
         default="",
         help=argparse.SUPPRESS,
@@ -422,6 +445,7 @@ def main() -> int:
             or args.require_openssl
             or args.set_npm_token_rotation_marker
             or args.confirm_npm_token_rotated
+            or args.set_npm_token_rotation_marker_from_secret_updated_at
         ):
             raise ValueError("env template generation cannot be combined with setup options")
         if args.check_env_file:
@@ -434,19 +458,32 @@ def main() -> int:
                 or args.require_openssl
                 or args.set_npm_token_rotation_marker
                 or args.confirm_npm_token_rotated
+                or args.set_npm_token_rotation_marker_from_secret_updated_at
             ):
                 raise ValueError("--check-env-file cannot be combined with setup options")
         if args.require_openssl and not args.preflight_values:
             raise ValueError("--require-openssl requires --preflight-values")
         if args.env_file_only and not args.env_file:
             raise ValueError("--env-file-only requires --env-file")
-        if args.confirm_npm_token_rotated and not args.set_npm_token_rotation_marker:
+        if (
+            args.set_npm_token_rotation_marker
+            and args.set_npm_token_rotation_marker_from_secret_updated_at
+        ):
             raise ValueError(
-                "--confirm-npm-token-rotated requires --set-npm-token-rotation-marker"
+                "--set-npm-token-rotation-marker and "
+                "--set-npm-token-rotation-marker-from-secret-updated-at are mutually exclusive"
             )
-        if args.set_npm_token_rotation_marker and not args.confirm_npm_token_rotated:
+        marker_option_requested = bool(
+            args.set_npm_token_rotation_marker
+            or args.set_npm_token_rotation_marker_from_secret_updated_at
+        )
+        if args.confirm_npm_token_rotated and not marker_option_requested:
             raise ValueError(
-                "--set-npm-token-rotation-marker requires --confirm-npm-token-rotated"
+                "--confirm-npm-token-rotated requires a NPM token rotation marker setup option"
+            )
+        if marker_option_requested and not args.confirm_npm_token_rotated:
+            raise ValueError(
+                "NPM token rotation marker setup requires --confirm-npm-token-rotated"
             )
         if args.print_env_template:
             print(render_env_template(REQUIRED_RELEASE_SECRETS), end="")
@@ -475,7 +512,7 @@ def main() -> int:
                 print(f"present: {name}")
             return 0
 
-        marker_requested = bool(args.set_npm_token_rotation_marker)
+        marker_requested = marker_option_requested
         secret_setup_requested = (
             not marker_requested
             or bool(args.env_file)
@@ -483,7 +520,7 @@ def main() -> int:
             or args.preflight_values
         )
         marker_timestamp = ""
-        if marker_requested:
+        if args.set_npm_token_rotation_marker:
             marker_timestamp = normalize_npm_rotation_marker_timestamp(
                 args.set_npm_token_rotation_marker
             )
@@ -517,10 +554,15 @@ def main() -> int:
         if secret_setup_requested:
             configured = configure_release_secrets(repo, gh, values, args.dry_run)
         if marker_requested:
+            if args.set_npm_token_rotation_marker_from_secret_updated_at:
+                marker_timestamp = load_npm_rotation_marker_timestamp_from_secret_metadata(
+                    repo,
+                    gh,
+                )
             marker_timestamp = configure_npm_rotation_marker(
                 repo,
                 gh,
-                args.set_npm_token_rotation_marker,
+                marker_timestamp or args.set_npm_token_rotation_marker,
                 args.confirm_npm_token_rotated,
                 args.dry_run,
             )


### PR DESCRIPTION
## **User description**
## Summary
- add a guarded setup mode that derives CONU_NPM_TOKEN_ROTATED_AFTER from GitHub NPM_TOKEN updatedAt metadata
- require --confirm-npm-token-rotated and reject missing, invalid, or stale metadata before setting the repository variable
- keep marker-only dry-run behavior without requiring all signing secrets
- add regression coverage for metadata-derived setup, mutual exclusion, stale metadata, invalid metadata, and output redaction

## Validation
- python scripts\check-python-script-compile.py
- python scripts\set-github-release-secrets-regression.py
- python scripts\check-release-secret-rotation-gate-regression.py
- python scripts\check-tagged-release-readiness-regression.py
- python scripts\check-github-workflow-permissions.py
- python scripts\check-github-workflow-permissions-regression.py
- python scripts\verify-release-versions.py
- git diff --check
- live dry-run refused current stale NPM_TOKEN metadata: `python scripts\set-github-release-secrets.py --repo imthegoodboy/conU --gh gh --set-npm-token-rotation-marker-from-secret-updated-at --confirm-npm-token-rotated --dry-run`

Closes #786

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a guarded mode to set the NPM token rotation marker from the GitHub `NPM_TOKEN` secret’s updatedAt metadata. Requires explicit confirmation, validates and normalizes the timestamp, and preserves marker-only dry-run behavior.

- **New Features**
  - New flag: `--set-npm-token-rotation-marker-from-secret-updated-at`.
  - Requires `--confirm-npm-token-rotated`; fails without it.
  - Loads metadata via `load_secret_metadata`, normalizes to UTC `Z`, and rejects missing, stale, or non‑ISO‑8601 timestamps.
  - Mutually exclusive with `--set-npm-token-rotation-marker`.
  - Marker-only dry-run doesn’t require signing secrets and keeps sensitive output redacted.
  - Adds regression tests for metadata-derived setup, mutual exclusion, stale/invalid metadata, and output redaction.

<sup>Written for commit 4430189d3d24b3f64135fae3f906c052b87fca5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Set the NPM rotation marker from the secret’s last-updated time**

### What Changed
- Added a new setup path that fills the NPM rotation marker from the GitHub secret’s updated time instead of requiring a manual timestamp
- The new path only works after explicit rotation confirmation, and it is blocked if the marker is missing, stale, or not a valid timestamp
- The manual timestamp path and the metadata-based path cannot be used together
- Marker-only dry runs still work without requiring the full set of release secrets, and sensitive values stay hidden in output

### Impact
`✅ Shorter NPM token rotation setup`
`✅ Fewer manual timestamp entry mistakes`
`✅ Clearer rotation checks before updating release settings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
