### PR TITLE
Reject unsafe release update URLs

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -10273,6 +10273,15 @@ fn parse_https_update_url(
             "release update policy {label} must not include credentials"
         ));
     }
+    if authority
+        .as_bytes()
+        .iter()
+        .any(|byte| is_update_url_authority_control(*byte))
+    {
+        return Err(format!(
+            "release update policy {label} authority is invalid"
+        ));
+    }
     if authority.chars().any(char::is_whitespace)
         || path_and_query.chars().any(char::is_whitespace)
         || path_and_query.contains('\\')
@@ -10350,8 +10359,21 @@ fn validate_update_url_path(path_and_query: &str, label: &str) -> Result<(), Str
                 "release update policy {label} path must not contain encoded separators"
             ));
         }
+        if decoded.iter().any(|byte| is_update_url_path_control(*byte)) {
+            return Err(format!(
+                "release update policy {label} path must not contain whitespace or control characters"
+            ));
+        }
     }
     Ok(())
+}
+
+fn is_update_url_authority_control(value: u8) -> bool {
+    value <= b' ' || value == 0x7f || value == b'\\' || value == b'%'
+}
+
+fn is_update_url_path_control(value: u8) -> bool {
+    value <= b' ' || value == 0x7f
 }
 
 fn percent_decode_update_path_segment(segment: &str, label: &str) -> Result<Vec<u8>, String> {
@@ -11841,6 +11863,9 @@ mod tests {
             "https://github.com:bad/conu-0.1.0-update-policy.json",
             "https://github.com:443x/conu-0.1.0-update-policy.json",
             "https://:443/conu-0.1.0-update-policy.json",
+            "https://github.com%20.evil/conu-0.1.0-update-policy.json",
+            "https://github.com%40evil.test/conu-0.1.0-update-policy.json",
+            "https://github.com\\evil.test/conu-0.1.0-update-policy.json",
         ] {
             let output = run(["update", "check", "--policy-url", url]);
 
@@ -11861,6 +11886,9 @@ mod tests {
             "https://github.com:bad/releases/download/v0.1.0",
             "https://github.com:443x/releases/download/v0.1.0",
             "https://:443/releases/download/v0.1.0",
+            "https://github.com%20.evil/releases/download/v0.1.0",
+            "https://github.com%40evil.test/releases/download/v0.1.0",
+            "https://github.com\\evil.test/releases/download/v0.1.0",
         ] {
             let error =
                 validate_public_https_url(url, "releaseBaseUrl").expect_err("URL should fail");
@@ -11891,6 +11919,10 @@ mod tests {
                 "https://github.com/imthegoodboy/conU/releases/download/bad%zz/conu-0.1.0-update-policy.json",
                 "URL is invalid",
             ),
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/v0.1.0/%00/conu-0.1.0-update-policy.json",
+                "whitespace or control characters",
+            ),
         ] {
             let output = run(["update", "check", "--policy-url", url]);
 
@@ -11914,6 +11946,10 @@ mod tests {
             (
                 "https://github.com/imthegoodboy/conU/releases/download/v0.1.0%2fother",
                 "path must not contain encoded separators",
+            ),
+            (
+                "https://github.com/imthegoodboy/conU/releases/download/v0.1.0/%00",
+                "whitespace or control characters",
             ),
         ] {
             let error =

--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -210,6 +210,18 @@ def main() -> int:
                 release_base_url=bad_url,
             )
 
+        for bad_url in (
+            "https://github.com%20.evil/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://github.com%40evil.test/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://github.com\\evil.test/imthegoodboy/conU/releases/download/v0.1.0",
+        ):
+            expect_failure(
+                "unsafe release base URL authority",
+                dist,
+                "authority",
+                release_base_url=bad_url,
+            )
+
         expect_failure(
             "release base URL with raw dot segment",
             dist,
@@ -229,6 +241,13 @@ def main() -> int:
             dist,
             "path must not contain encoded separators",
             release_base_url="https://github.com/imthegoodboy/conU/releases/download/v0.1.0%2fother",
+        )
+
+        expect_failure(
+            "release base URL with encoded control path",
+            dist,
+            "whitespace or control characters",
+            release_base_url="https://github.com/imthegoodboy/conU/releases/download/v0.1.0/%00",
         )
 
         expect_failure(

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -237,6 +237,10 @@ def validate_release_base_url(raw: str, repo: str, tag: str) -> str:
         raise SystemExit("release update policy base URL path must not contain dot segments")
     if any("/" in part or "\\" in part for part in decoded_parts):
         raise SystemExit("release update policy base URL path must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise SystemExit(
+            "release update policy base URL path must not contain whitespace or control characters"
+        )
     normalized_path = "/" + "/".join(parts) if parts else ""
     return urlunparse(("https", netloc, normalized_path, "", "", ""))
 
@@ -251,12 +255,23 @@ def normalize_url_netloc(parsed, label: str) -> str:
         raise SystemExit(f"{label} authority must include a host")
     if port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
         raise SystemExit(f"{label} authority is invalid")
+    raw_authority = parsed.netloc.rsplit("@", 1)[-1]
+    if has_url_authority_control(raw_authority) or has_url_authority_control(host):
+        raise SystemExit(f"{label} authority is invalid")
     host = host.lower()
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     if port is None:
         return host
     return f"{host}:{port}"
+
+
+def has_url_authority_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 or char in {"\\", "%"} for char in value)
+
+
+def has_url_path_control(value: str) -> bool:
+    return any(ord(char) <= 32 or ord(char) == 127 for char in value)
 
 
 def build_update_policy(


### PR DESCRIPTION
## **User description**
Closes #828.\n\n## Summary\n- reject percent-encoded and backslash authority shapes in generated release update policy base URLs\n- reject decoded whitespace/control path segments in generated update policy URLs\n- apply the same fail-closed checks in the installed Rust update URL validator\n\n## Validation\n- python scripts/check-python-script-compile.py\n- python scripts/check-release-update-policy.py\n- python scripts/check-release-update-download-gate.py\n- python scripts/verify-release-versions.py\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-github-workflow-permissions-regression.py\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions\n- cargo fmt --all -- --check\n- git diff --check\n\nLocal Rust test/check execution was attempted but this Windows workstation is missing both GNU dlltool.exe and MSVC link.exe. The PR CI Rust matrix should cover the added Rust unit tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened release update URL generation and validation to reject unsafe authorities and control-character paths. Aligns the Python policy generator and Rust `conu-cli` validator on the same fail-closed rules to prevent malformed or spoofed URLs.

- **Bug Fixes**
  - `scripts/generate-release-update-policy.py`: Reject authorities with `%`, `\`, or control/whitespace; reject decoded whitespace/control in path segments.
  - `scripts/check-release-update-policy.py`: Add negative tests for encoded/backslash authorities and control-character paths.
  - `crates/conu-cli/src/lib.rs`: Forbid credentials, `%`/`\`, and control/whitespace in authority; reject decoded whitespace/control bytes in path; add unit tests for new failure cases.

<sup>Written for commit f8a2cff09fd6f232c1b22a5ec1a8e23ac16ef9b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Block unsafe release update URLs in generated policies and checks

### What Changed
- Release update URLs now reject suspicious authority values such as encoded spaces, encoded email signs, backslashes, and control characters
- Release update URL paths now reject encoded null bytes and other whitespace or control characters, in addition to dot segments and encoded separators
- The policy generator and validation checks now fail on the same unsafe URL shapes, with matching test coverage

### Impact
`✅ Safer release update links`
`✅ Fewer malformed policy files`
`✅ Lower risk of accepting attacker-crafted update URLs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
