### PR TITLE
Reject loopback custom release endpoints

### DIFF
--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -912,6 +912,39 @@ def run_custom_repository_tests(module) -> None:
     ):
         raise AssertionError("malformed custom repository endpoint URL authority failure was missing")
 
+    loopback_endpoint = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=all_custom_secrets(module),
+        variable_values={
+            module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/",
+            module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+            module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+            module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "http://127.0.0.1:9000",
+            module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+        },
+        pages_payload=None,
+        release_payload=None,
+        npm_registry_check=False,
+        **ready_governance_kwargs(),
+    )
+    if loopback_endpoint.ready:
+        raise AssertionError("loopback custom repository endpoint URL should fail")
+    parsed_loopback_endpoint = assert_safe_report(loopback_endpoint)
+    if (
+        "custom repository S3 endpoint URL must use HTTPS"
+        not in json.dumps(parsed_loopback_endpoint)
+    ):
+        raise AssertionError("loopback custom repository endpoint URL failure was missing")
+
+    normalized_loopback_endpoint = module.validate_endpoint_url(
+        "http://127.0.0.1:9000",
+        allow_loopback_http=True,
+    )
+    if normalized_loopback_endpoint != "http://127.0.0.1:9000":
+        raise AssertionError("explicit loopback endpoint allowance should normalize URL")
+
 
 def run_safe_failure_tests(module) -> None:
     invalid = module.audit_tagged_release_readiness(

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -549,7 +549,7 @@ def is_loopback_host(host: str) -> bool:
     return host in {"localhost", "127.0.0.1", "::1"} or host.startswith("127.")
 
 
-def validate_endpoint_url(raw: str) -> str:
+def validate_endpoint_url(raw: str, *, allow_loopback_http: bool = False) -> str:
     value = raw.strip()
     if not value:
         return ""
@@ -563,8 +563,10 @@ def validate_endpoint_url(raw: str) -> str:
     netloc = normalize_url_netloc(parsed, "custom repository S3 endpoint URL")
     host = (parsed.hostname or "").lower()
     scheme = parsed.scheme.lower()
-    if scheme != "https" and not (scheme == "http" and is_loopback_host(host)):
-        raise ValueError("custom repository S3 endpoint URL must use HTTPS except loopback HTTP")
+    if scheme != "https" and not (
+        allow_loopback_http and scheme == "http" and is_loopback_host(host)
+    ):
+        raise ValueError("custom repository S3 endpoint URL must use HTTPS")
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise ValueError("custom repository S3 endpoint URL path must not contain dot segments")


### PR DESCRIPTION
## **User description**
Closes #822.\n\n## Summary\n- require HTTPS for custom Linux repository S3 endpoints in tagged release readiness by default\n- keep loopback HTTP only as an explicit validator allowance for local fixtures\n- add regression coverage for loopback endpoint rejection\n\n## Validation\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-python-script-compile.py\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/verify-release-versions.py\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces HTTPS for custom Linux repository S3 endpoints during tagged release readiness. Loopback HTTP endpoints are now rejected by default, with an opt-in for local testing.

- **Bug Fixes**
  - Require HTTPS for custom S3 endpoints; block loopback HTTP by default in release checks.
  - Add `allow_loopback_http` flag to `validate_endpoint_url` for local fixtures.
  - Add regression tests to verify loopback rejection and explicit opt-in behavior.

<sup>Written for commit 2c408a307789871d29b803fab0e58753ac4bde50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Reject loopback custom release endpoints by default

### What Changed
- Custom repository endpoint URLs now must use HTTPS in release checks
- Loopback HTTP addresses like `127.0.0.1` are rejected unless they are explicitly allowed for local fixtures
- Added coverage for both the rejected loopback case and the explicit local-test allowance

### Impact
`✅ Safer release endpoint checks`
`✅ Fewer accidental local endpoint approvals`
`✅ Clearer endpoint validation failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
