### PR TITLE
Catch equals-form release API field writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1097,6 +1097,30 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not api_equals_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("equals-form marker API write finding was not listed")
 
+    api_field_equals_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe field equals-form API NPM marker write\n"
+            "        run: gh api repos/$GITHUB_REPOSITORY/actions/variables/"
+            "CONU_NPM_TOKEN_ROTATED_AFTER "
+            "--field=value=2026-06-03T01:00:00Z\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if api_field_equals_write_report.ready:
+        raise AssertionError("field equals-form NPM marker API write should fail")
+    api_field_equals_write_parsed = assert_safe_report(api_field_equals_write_report)
+    api_field_equals_write_rendered = json.dumps(api_field_equals_write_parsed)
+    if (
+        "must not use direct NPM token rotation marker variable API write: "
+        "gh api actions/variables CONU_NPM_TOKEN_ROTATED_AFTER write"
+    ) not in api_field_equals_write_rendered:
+        raise AssertionError("field equals-form marker API write was not reported")
+    if not api_field_equals_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("field equals-form marker API write finding was not listed")
+
     variable_write_report = with_fixture(
         module,
         None,
@@ -1144,6 +1168,34 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not variable_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release variable API write finding was not listed")
 
+    variable_api_field_equals_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe field equals-form API release variable write\n"
+            "        run: gh api repos/$GITHUB_REPOSITORY/actions/variables/"
+            "CONU_LINUX_REPOSITORY_BASE_URL "
+            "--raw-field=value=https://example.invalid/conu\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if variable_api_field_equals_write_report.ready:
+        raise AssertionError("field equals-form release variable API write should fail")
+    variable_api_field_equals_write_parsed = assert_safe_report(
+        variable_api_field_equals_write_report
+    )
+    variable_api_field_equals_write_rendered = json.dumps(
+        variable_api_field_equals_write_parsed
+    )
+    if (
+        "must not use direct release variable workflow API write: "
+        "gh api actions/variables <release-variable> write"
+    ) not in variable_api_field_equals_write_rendered:
+        raise AssertionError("field equals-form variable API write was not reported")
+    if not variable_api_field_equals_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("field equals-form variable API write finding was not listed")
+
     secret_write_report = with_fixture(
         module,
         None,
@@ -1189,6 +1241,33 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("direct release secret API workflow write was not reported")
     if not secret_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release secret API write finding was not listed")
+
+    secret_api_field_equals_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe field equals-form API release secret write\n"
+            "        run: gh api repos/$GITHUB_REPOSITORY/actions/secrets/NPM_TOKEN "
+            "--field=encrypted_value=redacted --field=key_id=redacted\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if secret_api_field_equals_write_report.ready:
+        raise AssertionError("field equals-form release secret API write should fail")
+    secret_api_field_equals_write_parsed = assert_safe_report(
+        secret_api_field_equals_write_report
+    )
+    secret_api_field_equals_write_rendered = json.dumps(
+        secret_api_field_equals_write_parsed
+    )
+    if (
+        "must not use direct release secret workflow API write: "
+        "gh api actions/secrets <release-secret> write"
+    ) not in secret_api_field_equals_write_rendered:
+        raise AssertionError("field equals-form secret API write was not reported")
+    if not secret_api_field_equals_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("field equals-form secret API write finding was not listed")
 
 
 def run_checkout_credential_persistence_tests(module) -> None:

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -52,6 +52,14 @@ RELEASE_VARIABLE_WRITE_GUARD_NAMES: tuple[str, ...] = (
 RELEASE_VARIABLE_WRITE_GUARD_PATTERN = "|".join(
     re.escape(name) for name in RELEASE_VARIABLE_WRITE_GUARD_NAMES
 )
+API_VARIABLE_FIELD_WRITE_PATTERN = (
+    r"\s(?:(?:-f|-F)(?:\s+|=)?|(?:--field|--raw-field)(?:\s+|=))"
+    r"(?:name|value)="
+)
+API_SECRET_FIELD_WRITE_PATTERN = (
+    r"\s(?:(?:-f|-F)(?:\s+|=)?|(?:--field|--raw-field)(?:\s+|=))"
+    r"(?:encrypted_value|key_id|secret_name)="
+)
 FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     (
         "--allow-unverified-npm-token-rotation-marker",
@@ -74,7 +82,7 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             rf"(?=[^\n;&|]*\b{NPM_TOKEN_ROTATION_MARKER_VAR}\b)"
             rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
             rf"(?:POST|PUT|PATCH)\b|"
-            rf"\s(?:-f|-F|--field|--raw-field)\s+(?:name|value)=))",
+            rf"{API_VARIABLE_FIELD_WRITE_PATTERN}))",
             re.IGNORECASE,
         ),
         "direct NPM token rotation marker variable API write",
@@ -95,7 +103,7 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             rf"(?=[^\n;&|]*\b(?:{RELEASE_VARIABLE_WRITE_GUARD_PATTERN})\b)"
             rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
             rf"(?:POST|PUT|PATCH)\b|"
-            rf"\s(?:-f|-F|--field|--raw-field)\s+(?:name|value)=))",
+            rf"{API_VARIABLE_FIELD_WRITE_PATTERN}))",
             re.IGNORECASE,
         ),
         "direct release variable workflow API write",
@@ -116,8 +124,7 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             rf"(?=[^\n;&|]*\b(?:{RELEASE_SECRET_WRITE_GUARD_PATTERN})\b)"
             rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
             rf"(?:POST|PUT|PATCH)\b|"
-            rf"\s(?:-f|-F|--field|--raw-field)\s+"
-            rf"(?:encrypted_value|key_id|secret_name)=))",
+            rf"{API_SECRET_FIELD_WRITE_PATTERN}))",
             re.IGNORECASE,
         ),
         "direct release secret workflow API write",


### PR DESCRIPTION
Closes #802.\n\n## Summary\n- detect direct release API writes when gh api field flags use equals-form syntax\n- cover NPM rotation marker, release variable, and release secret API writes\n\n## Validation\n- python scripts/check-github-workflow-permissions.py --json\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-python-script-compile.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block direct release API writes that use equals-form `gh api` field flags. This closes a detection gap for variables and secrets, including the NPM token rotation marker.

- **Bug Fixes**
  - Detect equals-form `-f/-F/--field/--raw-field` in `gh api` for variable and secret writes.
  - Guard NPM rotation marker, release variables, and release secrets.
  - Added regression tests to verify detection and error messages.

<sup>Written for commit 7bd4f16fd541f39cf247bb5800b607628011edce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

