### PR TITLE
Forbid scripted Actions config workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1306,6 +1306,35 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not httpie_variable_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("HTTPie Actions variable API write finding was not listed")
 
+    node_variable_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe Node Actions variable write\n"
+            "        run: |\n"
+            "          node -e \"fetch('https://api.github.com/repos/"
+            "owner/repo/actions/variables/CONU_NPM_TOKEN_ROTATED_AFTER', "
+            "{method:'PATCH',body:'{}'})\"\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if node_variable_api_write_report.ready:
+        raise AssertionError("Node Actions variable API write should fail")
+    node_variable_api_write_parsed = assert_safe_report(
+        node_variable_api_write_report
+    )
+    node_variable_api_write_rendered = json.dumps(
+        node_variable_api_write_parsed
+    )
+    if (
+        "must not use scripted GitHub Actions variable workflow write: "
+        "script actions/variables write"
+    ) not in node_variable_api_write_rendered:
+        raise AssertionError("Node Actions variable API write was not reported")
+    if not node_variable_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("Node Actions variable API write finding was not listed")
+
     pwsh_variable_api_delete_report = with_fixture(
         module,
         None,
@@ -1602,6 +1631,35 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("HTTPie Actions secret API delete was not reported")
     if not httpie_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("HTTPie Actions secret API delete finding was not listed")
+
+    python_secret_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe Python Actions secret delete\n"
+            "        run: |\n"
+            "          python -c \"import urllib.request; "
+            "urllib.request.Request('https://api.github.com/repos/"
+            "owner/repo/actions/secrets/NPM_TOKEN', method='DELETE')\"\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if python_secret_api_delete_report.ready:
+        raise AssertionError("Python Actions secret API delete should fail")
+    python_secret_api_delete_parsed = assert_safe_report(
+        python_secret_api_delete_report
+    )
+    python_secret_api_delete_rendered = json.dumps(
+        python_secret_api_delete_parsed
+    )
+    if (
+        "must not use scripted GitHub Actions secret workflow write: "
+        "script actions/secrets write"
+    ) not in python_secret_api_delete_rendered:
+        raise AssertionError("Python Actions secret API delete was not reported")
+    if not python_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("Python Actions secret API delete finding was not listed")
 
     cmd_secret_api_delete_report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -83,6 +83,20 @@ HTTP_CLIENT_PATTERN = (
     r"\b(?:curl(?:\.exe)?|wget(?:\.exe)?|Invoke-RestMethod|"
     r"Invoke-WebRequest|irm|iwr)\b"
 )
+SCRIPT_CLIENT_PATTERN = (
+    r"\b(?:python(?:3)?|py(?:\.exe)?|node(?:\.exe)?|deno(?:\.exe)?|"
+    r"bun(?:\.exe)?)\b"
+)
+SCRIPT_COMMAND_SPAN_PATTERN = r"[^\n]*"
+SCRIPT_MUTATION_SIGNAL_PATTERN = (
+    r"(?:"
+    r"\brequests\.(?:post|put|patch|delete)\s*\("
+    r"|(?:\bfetch\s*\(|\burllib\.request\.Request\s*\(|\bRequest\s*\()"
+    rf"{SCRIPT_COMMAND_SPAN_PATTERN}\bmethod\s*[:=]\s*['\"]?"
+    r"(?:POST|PUT|PATCH|DELETE)\b"
+    r"|\bmethod\s*[:=]\s*['\"]?(?:POST|PUT|PATCH|DELETE)\b"
+    r")"
+)
 FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS: tuple[tuple[str, str], ...] = (
     (
         "--allow-unverified-npm-token-rotation-marker",
@@ -118,6 +132,16 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         "direct HTTP GitHub Actions variable workflow write",
     ),
     (
+        "script actions/variables write",
+        re.compile(
+            rf"{SCRIPT_CLIENT_PATTERN}"
+            rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}\bactions/variables\b)"
+            rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}{SCRIPT_MUTATION_SIGNAL_PATTERN})",
+            re.IGNORECASE,
+        ),
+        "scripted GitHub Actions variable workflow write",
+    ),
+    (
         "gh secret set <any-actions-secret>",
         re.compile(r"\bgh\s+secret\s+set\b"),
         "direct GitHub Actions secret workflow write",
@@ -143,6 +167,16 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             re.IGNORECASE,
         ),
         "direct HTTP GitHub Actions secret workflow write",
+    ),
+    (
+        "script actions/secrets write",
+        re.compile(
+            rf"{SCRIPT_CLIENT_PATTERN}"
+            rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}\bactions/secrets\b)"
+            rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}{SCRIPT_MUTATION_SIGNAL_PATTERN})",
+            re.IGNORECASE,
+        ),
+        "scripted GitHub Actions secret workflow write",
     ),
     (
         f"gh variable set {NPM_TOKEN_ROTATION_MARKER_VAR}",


### PR DESCRIPTION
## **User description**
Closes #816

## Summary
- block scripted Python/Node-style writes to GitHub Actions variables and secrets in the workflow permission checker
- add regression fixtures for Node fetch variable PATCH and Python urllib secret DELETE bypasses

## Validation
- python scripts/check-github-workflow-permissions.py --json
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- python scripts/verify-release-versions.py
- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks scripted writes to GitHub Actions variables and secrets by extending the workflow permission checker. Adds regression tests to prevent Node/Python-based HTTP bypasses.

- **Bug Fixes**
  - Flags scripted HTTP writes to `actions/variables` and `actions/secrets` from `python`, `node`, `deno`, and `bun`.
  - Detects mutation methods via `fetch`, `urllib.request.Request`, `requests.post|put|patch|delete`, and `Request(..., method=...)`.
  - Adds regression fixtures for Node `fetch` PATCH to variables and Python `urllib` DELETE to secrets.

<sup>Written for commit bc1d5801c496ecdf0bc676fb0248d782965124ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Block scripted GitHub Actions workflow writes from Python and Node commands

### What Changed
- Scripted commands can no longer write GitHub Actions variables or secrets through API calls
- The check now catches common Python and Node patterns that try to update `actions/variables` or `actions/secrets`
- Added regression coverage for a Node `fetch` variable update and a Python `urllib` secret delete bypass

### Impact
`✅ Fewer unsafe workflow config writes`
`✅ Blocked Python and Node bypasses`
`✅ Safer GitHub Actions variable and secret updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
