### PR TITLE
Forbid workflow release config mutation bypasses

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -1072,6 +1072,28 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not dynamic_variable_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("dynamic Actions variable write finding was not listed")
 
+    dynamic_variable_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe dynamic Actions variable delete\n"
+            "        run: gh variable delete \"$CONU_RELEASE_VAR_NAME\" --yes\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if dynamic_variable_delete_report.ready:
+        raise AssertionError("dynamic Actions variable workflow delete should fail")
+    dynamic_variable_delete_parsed = assert_safe_report(dynamic_variable_delete_report)
+    dynamic_variable_delete_rendered = json.dumps(dynamic_variable_delete_parsed)
+    if (
+        "must not use direct GitHub Actions variable workflow delete: "
+        "gh variable delete <any-actions-variable>"
+    ) not in dynamic_variable_delete_rendered:
+        raise AssertionError("dynamic Actions variable delete was not reported")
+    if not dynamic_variable_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("dynamic Actions variable delete finding was not listed")
+
     api_write_report = with_fixture(
         module,
         None,
@@ -1167,6 +1189,28 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not variable_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release variable write finding was not listed")
 
+    variable_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe direct release variable delete\n"
+            "        run: gh variable delete CONU_LINUX_REPOSITORY_BASE_URL --yes\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if variable_delete_report.ready:
+        raise AssertionError("direct release variable workflow delete should fail")
+    variable_delete_parsed = assert_safe_report(variable_delete_report)
+    variable_delete_rendered = json.dumps(variable_delete_parsed)
+    if (
+        "must not use direct release variable workflow delete: "
+        "gh variable delete <release-variable>"
+    ) not in variable_delete_rendered:
+        raise AssertionError("direct release variable workflow delete was not reported")
+    if not variable_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct release variable delete finding was not listed")
+
     variable_api_write_report = with_fixture(
         module,
         None,
@@ -1190,6 +1234,40 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("direct release variable API workflow write was not reported")
     if not variable_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release variable API write finding was not listed")
+
+    environment_variable_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe environment API release variable write\n"
+            "        run: gh api --method PATCH repos/$GITHUB_REPOSITORY/"
+            "environments/prod/variables/CONU_LINUX_REPOSITORY_BASE_URL "
+            "-f value=https://example.invalid/conu\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if environment_variable_api_write_report.ready:
+        raise AssertionError(
+            "environment release variable API workflow write should fail"
+        )
+    environment_variable_api_write_parsed = assert_safe_report(
+        environment_variable_api_write_report
+    )
+    environment_variable_api_write_rendered = json.dumps(
+        environment_variable_api_write_parsed
+    )
+    if (
+        "must not use direct release variable workflow API write: "
+        "gh api actions/variables <release-variable> write"
+    ) not in environment_variable_api_write_rendered:
+        raise AssertionError(
+            "environment release variable API workflow write was not reported"
+        )
+    if not environment_variable_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError(
+            "environment release variable API write finding was not listed"
+        )
 
     dynamic_variable_api_delete_report = with_fixture(
         module,
@@ -1248,6 +1326,40 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("curl Actions variable API write was not reported")
     if not curl_variable_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("curl Actions variable API write finding was not listed")
+
+    curl_environment_variable_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate custom Linux repository publication config\n",
+            "      - name: Unsafe curl environment Actions variable write\n"
+            "        run: |\n"
+            "          curl --fail-with-body -X PATCH \\\n"
+            "            https://api.github.com/repos/$GITHUB_REPOSITORY/"
+            "environments/prod/variables/\"$CONU_RELEASE_VAR_NAME\" \\\n"
+            "            -d '{\"value\":\"https://example.invalid/conu\"}'\n"
+            "      - name: Validate custom Linux repository publication config\n",
+        ),
+    )
+    if curl_environment_variable_api_write_report.ready:
+        raise AssertionError("curl environment Actions variable API write should fail")
+    curl_environment_variable_api_write_parsed = assert_safe_report(
+        curl_environment_variable_api_write_report
+    )
+    curl_environment_variable_api_write_rendered = json.dumps(
+        curl_environment_variable_api_write_parsed
+    )
+    if (
+        "must not use direct HTTP GitHub Actions variable workflow write: "
+        "HTTP actions/variables write"
+    ) not in curl_environment_variable_api_write_rendered:
+        raise AssertionError(
+            "curl environment Actions variable API write was not reported"
+        )
+    if not curl_environment_variable_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError(
+            "curl environment Actions variable API write finding was not listed"
+        )
 
     wget_variable_api_write_report = with_fixture(
         module,
@@ -1480,6 +1592,28 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not secret_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release secret write finding was not listed")
 
+    secret_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe direct release secret delete\n"
+            "        run: gh secret delete NPM_TOKEN --yes\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if secret_delete_report.ready:
+        raise AssertionError("direct release secret workflow delete should fail")
+    secret_delete_parsed = assert_safe_report(secret_delete_report)
+    secret_delete_rendered = json.dumps(secret_delete_parsed)
+    if (
+        "must not use direct release secret workflow delete: "
+        "gh secret delete <release-secret>"
+    ) not in secret_delete_rendered:
+        raise AssertionError("direct release secret workflow delete was not reported")
+    if not secret_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct release secret delete finding was not listed")
+
     dynamic_secret_write_report = with_fixture(
         module,
         None,
@@ -1502,6 +1636,28 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("dynamic Actions secret write was not reported")
     if not dynamic_secret_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("dynamic Actions secret write finding was not listed")
+
+    dynamic_secret_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe dynamic Actions secret delete\n"
+            "        run: gh secret delete \"$CONU_RELEASE_SECRET_NAME\" --yes\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if dynamic_secret_delete_report.ready:
+        raise AssertionError("dynamic Actions secret workflow delete should fail")
+    dynamic_secret_delete_parsed = assert_safe_report(dynamic_secret_delete_report)
+    dynamic_secret_delete_rendered = json.dumps(dynamic_secret_delete_parsed)
+    if (
+        "must not use direct GitHub Actions secret workflow delete: "
+        "gh secret delete <any-actions-secret>"
+    ) not in dynamic_secret_delete_rendered:
+        raise AssertionError("dynamic Actions secret delete was not reported")
+    if not dynamic_secret_delete_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("dynamic Actions secret delete finding was not listed")
 
     secret_api_write_report = with_fixture(
         module,
@@ -1526,6 +1682,38 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("direct release secret API workflow write was not reported")
     if not secret_api_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct release secret API write finding was not listed")
+
+    environment_secret_api_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe environment API release secret write\n"
+            "        run: gh api --method PUT repos/$GITHUB_REPOSITORY/"
+            "environments/prod/secrets/NPM_TOKEN -f encrypted_value=redacted "
+            "-f key_id=redacted\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if environment_secret_api_write_report.ready:
+        raise AssertionError("environment release secret API workflow write should fail")
+    environment_secret_api_write_parsed = assert_safe_report(
+        environment_secret_api_write_report
+    )
+    environment_secret_api_write_rendered = json.dumps(
+        environment_secret_api_write_parsed
+    )
+    if (
+        "must not use direct release secret workflow API write: "
+        "gh api actions/secrets <release-secret> write"
+    ) not in environment_secret_api_write_rendered:
+        raise AssertionError(
+            "environment release secret API workflow write was not reported"
+        )
+    if not environment_secret_api_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError(
+            "environment release secret API write finding was not listed"
+        )
 
     dynamic_secret_api_delete_report = with_fixture(
         module,
@@ -1731,6 +1919,48 @@ def run_forbidden_workflow_command_tests(module) -> None:
     if not node_block_secret_api_delete_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError(
             "Node block Actions secret API delete finding was not listed"
+        )
+
+    node_block_environment_secret_api_delete_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe Node block environment Actions secret delete\n"
+            "        run: |\n"
+            "          node <<'JS'\n"
+            "          fetch('https://api.github.com/repos/"
+            "owner/repo/environments/prod/secrets/NPM_TOKEN', "
+            "{ method: 'DELETE' })\n"
+            "          JS\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if node_block_environment_secret_api_delete_report.ready:
+        raise AssertionError(
+            "Node block environment Actions secret API delete should fail"
+        )
+    node_block_environment_secret_api_delete_parsed = assert_safe_report(
+        node_block_environment_secret_api_delete_report
+    )
+    node_block_environment_secret_api_delete_rendered = json.dumps(
+        node_block_environment_secret_api_delete_parsed
+    )
+    if (
+        "literal run block"
+        not in node_block_environment_secret_api_delete_rendered
+        or "must not use scripted GitHub Actions secret workflow write: "
+        "script actions/secrets write"
+        not in node_block_environment_secret_api_delete_rendered
+    ):
+        raise AssertionError(
+            "Node block environment Actions secret API delete was not reported"
+        )
+    if not node_block_environment_secret_api_delete_parsed[
+        "forbiddenWorkflowCommands"
+    ]:
+        raise AssertionError(
+            "Node block environment Actions secret API delete finding was not listed"
         )
 
     cmd_secret_api_delete_report = with_fixture(

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -52,6 +52,12 @@ RELEASE_VARIABLE_WRITE_GUARD_NAMES: tuple[str, ...] = (
 RELEASE_VARIABLE_WRITE_GUARD_PATTERN = "|".join(
     re.escape(name) for name in RELEASE_VARIABLE_WRITE_GUARD_NAMES
 )
+ACTIONS_VARIABLE_ENDPOINT_PATTERN = (
+    r"(?:\bactions/variables\b|\benvironments/[^\s/;&|\"']+/variables\b)"
+)
+ACTIONS_SECRET_ENDPOINT_PATTERN = (
+    r"(?:\bactions/secrets\b|\benvironments/[^\s/;&|\"']+/secrets\b)"
+)
 API_VARIABLE_FIELD_WRITE_PATTERN = (
     r"\s(?:(?:-f|-F)(?:\s+|=)?|(?:--field|--raw-field)(?:\s+|=))"
     r"(?:name|value)="
@@ -120,10 +126,15 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         "direct GitHub Actions variable workflow write",
     ),
     (
+        "gh variable delete <any-actions-variable>",
+        re.compile(r"\bgh\s+variable\s+delete\b"),
+        "direct GitHub Actions variable workflow delete",
+    ),
+    (
         "gh api actions/variables write",
         re.compile(
             rf"\bgh\s+api\b"
-            rf"(?=[^\n;&|]*\bactions/variables\b)"
+            rf"(?=[^\n;&|]*{ACTIONS_VARIABLE_ENDPOINT_PATTERN})"
             rf"(?=[^\n;&|]*(?:{API_MUTATION_METHOD_PATTERN}|"
             rf"{API_VARIABLE_FIELD_WRITE_PATTERN}))",
             re.IGNORECASE,
@@ -136,7 +147,7 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             rf"(?:{HTTP_CLIENT_PATTERN}"
             rf"(?=[^\n;&|]*{HTTP_MUTATION_SIGNAL_PATTERN})|"
             rf"{HTTPIE_MUTATION_METHOD_PATTERN})"
-            rf"(?=[^\n;&|]*\bactions/variables\b)",
+            rf"(?=[^\n;&|]*{ACTIONS_VARIABLE_ENDPOINT_PATTERN})",
             re.IGNORECASE,
         ),
         "direct HTTP GitHub Actions variable workflow write",
@@ -145,7 +156,7 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         "script actions/variables write",
         re.compile(
             rf"{SCRIPT_CLIENT_PATTERN}"
-            rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}\bactions/variables\b)"
+            rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}{ACTIONS_VARIABLE_ENDPOINT_PATTERN})"
             rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}{SCRIPT_MUTATION_SIGNAL_PATTERN})",
             re.IGNORECASE,
         ),
@@ -157,10 +168,15 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         "direct GitHub Actions secret workflow write",
     ),
     (
+        "gh secret delete <any-actions-secret>",
+        re.compile(r"\bgh\s+secret\s+delete\b"),
+        "direct GitHub Actions secret workflow delete",
+    ),
+    (
         "gh api actions/secrets write",
         re.compile(
             rf"\bgh\s+api\b"
-            rf"(?=[^\n;&|]*\bactions/secrets\b)"
+            rf"(?=[^\n;&|]*{ACTIONS_SECRET_ENDPOINT_PATTERN})"
             rf"(?=[^\n;&|]*(?:{API_MUTATION_METHOD_PATTERN}|"
             rf"{API_SECRET_FIELD_WRITE_PATTERN}))",
             re.IGNORECASE,
@@ -173,7 +189,7 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
             rf"(?:{HTTP_CLIENT_PATTERN}"
             rf"(?=[^\n;&|]*{HTTP_MUTATION_SIGNAL_PATTERN})|"
             rf"{HTTPIE_MUTATION_METHOD_PATTERN})"
-            rf"(?=[^\n;&|]*\bactions/secrets\b)",
+            rf"(?=[^\n;&|]*{ACTIONS_SECRET_ENDPOINT_PATTERN})",
             re.IGNORECASE,
         ),
         "direct HTTP GitHub Actions secret workflow write",
@@ -182,7 +198,7 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         "script actions/secrets write",
         re.compile(
             rf"{SCRIPT_CLIENT_PATTERN}"
-            rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}\bactions/secrets\b)"
+            rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}{ACTIONS_SECRET_ENDPOINT_PATTERN})"
             rf"(?={SCRIPT_COMMAND_SPAN_PATTERN}{SCRIPT_MUTATION_SIGNAL_PATTERN})",
             re.IGNORECASE,
         ),
