### PR TITLE
Detect shell-continuation workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1218,6 +1218,32 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not dynamic_variable_api_delete_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("dynamic Actions variable API delete finding was not listed")
 
+    pwsh_variable_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe pwsh Actions variable delete\n"
+            "        shell: pwsh\n"
+            "        run: |\n"
+            "          gh api repos/$GITHUB_REPOSITORY/actions/variables/"
+            "\"$CONU_RELEASE_VAR_NAME\" `\n"
+            "            --method=DELETE\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if pwsh_variable_api_delete_report.ready:
+        raise AssertionError("pwsh Actions variable API delete should fail")
+    pwsh_variable_api_delete_parsed = assert_safe_report(pwsh_variable_api_delete_report)
+    pwsh_variable_api_delete_rendered = json.dumps(pwsh_variable_api_delete_parsed)
+    if (
+        "must not use direct GitHub Actions variable workflow API write: "
+        "gh api actions/variables write"
+    ) not in pwsh_variable_api_delete_rendered:
+        raise AssertionError("pwsh Actions variable API delete was not reported")
+    if not pwsh_variable_api_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("pwsh Actions variable API delete finding was not listed")
+
     folded_variable_api_delete_report = with_fixture(
         module,
         None,
@@ -1371,6 +1397,32 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("dynamic Actions secret API delete was not reported")
     if not dynamic_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("dynamic Actions secret API delete finding was not listed")
+
+    cmd_secret_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe cmd Actions secret delete\n"
+            "        shell: cmd\n"
+            "        run: |\n"
+            "          gh api repos/%GITHUB_REPOSITORY%/actions/secrets/"
+            "%CONU_RELEASE_SECRET_NAME% ^\n"
+            "            -X DELETE\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if cmd_secret_api_delete_report.ready:
+        raise AssertionError("cmd Actions secret API delete should fail")
+    cmd_secret_api_delete_parsed = assert_safe_report(cmd_secret_api_delete_report)
+    cmd_secret_api_delete_rendered = json.dumps(cmd_secret_api_delete_parsed)
+    if (
+        "must not use direct GitHub Actions secret workflow API write: "
+        "gh api actions/secrets write"
+    ) not in cmd_secret_api_delete_rendered:
+        raise AssertionError("cmd Actions secret API delete was not reported")
+    if not cmd_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("cmd Actions secret API delete finding was not listed")
 
     folded_secret_api_delete_report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -2043,6 +2043,18 @@ def extract_uses_step_blocks(text: str, action: str) -> tuple[tuple[int, str], .
 FOLDED_RUN_DECLARATION_RE = re.compile(
     r"^(\s*)run:\s*>(?:[+-]?\d?|\d?[+-]?)?\s*(?:#.*)?$"
 )
+SHELL_CONTINUATION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\\\r?\n\s*"),
+    re.compile(r"`\r?\n\s*"),
+    re.compile(r"\^\r?\n\s*"),
+)
+
+
+def normalize_shell_continuations(text: str) -> str:
+    normalized = text
+    for pattern in SHELL_CONTINUATION_PATTERNS:
+        normalized = pattern.sub("", normalized)
+    return normalized
 
 
 def extract_folded_run_blocks(text: str) -> tuple[tuple[int, str], ...]:
@@ -2117,7 +2129,7 @@ def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
                 )
                 seen_patterns.add(command)
                 issues.append(issue)
-    continuation_normalized = re.sub(r"\\\r?\n\s*", "", text)
+    continuation_normalized = normalize_shell_continuations(text)
     for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
         if fragment in seen_fragments or fragment not in continuation_normalized:
             continue


### PR DESCRIPTION
## **User description**
Closes #808.\n\n## Summary\n- normalize Unix, PowerShell, and cmd line continuations before forbidden workflow command checks\n- catch mutating Actions variable API writes split with PowerShell backticks\n- catch mutating Actions secret API writes split with cmd carets\n\n## Validation\n- python scripts/check-github-workflow-permissions.py --json\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-python-script-compile.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize shell line continuations in workflow run blocks so forbidden Actions variable/secret `gh api` writes can’t evade checks. Supports Unix `\`, PowerShell backticks, and cmd carets; adds regression tests.

- **Bug Fixes**
  - Added `normalize_shell_continuations()` and applied it in `audit_forbidden_workflow_commands`.
  - New regression tests for `pwsh` variable delete and `cmd` secret delete split across lines.

<sup>Written for commit d2e58f9d462b80df74dabf6ed18188d0d00d19c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Detect workflow command writes split across shell line breaks

### What Changed
- The workflow permission check now catches unsafe GitHub Actions variable and secret writes even when the command is split across Unix, PowerShell, or cmd line continuations.
- Added regression coverage for PowerShell backtick and cmd caret cases so these hidden writes are blocked consistently.

### Impact
`✅ Fewer missed unsafe workflow writes`
`✅ Safer GitHub Actions permission checks`
`✅ Stronger protection against split-line secret and variable changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
