### PR TITLE
Forbid direct release secret workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1073,6 +1073,52 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct marker API write finding was not listed")
 
+    secret_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe direct release secret write\n"
+            "        run: gh secret set NPM_TOKEN --body \"$NODE_AUTH_TOKEN\"\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if secret_write_report.ready:
+        raise AssertionError("direct release secret workflow write should fail")
+    secret_write_parsed = assert_safe_report(secret_write_report)
+    secret_write_rendered = json.dumps(secret_write_parsed)
+    if (
+        "must not use direct release secret workflow write: "
+        "gh secret set <release-secret>"
+    ) not in secret_write_rendered:
+        raise AssertionError("direct release secret workflow write was not reported")
+    if not secret_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct release secret write finding was not listed")
+
+    secret_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe API release secret write\n"
+            "        run: gh api --method PUT repos/$GITHUB_REPOSITORY/"
+            "actions/secrets/NPM_TOKEN -f encrypted_value=redacted "
+            "-f key_id=redacted\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if secret_api_write_report.ready:
+        raise AssertionError("direct release secret API workflow write should fail")
+    secret_api_write_parsed = assert_safe_report(secret_api_write_report)
+    secret_api_write_rendered = json.dumps(secret_api_write_parsed)
+    if (
+        "must not use direct release secret workflow API write: "
+        "gh api actions/secrets <release-secret> write"
+    ) not in secret_api_write_rendered:
+        raise AssertionError("direct release secret API workflow write was not reported")
+    if not secret_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct release secret API write finding was not listed")
+
 
 def run_checkout_credential_persistence_tests(module) -> None:
     report = with_fixture(

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -20,6 +20,28 @@ except ModuleNotFoundError:  # pragma: no cover - exercised by dependency-free r
 DEFAULT_WORKFLOW_DIR = Path(".github/workflows")
 FORBIDDEN_EVENTS = ("pull_request_target", "workflow_run")
 NPM_TOKEN_ROTATION_MARKER_VAR = "CONU_NPM_TOKEN_ROTATED_AFTER"
+RELEASE_SECRET_WRITE_GUARD_NAMES: tuple[str, ...] = (
+    "CONU_WINDOWS_SIGN_CERT_PFX_BASE64",
+    "CONU_WINDOWS_SIGN_CERT_PASSWORD",
+    "CONU_WINDOWS_TIMESTAMP_URL",
+    "CONU_MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64",
+    "CONU_MACOS_DEVELOPER_ID_APPLICATION_PASSWORD",
+    "CONU_MACOS_CODESIGN_IDENTITY",
+    "CONU_MACOS_NOTARY_APPLE_ID",
+    "CONU_MACOS_NOTARY_TEAM_ID",
+    "CONU_MACOS_NOTARY_PASSWORD",
+    "CONU_LINUX_GPG_PRIVATE_KEY_BASE64",
+    "CONU_LINUX_GPG_PASSPHRASE",
+    "CONU_LINUX_GPG_KEY_ID",
+    "CONU_LINUX_GPG_KEY_FINGERPRINT",
+    "CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID",
+    "CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY",
+    "CONU_LINUX_REPOSITORY_AWS_SESSION_TOKEN",
+    "NPM_TOKEN",
+)
+RELEASE_SECRET_WRITE_GUARD_PATTERN = "|".join(
+    re.escape(name) for name in RELEASE_SECRET_WRITE_GUARD_NAMES
+)
 FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     (
         "--allow-unverified-npm-token-rotation-marker",
@@ -45,6 +67,28 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             re.IGNORECASE,
         ),
         "direct NPM token rotation marker variable API write",
+    ),
+    (
+        "gh secret set <release-secret>",
+        re.compile(
+            rf"\bgh\s+secret\s+set\b[^\n;&|]*\b"
+            rf"(?:{RELEASE_SECRET_WRITE_GUARD_PATTERN})\b"
+        ),
+        "direct release secret workflow write",
+    ),
+    (
+        "gh api actions/secrets <release-secret> write",
+        re.compile(
+            rf"\bgh\s+api\b"
+            rf"(?=[^\n;&|]*\bactions/secrets\b)"
+            rf"(?=[^\n;&|]*\b(?:{RELEASE_SECRET_WRITE_GUARD_PATTERN})\b)"
+            rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
+            rf"(?:POST|PUT|PATCH)\b|"
+            rf"\s(?:-f|-F|--field|--raw-field)\s+"
+            rf"(?:encrypted_value|key_id|secret_name)=))",
+            re.IGNORECASE,
+        ),
+        "direct release secret workflow API write",
     ),
 )
 ALLOWED_PERMISSION_KEYS = (


### PR DESCRIPTION
## Summary
- forbid workflow commands that directly write production release secrets with gh secret set
- forbid gh api actions/secrets write paths for release secret names
- add regression fixtures for direct CLI and REST API secret write attempts

## Validation
- python scripts/check-github-workflow-permissions.py --json
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- git diff --check

Fixes #796

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks workflows from directly writing production release secrets to prevent accidental overwrites. Detects unsafe `gh secret set` and `gh api actions/secrets` writes to guarded secret names and fails the check.

- **New Features**
  - Added `RELEASE_SECRET_WRITE_GUARD_NAMES` and detection for guarded secrets (NPM token, signing certs, GPG, AWS keys).
  - Blocked `gh secret set <release-secret>` and `gh api actions/secrets <release-secret> write` with clear error messages.
  - Added regression tests for CLI and REST API write attempts.

<sup>Written for commit 14015c4dc28a3bf28ae7a9d6dd39e32a59b0e00d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

