### PR TITLE
Catch equals-form marker API writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1073,6 +1073,30 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct marker API write finding was not listed")
 
+    api_equals_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe equals-form API NPM marker variable write\n"
+            "        run: gh api repos/$GITHUB_REPOSITORY/actions/variables/"
+            "CONU_NPM_TOKEN_ROTATED_AFTER --method=PATCH "
+            "-F value=2026-06-03T01:00:00Z\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if api_equals_write_report.ready:
+        raise AssertionError("equals-form direct NPM marker API write should fail")
+    api_equals_write_parsed = assert_safe_report(api_equals_write_report)
+    api_equals_write_rendered = json.dumps(api_equals_write_parsed)
+    if (
+        "must not use direct NPM token rotation marker variable API write: "
+        "gh api actions/variables CONU_NPM_TOKEN_ROTATED_AFTER write"
+    ) not in api_equals_write_rendered:
+        raise AssertionError("equals-form marker API write was not reported")
+    if not api_equals_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("equals-form marker API write finding was not listed")
+
     variable_write_report = with_fixture(
         module,
         None,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -72,8 +72,9 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             rf"\bgh\s+api\b"
             rf"(?=[^\n;&|]*\bactions/variables\b)"
             rf"(?=[^\n;&|]*\b{NPM_TOKEN_ROTATION_MARKER_VAR}\b)"
-            rf"(?=[^\n;&|]*(?:\b(?:--method|-X)\s+(?:POST|PUT|PATCH)\b|"
-            rf"\s(?:-f|--field|--raw-field)\s+(?:name|value)=))",
+            rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
+            rf"(?:POST|PUT|PATCH)\b|"
+            rf"\s(?:-f|-F|--field|--raw-field)\s+(?:name|value)=))",
             re.IGNORECASE,
         ),
         "direct NPM token rotation marker variable API write",


### PR DESCRIPTION
## **User description**
Closes #800.\n\n## Summary\n- detect direct CONU_NPM_TOKEN_ROTATED_AFTER API writes that use --method=PATCH\n- cover the equals-form API write with a workflow permission regression\n\n## Validation\n- python scripts/check-github-workflow-permissions.py --json\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-python-script-compile.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and block equals-form direct writes to `CONU_NPM_TOKEN_ROTATED_AFTER` via `gh api`, closing #800. Adds a regression test to ensure the workflow permission guard flags these unsafe writes.

- **Bug Fixes**
  - Expanded detection to match `--method` and `-X` with space or equals (e.g., `--method=PATCH`) and to catch `-F` field flags; covers POST/PUT/PATCH.
  - Added a regression test that fails on equals-form `gh api ... actions/variables/CONU_NPM_TOKEN_ROTATED_AFTER` writes and reports under `forbiddenWorkflowCommands`.

<sup>Written for commit 425d0b98321a503d1129f8b6eb09d5e6d7b7b510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Catch more unsafe NPM marker API writes**

### What Changed
- Blocks another form of direct API write to the NPM token rotation marker, including `gh api` calls that use `--method=PATCH` with `=` syntax
- Adds regression coverage so this unsafe write is reported and fails the workflow checks

### Impact
`✅ Fewer unsafe marker updates`
`✅ Stronger workflow permission checks`
`✅ Clearer detection of direct API writes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
