### PR TITLE
Forbid dynamic Actions config workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1049,6 +1049,29 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not marker_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct marker write finding was not listed")
 
+    dynamic_variable_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe dynamic Actions variable write\n"
+            "        run: gh variable set \"$CONU_RELEASE_VAR_NAME\" "
+            "--body \"$CONU_RELEASE_VAR_VALUE\"\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if dynamic_variable_write_report.ready:
+        raise AssertionError("dynamic Actions variable workflow write should fail")
+    dynamic_variable_write_parsed = assert_safe_report(dynamic_variable_write_report)
+    dynamic_variable_write_rendered = json.dumps(dynamic_variable_write_parsed)
+    if (
+        "must not use direct GitHub Actions variable workflow write: "
+        "gh variable set <any-actions-variable>"
+    ) not in dynamic_variable_write_rendered:
+        raise AssertionError("dynamic Actions variable write was not reported")
+    if not dynamic_variable_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("dynamic Actions variable write finding was not listed")
+
     api_write_report = with_fixture(
         module,
         None,
@@ -1168,6 +1191,33 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not variable_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release variable API write finding was not listed")
 
+    dynamic_variable_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe dynamic API Actions variable delete\n"
+            "        run: gh api repos/$GITHUB_REPOSITORY/actions/variables/"
+            "\"$CONU_RELEASE_VAR_NAME\" --method=DELETE\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if dynamic_variable_api_delete_report.ready:
+        raise AssertionError("dynamic Actions variable API delete should fail")
+    dynamic_variable_api_delete_parsed = assert_safe_report(
+        dynamic_variable_api_delete_report
+    )
+    dynamic_variable_api_delete_rendered = json.dumps(
+        dynamic_variable_api_delete_parsed
+    )
+    if (
+        "must not use direct GitHub Actions variable workflow API write: "
+        "gh api actions/variables write"
+    ) not in dynamic_variable_api_delete_rendered:
+        raise AssertionError("dynamic Actions variable API delete was not reported")
+    if not dynamic_variable_api_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("dynamic Actions variable API delete finding was not listed")
+
     variable_api_field_equals_write_report = with_fixture(
         module,
         None,
@@ -1218,6 +1268,29 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not secret_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release secret write finding was not listed")
 
+    dynamic_secret_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe dynamic Actions secret write\n"
+            "        run: gh secret set \"$CONU_RELEASE_SECRET_NAME\" "
+            "--body \"$CONU_RELEASE_SECRET_VALUE\"\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if dynamic_secret_write_report.ready:
+        raise AssertionError("dynamic Actions secret workflow write should fail")
+    dynamic_secret_write_parsed = assert_safe_report(dynamic_secret_write_report)
+    dynamic_secret_write_rendered = json.dumps(dynamic_secret_write_parsed)
+    if (
+        "must not use direct GitHub Actions secret workflow write: "
+        "gh secret set <any-actions-secret>"
+    ) not in dynamic_secret_write_rendered:
+        raise AssertionError("dynamic Actions secret write was not reported")
+    if not dynamic_secret_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("dynamic Actions secret write finding was not listed")
+
     secret_api_write_report = with_fixture(
         module,
         None,
@@ -1241,6 +1314,31 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("direct release secret API workflow write was not reported")
     if not secret_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release secret API write finding was not listed")
+
+    dynamic_secret_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe dynamic API Actions secret delete\n"
+            "        run: gh api repos/$GITHUB_REPOSITORY/actions/secrets/"
+            "\"$CONU_RELEASE_SECRET_NAME\" -X DELETE\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if dynamic_secret_api_delete_report.ready:
+        raise AssertionError("dynamic Actions secret API delete should fail")
+    dynamic_secret_api_delete_parsed = assert_safe_report(
+        dynamic_secret_api_delete_report
+    )
+    dynamic_secret_api_delete_rendered = json.dumps(dynamic_secret_api_delete_parsed)
+    if (
+        "must not use direct GitHub Actions secret workflow API write: "
+        "gh api actions/secrets write"
+    ) not in dynamic_secret_api_delete_rendered:
+        raise AssertionError("dynamic Actions secret API delete was not reported")
+    if not dynamic_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("dynamic Actions secret API delete finding was not listed")
 
     secret_api_field_equals_write_report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -60,6 +60,9 @@ API_SECRET_FIELD_WRITE_PATTERN = (
     r"\s(?:(?:-f|-F)(?:\s+|=)?|(?:--field|--raw-field)(?:\s+|=))"
     r"(?:encrypted_value|key_id|secret_name)="
 )
+API_MUTATION_METHOD_PATTERN = (
+    r"\s(?:--method|-X)(?:\s+|=)(?:POST|PUT|PATCH|DELETE)\b"
+)
 FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     (
         "--allow-unverified-npm-token-rotation-marker",
@@ -67,6 +70,38 @@ FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     ),
 )
 FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    (
+        "gh variable set <any-actions-variable>",
+        re.compile(r"\bgh\s+variable\s+set\b"),
+        "direct GitHub Actions variable workflow write",
+    ),
+    (
+        "gh api actions/variables write",
+        re.compile(
+            rf"\bgh\s+api\b"
+            rf"(?=[^\n;&|]*\bactions/variables\b)"
+            rf"(?=[^\n;&|]*(?:{API_MUTATION_METHOD_PATTERN}|"
+            rf"{API_VARIABLE_FIELD_WRITE_PATTERN}))",
+            re.IGNORECASE,
+        ),
+        "direct GitHub Actions variable workflow API write",
+    ),
+    (
+        "gh secret set <any-actions-secret>",
+        re.compile(r"\bgh\s+secret\s+set\b"),
+        "direct GitHub Actions secret workflow write",
+    ),
+    (
+        "gh api actions/secrets write",
+        re.compile(
+            rf"\bgh\s+api\b"
+            rf"(?=[^\n;&|]*\bactions/secrets\b)"
+            rf"(?=[^\n;&|]*(?:{API_MUTATION_METHOD_PATTERN}|"
+            rf"{API_SECRET_FIELD_WRITE_PATTERN}))",
+            re.IGNORECASE,
+        ),
+        "direct GitHub Actions secret workflow API write",
+    ),
     (
         f"gh variable set {NPM_TOKEN_ROTATION_MARKER_VAR}",
         re.compile(


### PR DESCRIPTION
## **User description**
Closes #804.\n\n## Summary\n- fail workflow audits on any direct GitHub Actions secret or variable write\n- catch dynamic-name gh secret/variable writes and mutating gh api calls\n- add regressions for dynamic variable/secret writes and DELETE mutations\n\n## Validation\n- python scripts/check-github-workflow-permissions.py --json\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-python-script-compile.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks any GitHub Actions secret/variable writes in workflows, including dynamic names and mutating `gh api` calls, to harden our audit. Adds regression tests to ensure these cases fail the audit.

- **Bug Fixes**
  - Detects direct writes: `gh variable set` and `gh secret set`.
  - Flags `gh api` to `actions/variables` or `actions/secrets` when using POST/PUT/PATCH/DELETE or field writes.
  - Adds regressions for dynamic names and DELETE mutations.

<sup>Written for commit 50cbc594f642beba7bb7870f4bffdab2b0b7b7c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block dynamic GitHub Actions secret and variable writes in workflow checks**

### What Changed
- Workflow checks now reject direct `gh variable set` and `gh secret set` writes, even when the target name is supplied dynamically.
- `gh api` calls that change Actions variables or secrets are now blocked when they use write/delete methods or field-based writes.
- New regression cases cover dynamic variable and secret writes, plus API delete requests, so these cases fail the audit instead of passing.

### Impact
`✅ Fewer unsafe workflow changes`
`✅ Clearer audit failures for Actions config writes`
`✅ Less risk of secrets or variables being changed from CI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
