### PR TITLE
Guard unverified NPM marker setup

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -753,8 +753,30 @@ def run_rotation_marker_main_tests(module) -> None:
                 "--dry-run",
             ],
         )
+        if exit_code == 0 or "--allow-unverified-npm-token-rotation-marker" not in rendered:
+            raise AssertionError(
+                f"expected manual marker dry-run without override to fail: {rendered}"
+            )
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("manual marker override error leaked a secret-like value")
+
+        exit_code, rendered = call_main(
+            module,
+            [
+                "set-github-release-secrets.py",
+                "--repo",
+                "owner/repo",
+                "--gh",
+                "gh",
+                "--set-npm-token-rotation-marker",
+                "2026-06-03T00:00:01+00:00",
+                "--allow-unverified-npm-token-rotation-marker",
+                "--confirm-npm-token-rotated",
+                "--dry-run",
+            ],
+        )
         if exit_code != 0:
-            raise AssertionError(f"expected marker-only dry-run to pass: {rendered}")
+            raise AssertionError(f"expected unverified manual marker dry-run to pass: {rendered}")
         if module.NPM_TOKEN_ROTATION_MARKER_VAR not in rendered:
             raise AssertionError("marker dry-run output omitted the marker variable name")
         if "2026-06-03T00:00:01Z" not in rendered:
@@ -805,6 +827,7 @@ def run_rotation_marker_main_tests(module) -> None:
                 "gh",
                 "--set-npm-token-rotation-marker",
                 "2026-06-03T00:00:01Z",
+                "--allow-unverified-npm-token-rotation-marker",
                 "--dry-run",
             ],
         )
@@ -840,6 +863,47 @@ def run_rotation_marker_main_tests(module) -> None:
                 "owner/repo",
                 "--gh",
                 "gh",
+                "--allow-unverified-npm-token-rotation-marker",
+                "--confirm-npm-token-rotated",
+                "--dry-run",
+            ],
+        )
+        if exit_code == 0 or "requires --set-npm-token-rotation-marker" not in rendered:
+            raise AssertionError(
+                f"expected unverified override without manual marker to fail: {rendered}"
+            )
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("unverified override argument error leaked a secret-like value")
+
+        exit_code, rendered = call_main(
+            module,
+            [
+                "set-github-release-secrets.py",
+                "--repo",
+                "owner/repo",
+                "--gh",
+                "gh",
+                "--set-npm-token-rotation-marker-from-secret-updated-at",
+                "--allow-unverified-npm-token-rotation-marker",
+                "--confirm-npm-token-rotated",
+                "--dry-run",
+            ],
+        )
+        if exit_code == 0 or "requires --set-npm-token-rotation-marker" not in rendered:
+            raise AssertionError(
+                f"expected unverified override with metadata marker to fail: {rendered}"
+            )
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("metadata override argument error leaked a secret-like value")
+
+        exit_code, rendered = call_main(
+            module,
+            [
+                "set-github-release-secrets.py",
+                "--repo",
+                "owner/repo",
+                "--gh",
+                "gh",
                 "--confirm-npm-token-rotated",
                 "--dry-run",
             ],
@@ -859,6 +923,7 @@ def run_rotation_marker_main_tests(module) -> None:
                 "gh",
                 "--set-npm-token-rotation-marker",
                 "2026-06-03T00:00:01Z",
+                "--allow-unverified-npm-token-rotation-marker",
                 "--set-npm-token-rotation-marker-from-secret-updated-at",
                 "--confirm-npm-token-rotated",
                 "--dry-run",
@@ -879,6 +944,7 @@ def run_rotation_marker_main_tests(module) -> None:
                 "gh",
                 "--set-npm-token-rotation-marker",
                 "2026-06-03T00:00:00Z",
+                "--allow-unverified-npm-token-rotation-marker",
                 "--confirm-npm-token-rotated",
                 "--dry-run",
             ],
@@ -898,6 +964,7 @@ def run_rotation_marker_main_tests(module) -> None:
                 "gh",
                 "--set-npm-token-rotation-marker",
                 SENSITIVE_SENTINEL,
+                "--allow-unverified-npm-token-rotation-marker",
                 "--confirm-npm-token-rotated",
                 "--dry-run",
             ],
@@ -948,6 +1015,7 @@ def run_rotation_marker_main_tests(module) -> None:
                     "--env-file-only",
                     "--set-npm-token-rotation-marker",
                     "2026-06-03T00:00:02Z",