@@ -199,7 +215,7 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         f"gh api actions/variables {NPM_TOKEN_ROTATION_MARKER_VAR} write",
         re.compile(
             rf"\bgh\s+api\b"
-            rf"(?=[^\n;&|]*\bactions/variables\b)"
+            rf"(?=[^\n;&|]*{ACTIONS_VARIABLE_ENDPOINT_PATTERN})"
             rf"(?=[^\n;&|]*\b{NPM_TOKEN_ROTATION_MARKER_VAR}\b)"
             rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
             rf"(?:POST|PUT|PATCH)\b|"
@@ -217,10 +233,18 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         "direct release variable workflow write",
     ),
     (
+        "gh variable delete <release-variable>",
+        re.compile(
+            rf"\bgh\s+variable\s+delete\b[^\n;&|]*\b"
+            rf"(?:{RELEASE_VARIABLE_WRITE_GUARD_PATTERN})\b"
+        ),
+        "direct release variable workflow delete",
+    ),
+    (
         "gh api actions/variables <release-variable> write",
         re.compile(
             rf"\bgh\s+api\b"
-            rf"(?=[^\n;&|]*\bactions/variables\b)"
+            rf"(?=[^\n;&|]*{ACTIONS_VARIABLE_ENDPOINT_PATTERN})"
             rf"(?=[^\n;&|]*\b(?:{RELEASE_VARIABLE_WRITE_GUARD_PATTERN})\b)"
             rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
             rf"(?:POST|PUT|PATCH)\b|"
@@ -238,10 +262,18 @@ FORBIDDEN_WORKFLOW_COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...
         "direct release secret workflow write",
     ),
     (
+        "gh secret delete <release-secret>",
+        re.compile(
+            rf"\bgh\s+secret\s+delete\b[^\n;&|]*\b"
+            rf"(?:{RELEASE_SECRET_WRITE_GUARD_PATTERN})\b"
+        ),
+        "direct release secret workflow delete",
+    ),
+    (
         "gh api actions/secrets <release-secret> write",
         re.compile(
             rf"\bgh\s+api\b"
-            rf"(?=[^\n;&|]*\bactions/secrets\b)"
+            rf"(?=[^\n;&|]*{ACTIONS_SECRET_ENDPOINT_PATTERN})"
             rf"(?=[^\n;&|]*\b(?:{RELEASE_SECRET_WRITE_GUARD_PATTERN})\b)"
             rf"(?=[^\n;&|]*(?:\b(?:--method|-X)(?:\s+|=)"
             rf"(?:POST|PUT|PATCH)\b|"
@@ -256,7 +288,7 @@ FORBIDDEN_WORKFLOW_BLOCK_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] 
         "script actions/variables write",
         re.compile(
             rf"{SCRIPT_CLIENT_PATTERN}"
-            rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}\bactions/variables\b)"
+            rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}{ACTIONS_VARIABLE_ENDPOINT_PATTERN})"
             rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}{SCRIPT_BLOCK_MUTATION_SIGNAL_PATTERN})",
             re.IGNORECASE,
         ),
