### PR TITLE
Reject unsafe hosted repository S3 buckets

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -75,6 +75,17 @@ def main() -> int:
         missing_bucket = run_publisher_raw(site_dir, "--dry-run", "--bucket", "")
         assert_failure("missing bucket", missing_bucket, "S3 bucket is required")
 
+        for bucket, expected in (
+            ("Conu-Packages", "S3 bucket contains unsupported characters"),
+            ("conu_packages", "S3 bucket contains unsupported characters"),
+            ("192.168.0.1", "S3 bucket must not be formatted as an IPv4 address"),
+            ("bad..bucket", "S3 bucket must not contain adjacent dots"),
+            ("bad.-bucket", "S3 bucket must not contain dot-hyphen boundaries"),
+            ("bad-.bucket", "S3 bucket must not contain dot-hyphen boundaries"),
+        ):
+            invalid_bucket = run_publisher_raw(site_dir, "--dry-run", "--bucket", bucket)
+            assert_failure(f"invalid bucket {bucket}", invalid_bucket, expected)
+
         mismatch = run_publisher_raw(
             site_dir,
             "--dry-run",
@@ -661,6 +672,24 @@ def assert_preflight() -> None:
         assert_safe_preflight_report(prefix_report)
         if expected not in json.dumps(prefix_report):
             raise AssertionError(f"custom repository preflight missed prefix failure {expected!r}")
+
+    for bucket, expected in (
+        ("Conu-Packages", "custom repository S3 bucket contains unsupported characters"),
+        ("conu_packages", "custom repository S3 bucket contains unsupported characters"),
+        ("192.168.0.1", "custom repository S3 bucket must not be formatted as an IPv4 address"),
+        ("bad..bucket", "custom repository S3 bucket must not contain adjacent dots"),
+        ("bad.-bucket", "custom repository S3 bucket must not contain dot-hyphen boundaries"),
+        ("bad-.bucket", "custom repository S3 bucket must not contain dot-hyphen boundaries"),
+    ):
+        bucket_env = preflight_env()
+        bucket_env["CONU_LINUX_REPOSITORY_S3_BUCKET"] = bucket
+        bucket_result = run_preflight_raw(bucket_env)
+        if bucket_result.returncode == 0:
+            raise AssertionError(f"unsafe custom repository bucket unexpectedly passed: {bucket}")
+        bucket_report = json.loads(bucket_result.stdout)
+        assert_safe_preflight_report(bucket_report)
+        if expected not in json.dumps(bucket_report):
+            raise AssertionError(f"custom repository preflight missed bucket failure {expected!r}")
 
     unsafe_env = preflight_env()
     unsafe_env["CONU_LINUX_REPOSITORY_BASE_URL"] = (

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -785,6 +785,37 @@ def run_custom_repository_tests(module) -> None:
         if expected not in json.dumps(parsed_invalid_prefix):
             raise AssertionError(f"expected S3 prefix failure was missing: {expected}")
 
+    for bucket, expected in (
+        ("Conu-Packages", "custom repository S3 bucket contains unsupported characters"),
+        ("conu_packages", "custom repository S3 bucket contains unsupported characters"),
+        ("192.168.0.1", "custom repository S3 bucket must not be formatted as an IPv4 address"),
+        ("bad..bucket", "custom repository S3 bucket must not contain adjacent dots"),
+        ("bad.-bucket", "custom repository S3 bucket must not contain dot-hyphen boundaries"),
+        ("bad-.bucket", "custom repository S3 bucket must not contain dot-hyphen boundaries"),
+    ):
+        invalid_bucket = module.audit_tagged_release_readiness(
+            repo="owner/repo",
+            tag=TAG,
+            version=VERSION,
+            secret_names=all_custom_secrets(module),
+            variable_values={
+                module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/",
+                module.CUSTOM_REPOSITORY_BUCKET_VAR: bucket,
+                module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+                module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com",
+                module.CUSTOM_REPOSITORY_REGION_VAR: "us-east-1",
+            },
+            pages_payload=None,
+            release_payload=None,
+            npm_registry_check=False,
+            **ready_governance_kwargs(),
+        )
+        if invalid_bucket.ready:
+            raise AssertionError(f"unsafe custom repository S3 bucket unexpectedly passed: {bucket}")
+        parsed_invalid_bucket = assert_safe_report(invalid_bucket)
+        if expected not in json.dumps(parsed_invalid_bucket):
+            raise AssertionError(f"expected S3 bucket failure was missing: {expected}")
+
     invalid_base_paths = module.audit_tagged_release_readiness(
         repo="owner/repo",
         tag=TAG,

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -32,7 +32,8 @@ from github_release_secrets import (
 
 ROOT = Path(__file__).resolve().parents[1]
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
-BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,253}[A-Za-z0-9]$")
+BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+IPV4_BUCKET_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
 SAFE_REGION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 CUSTOM_REPOSITORY_BASE_URL_VAR = "CONU_LINUX_REPOSITORY_BASE_URL"
 CUSTOM_REPOSITORY_BUCKET_VAR = "CONU_LINUX_REPOSITORY_S3_BUCKET"
@@ -531,6 +532,12 @@ def validate_bucket(raw: str) -> str:
         raise ValueError("custom repository S3 bucket must be a bucket name, not a URL or path")
     if not BUCKET_RE.fullmatch(bucket):
         raise ValueError("custom repository S3 bucket contains unsupported characters")
+    if ".." in bucket:
+        raise ValueError("custom repository S3 bucket must not contain adjacent dots")
+    if ".-" in bucket or "-." in bucket:
+        raise ValueError("custom repository S3 bucket must not contain dot-hyphen boundaries")
+    if IPV4_BUCKET_RE.fullmatch(bucket):
+        raise ValueError("custom repository S3 bucket must not be formatted as an IPv4 address")
     return bucket
 
 

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -32,7 +32,8 @@ MAX_FILE_BYTES = 2 * 1024 * 1024 * 1024
 MAX_TOTAL_BYTES = 4 * 1024 * 1024 * 1024
 MAX_CACHE_CONTROL_BYTES = 256
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
-BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,253}[A-Za-z0-9]$")
+BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+IPV4_BUCKET_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
 SAFE_REGION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
@@ -290,6 +291,12 @@ def validate_bucket(raw: str) -> str:
         raise PublicationError("S3 bucket must be a bucket name, not a URL or path")
     if not BUCKET_RE.fullmatch(bucket):
         raise PublicationError("S3 bucket contains unsupported characters")
+    if ".." in bucket:
+        raise PublicationError("S3 bucket must not contain adjacent dots")
+    if ".-" in bucket or "-." in bucket:
+        raise PublicationError("S3 bucket must not contain dot-hyphen boundaries")
+    if IPV4_BUCKET_RE.fullmatch(bucket):
+        raise PublicationError("S3 bucket must not be formatted as an IPv4 address")
     return bucket
 
 


### PR DESCRIPTION
## **User description**
Closes #836.\n\n## Summary\n- Require DNS-compatible lowercase custom hosted repository S3 bucket names.\n- Reject IPv4-shaped buckets, adjacent dots, and dot-hyphen/hyphen-dot boundaries before upload/readiness paths can proceed.\n- Cover both direct S3 publication and tagged release readiness regression paths.\n\n## Validation\n- python scripts/check-hosted-linux-repository-s3-publication.py\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-python-script-compile.py\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens validation for hosted repository S3 buckets to enforce lowercase, DNS-compatible names and block unsafe patterns before publish/readiness steps. Applies to both direct S3 publication and tagged-release readiness checks to prevent misrouting and unsafe bucket resolution.

- **Bug Fixes**
  - Restrict bucket names to lowercase DNS format (regex: `^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`).
  - Reject IPv4-shaped names, adjacent dots, and dot-hyphen or hyphen-dot boundaries.
  - Apply checks in `publish-hosted-linux-repository-s3.py` and readiness audit scripts.
  - Add negative tests covering all new rules.

- **Migration**
  - Use a lowercase, DNS-compatible bucket name (letters, digits, dots, hyphens; 3–63 chars).
  - Update configs that use uppercase, underscores, adjacent dots, or IPv4-like names.

<sup>Written for commit 915055c49baa89250ce9cc09cbc4daed4178562d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Reject unsafe S3 bucket names before hosted repository publishing and release checks run

### What Changed
- Bucket names now must use lowercase letters, digits, dots, and hyphens only, and they must fit the safer S3 naming range
- Buckets with adjacent dots, dot-hyphen or hyphen-dot boundaries, or IPv4-style names are now blocked with clear error messages
- Added checks to both hosted repository publication and tagged-release readiness paths, including test coverage for the rejected bucket patterns

### Impact
`✅ Fewer failed uploads from invalid bucket names`
`✅ Clearer setup errors for hosted repositories`
`✅ Safer release readiness checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
