### PR TITLE
Reject unsafe hosted repository S3 prefixes

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -646,6 +646,22 @@ def assert_preflight() -> None:
         if expected not in rendered:
             raise AssertionError(f"custom repository preflight missed {expected!r}")
 
+    for prefix, expected in (
+        ("bad prefix", "custom repository S3 prefix must not contain whitespace or control characters"),
+        ("bad/%00/prefix", "custom repository S3 prefix must not contain whitespace or control characters"),
+        ("bad/%2f/prefix", "custom repository S3 prefix must not contain encoded separators"),
+        ("bad/%2e%2e/prefix", "custom repository S3 prefix must not contain dot segments"),
+    ):
+        prefix_env = preflight_env()
+        prefix_env["CONU_LINUX_REPOSITORY_S3_PREFIX"] = prefix
+        prefix_result = run_preflight_raw(prefix_env)
+        if prefix_result.returncode == 0:
+            raise AssertionError(f"unsafe custom repository prefix unexpectedly passed: {prefix}")
+        prefix_report = json.loads(prefix_result.stdout)
+        assert_safe_preflight_report(prefix_report)
+        if expected not in json.dumps(prefix_report):
+            raise AssertionError(f"custom repository preflight missed prefix failure {expected!r}")
+
     unsafe_env = preflight_env()
     unsafe_env["CONU_LINUX_REPOSITORY_BASE_URL"] = (
         "https://packages.example.com%40evil.test/conu"

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -756,6 +756,35 @@ def run_custom_repository_tests(module) -> None:
         if expected not in rendered_invalid_optional:
             raise AssertionError(f"expected optional variable failure was missing: {expected}")
 
+    for prefix, expected in (
+        ("bad prefix", "custom repository S3 prefix must not contain whitespace or control characters"),
+        ("bad/%00/prefix", "custom repository S3 prefix must not contain whitespace or control characters"),
+        ("bad/%2f/prefix", "custom repository S3 prefix must not contain encoded separators"),
+        ("bad/%2e%2e/prefix", "custom repository S3 prefix must not contain dot segments"),
+    ):
+        invalid_prefix = module.audit_tagged_release_readiness(
+            repo="owner/repo",
+            tag=TAG,
+            version=VERSION,
+            secret_names=all_custom_secrets(module),
+            variable_values={
+                module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/",
+                module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+                module.CUSTOM_REPOSITORY_PREFIX_VAR: prefix,
+                module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com",
+                module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+            },
+            pages_payload=None,
+            release_payload=None,
+            npm_registry_check=False,
+            **ready_governance_kwargs(),
+        )
+        if invalid_prefix.ready:
+            raise AssertionError(f"unsafe custom repository S3 prefix unexpectedly passed: {prefix}")
+        parsed_invalid_prefix = assert_safe_report(invalid_prefix)
+        if expected not in json.dumps(parsed_invalid_prefix):
+            raise AssertionError(f"expected S3 prefix failure was missing: {expected}")
+
     invalid_base_paths = module.audit_tagged_release_readiness(
         repo="owner/repo",
         tag=TAG,

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -541,10 +541,19 @@ def validate_prefix(raw: str) -> str:
     if "?" in prefix or "#" in prefix:
         raise ValueError("custom repository S3 prefix must not contain query or fragment markers")
     parts = [part for part in prefix.split("/") if part]
-    if any(part in {".", ".."} for part in parts):
-        raise ValueError("custom repository S3 prefix must not contain dot segments")
     if len(parts) != len(prefix.split("/")):
         raise ValueError("custom repository S3 prefix must not contain empty path segments")
+    if any(has_url_path_control(part) for part in parts):
+        raise ValueError("custom repository S3 prefix must not contain whitespace or control characters")
+    if any(part in {".", ".."} for part in parts):
+        raise ValueError("custom repository S3 prefix must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise ValueError("custom repository S3 prefix must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise ValueError("custom repository S3 prefix must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise ValueError("custom repository S3 prefix must not contain whitespace or control characters")
     return "/".join(parts)
 
 

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -300,10 +300,19 @@ def validate_prefix(raw: str) -> str:
     if "?" in prefix or "#" in prefix:
         raise PublicationError("S3 prefix must not contain query or fragment markers")
     parts = [part for part in prefix.split("/") if part]
-    if any(part in {".", ".."} for part in parts):
-        raise PublicationError("S3 prefix must not contain dot segments")
     if len(parts) != len(prefix.split("/")):
         raise PublicationError("S3 prefix must not contain empty path segments")
+    if any(has_url_path_control(part) for part in parts):
+        raise PublicationError("S3 prefix must not contain whitespace or control characters")
+    if any(part in {".", ".."} for part in parts):
+        raise PublicationError("S3 prefix must not contain dot segments")
+    decoded_parts = [unquote(part) for part in parts]
+    if any(part in {".", ".."} for part in decoded_parts):
+        raise PublicationError("S3 prefix must not contain dot segments")
+    if any("/" in part or "\\" in part for part in decoded_parts):
+        raise PublicationError("S3 prefix must not contain encoded separators")
+    if any(has_url_path_control(part) for part in decoded_parts):
+        raise PublicationError("S3 prefix must not contain whitespace or control characters")
     return "/".join(parts)
 
 


### PR DESCRIPTION
## **User description**
Closes #834.\n\n## Summary\n- Reject raw or decoded whitespace/control characters in custom hosted repository S3 prefixes.\n- Reject percent-decoded dot segments and encoded separators before publication/readiness can accept a prefix.\n- Cover both tagged release readiness and S3 publication regression paths.\n\n## Validation\n- python scripts/check-hosted-linux-repository-s3-publication.py\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-python-script-compile.py\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened validation for custom hosted repository S3 prefixes to block unsafe values and prevent traversal or injection during publication and release readiness. Applied consistent checks across readiness and S3 publication scripts with new regression coverage.

- **Bug Fixes**
  - Reject whitespace/control characters (raw or percent-decoded).
  - Reject dot segments, including decoded "." and "..".
  - Reject encoded separators (e.g., "%2f") and backslashes after decoding.
  - Enforce in `check-tagged-release-readiness.py` and `publish-hosted-linux-repository-s3.py`; add regression tests in `check-hosted-linux-repository-s3-publication.py` and `check-tagged-release-readiness-regression.py`.

<sup>Written for commit dc73338a8f39d0e83096cb6de247f066b605ffd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject unsafe hosted repository S3 prefixes**

### What Changed
- Prefix checks now reject values with whitespace or control characters, including percent-encoded forms.
- Prefixes that decode to dot segments or encoded path separators are now blocked before release readiness or publication can pass.
- Added regression coverage for unsafe prefixes in both readiness checks and S3 publication checks.

### Impact
`✅ Safer hosted repository URLs`
`✅ Fewer path traversal attempts slipping through`
`✅ Clearer prefix validation errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added regression test coverage for S3 repository prefix validation to ensure invalid configurations are properly rejected.

* **Bug Fixes**
  * Strengthened S3 repository prefix validation to reject prefixes containing whitespace, control characters, encoded separators, dot-segments, and empty path segments with improved error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->