+                    "--allow-unverified-npm-token-rotation-marker",
                     "--confirm-npm-token-rotated",
                     "--dry-run",
                 ],

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -405,6 +405,15 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--allow-unverified-npm-token-rotation-marker",
+        action="store_true",
+        help=(
+            "allow manual NPM rotation marker timestamps without checking GitHub "
+            f"{NPM_TOKEN_SECRET_NAME} updatedAt metadata; prefer "
+            "--set-npm-token-rotation-marker-from-secret-updated-at"
+        ),
+    )
+    parser.add_argument(
         "--confirm-npm-token-rotated",
         action="store_true",
         help=(
@@ -444,6 +453,7 @@ def main() -> int:
             or args.preflight_values
             or args.require_openssl
             or args.set_npm_token_rotation_marker
+            or args.allow_unverified_npm_token_rotation_marker
             or args.confirm_npm_token_rotated
             or args.set_npm_token_rotation_marker_from_secret_updated_at
         ):
@@ -457,6 +467,7 @@ def main() -> int:
                 or args.preflight_values
                 or args.require_openssl
                 or args.set_npm_token_rotation_marker
+                or args.allow_unverified_npm_token_rotation_marker
                 or args.confirm_npm_token_rotated
                 or args.set_npm_token_rotation_marker_from_secret_updated_at
             ):
@@ -472,6 +483,23 @@ def main() -> int:
             raise ValueError(
                 "--set-npm-token-rotation-marker and "
                 "--set-npm-token-rotation-marker-from-secret-updated-at are mutually exclusive"
+            )
+        if (
+            args.allow_unverified_npm_token_rotation_marker
+            and not args.set_npm_token_rotation_marker
+        ):
+            raise ValueError(
+                "--allow-unverified-npm-token-rotation-marker requires "
+                "--set-npm-token-rotation-marker"
+            )
+        if (
+            args.set_npm_token_rotation_marker
+            and not args.allow_unverified_npm_token_rotation_marker
+        ):
+            raise ValueError(
+                "--set-npm-token-rotation-marker requires "
+                "--allow-unverified-npm-token-rotation-marker; prefer "
+                "--set-npm-token-rotation-marker-from-secret-updated-at"
             )
         marker_option_requested = bool(
             args.set_npm_token_rotation_marker


### PR DESCRIPTION
## **User description**
## Summary
- require --allow-unverified-npm-token-rotation-marker before accepting manual CONU_NPM_TOKEN_ROTATED_AFTER timestamps
- keep --set-npm-token-rotation-marker-from-secret-updated-at as the normal safer setup path
- reject unverified override usage when no manual timestamp is provided
- add regression coverage for the new guard and token-safe error paths

## Validation
- python scripts\check-python-script-compile.py
- python scripts\set-github-release-secrets-regression.py
- python scripts\check-release-secret-rotation-gate-regression.py
- python scripts\check-tagged-release-readiness-regression.py
- python scripts\check-github-workflow-permissions.py
- python scripts\check-github-workflow-permissions-regression.py
- python scripts\verify-release-versions.py
- git diff --check
- live metadata-derived dry-run refused stale NPM_TOKEN metadata
- live manual marker dry-run refused without --allow-unverified-npm-token-rotation-marker

Closes #788

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guard for manual NPM token rotation markers to prevent unsafe setup. Manual timestamps now require the `--allow-unverified-npm-token-rotation-marker` flag; prefer `--set-npm-token-rotation-marker-from-secret-updated-at` using verified secret metadata (closes #788).

- **Migration**
  - Prefer `--set-npm-token-rotation-marker-from-secret-updated-at` for verified markers.
  - If setting a manual marker, use `--set-npm-token-rotation-marker <ISO8601>` together with `--allow-unverified-npm-token-rotation-marker`.

<sup>Written for commit 8f865d32fc968ffbae54d963502b632bf1322e05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Require an explicit override for manual NPM rotation markers**

### What Changed
- Manual NPM rotation marker timestamps now fail unless the user also sets the new override flag
- The safe path that reads the marker timestamp from the secret’s update time stays the default option
- The script now rejects the override if no manual marker is provided, or if it is used with the secret-based marker flow
- Regression checks cover the new allowed and blocked marker setup cases

### Impact
`✅ Fewer unsafe NPM marker setups`
`✅ Clearer guardrails for release secret rotation`
`✅ Safer manual timestamp overrides`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
