### PR TITLE
Reject unsafe custom repository URLs

### DIFF
--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -79,6 +79,10 @@ def main() -> int:
                 (f"{base_url}:", "authority"),
                 ("http://:443/conu", "host"),
                 (f"{base_url}:443x", "authority"),
+                ("https://packages.example.com%20.evil/conu", "authority"),
+                ("https://packages.example.com%40evil.test/conu", "authority"),
+                ("https://packages.example.com\\evil.test/conu", "authority"),
+                (f"{base_url}/%00", "whitespace or control characters"),
             ):
                 run_checker_expect_failure(
                     bad_url,
@@ -200,6 +204,27 @@ def main() -> int:
             run_checker_expect_failure(
                 base_url,
                 "path must not contain dot segments",
+                "--expected-version",
+                VERSION,
+            )
+
+        control_download_url = temp / "control-download-url"
+        shutil.copytree(site_root, control_download_url)
+        with serve_site(control_download_url, mode="good") as base_url:
+            rewrite_base_url(control_download_url, PLACEHOLDER_BASE_URL, base_url)
+            repository_path = control_download_url / "repository.json"
+            repository = json.loads(repository_path.read_text(encoding="ascii"))
+            repository["downloads"]["hostedBundleUrl"] = repository["downloads"][
+                "hostedBundleUrl"
+            ].replace("/downloads/", "/downloads/%00/")
+            repository_path.write_text(
+                json.dumps(repository, indent=2, sort_keys=True) + "\n",
+                encoding="ascii",
+                newline="\n",
+            )
+            run_checker_expect_failure(
+                base_url,
+                "whitespace or control characters",
                 "--expected-version",
                 VERSION,
             )

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -259,6 +259,9 @@ def normalize_base_url(raw_value: str, *, allow_loopback_http: bool) -> str:
         raise EndpointReadinessError("hosted Linux repository base URL authority is invalid") from exc
     if not host:
         raise EndpointReadinessError("hosted Linux repository base URL must include a host")
+    raw_authority = parsed.netloc.rsplit("@", 1)[-1]
+    if has_url_authority_control(raw_authority) or has_url_authority_control(host):
+        raise EndpointReadinessError("hosted Linux repository base URL authority is invalid")
     scheme = parsed.scheme.lower()
     host_lower = host.lower()
     if scheme != "https":
@@ -276,6 +279,10 @@ def normalize_base_url(raw_value: str, *, allow_loopback_http: bool) -> str:
     if any("/" in part or "\\" in part for part in decoded_path_parts):
         raise EndpointReadinessError(
             "hosted Linux repository base URL path must not contain encoded separators"
+        )
+    if any(has_url_path_control(part) for part in decoded_path_parts):
+        raise EndpointReadinessError(
+            "hosted Linux repository base URL path must not contain whitespace or control characters"
         )
     path = "/" + "/".join(path_parts) if path_parts else ""
     netloc = normalize_netloc(host_lower, port)
@@ -307,6 +314,14 @@ def is_loopback_host(host: str) -> bool:
         return socket.gethostbyname(host).startswith("127.")
     except OSError:
         return False
+
+
+def has_url_authority_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 or char in {"\\", "%"} for char in value)
+
+
+def has_url_path_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 for char in value)
 
 
 def fetch_path(
@@ -482,6 +497,8 @@ def validate_repository_path(path: str, label: str) -> str:
     parts = path.split("/")
     if any(part in {"", ".", ".."} for part in parts[1:]):
         raise EndpointReadinessError(f"{label} must not contain empty or dot segments")
+    if any(has_url_path_control(part) for part in parts[1:]):
+        raise EndpointReadinessError(f"{label} must not contain whitespace or control characters")
     forbidden = sorted({part.lower() for part in parts[1:]} & FORBIDDEN_PATH_SEGMENTS)
     if forbidden:
         raise EndpointReadinessError(
@@ -628,6 +645,8 @@ def url_to_base_path(base_url: str, value: str, label: str) -> str:
         raise EndpointReadinessError(f"{label} path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_path_parts):
         raise EndpointReadinessError(f"{label} path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_path_parts):
+        raise EndpointReadinessError(f"{label} path must not contain whitespace or control characters")
     forbidden = sorted({part.lower() for part in decoded_path_parts} & FORBIDDEN_PATH_SEGMENTS)
     if forbidden:
         raise EndpointReadinessError(

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -55,12 +55,20 @@ def main() -> int:
             "https://imthegoodboy.github.io:/conU",
             "https://:443/conU",
             "https://imthegoodboy.github.io:443x/conU",
+            "https://imthegoodboy.github.io%20.evil/conU",
+            "https://imthegoodboy.github.io%40evil.test/conU",
+            "https://imthegoodboy.github.io\\evil.test/conU",
         ):
             expect_action_failure(
                 lambda bad_url=bad_url: preparer.validate_repository_base_url(bad_url),
                 "authority",
                 "malformed repository base URL authority",
             )
+        expect_action_failure(
+            lambda: preparer.validate_repository_base_url(f"{BASE_URL}/%00"),
+            "whitespace or control characters",
+            "control repository base URL path",
+        )
         expect_zip_bound_failure(
             preparer,
             site,
@@ -306,6 +314,30 @@ def main() -> int:
             "baseUrl path must not contain encoded separators",
         )
 
+        control_base = temp / "control-base"
+        shutil.copytree(dist, control_base)
+        repository = read_site_json(control_base / SITE_BUNDLE)
+        cache_policy = read_site_json_member(control_base / SITE_BUNDLE, "cache-policy.json")
+        control_url = f"{BASE_URL}/%00"
+        rewrite_repository_base_url(repository, control_url)
+        cache_policy["baseUrl"] = control_url
+        rewrite_site_zip(
+            control_base / SITE_BUNDLE,
+            {
+                "repository.json": json.dumps(repository, indent=2, sort_keys=True).encode("ascii")
+                + b"\n",
+                "cache-policy.json": json.dumps(cache_policy, indent=2, sort_keys=True).encode("ascii")
+                + b"\n",
+            },
+        )
+        sign_site(control_base / SITE_BUNDLE)
+        expect_failure(
+            "control repository base URL",
+            control_base / SITE_BUNDLE,
+            temp / "control-base-pages",
+            "baseUrl path must not contain whitespace or control characters",
+        )
+
         off_origin_key = temp / "off-origin-key"
         shutil.copytree(dist, off_origin_key)
         repository = read_site_json(off_origin_key / SITE_BUNDLE)
@@ -354,6 +386,24 @@ def main() -> int:
             escaped_download / SITE_BUNDLE,
             temp / "escaped-download-pages",
             "repository.json downloads.hostedBundleUrl path must not contain dot segments",
+        )
+
+        control_download = temp / "control-download"
+        shutil.copytree(dist, control_download)
+        repository = read_site_json(control_download / SITE_BUNDLE)
+        repository["downloads"]["hostedBundleUrl"] = repository["downloads"][
+            "hostedBundleUrl"
+        ].replace("/downloads/", "/downloads/%00/")
+        rewrite_site_zip(
+            control_download / SITE_BUNDLE,
+            {"repository.json": json.dumps(repository, indent=2, sort_keys=True).encode("ascii") + b"\n"},
+        )
+        sign_site(control_download / SITE_BUNDLE)
+        expect_failure(
+            "control download URL",
+            control_download / SITE_BUNDLE,
+            temp / "control-download-pages",
+            "repository.json downloads.hostedBundleUrl path must not contain whitespace or control characters",
         )
 
         non_empty_output = temp / "non-empty"

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -113,6 +113,35 @@ def main() -> int:
                 "repository base URL authority",
             )
 
+        for bad_url in (
+            "https://packages.example.com%20.evil/conu",
+            "https://packages.example.com%40evil.test/conu",
+            "https://packages.example.com\\evil.test/conu",
+        ):
+            unsafe_base_authority = run_publisher_raw(
+                site_dir,
+                "--dry-run",
+                "--base-url",
+                bad_url,
+            )
+            assert_failure(
+                "unsafe repository base URL authority",
+                unsafe_base_authority,
+                "repository base URL authority",
+            )
+
+        control_base_path = run_publisher_raw(
+            site_dir,
+            "--dry-run",
+            "--base-url",
+            f"{BASE_URL}/%00",
+        )
+        assert_failure(
+            "control repository base URL path",
+            control_base_path,
+            "whitespace or control characters",
+        )
+
         query_download_url = temp / "query-download-url-site"
         shutil.copytree(site_dir, query_download_url)
         repository_path = query_download_url / "repository.json"
@@ -241,6 +270,43 @@ def main() -> int:
                 malformed_endpoint,
                 "S3 endpoint URL authority",
             )
+
+        for bad_url in (
+            "https://s3.example.com%20.evil/api",
+            "https://s3.example.com%40evil.test/api",
+            "https://s3.example.com\\evil.test/api",
+        ):
+            unsafe_endpoint_authority = run_publisher_raw(
+                site_dir,
+                "--dry-run",
+                "--endpoint-url",
+                bad_url,
+            )
+            assert_failure(
+                "unsafe endpoint URL authority",
+                unsafe_endpoint_authority,
+                "S3 endpoint URL authority",
+            )
+
+        control_endpoint_path = run_publisher_raw(
+            site_dir,
+            "--dry-run",
+            "--endpoint-url",
+            "https://s3.example.com/api/%00/v1",
+        )
+        assert_failure(
+            "control endpoint URL path",
+            control_endpoint_path,
+            "whitespace or control characters",
+        )
+
+        unsafe_region = run_publisher_raw(
+            site_dir,
+            "--dry-run",
+            "--region",
+            "us-east-1;rm",
+        )
+        assert_failure("unsafe AWS region", unsafe_region, "AWS region contains unsupported characters")
 
         oversized_metadata = temp / "oversized-metadata-site"
         shutil.copytree(site_dir, oversized_metadata)
@@ -578,6 +644,28 @@ def assert_preflight() -> None:
         "single-line secret value",
     ):
         if expected not in rendered:
