### PR TITLE
Forbid direct HTTP Actions config workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1218,6 +1218,37 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not dynamic_variable_api_delete_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("dynamic Actions variable API delete finding was not listed")
 
+    curl_variable_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe curl Actions variable write\n"
+            "        run: |\n"
+            "          curl --fail-with-body -X PATCH \\\n"
+            "            https://api.github.com/repos/$GITHUB_REPOSITORY/"
+            "actions/variables/\"$CONU_RELEASE_VAR_NAME\" \\\n"
+            "            -d '{\"name\":\"CONU_LINUX_REPOSITORY_BASE_URL\","
+            "\"value\":\"https://example.invalid/conu\"}'\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if curl_variable_api_write_report.ready:
+        raise AssertionError("curl Actions variable API write should fail")
+    curl_variable_api_write_parsed = assert_safe_report(
+        curl_variable_api_write_report
+    )
+    curl_variable_api_write_rendered = json.dumps(
+        curl_variable_api_write_parsed
+    )
+    if (
+        "must not use direct HTTP GitHub Actions variable workflow write: "
+        "HTTP actions/variables write"
+    ) not in curl_variable_api_write_rendered:
+        raise AssertionError("curl Actions variable API write was not reported")
+    if not curl_variable_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("curl Actions variable API write finding was not listed")
+
     pwsh_variable_api_delete_report = with_fixture(
         module,
         None,
@@ -1397,6 +1428,38 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("dynamic Actions secret API delete was not reported")
     if not dynamic_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("dynamic Actions secret API delete finding was not listed")
+
+    pwsh_http_secret_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe PowerShell HTTP Actions secret delete\n"
+            "        shell: pwsh\n"
+            "        run: |\n"
+            "          Invoke-RestMethod -Method DELETE `\n"
+            "            \"https://api.github.com/repos/$env:GITHUB_REPOSITORY/"
+            "actions/secrets/$env:CONU_RELEASE_SECRET_NAME\"\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if pwsh_http_secret_api_delete_report.ready:
+        raise AssertionError("PowerShell HTTP Actions secret API delete should fail")
+    pwsh_http_secret_api_delete_parsed = assert_safe_report(
+        pwsh_http_secret_api_delete_report
+    )
+    pwsh_http_secret_api_delete_rendered = json.dumps(
+        pwsh_http_secret_api_delete_parsed
+    )
+    if (
+        "must not use direct HTTP GitHub Actions secret workflow write: "
+        "HTTP actions/secrets write"
+    ) not in pwsh_http_secret_api_delete_rendered:
+        raise AssertionError("PowerShell HTTP Actions secret API delete was not reported")
+    if not pwsh_http_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError(
+            "PowerShell HTTP Actions secret API delete finding was not listed"
+        )
 
     cmd_secret_api_delete_report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -63,6 +63,20 @@ API_SECRET_FIELD_WRITE_PATTERN = (
 API_MUTATION_METHOD_PATTERN = (
     r"\s(?:--method|-X)(?:\s+|=)(?:POST|PUT|PATCH|DELETE)\b"
 )
+HTTP_MUTATION_METHOD_PATTERN = (
+    r"\s(?:-X|--request|--method|-Method)(?:\s+|=)"
+    r"(?:POST|PUT|PATCH|DELETE)\b"
+)
+HTTP_BODY_WRITE_PATTERN = (
+    r"\s(?:-d|--data|--data-raw|--data-binary|--data-urlencode|"
+    r"--json|--form|-Body)(?:\s+|=)"
+)
+HTTP_MUTATION_SIGNAL_PATTERN = (
+    rf"(?:{HTTP_MUTATION_METHOD_PATTERN}|{HTTP_BODY_WRITE_PATTERN})"
+)
+HTTP_CLIENT_PATTERN = (
+    r"\b(?:curl(?:\.exe)?|Invoke-RestMethod|Invoke-WebRequest|irm|iwr)\b"
+)
 FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     (
         "--allow-unverified-npm-token-rotation-marker",
@@ -87,6 +101,16 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         "direct GitHub Actions variable workflow API write",
     ),
     (
+        "HTTP actions/variables write",
+        re.compile(
+            rf"{HTTP_CLIENT_PATTERN}"
+            rf"(?=[^\n;&|]*\bactions/variables\b)"
+            rf"(?=[^\n;&|]*{HTTP_MUTATION_SIGNAL_PATTERN})",
+            re.IGNORECASE,
+        ),
+        "direct HTTP GitHub Actions variable workflow write",
+    ),
+    (
         "gh secret set <any-actions-secret>",
         re.compile(r"\bgh\s+secret\s+set\b"),
         "direct GitHub Actions secret workflow write",
@@ -101,6 +125,16 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             re.IGNORECASE,
         ),
         "direct GitHub Actions secret workflow API write",
+    ),
+    (
+        "HTTP actions/secrets write",
+        re.compile(
+            rf"{HTTP_CLIENT_PATTERN}"
+            rf"(?=[^\n;&|]*\bactions/secrets\b)"
+            rf"(?=[^\n;&|]*{HTTP_MUTATION_SIGNAL_PATTERN})",
+            re.IGNORECASE,
+        ),
+        "direct HTTP GitHub Actions secret workflow write",
     ),
     (
         f"gh variable set {NPM_TOKEN_ROTATION_MARKER_VAR}",


### PR DESCRIPTION
## **User description**
Closes #810.\n\n## Summary\n- Adds workflow audit guards for direct HTTP writes to GitHub Actions variables and secrets endpoints via curl and PowerShell web cmdlets.\n- Adds regressions for curl variable PATCH and PowerShell secret DELETE workflow commands.\n\n## Validation\n- python scripts/check-github-workflow-permissions.py --json\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-python-script-compile.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks direct HTTP writes to GitHub Actions variables and secrets in workflows by detecting `curl` and PowerShell web cmdlets. Adds audit guards and regression tests to prevent unsafe mutations and closes #810.

- **New Features**
  - Detect HTTP clients (`curl`, `Invoke-RestMethod`, `Invoke-WebRequest`, `irm`, `iwr`) hitting `actions/variables` or `actions/secrets` with mutation signals (`POST|PUT|PATCH|DELETE` or body flags).
  - Add forbidden fragments: "HTTP actions/variables write" and "HTTP actions/secrets write" with clear error messages.
  - Add regressions for a `curl` variable PATCH and a PowerShell secret DELETE.

<sup>Written for commit 3612e8eb4d425cdcfdf070b7e72bd48e320089f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block direct HTTP writes to GitHub Actions variables and secrets in workflows**

### What Changed
- Workflow checks now catch direct HTTP requests that try to change GitHub Actions variables or secrets, including curl and PowerShell web requests.
- These unsafe writes are rejected when the request targets the variables or secrets endpoints with a change method or request body.
- Added regression coverage for a curl variable update and a PowerShell secret delete so these workflow writes stay blocked.

### Impact
`✅ Fewer unsafe workflow config changes`
`✅ Clearer protection against Actions variable and secret tampering`
`✅ Less chance of accidental or malicious workflow mutation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