@@ -266,7 +298,7 @@ FORBIDDEN_WORKFLOW_BLOCK_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] 
         "script actions/secrets write",
         re.compile(
             rf"{SCRIPT_CLIENT_PATTERN}"
-            rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}\bactions/secrets\b)"
+            rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}{ACTIONS_SECRET_ENDPOINT_PATTERN})"
             rf"(?={SCRIPT_BLOCK_SPAN_PATTERN}{SCRIPT_BLOCK_MUTATION_SIGNAL_PATTERN})",
             re.IGNORECASE,
         ),


### PR DESCRIPTION
## **User description**
Closes #820.\n\n## Summary\n- block destructive gh variable/secret delete commands in workflow guard\n- detect environment-scoped Actions variable/secret REST endpoints\n- add regressions for CLI deletes and environment API/script bypasses\n\n## Validation\n- python scripts/check-github-workflow-permissions.py --json\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-python-script-compile.py\n- python scripts/verify-release-versions.py\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the workflow permission guard to prevent release config mutations via delete commands and environment-scoped API endpoints. Adds targeted regression tests to ensure CLI, HTTP, and script bypasses are blocked.

- **Bug Fixes**
  - Block `gh` variable and secret deletes in workflows, including release-scoped targets.
  - Detect environment-scoped Actions endpoints for variables/secrets (`environments/<env>/variables`, `environments/<env>/secrets`) across `gh api`, `curl`/HTTP, and script usage.
  - Expand guard patterns for scripted and block-style mutations, including Node `fetch` calls.

<sup>Written for commit c6b293126a6e90c3e758e84ff3b9e5318388b921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Block workflow config changes that bypass release protections**

### What Changed
- Workflow checks now block deleting protected GitHub Actions variables and secrets, not just setting them
- Requests that target environment-scoped variables and secrets are treated as protected release changes too
- Regression coverage was added for direct commands, API calls, and scripted requests that try to change these settings

### Impact
`✅ Fewer accidental release config changes`
`✅ Fewer bypasses for protected workflow settings`
`✅ Clearer blocking of unsafe variable and secret updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended security validation to detect GitHub Actions variable and secret deletions via additional command methods including API calls, HTTP requests, and dynamic variable references.

* **Tests**
  * Added comprehensive regression test coverage for new security detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->