### PR TITLE
Reject loopback S3 publication endpoints

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -169,6 +169,25 @@ def main() -> int:
         )
         assert_failure("bad endpoint URL", bad_endpoint, "S3 endpoint URL must use HTTPS")
 
+        loopback_endpoint = run_publisher_raw(
+            site_dir,
+            "--dry-run",
+            "--endpoint-url",
+            "http://127.0.0.1:9000",
+        )
+        assert_failure(
+            "loopback endpoint URL",
+            loopback_endpoint,
+            "S3 endpoint URL must use HTTPS",
+        )
+        publisher = load_publisher()
+        normalized_loopback_endpoint = publisher.validate_endpoint_url(
+            "http://127.0.0.1:9000",
+            allow_loopback_http=True,
+        )
+        if normalized_loopback_endpoint != "http://127.0.0.1:9000":
+            raise AssertionError("explicit loopback endpoint allowance should normalize URL")
+
         raw_dot_endpoint = run_publisher_raw(
             site_dir,
             "--dry-run",
@@ -326,6 +345,18 @@ def load_site_checker():
     spec = importlib.util.spec_from_file_location("check_hosted_linux_repository_site", SITE_CHECKER)
     if spec is None or spec.loader is None:
         raise RuntimeError("could not load hosted Linux repository site checker")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_publisher():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("publish_hosted_linux_repository_s3", PUBLISHER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load hosted Linux repository S3 publisher")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -187,7 +187,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--endpoint-url",
         default=os.environ.get("CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL", ""),
-        help="optional S3-compatible endpoint URL; HTTPS required except loopback HTTP",
+        help="optional S3-compatible endpoint URL; HTTPS required",
     )
     parser.add_argument(
         "--region",
@@ -305,7 +305,7 @@ def validate_prefix(raw: str) -> str:
     return "/".join(parts)
 
 
-def validate_endpoint_url(raw: str) -> str:
+def validate_endpoint_url(raw: str, *, allow_loopback_http: bool = False) -> str:
     value = raw.strip()
     if not value:
         return ""
@@ -319,8 +319,10 @@ def validate_endpoint_url(raw: str) -> str:
     netloc = normalize_url_netloc(parsed, "S3 endpoint URL")
     host = (parsed.hostname or "").lower()
     scheme = parsed.scheme.lower()
-    if scheme != "https" and not (scheme == "http" and is_loopback_host(host)):
-        raise PublicationError("S3 endpoint URL must use HTTPS except loopback HTTP")
+    if scheme != "https" and not (
+        allow_loopback_http and scheme == "http" and is_loopback_host(host)
+    ):
+        raise PublicationError("S3 endpoint URL must use HTTPS")
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise PublicationError("S3 endpoint URL path must not contain dot segments")


### PR DESCRIPTION
## **User description**
Closes #824.\n\n## Summary\n- require HTTPS for S3-compatible endpoint URLs in the hosted Linux repository publisher by default\n- keep loopback HTTP only as an explicit validator allowance for local fixtures\n- add regression coverage for loopback endpoint rejection\n\n## Validation\n- python scripts/check-hosted-linux-repository-s3-publication.py\n- python scripts/check-python-script-compile.py\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/verify-release-versions.py\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require HTTPS for S3-compatible publication endpoints and reject loopback HTTP by default. Added regression tests, a new `allow_loopback_http` flag in `validate_endpoint_url`, and updated `--endpoint-url` help to HTTPS-only.

<sup>Written for commit a3244b5ad1adabb9190794779d5f33dff8aacbbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject insecure S3 publication endpoints by default**

### What Changed
- The hosted Linux repository publisher now rejects non-HTTPS S3 endpoint URLs, including loopback addresses, during normal use
- Local loopback HTTP endpoints are still allowed only when explicitly enabled for validator-style checks
- The error message shown for insecure endpoints is now the same in all rejected cases
- Regression coverage was added for loopback endpoint rejection and the explicit allowance path

### Impact
`✅ Fewer insecure repository publication configs`
`✅ Clearer endpoint validation errors`
`✅ Safer local publishing defaults`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
