### PR TITLE
Reject malformed GitHub repository identifiers

### DIFF
--- a/scripts/check-github-actions-permissions.py
+++ b/scripts/check-github-actions-permissions.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from github_release_secrets import find_gh, infer_repo
+from github_release_secrets import find_gh, infer_repo, normalize_repo
 
 
 DEFAULT_REQUIRED_SELECTED_PATTERNS = ("dtolnay/rust-toolchain@stable",)
@@ -288,7 +288,7 @@ def main() -> int:
     args = parse_args()
     try:
         gh = args.gh or find_gh()
-        repo = args.repo.strip() or infer_repo(gh)
+        repo = normalize_repo(args.repo.strip() or infer_repo(gh))
         if args.actions_json is None:
             actions_payload = load_actions_permissions(repo, gh)
         else:

--- a/scripts/check-github-main-protection.py
+++ b/scripts/check-github-main-protection.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-from github_release_secrets import find_gh, infer_repo
+from github_release_secrets import find_gh, infer_repo, normalize_repo
 
 
 DEFAULT_BRANCH = "main"
@@ -295,7 +295,7 @@ def main() -> int:
     args = parse_args()
     try:
         gh = args.gh or find_gh()
-        repo = args.repo.strip() or infer_repo(gh)
+        repo = normalize_repo(args.repo.strip() or infer_repo(gh))
         required_status = tuple(args.required_status or DEFAULT_REQUIRED_STATUS_CHECKS)
         if args.protection_json is None:
             payload = load_branch_protection(repo, args.branch, gh)

--- a/scripts/check-github-pages-readiness.py
+++ b/scripts/check-github-pages-readiness.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse, urlunparse
 
-from github_release_secrets import find_gh, infer_repo, run_gh_json
+from github_release_secrets import find_gh, infer_repo, normalize_repo, run_gh_json
 
 
 @dataclass(frozen=True)
@@ -38,10 +38,8 @@ class PagesReadiness:
 
 
 def split_repo(repo: str) -> tuple[str, str]:
-    parts = repo.strip().split("/", 1)
-    if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
-        raise ValueError("repository must be in owner/name form")
-    return parts[0].strip(), parts[1].strip()
+    owner, name = normalize_repo(repo).split("/", 1)
+    return owner, name
 
 
 def normalize_https_url(value: str, field_name: str) -> str:
@@ -262,6 +260,7 @@ def main() -> int:
         if not repo:
             gh = gh or find_gh()
             repo = infer_repo(gh)
+        repo = normalize_repo(repo)
         pages_payload = None
         if not custom_base_url:
             if args.pages_json:

--- a/scripts/check-github-release-assets-published.py
+++ b/scripts/check-github-release-assets-published.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from github_release_secrets import find_gh, infer_repo, run_gh_json
+from github_release_secrets import find_gh, infer_repo, normalize_repo, run_gh_json
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
@@ -487,12 +487,13 @@ def main() -> int:
             raise ValueError("--release-json and --dist-dir cannot be used together")
 
         if args.dist_dir is not None:
-            repo = repo or "local/dist"
+            repo = normalize_repo(repo or "local/dist")
             payload = load_dist_metadata(tag, args.dist_dir)
         else:
             if not repo:
                 gh = gh or find_gh()
                 repo = infer_repo(gh)
+            repo = normalize_repo(repo)
 
             if args.release_json:
                 payload = load_release_json(args.release_json)
@@ -503,6 +504,7 @@ def main() -> int:
         if not repo:
             gh = gh or find_gh()
             repo = infer_repo(gh)
+        repo = normalize_repo(repo)
 
         report = audit_release_assets(repo, tag, payload)
     except (OSError, ValueError) as exc:

--- a/scripts/check-github-release-clobber-preflight.py
+++ b/scripts/check-github-release-clobber-preflight.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from github_release_secrets import find_gh, infer_repo
+from github_release_secrets import find_gh, infer_repo, normalize_repo
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
@@ -275,6 +275,7 @@ def main() -> int:
         if not repo:
             gh = gh or find_gh()
             repo = infer_repo(gh)
+        repo = normalize_repo(repo)
 
         if args.release_json:
             payload = load_release_json(args.release_json)

--- a/scripts/check-github-release-secret-readiness-regression.py
+++ b/scripts/check-github-release-secret-readiness-regression.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import contextlib
 import io
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -50,6 +51,36 @@ def run_audit_tests(module) -> None:
     not_ready = module.audit_secret_names("owner/repo", configured)
     if not not_ready.missing == (missing_name,):
         raise AssertionError(f"expected only {missing_name} missing, got {not_ready.missing}")
