### PR TITLE
Forbid direct release variable workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1073,6 +1073,53 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct marker API write finding was not listed")
 
+    variable_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe direct release variable write\n"
+            "        run: gh variable set CONU_LINUX_REPOSITORY_BASE_URL "
+            "--body https://example.invalid/conu\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if variable_write_report.ready:
+        raise AssertionError("direct release variable workflow write should fail")
+    variable_write_parsed = assert_safe_report(variable_write_report)
+    variable_write_rendered = json.dumps(variable_write_parsed)
+    if (
+        "must not use direct release variable workflow write: "
+        "gh variable set <release-variable>"
+    ) not in variable_write_rendered:
+        raise AssertionError("direct release variable workflow write was not reported")
+    if not variable_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct release variable write finding was not listed")
+
+    variable_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe API release variable write\n"
+            "        run: gh api --method PATCH repos/$GITHUB_REPOSITORY/"
+            "actions/variables/CONU_LINUX_REPOSITORY_BASE_URL "
+            "-f value=https://example.invalid/conu\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if variable_api_write_report.ready:
+        raise AssertionError("direct release variable API workflow write should fail")
+    variable_api_write_parsed = assert_safe_report(variable_api_write_report)
+    variable_api_write_rendered = json.dumps(variable_api_write_parsed)
+    if (
+        "must not use direct release variable workflow API write: "
+        "gh api actions/variables <release-variable> write"
+    ) not in variable_api_write_rendered:
+        raise AssertionError("direct release variable API workflow write was not reported")
+    if not variable_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct release variable API write finding was not listed")
+
     secret_write_report = with_fixture(
         module,
         None,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -42,6 +42,16 @@ RELEASE_SECRET_WRITE_GUARD_NAMES: tuple[str, ...] = (
 RELEASE_SECRET_WRITE_GUARD_PATTERN = "|".join(
     re.escape(name) for name in RELEASE_SECRET_WRITE_GUARD_NAMES
 )
+RELEASE_VARIABLE_WRITE_GUARD_NAMES: tuple[str, ...] = (
+    "CONU_LINUX_REPOSITORY_BASE_URL",
+    "CONU_LINUX_REPOSITORY_S3_BUCKET",
+    "CONU_LINUX_REPOSITORY_S3_PREFIX",
+    "CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL",
+    "CONU_LINUX_REPOSITORY_AWS_REGION",
+)
+RELEASE_VARIABLE_WRITE_GUARD_PATTERN = "|".join(
+    re.escape(name) for name in RELEASE_VARIABLE_WRITE_GUARD_NAMES
+)
 FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     (
         "--allow-unverified-npm-token-rotation-marker",
@@ -67,6 +77,27 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             re.IGNORECASE,
         ),
         "direct NPM token rotation marker variable API write",
+    ),
+    (
+        "gh variable set <release-variable>",
+        re.compile(
+            rf"\bgh\s+variable\s+set\b[^\n;&|]*\b"
+            rf"(?:{RELEASE_VARIABLE_WRITE_GUARD_PATTERN})\b"
+        ),
+        "direct release variable workflow write",
+    ),
+    (
+        "gh api actions/variables <release-variable> write",
+        re.compile(
+            rf"\bgh\s+api\b"
+            rf"(?=[^\n;&|]*\bactions/variables\b)"
+            rf"(?=[^\n;&|]*\b(?:{RELEASE_VARIABLE_WRITE_GUARD_PATTERN})\b)"
+            rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
+            rf"(?:POST|PUT|PATCH)\b|"
+            rf"\s(?:-f|-F|--field|--raw-field)\s+(?:name|value)=))",
+            re.IGNORECASE,
+        ),
+        "direct release variable workflow API write",
     ),
     (
         "gh secret set <release-secret>",


### PR DESCRIPTION
## **User description**
## Summary
- forbid workflow commands that directly write hosted release configuration variables with gh variable set
- forbid gh api actions/variables write paths for hosted Linux repository release variables
- add regression fixtures for direct CLI and REST API variable write attempts

## Validation
- python scripts/check-github-workflow-permissions.py --json
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- git diff --check

Fixes #798

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent GitHub Actions workflows from directly writing hosted release variables used for Linux repository publication. Adds guards that fail runs using `gh variable set` or `gh api actions/variables` to modify these variables.

- **New Features**
  - Add write guards for `CONU_LINUX_REPOSITORY_BASE_URL`, `S3_BUCKET`, `S3_PREFIX`, `S3_ENDPOINT_URL`, `AWS_REGION`.
  - Detect and report clear violations under `forbiddenWorkflowCommands`.
  - Add regression tests covering both CLI and REST API write attempts.

<sup>Written for commit 5c5ee962455d3c1bc3f4ed1e8c51b7d7da4152a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block direct writes to release configuration variables in workflows**

### What Changed
- Workflow runs that try to change hosted release variables are now rejected
- This blocks both direct `gh variable set` writes and API calls to `gh api actions/variables` for release variables such as the Linux publication settings
- Regression checks now cover these blocked write attempts so they fail with a clear report

### Impact
`✅ Prevents accidental release config changes`
`✅ Fewer broken publication workflows`
`✅ Clearer workflow permission failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