+            raise AssertionError(f"custom repository preflight missed {expected!r}")
+
+    unsafe_env = preflight_env()
+    unsafe_env["CONU_LINUX_REPOSITORY_BASE_URL"] = (
+        "https://packages.example.com%40evil.test/conu"
+    )
+    unsafe_env["CONU_LINUX_REPOSITORY_S3_ENDPOINT_URL"] = (
+        "https://s3.example.com%20.evil/api"
+    )
+    unsafe_env["CONU_LINUX_REPOSITORY_AWS_REGION"] = "us-east-1;rm"
+    unsafe = run_preflight_raw(unsafe_env)
+    if unsafe.returncode == 0:
+        raise AssertionError("unsafe custom repository preflight config unexpectedly passed")
+    unsafe_report = json.loads(unsafe.stdout)
+    assert_safe_preflight_report(unsafe_report)
+    unsafe_rendered = json.dumps(unsafe_report)
+    for expected in (
+        "custom repository base URL authority is invalid",
+        "custom repository S3 endpoint URL authority is invalid",
+        "custom repository AWS region contains unsupported characters",
+    ):
+        if expected not in unsafe_rendered:
             raise AssertionError(f"custom repository preflight missed {expected!r}")
 
 

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -318,6 +318,20 @@ def main() -> int:
                 "authority",
             )
 
