### PR TITLE
Reject unsafe hosted repository AWS CLI wrappers

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -71,6 +71,8 @@ def main() -> int:
         confirm_report = json.loads(confirm)
         assert_publication_report(confirm_report, published=True)
         assert_fake_aws_log(fake_log, confirm_report["fileCount"])
+        publisher = load_publisher()
+        assert_aws_cli_wrapper_guard(publisher, fake_aws)
 
         missing_bucket = run_publisher_raw(site_dir, "--dry-run", "--bucket", "")
         assert_failure("missing bucket", missing_bucket, "S3 bucket is required")
@@ -220,7 +222,6 @@ def main() -> int:
             loopback_endpoint,
             "S3 endpoint URL must use HTTPS",
         )
-        publisher = load_publisher()
         normalized_loopback_endpoint = publisher.validate_endpoint_url(
             "http://127.0.0.1:9000",
             allow_loopback_http=True,
@@ -612,6 +613,40 @@ def assert_fake_aws_log(log: Path, expected_count: int) -> None:
 def assert_failure(description: str, result: subprocess.CompletedProcess[str], expected: str) -> None:
     if result.returncode == 0 or expected not in result.stdout:
         raise AssertionError(f"{description} failed with {result.stdout!r}, expected {expected!r}")
+
+
+def assert_aws_cli_wrapper_guard(publisher, fake_aws: str) -> None:
+    if publisher.parse_aws_cli("aws") != ["aws"]:
+        raise AssertionError("plain aws CLI wrapper did not parse")
+    if len(publisher.parse_aws_cli(fake_aws)) < 2:
+        raise AssertionError("fake AWS CLI wrapper with a script path did not parse")
+
+    for raw, expected in (
+        ("aws s3 rm s3://victim --recursive", "S3 service or upload subcommands"),
+        ("aws s3api delete-object --bucket victim --key release", "S3 service or upload subcommands"),
+        ("aws s3://victim", "S3 targets"),
+        ("aws --endpoint-url https://evil.example", "publication-owned or unsafe options"),
+        ("aws --region us-east-1", "publication-owned or unsafe options"),
+        ("aws --cache-control public", "publication-owned or unsafe options"),
+        ("aws --debug", "publication-owned or unsafe options"),
+        ("aws --no-verify-ssl", "publication-owned or unsafe options"),
+        ("--profile release", "executable must not be an option"),
+    ):
+        try:
+            publisher.parse_aws_cli(raw)
+        except publisher.PublicationError as exc:
+            if expected not in str(exc):
+                raise AssertionError(f"unexpected AWS CLI wrapper failure for {raw!r}: {exc}")
+        else:
+            raise AssertionError(f"unsafe AWS CLI wrapper unexpectedly parsed: {raw}")
+
+    try:
+        publisher.validate_aws_cli_wrapper(["aws", "bad\narg"])
+    except publisher.PublicationError as exc:
+        if "control arguments" not in str(exc):
+            raise AssertionError(f"unexpected AWS CLI control argument failure: {exc}")
+    else:
+        raise AssertionError("AWS CLI wrapper with a control character unexpectedly parsed")
 
 
 def assert_preflight() -> None:

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -35,6 +35,33 @@ PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
 IPV4_BUCKET_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
 SAFE_REGION_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$")
+AWS_CLI_RESERVED_TOKENS = {
+    "--",
+    "-",
+    "cp",
+    "ls",
+    "mb",
+    "mv",
+    "presign",
+    "rb",
+    "rm",
+    "s3",
+    "s3api",
+    "sync",
+}
+AWS_CLI_RESERVED_OPTIONS = {
+    "--acl",
+    "--cache-control",
+    "--content-type",
+    "--debug",
+    "--endpoint-url",
+    "--expected-size",
+    "--metadata",
+    "--no-verify-ssl",
+    "--only-show-errors",
+    "--recursive",
+    "--region",
+}
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 FORBIDDEN_SEGMENTS = {
@@ -874,6 +901,7 @@ def parse_aws_cli(raw: str) -> list[str]:
         parsed = [strip_matching_quotes(item) for item in parsed]
     if not parsed:
         raise PublicationError("AWS CLI command must not be empty")
+    validate_aws_cli_wrapper(parsed)
     return parsed
 
 
@@ -881,6 +909,26 @@ def strip_matching_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def validate_aws_cli_wrapper(args: list[str]) -> None:
+    executable = args[0]
+    if executable.startswith("-"):
+        raise PublicationError("AWS CLI command executable must not be an option")
+    for item in args:
+        if not item or any(ord(character) < 32 or ord(character) == 127 for character in item):
+            raise PublicationError("AWS CLI command must not contain empty or control arguments")
+
+        normalized = item.lower()
+        option_name = normalized.split("=", 1)[0]
+        if normalized in AWS_CLI_RESERVED_TOKENS:
+            raise PublicationError("AWS CLI command must not include S3 service or upload subcommands")
+        if normalized.startswith("s3://"):
+            raise PublicationError("AWS CLI command must not include S3 targets")
+        if option_name in AWS_CLI_RESERVED_OPTIONS:
+            raise PublicationError(
+                "AWS CLI command must not include publication-owned or unsafe options"
+            )
 
 
 def run_endpoint_check(plan: PublishPlan, args: argparse.Namespace) -> None:


### PR DESCRIPTION
Closes #840.\n\nChanges:\n- Reject hosted repository AWS CLI wrapper values that already include S3 service/upload subcommands, S3 targets, publication-owned upload flags, debug mode, no-verify TLS, or control arguments.\n- Keep plain aws, profile-style wrapper args, and quoted wrapper script paths working.\n- Add regression coverage in the hosted repository S3 publication check.\n\nValidation:\n- python scripts/check-hosted-linux-repository-s3-publication.py\n- python scripts/check-python-script-compile.py\n- python scripts/check-tagged-release-readiness-regression.py\n- git diff --check\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unsafe AWS CLI wrappers in hosted repository S3 publication. Blocks S3 subcommands/targets and unsafe or publication-owned options, while keeping plain aws, profile args, and quoted script paths working.

- **Bug Fixes**
  - Added `validate_aws_cli_wrapper` and called it from `parse_aws_cli`.
  - Reject S3 subcommands/targets (e.g., s3, s3api, cp, sync, rm, s3://...).
  - Reject publication-owned/unsafe flags (`--endpoint-url`, `--region`, `--cache-control`, `--debug`, `--no-verify-ssl`, etc.).
  - Disallow executables starting with "-" and empty/control-character args.
  - Added regression coverage in `check-hosted-linux-repository-s3-publication.py`.

- **Migration**
  - Remove S3 subcommands, targets, and the flags above from any AWS wrapper. The publisher sets these. 
  - Keep wrappers to plain `aws` plus profile/env setup or a quoted script path.

<sup>Written for commit 75be2e6ba2ea4f233de55d982a9e0b55dc769f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AWS CLI command validation now rejects unsafe patterns, reserved service options, and control characters before executing S3 publication operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->