+
+
+def run_repo_normalization_tests(module) -> None:
+    helper = sys.modules["github_release_secrets"]
+
+    for repo in ("owner/repo", "owner-name/repo.name", "owner/repo_name"):
+        if helper.normalize_repo(repo) != repo:
+            raise AssertionError(f"valid repository did not normalize cleanly: {repo}")
+
+    for repo, expected in (
+        ("owner/repo/branches/main", "owner/name form"),
+        ("../repo", "owner contains unsupported characters"),
+        ("owner/..", "repository name is invalid"),
+        ("owner repo/name", "owner contains unsupported characters"),
+        ("owner/repo?secret=value", "name contains unsupported characters"),
+        ("https://github.com/owner/repo", "owner/name form"),
+        ("owner/re%70o", "name contains unsupported characters"),
+    ):
+        assert_raises(lambda repo=repo: helper.normalize_repo(repo), expected)
+        assert_raises(lambda repo=repo: module.audit_secret_names(repo, set()), expected)
+
+    original = os.environ.get("GH_REPO")
+    os.environ["GH_REPO"] = "owner/repo/extra"
+    try:
+        assert_raises(lambda: helper.infer_repo("gh"), "owner/name form")
+    finally:
+        if original is None:
+            os.environ.pop("GH_REPO", None)
+        else:
+            os.environ["GH_REPO"] = original
 
 
 def run_gh_payload_tests(module) -> None:
@@ -148,10 +179,38 @@ def run_main_tests(module) -> None:
     if SENSITIVE_SENTINEL in rendered:
         raise AssertionError("main() output leaked a secret value")
 
+    sys.argv = [
+        "check-github-release-secret-readiness.py",
+        "--repo",
+        "owner/repo/branches/main",
+        "--gh",
+        "gh",
+    ]
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    helper.subprocess.run = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        AssertionError("gh should not run for invalid repository names")
+    )
+    try:
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = module.main()
+    finally:
+        helper.subprocess.run = original_run
+        sys.argv = original_argv
+
+    rendered = stdout.getvalue() + stderr.getvalue()
+    if exit_code == 0:
+        raise AssertionError("invalid repository name should fail main()")
+    if "owner/name form" not in rendered:
+        raise AssertionError(f"invalid repository failure was not reported: {rendered!r}")
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("invalid repository failure leaked a secret value")
+
 
 def main() -> int:
     module = load_module()
     run_audit_tests(module)
+    run_repo_normalization_tests(module)
     run_gh_payload_tests(module)
     run_error_tests(module)
     run_main_tests(module)

--- a/scripts/check-github-release-secret-readiness.py
+++ b/scripts/check-github-release-secret-readiness.py
@@ -16,6 +16,7 @@ from github_release_secrets import (
     find_gh,
     infer_repo,
     load_secret_names,
+    normalize_repo,
 )
 
 
@@ -65,7 +66,7 @@ def main() -> int:
         os.chdir(repo_root)
 
         gh = args.gh or find_gh()
-        repo = args.repo.strip() or infer_repo(gh)
+        repo = normalize_repo(args.repo.strip() or infer_repo(gh))
         report = audit_secret_names(repo, load_secret_names(repo, gh))
     except (OSError, ValueError) as exc:
         print(f"GitHub release secret readiness failed: {exc}", file=sys.stderr)

--- a/scripts/check-github-repository-security.py
+++ b/scripts/check-github-repository-security.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from github_release_secrets import find_gh, infer_repo
+from github_release_secrets import find_gh, infer_repo, normalize_repo
 
 
 @dataclass(frozen=True)
@@ -307,7 +307,7 @@ def main() -> int:
     args = parse_args()
     try:
         gh = args.gh or find_gh()