+        for index, bad_url in enumerate((
+            "https://packages.example.com%20.evil/conu",
+            "https://packages.example.com%40evil.test/conu",
+            "https://packages.example.com\\evil.test/conu",
+        )):
+            unsafe_url = temp / f"unsafe-authority-url-{index}"
+            shutil.copytree(dist, unsafe_url)
+            expect_failure(
+                "unsafe base URL authority",
+                unsafe_url,
+                bad_url,
+                "authority",
+            )
+
         encoded_base_url = temp / "encoded-base-url"
         shutil.copytree(dist, encoded_base_url)
         expect_failure(
@@ -325,6 +339,15 @@ def main() -> int:
             encoded_base_url,
             f"{BASE_URL}/%2e%2e%2fother",
             "path must not contain encoded separators",
+        )
+
+        control_base_url = temp / "control-base-url"
+        shutil.copytree(dist, control_base_url)
+        expect_failure(
+            "control base URL path",
+            control_base_url,
+            f"{BASE_URL}/%00",
+            "whitespace or control characters",
         )
 
     print("Hosted Linux repository site regression checks passed")

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -834,6 +834,27 @@ def run_custom_repository_tests(module) -> None:
     ):
         raise AssertionError("malformed custom repository base URL authority failure was missing")
 
+    for bad_base_url in (
+        "https://packages.example.com%20.evil/conu",
+        "https://packages.example.com%40evil.test/conu",
+        "https://packages.example.com\\evil.test/conu",
+    ):
+        try:
+            module.normalize_custom_base_url(bad_base_url)
+        except ValueError as exc:
+            if "custom repository base URL authority is invalid" not in str(exc):
+                raise AssertionError(f"unexpected custom base URL authority failure: {exc}")
+        else:
+            raise AssertionError(f"unsafe custom base URL authority unexpectedly passed: {bad_base_url}")
+
+    try:
+        module.normalize_custom_base_url("https://packages.example.com/conu/%00/v0.1.0")
+    except ValueError as exc:
+        if "whitespace or control characters" not in str(exc):
+            raise AssertionError(f"unexpected custom base URL path failure: {exc}")
+    else:
+        raise AssertionError("custom base URL with encoded control path unexpectedly passed")
+
     invalid_endpoint_paths = module.audit_tagged_release_readiness(
         repo="owner/repo",
         tag=TAG,
@@ -911,6 +932,35 @@ def run_custom_repository_tests(module) -> None:
         not in json.dumps(parsed_invalid_endpoint_authority)
     ):
         raise AssertionError("malformed custom repository endpoint URL authority failure was missing")
