### PR TITLE
Require NPM rotation marker on secret upload

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -519,6 +519,25 @@ def run_dry_run_tests(module) -> None:
             raise AssertionError("dry run should report every required secret name")
         if calls:
             raise AssertionError("dry run must not call gh secret set")
+
+        module.require_npm_rotation_marker_for_token_write(
+            values=values,
+            marker_requested=False,
+            dry_run=True,
+        )
+        module.require_npm_rotation_marker_for_token_write(
+            values=values,
+            marker_requested=True,
+            dry_run=False,
+        )
+        assert_raises(
+            lambda: module.require_npm_rotation_marker_for_token_write(
+                values=values,
+                marker_requested=False,
+                dry_run=False,
+            ),
+            module.NPM_TOKEN_ROTATION_MARKER_VAR,
+        )
     finally:
         restore_env(original)
 
@@ -568,6 +587,28 @@ def run_env_file_main_tests(module) -> None:
                 raise AssertionError(f"expected env-file-only dry run to pass: {rendered}")
             if SENSITIVE_SENTINEL in rendered:
                 raise AssertionError("env-file-only dry-run output leaked a secret value")
+
+            exit_code, rendered = call_main(
+                module,
+                [
+                    "set-github-release-secrets.py",
+                    "--repo",
+                    "owner/repo",
+                    "--gh",
+                    "gh",
+                    "--env-file",
+                    str(env_file),
+                    "--env-file-only",
+                ]
+            )
+            if exit_code == 0 or module.NPM_TOKEN_ROTATION_MARKER_VAR not in rendered:
+                raise AssertionError(
+                    f"expected real NPM token setup without marker to fail: {rendered}"
+                )
+            if "missing local release secret values" in rendered:
+                raise AssertionError("marker guard should run after complete env-file loading")
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("marker guard error leaked a secret value")
 
             original_find_gh = module.find_gh
             original_infer_repo = module.infer_repo

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -341,6 +341,24 @@ def configure_release_secrets(
     return names
 
 
+def require_npm_rotation_marker_for_token_write(
+    *,
+    values: Mapping[str, str],
+    marker_requested: bool,
+    dry_run: bool,
+) -> None:
+    if dry_run or marker_requested:
+        return
+    if (value := values.get(NPM_TOKEN_SECRET_NAME)) is None or value.strip() == "":
+        return
+    raise ValueError(
+        f"{NPM_TOKEN_SECRET_NAME} upload requires "
+        f"{NPM_TOKEN_ROTATION_MARKER_VAR}; add "
+        "--set-npm-token-rotation-marker-from-secret-updated-at "
+        "--confirm-npm-token-rotated after rotating the token"
+    )
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -571,6 +589,11 @@ def main() -> int:
                     sys.stderr,
                 )
                 return 1
+            require_npm_rotation_marker_for_token_write(
+                values=values,
+                marker_requested=marker_requested,
+                dry_run=args.dry_run,
+            )
 
             if args.preflight_values:
                 run_value_preflights(require_openssl=args.require_openssl, values=values)


### PR DESCRIPTION
## **User description**
Closes #832

Summary:
- fail a real NPM_TOKEN release-secret upload unless CONU_NPM_TOKEN_ROTATED_AFTER is requested in the same setup run
- keep dry-runs and marker-only workflows usable
- add regression coverage that the guard runs after complete env-file loading and does not print token values

Validation:
- python scripts/set-github-release-secrets-regression.py
- python scripts/check-python-script-compile.py
- python scripts/check-release-secret-rotation-gate-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Live readiness note:
- python scripts/check-github-release-secret-readiness.py --repo imthegoodboy/conU still fails because #274 is missing 12 signing secret names; this change prevents uploading NPM_TOKEN while forgetting the required non-secret rotation marker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a rotation marker to upload a real `NPM_TOKEN` during release-secret setup, closing #832. Dry runs and marker-only flows are unchanged.

- New Features
  - Fail non-dry runs that set `NPM_TOKEN` unless `CONU_NPM_TOKEN_ROTATED_AFTER` is requested in the same run, with a clear error.
  - Guard executes after full env-file loading and never prints secret values; added regression tests to cover this.

- Migration
  - When rotating and uploading `NPM_TOKEN`, pass `--set-npm-token-rotation-marker-from-secret-updated-at --confirm-npm-token-rotated` in the same run.

<sup>Written for commit 885064608783f73b85a0116baaee0845100f8004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Require a rotation marker before uploading an NPM token

### What Changed
- Uploading a real `NPM_TOKEN` now fails unless the rotation marker is included in the same setup run
- Dry runs and marker-only runs still work without blocking
- The check runs after all env-file values are loaded, so it reports the missing marker instead of stopping on missing secret values
- Regression coverage now verifies the guard, the dry-run behavior, and that secret values are not printed in errors

### Impact
`✅ Safer NPM token rotations`
`✅ Fewer accidental secret uploads`
`✅ Clearer setup errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
