### PR TITLE
Forbid script block Actions config workflow writes

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1335,6 +1335,43 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not node_variable_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("Node Actions variable API write finding was not listed")
 
+    python_block_variable_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe Python block Actions variable write\n"
+            "        run: |\n"
+            "          python - <<'PY'\n"
+            "          import requests\n"
+            "          requests.patch('https://api.github.com/repos/"
+            "owner/repo/actions/variables/CONU_NPM_TOKEN_ROTATED_AFTER', "
+            "json={'value':'2026-06-03T00:00:00Z'})\n"
+            "          PY\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if python_block_variable_api_write_report.ready:
+        raise AssertionError("Python block Actions variable API write should fail")
+    python_block_variable_api_write_parsed = assert_safe_report(
+        python_block_variable_api_write_report
+    )
+    python_block_variable_api_write_rendered = json.dumps(
+        python_block_variable_api_write_parsed
+    )
+    if (
+        "literal run block"
+        not in python_block_variable_api_write_rendered
+        or "must not use scripted GitHub Actions variable workflow write: "
+        "script actions/variables write"
+        not in python_block_variable_api_write_rendered
+    ):
+        raise AssertionError("Python block Actions variable API write was not reported")
+    if not python_block_variable_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError(
+            "Python block Actions variable API write finding was not listed"
+        )
+
     pwsh_variable_api_delete_report = with_fixture(
         module,
         None,
@@ -1660,6 +1697,41 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("Python Actions secret API delete was not reported")
     if not python_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("Python Actions secret API delete finding was not listed")
+
+    node_block_secret_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe Node block Actions secret delete\n"
+            "        run: |\n"
+            "          node <<'JS'\n"
+            "          fetch('https://api.github.com/repos/"
+            "owner/repo/actions/secrets/NPM_TOKEN', { method: 'DELETE' })\n"
+            "          JS\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if node_block_secret_api_delete_report.ready:
+        raise AssertionError("Node block Actions secret API delete should fail")
+    node_block_secret_api_delete_parsed = assert_safe_report(
+        node_block_secret_api_delete_report
+    )
+    node_block_secret_api_delete_rendered = json.dumps(
+        node_block_secret_api_delete_parsed
+    )
+    if (
+        "literal run block"
+        not in node_block_secret_api_delete_rendered
+        or "must not use scripted GitHub Actions secret workflow write: "
+        "script actions/secrets write"
+        not in node_block_secret_api_delete_rendered
+    ):
+        raise AssertionError("Node block Actions secret API delete was not reported")
+    if not node_block_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError(
+            "Node block Actions secret API delete finding was not listed"
+        )
 
     cmd_secret_api_delete_report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -88,11 +88,21 @@ SCRIPT_CLIENT_PATTERN = (
     r"bun(?:\.exe)?)\b"
 )
 SCRIPT_COMMAND_SPAN_PATTERN = r"[^\n]*"
+SCRIPT_BLOCK_SPAN_PATTERN = r"[\s\S]*"
 SCRIPT_MUTATION_SIGNAL_PATTERN = (
     r"(?:"
     r"\brequests\.(?:post|put|patch|delete)\s*\("
     r"|(?:\bfetch\s*\(|\burllib\.request\.Request\s*\(|\bRequest\s*\()"
     rf"{SCRIPT_COMMAND_SPAN_PATTERN}\bmethod\s*[:=]\s*['\"]?"
+    r"(?:POST|PUT|PATCH|DELETE)\b"
+    r"|\bmethod\s*[:=]\s*['\"]?(?:POST|PUT|PATCH|DELETE)\b"
+    r")"
+)
+SCRIPT_BLOCK_MUTATION_SIGNAL_PATTERN = (
+    r"(?:"
+    r"\brequests\.(?:post|put|patch|delete)\s*\("
+    r"|(?:\bfetch\s*\(|\burllib\.request\.Request\s*\(|\bRequest\s*\()"
+    rf"{SCRIPT_BLOCK_SPAN_PATTERN}\bmethod\s*[:=]\s*['\"]?"
     r"(?:POST|PUT|PATCH|DELETE)\b"
     r"|\bmethod\s*[:=]\s*['\"]?(?:POST|PUT|PATCH|DELETE)\b"
     r")"
@@ -239,6 +249,28 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             re.IGNORECASE,
         ),
         "direct release secret workflow API write",
+    ),
+)
+FORBIDDEN_WORKFLOW_BLOCK_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    (
+        "script actions/variables write",
+        re.compile(
+            rf"{SCRIPT_CLIENT_PATTERN}"
+            rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}\bactions/variables\b)"
+            rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}{SCRIPT_BLOCK_MUTATION_SIGNAL_PATTERN})",
+            re.IGNORECASE,
+        ),
+        "scripted GitHub Actions variable workflow write",
+    ),
+    (
+        "script actions/secrets write",
+        re.compile(
+            rf"{SCRIPT_CLIENT_PATTERN}"
+            rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}\bactions/secrets\b)"
+            rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}{SCRIPT_BLOCK_MUTATION_SIGNAL_PATTERN})",
+            re.IGNORECASE,
+        ),
+        "scripted GitHub Actions secret workflow write",
     ),
 )
 ALLOWED_PERMISSION_KEYS = (
@@ -2119,6 +2151,9 @@ def extract_uses_step_blocks(text: str, action: str) -> tuple[tuple[int, str], .
 FOLDED_RUN_DECLARATION_RE = re.compile(
     r"^(\s*)run:\s*>(?:[+-]?\d?|\d?[+-]?)?\s*(?:#.*)?$"
 )
+LITERAL_RUN_DECLARATION_RE = re.compile(
+    r"^(\s*)run:\s*\|(?:[+-]?\d?|\d?[+-]?)?\s*(?:#.*)?$"
+)
 SHELL_CONTINUATION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\\\r?\n\s*"),
     re.compile(r"`\r?\n\s*"),
@@ -2160,6 +2195,36 @@ def extract_folded_run_blocks(text: str) -> tuple[tuple[int, str], ...]:
             index += 1
         if folded_lines:
             blocks.append((line_number, " ".join(folded_lines)))
+    return tuple(blocks)
+
+
+def extract_literal_run_blocks(text: str) -> tuple[tuple[int, str], ...]:
+    lines = text.splitlines()
+    blocks: list[tuple[int, str]] = []
+    index = 0
+    while index < len(lines):
+        match = LITERAL_RUN_DECLARATION_RE.match(lines[index])
+        if match is None:
+            index += 1
+            continue
+
+        line_number = index + 1
+        base_indent = len(match.group(1))
+        literal_lines: list[str] = []
+        index += 1
+        while index < len(lines):
+            line = lines[index]
+            if not line.strip():
+                literal_lines.append("")
+                index += 1
+                continue
+            indent = len(line) - len(line.lstrip(" "))
+            if indent <= base_indent:
+                break
+            literal_lines.append(line.strip())
+            index += 1
+        if literal_lines:
+            blocks.append((line_number, "\n".join(literal_lines)))
     return tuple(blocks)
 
 
@@ -2229,6 +2294,23 @@ def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
             seen_patterns.add(command)
             issues.append(
                 f"{path.name}:folded run block at line {line_number} must not use "
+                f"{description}: {command}"
+            )
+        for command, pattern, description in FORBIDDEN_WORKFLOW_BLOCK_PATTERNS:
+            if command in seen_patterns or not pattern.search(block):
+                continue
+            seen_patterns.add(command)
+            issues.append(
+                f"{path.name}:folded run block at line {line_number} must not use "
+                f"{description}: {command}"
+            )
+    for line_number, block in extract_literal_run_blocks(text):
+        for command, pattern, description in FORBIDDEN_WORKFLOW_BLOCK_PATTERNS:
+            if command in seen_patterns or not pattern.search(block):
+                continue
+            seen_patterns.add(command)
+            issues.append(
+                f"{path.name}:literal run block at line {line_number} must not use "
                 f"{description}: {command}"
             )
     return tuple(issues)


### PR DESCRIPTION
Closes #818

## Summary
- add block-level detection for scripted GitHub Actions variable/secret writes inside literal and folded run blocks
- add regressions for Python heredoc Actions variable PATCH and Node heredoc Actions secret DELETE bypasses

## Validation
- python scripts/check-github-workflow-permissions.py --json
- python scripts/check-github-workflow-permissions-regression.py
- python scripts/check-python-script-compile.py
- python scripts/verify-release-versions.py
- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks scripted writes to GitHub Actions variables and secrets from within `run` heredoc steps by scanning both folded (`>`) and literal (`|`) blocks, closing bypasses in Python and Node scripts.

- **Bug Fixes**
  - Detect `actions/variables` and `actions/secrets` writes (POST/PUT/PATCH/DELETE) in heredoc `run` blocks via Python `requests` and Node `fetch`.
  - Add block-level patterns and literal block extraction to `scripts/check-github-workflow-permissions.py`; report findings per block type.
  - Add regressions in `scripts/check-github-workflow-permissions-regression.py` for Python variable PATCH and Node secret DELETE heredoc bypasses.

<sup>Written for commit 6af4b4fbba4ede29c3208fc6c987cbe4a71306d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