-        repo = args.repo.strip() or infer_repo(gh)
+        repo = normalize_repo(args.repo.strip() or infer_repo(gh))
         repo_payload = (
             load_repo_payload(repo, gh)
             if args.repo_json is None

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -26,6 +26,7 @@ from github_release_secrets import (
     infer_repo,
     load_secret_metadata,
     load_secret_names,
+    normalize_repo,
     run_gh_json,
 )
 
@@ -1300,7 +1301,7 @@ def main() -> int:
         version = read_repo_version()
         tag = validate_tag_for_version(args.tag or default_tag(version), version)
         gh = args.gh or find_gh()
-        repo = args.repo.strip() or infer_repo(gh)
+        repo = normalize_repo(args.repo.strip() or infer_repo(gh))
         secret_rotation_requirements = parse_secret_rotation_requirements(
             args.require_secret_updated_after
         )

--- a/scripts/github_release_secrets.py
+++ b/scripts/github_release_secrets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -14,6 +15,8 @@ from typing import Any
 NPM_TOKEN_SECRET_NAME = "NPM_TOKEN"
 NPM_TOKEN_ROTATION_MARKER_VAR = "CONU_NPM_TOKEN_ROTATED_AFTER"
 NPM_TOKEN_ROTATION_REQUIRED_AFTER = "2026-06-03T00:00:00Z"
+REPO_OWNER_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,98}[A-Za-z0-9])?$")
+REPO_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}$")
 
 
 REQUIRED_RELEASE_SECRETS: tuple[str, ...] = (
@@ -69,6 +72,23 @@ def find_gh() -> str:
     raise ValueError("GitHub CLI executable was not found on PATH")
 
 
+def normalize_repo(repo: str) -> str:
+    value = repo.strip()
+    parts = value.split("/")
+    if len(parts) != 2:
+        raise ValueError("GitHub repository must be in owner/name form")
+    owner, name = (part.strip() for part in parts)
+    if not owner or not name:
+        raise ValueError("GitHub repository must be in owner/name form")
+    if name in {".", ".."}:
+        raise ValueError("GitHub repository name is invalid")
+    if not REPO_OWNER_RE.fullmatch(owner):
+        raise ValueError("GitHub repository owner contains unsupported characters")
+    if not REPO_NAME_RE.fullmatch(name):
+        raise ValueError("GitHub repository name contains unsupported characters")
+    return f"{owner}/{name}"
+
+
 def run_gh_json(gh: str, args: list[str], description: str) -> Any:
     result = subprocess.run(
         [gh, *args],
@@ -91,7 +111,7 @@ def run_gh_json(gh: str, args: list[str], description: str) -> Any:
 def infer_repo(gh: str) -> str:
     env_repo = os.environ.get("GH_REPO", "").strip()
     if env_repo:
-        return env_repo
+        return normalize_repo(env_repo)
 
     payload = run_gh_json(
         gh,
@@ -103,10 +123,11 @@ def infer_repo(gh: str) -> str:
     repo = payload.get("nameWithOwner")
     if not isinstance(repo, str) or not repo.strip():
         raise ValueError("gh repo view did not return nameWithOwner")
-    return repo.strip()
+    return normalize_repo(repo)
 
 
 def load_secret_metadata(repo: str, gh: str) -> dict[str, SecretMetadata]:
+    repo = normalize_repo(repo)
     payload = run_gh_json(
         gh,
         ["secret", "list", "--repo", repo, "--json", "name,updatedAt"],
@@ -138,6 +159,7 @@ def load_secret_names(repo: str, gh: str) -> set[str]:
 
 
 def audit_secret_names(repo: str, configured_names: set[str]) -> SecretReadiness:
+    repo = normalize_repo(repo)
     present = tuple(name for name in REQUIRED_RELEASE_SECRETS if name in configured_names)
     missing = tuple(name for name in REQUIRED_RELEASE_SECRETS if name not in configured_names)
     return SecretReadiness(

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -21,6 +21,7 @@ from github_release_secrets import (
     find_gh,
     infer_repo,
     load_secret_metadata,
+    normalize_repo,
 )
 
 
@@ -601,7 +602,7 @@ def main() -> int:
             values = {}
 
         gh = args.gh or find_gh()
-        repo = args.repo.strip() or infer_repo(gh)
+        repo = normalize_repo(args.repo.strip() or infer_repo(gh))
         if secret_setup_requested:
             configured = configure_release_secrets(repo, gh, values, args.dry_run)
         if marker_requested:


### PR DESCRIPTION
## **User description**
Closes #842.\n\nChanges:\n- Add shared GitHub owner/name normalization for release-readiness tooling.\n- Reject malformed repo identifiers before live gh/API calls, including extra path segments, traversal-style names, whitespace, URLs, query/fragment characters, and percent escapes.\n- Apply the guard to release secret readiness/setup, tagged release readiness, Pages readiness, GitHub Release clobber and asset checks, branch protection, Actions permissions, and repository security checks.\n- Add regression coverage proving invalid repos fail before gh runs and without leaking secret values.\n\nValidation:\n- python scripts/check-github-release-secret-readiness-regression.py\n- python scripts/set-github-release-secrets-regression.py\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-github-release-assets-published-regression.py\n- python scripts/check-github-pages-readiness-regression.py\n- python scripts/check-github-release-clobber-preflight-regression.py\n- python scripts/check-github-main-protection-regression.py\n- python scripts/check-github-actions-permissions-regression.py\n- python scripts/check-github-repository-security-regression.py\n- python scripts/check-python-script-compile.py\n- git diff --check\n- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared GitHub repo identifier normalizer and enforce strict owner/name validation across all GitHub tooling scripts. This blocks malformed inputs before any `gh` calls, preventing runtime errors and secret leaks.

- **New Features**
  - Added `normalize_repo` with strict checks; rejects extra path segments, traversal, whitespace, URLs, query/fragment characters, and percent-escaped names.
  - Applied normalization across secret readiness/setup, tagged release readiness, Pages readiness, release assets/clobber checks, main branch protection, Actions permissions, and repository security checks.
  - Added regression tests to ensure invalid repos fail early, do not invoke `gh`, and do not leak secret values.

<sup>Written for commit ac2f509cc72850f2bbfe44088de964dd971c1515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject malformed GitHub repository identifiers across release checks**

### What Changed
- Release and repository audits now validate repository identifiers before using them, so invalid values fail fast with a clear owner/name format error.
- Repository values from command line input, environment lookup, and inferred GitHub CLI output are normalized before any GitHub calls run.
- The same validation now applies across secret readiness, release secret setup, tagged release readiness, release asset checks, Pages readiness, branch protection, Actions permissions, repository security, and release clobber checks.
- Regression coverage now includes invalid repository names, URL-like values, extra path segments, and a check that failures do not leak secret values.

### Impact
`✅ Fewer failed GitHub checks from malformed repo names`
`✅ Clearer error messages for invalid repository input`
`✅ Reduced risk of accidental GitHub CLI calls with bad repo values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
