### PR TITLE
Forbid wget Actions config workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1249,6 +1249,35 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not curl_variable_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("curl Actions variable API write finding was not listed")
 
+    wget_variable_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe wget Actions variable write\n"
+            "        run: |\n"
+            "          wget --method=PATCH --body-data=value=redacted \\\n"
+            "            https://api.github.com/repos/$GITHUB_REPOSITORY/"
+            "actions/variables/\"$CONU_RELEASE_VAR_NAME\"\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if wget_variable_api_write_report.ready:
+        raise AssertionError("wget Actions variable API write should fail")
+    wget_variable_api_write_parsed = assert_safe_report(
+        wget_variable_api_write_report
+    )
+    wget_variable_api_write_rendered = json.dumps(
+        wget_variable_api_write_parsed
+    )
+    if (
+        "must not use direct HTTP GitHub Actions variable workflow write: "
+        "HTTP actions/variables write"
+    ) not in wget_variable_api_write_rendered:
+        raise AssertionError("wget Actions variable API write was not reported")
+    if not wget_variable_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("wget Actions variable API write finding was not listed")
+
     pwsh_variable_api_delete_report = with_fixture(
         module,
         None,
@@ -1460,6 +1489,35 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError(
             "PowerShell HTTP Actions secret API delete finding was not listed"
         )
+
+    wget_secret_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe wget Actions secret delete\n"
+            "        run: |\n"
+            "          wget --method=DELETE \\\n"
+            "            https://api.github.com/repos/$GITHUB_REPOSITORY/"
+            "actions/secrets/\"$CONU_RELEASE_SECRET_NAME\"\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if wget_secret_api_delete_report.ready:
+        raise AssertionError("wget Actions secret API delete should fail")
+    wget_secret_api_delete_parsed = assert_safe_report(
+        wget_secret_api_delete_report
+    )
+    wget_secret_api_delete_rendered = json.dumps(
+        wget_secret_api_delete_parsed
+    )
+    if (
+        "must not use direct HTTP GitHub Actions secret workflow write: "
+        "HTTP actions/secrets write"
+    ) not in wget_secret_api_delete_rendered:
+        raise AssertionError("wget Actions secret API delete was not reported")
+    if not wget_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("wget Actions secret API delete finding was not listed")
 
     cmd_secret_api_delete_report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -69,13 +69,15 @@ HTTP_MUTATION_METHOD_PATTERN = (
 )
 HTTP_BODY_WRITE_PATTERN = (
     r"\s(?:-d|--data|--data-raw|--data-binary|--data-urlencode|"
-    r"--json|--form|-Body)(?:\s+|=)"
+    r"--json|--form|--body-data|--body-file|--post-data|--post-file|"
+    r"-Body)(?:\s+|=)"
 )
 HTTP_MUTATION_SIGNAL_PATTERN = (
     rf"(?:{HTTP_MUTATION_METHOD_PATTERN}|{HTTP_BODY_WRITE_PATTERN})"
 )
 HTTP_CLIENT_PATTERN = (
-    r"\b(?:curl(?:\.exe)?|Invoke-RestMethod|Invoke-WebRequest|irm|iwr)\b"
+    r"\b(?:curl(?:\.exe)?|wget(?:\.exe)?|Invoke-RestMethod|"
+    r"Invoke-WebRequest|irm|iwr)\b"
 )
 FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     (


### PR DESCRIPTION
## **User description**
Closes #812.\n\n## Summary\n- Adds wget and wget.exe to the direct HTTP workflow-command guard for GitHub Actions variables and secrets endpoints.\n- Adds wget body-write flags to the mutation signal set.\n- Adds regressions for wget variable PATCH and secret DELETE workflow commands.\n\n## Validation\n- python scripts/check-github-workflow-permissions.py --json\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-python-script-compile.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the workflow permissions checker to detect and block `wget`-based writes to GitHub Actions variables and secrets. This closes a gap so direct HTTP mutations via `wget` are flagged like `curl` and PowerShell clients.

- **Bug Fixes**
  - Add `wget` and `wget.exe` to HTTP client detection.
  - Recognize `wget` body-write flags in mutation signals: `--body-data`, `--body-file`, `--post-data`, `--post-file`.
  - Add regression tests for `wget` variable PATCH and secret DELETE commands.

<sup>Written for commit 52cddbe70bc0fc1fc7ed068e274164b2f3b42075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block wget-based GitHub Actions config writes**

### What Changed
- Blocks `wget` and `wget.exe` from making direct HTTP writes to GitHub Actions variables and secrets endpoints
- Recognizes more `wget` request body options as write attempts, so unsafe variable and secret changes are caught even when different body flags are used
- Adds coverage for `wget` variable updates and secret deletions to prevent these writes from slipping through

### Impact
`✅ Fewer unsafe workflow config changes`
`✅ Clearer protection against secret and variable tampering`
`✅ Reduced chance of missed direct-write attempts in Actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
