### PR TITLE
Forbid direct NPM marker workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1026,6 +1026,53 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not split_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("split forbidden workflow command finding was not listed")
 
+    marker_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe direct NPM marker variable write\n"
+            "        run: gh variable set CONU_NPM_TOKEN_ROTATED_AFTER "
+            "--body 2026-06-03T01:00:00Z\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if marker_write_report.ready:
+        raise AssertionError("direct NPM marker workflow write should fail")
+    marker_write_parsed = assert_safe_report(marker_write_report)
+    marker_write_rendered = json.dumps(marker_write_parsed)
+    if (
+        "must not use direct NPM token rotation marker variable write: "
+        "gh variable set CONU_NPM_TOKEN_ROTATED_AFTER"
+    ) not in marker_write_rendered:
+        raise AssertionError("direct NPM marker workflow write was not reported")
+    if not marker_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct marker write finding was not listed")
+
+    api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe API NPM marker variable write\n"
+            "        run: gh api repos/$GITHUB_REPOSITORY/actions/variables/"
+            "CONU_NPM_TOKEN_ROTATED_AFTER --method PATCH "
+            "-f value=2026-06-03T01:00:00Z\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if api_write_report.ready:
+        raise AssertionError("direct NPM marker API workflow write should fail")
+    api_write_parsed = assert_safe_report(api_write_report)
+    api_write_rendered = json.dumps(api_write_parsed)
+    if (
+        "must not use direct NPM token rotation marker variable API write: "
+        "gh api actions/variables CONU_NPM_TOKEN_ROTATED_AFTER write"
+    ) not in api_write_rendered:
+        raise AssertionError("direct NPM marker API workflow write was not reported")
+    if not api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct marker API write finding was not listed")
+
 
 def run_checkout_credential_persistence_tests(module) -> None:
     report = with_fixture(

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -19,10 +19,32 @@ except ModuleNotFoundError:  # pragma: no cover - exercised by dependency-free r
 
 DEFAULT_WORKFLOW_DIR = Path(".github/workflows")
 FORBIDDEN_EVENTS = ("pull_request_target", "workflow_run")
+NPM_TOKEN_ROTATION_MARKER_VAR = "CONU_NPM_TOKEN_ROTATED_AFTER"
 FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     (
         "--allow-unverified-npm-token-rotation-marker",
         "unverified NPM token rotation marker override",
+    ),
+)
+FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    (
+        f"gh variable set {NPM_TOKEN_ROTATION_MARKER_VAR}",
+        re.compile(
+            rf"\bgh\s+variable\s+set\b[^\n;&|]*\b{NPM_TOKEN_ROTATION_MARKER_VAR}\b"
+        ),
+        "direct NPM token rotation marker variable write",
+    ),
+    (
+        f"gh api actions/variables {NPM_TOKEN_ROTATION_MARKER_VAR} write",
+        re.compile(
+            rf"\bgh\s+api\b"
+            rf"(?=[^\n;&|]*\bactions/variables\b)"
+            rf"(?=[^\n;&|]*\b{NPM_TOKEN_ROTATION_MARKER_VAR}\b)"
+            rf"(?=[^\n;&|]*(?:\b(?:--method|-X)\s+(?:POST|PUT|PATCH)\b|"
+            rf"\s(?:-f|--field|--raw-field)\s+(?:name|value)=))",
+            re.IGNORECASE,
+        ),
+        "direct NPM token rotation marker variable API write",
     ),
 )
 ALLOWED_PERMISSION_KEYS = (
@@ -1923,7 +1945,8 @@ def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
         raise ValueError(f"failed to read workflow {path.name}: {exc}") from exc
 
     issues: list[str] = []
-    seen: set[str] = set()
+    seen_fragments: set[str] = set()
+    seen_patterns: set[str] = set()
     for line_number, line in enumerate(text.splitlines(), start=1):
         for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
             if fragment in line:
@@ -1931,13 +1954,25 @@ def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
                     f"{path.name}:line {line_number} must not use {description}: "
                     f"{fragment}"
                 )
-                seen.add(fragment)
+                seen_fragments.add(fragment)
+                issues.append(issue)
+        for command, pattern, description in FORBIDDEN_WORKFLOW_COMMAND_PATTERNS:
+            if pattern.search(line):
+                issue = (
+                    f"{path.name}:line {line_number} must not use {description}: "
+                    f"{command}"
+                )
+                seen_patterns.add(command)
                 issues.append(issue)
     continuation_normalized = re.sub(r"\\\r?\n\s*", "", text)
     for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
-        if fragment in seen or fragment not in continuation_normalized:
+        if fragment in seen_fragments or fragment not in continuation_normalized:
             continue
         issues.append(f"{path.name} must not use {description}: {fragment}")
+    for command, pattern, description in FORBIDDEN_WORKFLOW_COMMAND_PATTERNS:
+        if command in seen_patterns or not pattern.search(continuation_normalized):
+            continue
+        issues.append(f"{path.name} must not use {description}: {command}")
     return tuple(issues)
 
 


### PR DESCRIPTION
## Summary
- forbid release workflows from directly writing CONU_NPM_TOKEN_ROTATED_AFTER with gh variable set
- forbid gh api actions/variables writes that target the same marker
- add regression fixtures for both forbidden write paths

## Validation
- python scripts/check-github-workflow-permissions.py --json
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- git diff --check

Fixes #794

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent GitHub workflows from directly writing the NPM rotation marker `CONU_NPM_TOKEN_ROTATED_AFTER` via `gh variable set` or `gh api` writes. Adds pattern-based guards and regression tests to block unsafe marker updates. Fixes #794.

- **New Features**
  - Add regex checks in `scripts/check-github-workflow-permissions.py` to flag `gh variable set CONU_NPM_TOKEN_ROTATED_AFTER` and `gh api ...actions/variables... CONU_NPM_TOKEN_ROTATED_AFTER` writes (POST/PUT/PATCH, multiline supported).
  - Expand `scripts/check-github-workflow-permissions-regression.py` with fixtures that ensure both direct and API writes fail and are reported under forbidden workflow commands.

<sup>Written for commit 11a603ba7232c2060edea81bd7cd41446c51b833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

