### PR TITLE
Forbid unverified NPM marker workflow override

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -972,6 +972,33 @@ def run_forbidden_event_tests(module) -> None:
         raise AssertionError("forbidden event issue was not reported")
 
 
+def run_forbidden_workflow_command_tests(module) -> None:
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe unverified NPM marker setup\n"
+            "        run: python scripts/set-github-release-secrets.py "
+            "--set-npm-token-rotation-marker 2026-06-03T01:00:00Z "
+            "--allow-unverified-npm-token-rotation-marker "
+            "--confirm-npm-token-rotated --dry-run\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("unverified NPM marker workflow override should fail")
+    parsed = assert_safe_report(report)
+    rendered = json.dumps(parsed)
+    if (
+        "must not use unverified NPM token rotation marker override: "
+        "--allow-unverified-npm-token-rotation-marker"
+    ) not in rendered:
+        raise AssertionError("unverified NPM marker workflow override was not reported")
+    if not parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("forbidden workflow command finding was not listed")
+
+
 def run_checkout_credential_persistence_tests(module) -> None:
     report = with_fixture(
         module,
@@ -2455,6 +2482,7 @@ def main() -> int:
     run_ready_tests(module)
     run_top_level_permission_tests(module)
     run_forbidden_event_tests(module)
+    run_forbidden_workflow_command_tests(module)
     run_checkout_credential_persistence_tests(module)
     run_unexpected_job_write_tests(module)
     run_required_ci_package_checks_job_tests(module)

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -19,6 +19,12 @@ except ModuleNotFoundError:  # pragma: no cover - exercised by dependency-free r
 
 DEFAULT_WORKFLOW_DIR = Path(".github/workflows")
 FORBIDDEN_EVENTS = ("pull_request_target", "workflow_run")
+FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
+    (
+        "--allow-unverified-npm-token-rotation-marker",
+        "unverified NPM token rotation marker override",
+    ),
+)
 ALLOWED_PERMISSION_KEYS = (
     "actions",
     "attestations",
@@ -1617,6 +1623,7 @@ class WorkflowPermissionsReadiness:
     jobs_with_write_permissions: tuple[str, ...]
     unsafe_environment_file_writes: tuple[str, ...]
     forbidden_events: tuple[str, ...]
+    forbidden_workflow_commands: tuple[str, ...]
     issues: tuple[str, ...]
 
     def as_json(self) -> dict[str, Any]:
@@ -1631,6 +1638,7 @@ class WorkflowPermissionsReadiness:
             "jobsWithWritePermissions": list(self.jobs_with_write_permissions),
             "unsafeEnvironmentFileWrites": list(self.unsafe_environment_file_writes),
             "forbiddenEvents": list(self.forbidden_events),
+            "forbiddenWorkflowCommands": list(self.forbidden_workflow_commands),
             "issues": list(self.issues),
             "payloadDisplayed": False,
             "tokenDisplayed": False,
@@ -1905,6 +1913,23 @@ def audit_checkout_credential_persistence(path: Path) -> tuple[str, ...]:
                 f"{path.name}:checkout step at line {line_number} must set "
                 "persist-credentials=false"
             )
+    return tuple(issues)
+
+
+def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
+
+    issues: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
+            if fragment in line:
+                issues.append(
+                    f"{path.name}:line {line_number} must not use {description}: "
+                    f"{fragment}"
+                )
     return tuple(issues)
 
 
@@ -2356,6 +2381,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
     write_jobs: list[str] = []
     unsafe_env_writes: list[str] = []
     forbidden_events_seen: set[str] = set()
+    forbidden_workflow_commands: list[str] = []
 
     if not workflow_paths:
         issues.append("no workflow files found")
@@ -2366,6 +2392,9 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
         payload = load_workflow(path)
         for finding in audit_environment_file_writes(path):
             unsafe_env_writes.append(finding)
+            issues.append(finding)
+        for finding in audit_forbidden_workflow_commands(path):
+            forbidden_workflow_commands.append(finding)
             issues.append(finding)
         issues.extend(audit_checkout_credential_persistence(path))
         issues.extend(audit_required_release_preflight_steps(path))
@@ -2458,6 +2487,7 @@ def audit_workflows(workflow_paths: tuple[Path, ...]) -> WorkflowPermissionsRead
         jobs_with_write_permissions=tuple(sorted(write_jobs)),
         unsafe_environment_file_writes=tuple(sorted(unsafe_env_writes)),
         forbidden_events=tuple(sorted(forbidden_events_seen)),
+        forbidden_workflow_commands=tuple(sorted(forbidden_workflow_commands)),
         issues=tuple(issues),
     )
 


### PR DESCRIPTION
## **User description**
Closes #790

## Change
- Adds a GitHub workflow audit check for `--allow-unverified-npm-token-rotation-marker`.
- Reports forbidden workflow commands as metadata-only findings without printing workflow contents.
- Adds a regression fixture that injects the forbidden override into the release workflow and expects the audit to fail.

## Validation
- `python scripts/check-github-workflow-permissions.py --json`
- `python scripts/check-github-workflow-permissions-regression.py`
- `python scripts/check-python-script-compile.py`
- `python scripts/set-github-release-secrets-regression.py`
- `python scripts/check-release-secret-rotation-gate-regression.py`
- `python scripts/check-tagged-release-readiness-regression.py`
- `git diff --check`

## Security Review
payload exposure risk: Low; report includes workflow names, line numbers, and forbidden flag metadata only.
trust/permission risk: Low; hardens release automation against unverified npm rotation-marker overrides.
storage/logging risk: Low; no storage changes and no secret values are logged.
relay/network risk: None; no relay or network path changes.
required fixes: Live release signing secrets and rotated npm token/marker from issue #274 are still required before production tag publication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks use of the unverified NPM token rotation marker override in GitHub workflows and fails the audit when detected. This hardens the release pipeline by flagging the override as a metadata-only finding.

- **New Features**
  - Audit detects the forbidden workflow command: --allow-unverified-npm-token-rotation-marker.
  - Findings are reported with file and line under forbiddenWorkflowCommands; no workflow contents are printed.
  - Added a regression test that injects the override into release.yml and expects the audit to fail.

<sup>Written for commit 952de3569ed5626f61efcce7f56e89e896a349ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block unverified NPM token rotation marker overrides in workflow checks**

### What Changed
- Workflow audits now fail when a release workflow includes the `--allow-unverified-npm-token-rotation-marker` override.
- The audit report now lists this as a forbidden workflow command so the issue is visible in the JSON output.
- Added a regression check that injects the override into the release workflow and confirms the audit rejects it.

### Impact
`✅ Fewer unsafe release workflow overrides`
`✅ Clearer audit failures for blocked commands`
`✅ Stronger protection for NPM token rotation handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow permissions audit now detects forbidden workflow command fragments in GitHub workflows.
  * Audit reports include findings on forbidden workflow commands.

* **Tests**
  * Added regression test to verify detection of forbidden workflow command scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->