### PR TITLE
Reject unsafe hosted repository AWS regions

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -318,6 +318,15 @@ def main() -> int:
             "us-east-1;rm",
         )
         assert_failure("unsafe AWS region", unsafe_region, "AWS region contains unsupported characters")
+        for region, expected in (
+            ("US-EAST-1", "AWS region contains unsupported characters"),
+            ("us_east_1", "AWS region contains unsupported characters"),
+            ("us.east.1", "AWS region contains unsupported characters"),
+            ("us-east-", "AWS region contains unsupported characters"),
+            ("us--east-1", "AWS region must not contain consecutive hyphens"),
+        ):
+            invalid_region = run_publisher_raw(site_dir, "--dry-run", "--region", region)
+            assert_failure(f"invalid AWS region {region}", invalid_region, expected)
 
         oversized_metadata = temp / "oversized-metadata-site"
         shutil.copytree(site_dir, oversized_metadata)
@@ -690,6 +699,23 @@ def assert_preflight() -> None:
         assert_safe_preflight_report(bucket_report)
         if expected not in json.dumps(bucket_report):
             raise AssertionError(f"custom repository preflight missed bucket failure {expected!r}")
+
+    for region, expected in (
+        ("US-EAST-1", "custom repository AWS region contains unsupported characters"),
+        ("us_east_1", "custom repository AWS region contains unsupported characters"),
+        ("us.east.1", "custom repository AWS region contains unsupported characters"),
+        ("us-east-", "custom repository AWS region contains unsupported characters"),
+        ("us--east-1", "custom repository AWS region must not contain consecutive hyphens"),
+    ):
+        region_env = preflight_env()
+        region_env["CONU_LINUX_REPOSITORY_AWS_REGION"] = region
+        region_result = run_preflight_raw(region_env)
+        if region_result.returncode == 0:
+            raise AssertionError(f"unsafe custom repository AWS region unexpectedly passed: {region}")
+        region_report = json.loads(region_result.stdout)
+        assert_safe_preflight_report(region_report)
+        if expected not in json.dumps(region_report):
+            raise AssertionError(f"custom repository preflight missed region failure {expected!r}")
 
     unsafe_env = preflight_env()
     unsafe_env["CONU_LINUX_REPOSITORY_BASE_URL"] = (

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -1022,6 +1022,36 @@ def run_custom_repository_tests(module) -> None:
     else:
         raise AssertionError("custom AWS region with unsafe punctuation unexpectedly passed")
 
+    for region, expected in (
+        ("US-EAST-1", "custom repository AWS region contains unsupported characters"),
+        ("us_east_1", "custom repository AWS region contains unsupported characters"),
+        ("us.east.1", "custom repository AWS region contains unsupported characters"),
+        ("us-east-", "custom repository AWS region contains unsupported characters"),
+        ("us--east-1", "custom repository AWS region must not contain consecutive hyphens"),
+    ):
+        invalid_region = module.audit_tagged_release_readiness(
+            repo="owner/repo",
+            tag=TAG,
+            version=VERSION,
+            secret_names=all_custom_secrets(module),
+            variable_values={
+                module.CUSTOM_REPOSITORY_BASE_URL_VAR: "https://packages.example.com/conu/",
+                module.CUSTOM_REPOSITORY_BUCKET_VAR: "conu-packages",
+                module.CUSTOM_REPOSITORY_PREFIX_VAR: "stable/conu",
+                module.CUSTOM_REPOSITORY_ENDPOINT_VAR: "https://s3.example.com",
+                module.CUSTOM_REPOSITORY_REGION_VAR: region,
+            },
+            pages_payload=None,
+            release_payload=None,
+            npm_registry_check=False,
+            **ready_governance_kwargs(),
+        )
+        if invalid_region.ready:
+            raise AssertionError(f"unsafe custom repository AWS region unexpectedly passed: {region}")
+        parsed_invalid_region = assert_safe_report(invalid_region)
+        if expected not in json.dumps(parsed_invalid_region):
+            raise AssertionError(f"expected custom AWS region failure was missing: {expected}")
+
     loopback_endpoint = module.audit_tagged_release_readiness(
         repo="owner/repo",
         tag=TAG,

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -34,7 +34,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
 IPV4_BUCKET_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
-SAFE_REGION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+SAFE_REGION_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$")
 CUSTOM_REPOSITORY_BASE_URL_VAR = "CONU_LINUX_REPOSITORY_BASE_URL"
 CUSTOM_REPOSITORY_BUCKET_VAR = "CONU_LINUX_REPOSITORY_S3_BUCKET"
 CUSTOM_REPOSITORY_PREFIX_VAR = "CONU_LINUX_REPOSITORY_S3_PREFIX"
@@ -633,6 +633,8 @@ def validate_region(raw: str) -> str:
         raise ValueError("custom repository AWS region must be a region name, not a URL or path")
     if not SAFE_REGION_RE.fullmatch(region):
         raise ValueError("custom repository AWS region contains unsupported characters")
+    if "--" in region:
+        raise ValueError("custom repository AWS region must not contain consecutive hyphens")
     return region
 
 

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -34,7 +34,7 @@ MAX_CACHE_CONTROL_BYTES = 256
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
 IPV4_BUCKET_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
-SAFE_REGION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+SAFE_REGION_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$")
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 FORBIDDEN_SEGMENTS = {
@@ -414,6 +414,8 @@ def validate_region(raw: str) -> str:
         raise PublicationError("AWS region must be a region name, not a URL or path")
     if not SAFE_REGION_RE.fullmatch(region):
         raise PublicationError("AWS region contains unsupported characters")
+    if "--" in region:
+        raise PublicationError("AWS region must not contain consecutive hyphens")
     return region
 
 


### PR DESCRIPTION
## **User description**
Closes #838.\n\n## Summary\n- Limit custom hosted repository AWS region values to lowercase alphanumeric tokens with single hyphen separators.\n- Reject uppercase, underscores, dots, trailing hyphens, and consecutive hyphens before S3 publication/readiness paths can proceed.\n- Cover direct S3 publication, custom publication preflight, and tagged release readiness regression paths.\n\n## Validation\n- python scripts/check-hosted-linux-repository-s3-publication.py\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-python-script-compile.py\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unsafe AWS region values and enforces a strict, lowercase format to prevent bad inputs in S3 publication and tagged-release readiness flows.

- **Bug Fixes**
  - Accept only lowercase alphanumerics with single hyphens for regions (regex `^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$`); reject uppercase, underscores, dots, trailing hyphens, and consecutive hyphens.
  - Apply validation with clear errors in `publish-hosted-linux-repository-s3.py` and `check-tagged-release-readiness.py` (including `CONU_LINUX_REPOSITORY_AWS_REGION`).
  - Add tests covering invalid regions in `check-hosted-linux-repository-s3-publication.py` and `check-tagged-release-readiness-regression.py` to ensure failures occur early with actionable messages.

<sup>Written for commit 97f4a861dc9a6561cc4bdc63c8cc3ff77a873e8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject unsafe hosted repository AWS regions**

### What Changed
- Hosted repository AWS regions now accept only lowercase region-style values with hyphens, and reject uppercase letters, underscores, dots, trailing hyphens, and consecutive hyphens.
- The publication and tagged-release readiness checks fail early with clear messages when an unsafe region is provided.
- Regression coverage now includes these invalid region formats in both the publication and readiness flows.

### Impact
`✅ Fewer bad-region publish attempts`
`✅ Clearer AWS region validation errors`
`✅ Safer hosted repository release checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
