### PR TITLE
Stabilize direct QUIC delivery timeout

### DIFF
--- a/crates/conu-core/src/direct_transport.rs
+++ b/crates/conu-core/src/direct_transport.rs
@@ -36,6 +36,7 @@ use crate::trust::{self, TrustStatus, TrustedPeer};
 
 const DIRECT_VERSION: &str = "1";
 pub(crate) const DEFAULT_DIRECT_TIMEOUT_MS: u64 = 2_000;
+const DEFAULT_DIRECT_DELIVERY_TIMEOUT_MS: u64 = 5_000;
 const MAX_DIRECT_FRAME_BYTES: usize = 80 * 1024;
 const MAX_DIRECT_PAYLOAD_BYTES: usize = 64 * 1024;
 
@@ -523,11 +524,8 @@ fn send_direct_envelope(
     validate_direct_peer_endpoint(endpoint)?;
     let envelope_id = frame.envelope_id.to_string();
     let request = render_direct_frame(frame);
-    let response = direct_client_round_trip(
-        endpoint,
-        request.as_bytes(),
-        Duration::from_millis(DEFAULT_DIRECT_TIMEOUT_MS),
-    )?;
+    let response =
+        direct_client_round_trip(endpoint, request.as_bytes(), direct_delivery_timeout())?;
     let values = parse_direct_response(&response)?;
     if value_or_empty(&values, "type") != "direct_ack" {
         return Err(DirectTransportError::InvalidRequest {
@@ -548,6 +546,10 @@ fn send_direct_envelope(
     }
     record_direct_log(paths, "ack_received", &envelope_id, &peer.peer_node_id, 0);
     Ok(values)
+}
+
+fn direct_delivery_timeout() -> Duration {
+    Duration::from_millis(DEFAULT_DIRECT_DELIVERY_TIMEOUT_MS)
 }
 
 async fn accept_direct_frames(
@@ -1591,6 +1593,12 @@ mod tests {
         assert!(validate_direct_peer_endpoint("quic://224.0.0.1:9443").is_err());
         assert!(validate_direct_peer_endpoint("quic://[ff02::1]:9443").is_err());
         assert!(validate_direct_peer_endpoint("quic://255.255.255.255:9443").is_err());
+    }
+
+    #[test]
+    fn direct_delivery_timeout_is_longer_than_route_probe_timeout() {
+        assert!(direct_delivery_timeout() > Duration::from_millis(DEFAULT_DIRECT_TIMEOUT_MS));
+        assert!(direct_delivery_timeout() >= direct_quic_test_timeout());
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #830

Summary:
- split direct delivery timeout from the faster route probe timeout
- give direct message/stream ACK reads a 5s delivery window on slower runners
- add a regression assertion that delivery timeout stays above the probe timeout/test window

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo test -p conu-core direct_delivery_timeout_is_longer_than_route_probe_timeout --lib (blocked locally: MSVC link.exe is missing; PR CI runs the Rust matrix)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes direct QUIC delivery by separating the delivery timeout from the faster route probe timeout. Uses a 5s ACK read window to reduce flakiness on slower runners.

- **Bug Fixes**
  - Split delivery timeout and probe timeout; `send_direct_envelope` now uses `direct_delivery_timeout()`.
  - Set `DEFAULT_DIRECT_DELIVERY_TIMEOUT_MS` to 5000 ms for ACKs.
  - Added a regression test to ensure delivery timeout > probe timeout and >= test window.

<sup>Written for commit 4ff15a624a01e41e055ef4f1a2de6cb4df12509c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Stabilize direct QUIC delivery timeouts**

### What Changed
- Direct QUIC acknowledgements now wait longer before timing out, which helps direct deliveries succeed on slower machines and CI runners.
- The shorter timeout used for route probing is kept separate from the delivery wait, so probing stays quick while delivery has more time to complete.
- A regression check now ensures the delivery timeout stays longer than the probe timeout and long enough for the test window.

### Impact
`✅ Fewer direct delivery timeouts`
`✅ More stable CI runs on slower runners`
`✅ Faster route probes without hurting delivery`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