+
+    for bad_endpoint in (
+        "https://s3.example.com%20.evil/api",
+        "https://s3.example.com%40evil.test/api",
+        "https://s3.example.com\\evil.test/api",
+    ):
+        try:
+            module.validate_endpoint_url(bad_endpoint)
+        except ValueError as exc:
+            if "custom repository S3 endpoint URL authority is invalid" not in str(exc):
+                raise AssertionError(f"unexpected custom endpoint authority failure: {exc}")
+        else:
+            raise AssertionError(f"unsafe custom endpoint authority unexpectedly passed: {bad_endpoint}")
+
+    try:
+        module.validate_endpoint_url("https://s3.example.com/api/%00/v1")
+    except ValueError as exc:
+        if "whitespace or control characters" not in str(exc):
+            raise AssertionError(f"unexpected custom endpoint path failure: {exc}")
+    else:
+        raise AssertionError("custom endpoint URL with encoded control path unexpectedly passed")
+
+    try:
+        module.validate_region("us-east-1;rm")
+    except ValueError as exc:
+        if "unsupported characters" not in str(exc):
+            raise AssertionError(f"unexpected custom region failure: {exc}")
+    else:
+        raise AssertionError("custom AWS region with unsafe punctuation unexpectedly passed")
 
     loopback_endpoint = module.audit_tagged_release_readiness(
         repo="owner/repo",

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -33,6 +33,7 @@ from github_release_secrets import (
 ROOT = Path(__file__).resolve().parents[1]
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,253}[A-Za-z0-9]$")
+SAFE_REGION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 CUSTOM_REPOSITORY_BASE_URL_VAR = "CONU_LINUX_REPOSITORY_BASE_URL"
 CUSTOM_REPOSITORY_BUCKET_VAR = "CONU_LINUX_REPOSITORY_S3_BUCKET"
 CUSTOM_REPOSITORY_PREFIX_VAR = "CONU_LINUX_REPOSITORY_S3_PREFIX"
@@ -516,6 +517,8 @@ def normalize_custom_base_url(raw: str) -> str:
         raise ValueError("custom repository base URL path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise ValueError("custom repository base URL path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise ValueError("custom repository base URL path must not contain whitespace or control characters")
     path = "/" + "/".join(parts) if parts else ""
     return urlunparse(("https", netloc, path, "", "", ""))
 
@@ -575,6 +578,10 @@ def validate_endpoint_url(raw: str, *, allow_loopback_http: bool = False) -> str
         raise ValueError("custom repository S3 endpoint URL path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise ValueError("custom repository S3 endpoint URL path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise ValueError(
+            "custom repository S3 endpoint URL path must not contain whitespace or control characters"
+        )
     path = "/" + "/".join(parts) if parts else ""
     return urlunparse((scheme, netloc, path, "", "", ""))
 
@@ -588,6 +595,9 @@ def normalize_url_netloc(parsed, label: str) -> str:
     if not host:
         raise ValueError(f"{label} authority must include a host")
     if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise ValueError(f"{label} authority is invalid")
+    raw_authority = parsed.netloc.rsplit("@", 1)[-1]
+    if has_url_authority_control(raw_authority) or has_url_authority_control(host):
         raise ValueError(f"{label} authority is invalid")
     host = host.lower()
     if ":" in host and not host.startswith("["):
@@ -605,7 +615,17 @@ def validate_region(raw: str) -> str:
         raise ValueError("custom repository AWS region must not contain whitespace")
     if "/" in region or "\\" in region or "?" in region or "#" in region:
         raise ValueError("custom repository AWS region must be a region name, not a URL or path")
+    if not SAFE_REGION_RE.fullmatch(region):
+        raise ValueError("custom repository AWS region contains unsupported characters")
     return region
+
+
+def has_url_authority_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 or char in {"\\", "%"} for char in value)
+
+
+def has_url_path_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 for char in value)
 
 
 def audit_linux_repository(

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -199,6 +199,10 @@ def validate_base_url(raw: str) -> str:
         raise SystemExit("hosted Linux repository base URL path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise SystemExit("hosted Linux repository base URL path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise SystemExit(
+            "hosted Linux repository base URL path must not contain whitespace or control characters"
+        )
     normalized_path = "/" + "/".join(parts) if parts else ""
     return urlunparse(("https", netloc, normalized_path, "", "", ""))
 
@@ -213,12 +217,23 @@ def normalize_url_netloc(parsed, label: str) -> str:
         raise SystemExit(f"{label} authority must include a host")
     if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
         raise SystemExit(f"{label} authority is invalid")
+    raw_authority = parsed.netloc.rsplit("@", 1)[-1]
+    if has_url_authority_control(raw_authority) or has_url_authority_control(host):
+        raise SystemExit(f"{label} authority is invalid")
     host = host.lower()
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     if port is None:
         return host
     return f"{host}:{port}"
+
+
+def has_url_authority_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 or char in {"\\", "%"} for char in value)
+
+
+def has_url_path_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 for char in value)
 
 
 def hosted_repository_bundle_filename(version: str) -> str:

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -522,6 +522,10 @@ def validate_repository_base_url(raw: str) -> str:
         raise SystemExit("repository.json baseUrl path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise SystemExit("repository.json baseUrl path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise SystemExit(
+            "repository.json baseUrl path must not contain whitespace or control characters"
+        )
     normalized_path = "/" + "/".join(path_parts) if path_parts else ""
     return urlunparse(("https", netloc, normalized_path, "", "", ""))
 
@@ -535,6 +539,9 @@ def normalize_url_netloc(parsed, label: str) -> str:
     if not host:
         raise SystemExit(f"{label} authority must include a host")
     if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise SystemExit(f"{label} authority is invalid")
+    raw_authority = parsed.netloc.rsplit("@", 1)[-1]
+    if has_url_authority_control(raw_authority) or has_url_authority_control(host):
         raise SystemExit(f"{label} authority is invalid")
     host = host.lower()
     if ":" in host and not host.startswith("["):
@@ -568,6 +575,8 @@ def url_to_base_path(base_url: str, value: object, label: str) -> str:
         raise SystemExit(f"{label} path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise SystemExit(f"{label} path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise SystemExit(f"{label} path must not contain whitespace or control characters")
     forbidden = sorted({part.lower() for part in decoded_parts} & FORBIDDEN_SEGMENTS)
     if forbidden:
         raise SystemExit(
@@ -594,10 +603,20 @@ def validate_repository_path(path: str, label: str) -> str:
     parts = path.split("/")
     if any(part in {"", ".", ".."} for part in parts[1:]):
         raise SystemExit(f"{label} must not contain empty or dot segments")
+    if any(has_url_path_control(part) for part in parts[1:]):
+        raise SystemExit(f"{label} must not contain whitespace or control characters")
     forbidden = sorted({part.lower() for part in parts[1:]} & FORBIDDEN_SEGMENTS)
     if forbidden:
         raise SystemExit(f"{label} contains forbidden local-state segment: {', '.join(forbidden)}")
     return path
+
+
+def has_url_authority_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 or char in {"\\", "%"} for char in value)
+
+
+def has_url_path_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 for char in value)
 
 
 def validate_cache_policy_json(version: str, base_url: str, data: bytes) -> None:

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -33,6 +33,7 @@ MAX_TOTAL_BYTES = 4 * 1024 * 1024 * 1024
 MAX_CACHE_CONTROL_BYTES = 256
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,253}[A-Za-z0-9]$")
+SAFE_REGION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 FORBIDDEN_SEGMENTS = {
@@ -238,6 +239,7 @@ def build_publish_plan(args: argparse.Namespace) -> PublishPlan:
     bucket = validate_bucket(args.bucket)
     prefix = validate_prefix(args.prefix)
     validate_endpoint_url(args.endpoint_url)
+    validate_region(args.region)
     if args.post_upload_retries < 1:
         raise PublicationError("--post-upload-retries must be at least 1")
     if args.post_upload_retry_seconds < 0:
@@ -331,6 +333,8 @@ def validate_endpoint_url(raw: str, *, allow_loopback_http: bool = False) -> str
         raise PublicationError("S3 endpoint URL path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise PublicationError("S3 endpoint URL path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise PublicationError("S3 endpoint URL path must not contain whitespace or control characters")
     path = "/" + "/".join(parts) if parts else ""
     return urlunparse((scheme, netloc, path, "", "", ""))
 
@@ -357,6 +361,8 @@ def validate_base_url(raw: str) -> str:
         raise PublicationError("repository base URL path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise PublicationError("repository base URL path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise PublicationError("repository base URL path must not contain whitespace or control characters")
     normalized_path = "/" + "/".join(parts) if parts else ""
     return urlunparse(("https", netloc, normalized_path, "", "", ""))
 
@@ -371,12 +377,36 @@ def normalize_url_netloc(parsed, label: str) -> str:
         raise PublicationError(f"{label} authority must include a host")
     if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
         raise PublicationError(f"{label} authority is invalid")
+    raw_authority = parsed.netloc.rsplit("@", 1)[-1]
+    if has_url_authority_control(raw_authority) or has_url_authority_control(host):
+        raise PublicationError(f"{label} authority is invalid")
     host = host.lower()
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     if port is None:
         return host
     return f"{host}:{port}"
+
+
+def validate_region(raw: str) -> str:
+    region = raw.strip()
+    if not region:
+        return ""
+    if any(char.isspace() for char in region):
+        raise PublicationError("AWS region must not contain whitespace")
+    if "/" in region or "\\" in region or "?" in region or "#" in region:
+        raise PublicationError("AWS region must be a region name, not a URL or path")
+    if not SAFE_REGION_RE.fullmatch(region):
+        raise PublicationError("AWS region contains unsupported characters")
+    return region
+
+
+def has_url_authority_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 or char in {"\\", "%"} for char in value)
+
+
+def has_url_path_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 for char in value)
 
 
 def read_json_file(path: Path, label: str) -> dict[str, Any]:
@@ -464,6 +494,8 @@ def url_to_base_path(base_url: str, value: str, label: str) -> str:
         raise PublicationError(f"{label} path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_path_parts):
         raise PublicationError(f"{label} path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_path_parts):
+        raise PublicationError(f"{label} path must not contain whitespace or control characters")
     forbidden = sorted({part.lower() for part in decoded_path_parts} & FORBIDDEN_SEGMENTS)
     if forbidden:
         raise PublicationError(
@@ -540,6 +572,8 @@ def validate_cache_path(path: str, label: str) -> str:
     parts = path.split("/")
     if any(part in {"", ".", ".."} for part in parts[1:]):
         raise PublicationError(f"{label} must not contain empty or dot segments")
+    if any(has_url_path_control(part) for part in parts[1:]):
+        raise PublicationError(f"{label} must not contain whitespace or control characters")
     forbidden = sorted({part.lower() for part in parts[1:]} & FORBIDDEN_SEGMENTS)
     if forbidden:
         raise PublicationError(
@@ -773,8 +807,9 @@ def publish_plan(plan: PublishPlan, args: argparse.Namespace) -> None:
     endpoint_url = validate_endpoint_url(args.endpoint_url)
     if endpoint_url:
         global_args.extend(["--endpoint-url", endpoint_url])
-    if args.region.strip():
-        global_args.extend(["--region", args.region.strip()])
+    region = validate_region(args.region)
+    if region:
+        global_args.extend(["--region", region])
     for file in plan.files:
         label = f"site file {file.relative_path}"
         handle, size = open_regular_file(file.path, label, max_bytes=MAX_FILE_BYTES)


### PR DESCRIPTION
## **User description**
Closes #826.\n\n## Summary\n- reject percent-encoded, backslash, whitespace/control custom repository URL authorities before release site generation, endpoint checks, Pages prep, tagged readiness, and S3 publication\n- reject decoded whitespace/control path segments in custom repository base, endpoint, and declared asset URLs\n- restrict custom S3 AWS region config to a safe region token before preflight/publication\n\n## Validation\n- python scripts/check-python-script-compile.py\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-hosted-linux-repository-site.py\n- python scripts/check-hosted-linux-repository-pages.py\n- python scripts/check-hosted-linux-repository-endpoint-regression.py\n- python scripts/check-hosted-linux-repository-s3-publication.py\n- python scripts/verify-release-versions.py\n- python scripts/check-github-workflow-permissions-regression.py\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened custom repository configuration by rejecting unsafe URL authorities/paths and enforcing a safe AWS region token across site generation, release readiness checks, Pages prep, endpoint checks, and S3 publication. This blocks control characters, backslashes, and percent-encoded tricks to prevent misrouting and unsafe releases.

- **Bug Fixes**
  - Reject percent-encoded, backslash, and whitespace/control characters in URL authorities for base and S3 endpoint URLs.
  - Reject whitespace/control characters in decoded path segments for base URLs, endpoints, cache paths, and download/asset URLs.
  - Enforce a safe AWS region pattern; reject whitespace, URL-like values, and unsupported characters.
  - Added regression and preflight tests covering the new rejection cases.

- **Migration**
  - Ensure any custom base URL, endpoint URL, and AWS region values meet these rules; otherwise generation, preflight, Pages prep, or publication will fail.

<sup>Written for commit eb8c7ca75b69921abbb6f42a2e2f7c0c19717bcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject unsafe custom repository URLs and invalid AWS regions**

### What Changed
- Custom repository base URLs and S3 endpoint URLs now reject unsafe hostnames and paths, including percent-encoded tricks, backslashes, and hidden control characters.
- Repository paths in generated sites, Pages output, endpoint checks, and publication steps now reject encoded control characters in URL paths.
- Custom AWS region values now accept only simple region names, blocking malformed values like URL-like text or shell-like punctuation.

### Impact
`✅ Fewer unsafe repository configurations`
`✅ Clearer release readiness failures`
`✅ Fewer publication and Pages setup errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation to reject control characters, backslashes, and percent-encoded unsafe patterns in repository base URLs and endpoint URLs across all hosted Linux and S3 publication scripts.
  * Added AWS region validation to prevent unsupported characters.
  * Improved detection and rejection of null bytes and whitespace in URL paths and authorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->