### PR TITLE
Catch split forbidden workflow commands

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -998,6 +998,34 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("forbidden workflow command finding was not listed")
 
+    split_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe split unverified NPM marker setup\n"
+            "        run: |\n"
+            "          python scripts/set-github-release-secrets.py "
+            "--set-npm-token-rotation-marker 2026-06-03T01:00:00Z "
+            "--allow-unverified-npm-token-\\\n"
+            "            rotation-marker --confirm-npm-token-rotated --dry-run\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if split_report.ready:
+        raise AssertionError("split unverified NPM marker workflow override should fail")
+    split_parsed = assert_safe_report(split_report)
+    split_rendered = json.dumps(split_parsed)
+    if (
+        "must not use unverified NPM token rotation marker override: "
+        "--allow-unverified-npm-token-rotation-marker"
+    ) not in split_rendered:
+        raise AssertionError(
+            "split unverified NPM marker workflow override was not reported"
+        )
+    if not split_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("split forbidden workflow command finding was not listed")
+
 
 def run_checkout_credential_persistence_tests(module) -> None:
     report = with_fixture(

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -1923,13 +1923,21 @@ def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
         raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
 
     issues: list[str] = []
+    seen: set[str] = set()
     for line_number, line in enumerate(text.splitlines(), start=1):
         for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
             if fragment in line:
-                issues.append(
+                issue = (
                     f"{path.name}:line {line_number} must not use {description}: "
                     f"{fragment}"
                 )
+                seen.add(fragment)
+                issues.append(issue)
+    continuation_normalized = re.sub(r"\\\r?\n\s*", "", text)
+    for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
+        if fragment in seen or fragment not in continuation_normalized:
+            continue
+        issues.append(f"{path.name} must not use {description}: {fragment}")
     return tuple(issues)
 
 


### PR DESCRIPTION
## **User description**
Closes #792

## Change
- Normalizes shell line-continuations before checking forbidden workflow command fragments.
- Keeps direct line-number findings for normal matches and adds a workflow-level metadata-only finding for continuation-split matches.
- Adds regression coverage for a split `--allow-unverified-npm-token-rotation-marker` release workflow command.

## Validation
- `python scripts/check-github-workflow-permissions.py --json`
- `python scripts/check-github-workflow-permissions.py`
- `python scripts/check-github-workflow-permissions-regression.py`
- `python scripts/check-python-script-compile.py`
- `git diff --check`
- Attempted `./scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`; it timed out locally after 10 minutes with no leftover process to inspect.

## Security Review
payload exposure risk: Low; report only includes workflow name/line metadata and forbidden flag category.
trust/permission risk: Low; hardens release workflow policy checks against split unverified npm marker override commands.
storage/logging risk: Low; no storage changes and no secret values are logged.
relay/network risk: None; no relay or network path changes.
required fixes: Live release signing secrets and rotated npm token/marker from issue #274 are still required before production tag publication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catches forbidden workflow commands even when split across shell line continuations, preventing bypasses. Adds regression coverage for the split unverified NPM marker override.

- **Bug Fixes**
  - Normalize backslash-newline continuations when auditing to detect fragments split across lines.
  - Keep line-numbered findings for direct matches; add workflow-level finding for continuation-only matches to avoid duplicates.
  - Add regression test for split `--allow-unverified-npm-token-rotation-marker` in the release workflow.

<sup>Written for commit 848042d55f688076f914913f0fbbf3264714e1f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Catch forbidden workflow commands even when they are split across lines**

### What Changed
- Workflow checks now catch blocked commands even if the command text is split with line continuations.
- Direct matches still report the exact line number, while split-only matches now still produce a workflow-level warning.
- Added regression coverage for a release workflow example that tries to hide the unverified NPM marker override across multiple lines.

### Impact
`✅ Fewer release workflow bypasses`
`✅ Clearer forbidden command reports`
`✅ Safer workflow policy checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
