### PR TITLE
Harden release metadata repository identifiers

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -791,6 +791,20 @@ def main() -> int:
         raise AssertionError("package-manager generator rejected semver prerelease plus build metadata")
     if generator.validate_tag("v1.2.3-rc.1+build.5") != "v1.2.3-rc.1+build.5":
         raise AssertionError("package-manager generator rejected semver release tag")
+    for repo in ("owner/repo", "owner-name/repo.name", "owner/repo_name"):
+        if generator.validate_repo(repo) != repo:
+            raise AssertionError(f"valid package-manager repository changed during validation: {repo}")
+    for repo, expected in (
+        ("owner_name/repo", "owner contains unsupported characters"),
+        ("owner/..", "repository name is invalid"),
+        ("owner/repo/extra", "owner/name form"),
+        ("owner/repo?secret=value", "name contains unsupported characters"),
+    ):
+        expect_failure(
+            f"invalid package-manager repository {repo}",
+            lambda repo=repo: generator.validate_repo(repo),
+            expected,
+        )
     with tempfile.TemporaryDirectory(prefix="conu-package-manifest-") as temp_text:
         temp = Path(temp_text)
 
@@ -832,6 +846,15 @@ def main() -> int:
                 temp / "symlink-dist-out",
                 "release dist directory must not be a symlink",
             )
+
+        expect_cli_failure(
+            "invalid package-manager repository CLI",
+            rootless_dist,
+            temp / "invalid-repo-out",
+            "owner contains unsupported characters",
+            "--repo",
+            "owner_name/repo",
+        )
 
         symlink_asset = temp / "symlink-asset"
         shutil.copytree(rootless_dist, symlink_asset)

--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -71,6 +71,20 @@ def main() -> int:
             raise AssertionError("release update policy was not deterministic")
 
         generator = load_generator_module()
+        for repo in ("owner/repo", "owner-name/repo.name", "owner/repo_name"):
+            if generator.validate_repo(repo) != repo:
+                raise AssertionError(f"valid update-policy repository changed during validation: {repo}")
+        for repo, expected in (
+            ("owner_name/repo", "owner contains unsupported characters"),
+            ("owner/..", "repository name is invalid"),
+            ("owner/repo/extra", "owner/name form"),
+            ("owner/repo?secret=value", "name contains unsupported characters"),
+        ):
+            expect_module_failure(
+                f"invalid update-policy repository {repo}",
+                lambda repo=repo: generator.validate_repo(repo),
+                expected,
+            )
         expect_module_failure_with_limit(
             generator,
             "text asset size bound",
@@ -257,6 +271,13 @@ def main() -> int:
             tag="v0.2.0",
         )
 
+        expect_failure(
+            "invalid update-policy repository CLI",
+            dist,
+            "owner contains unsupported characters",
+            repo="owner_name/repo",
+        )
+
         forbidden_text = temp / "forbidden-text"
         shutil.copytree(dist, forbidden_text)
         (forbidden_text / "conu.rb").write_text(
@@ -356,6 +377,7 @@ def expect_failure(
     expected: str,
     *,
     release_base_url: str = BASE_URL,
+    repo: str = REPO,
     tag: str = TAG,
 ) -> None:
     failed = subprocess.run(
@@ -370,7 +392,7 @@ def expect_failure(
             "--tag",
             tag,
             "--repo",
-            REPO,
+            repo,
             "--release-base-url",
             release_base_url,
         ],

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -23,11 +23,12 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, BinaryIO
 
+from github_release_secrets import normalize_repo
+
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 TAG_RE = re.compile(r"^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
-REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 MAX_CHECKSUM_BYTES = 4096
 HASH_CHUNK_BYTES = 1024 * 1024
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
@@ -257,9 +258,10 @@ def validate_version(version: str) -> str:
 
 
 def validate_repo(repo: str) -> str:
-    if not REPO_RE.fullmatch(repo):
-        raise SystemExit(f"invalid GitHub repository owner/name: {repo}")
-    return repo
+    try:
+        return normalize_repo(repo)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 def validate_tag(tag: str) -> str:

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -16,11 +16,12 @@ from pathlib import Path
 from typing import Any, BinaryIO
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
+from github_release_secrets import normalize_repo
+
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 TAG_RE = re.compile(r"^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
-REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 HASH_CHUNK_BYTES = 1024 * 1024
 MAX_CHECKSUM_BYTES = 4096
 MAX_SIGNATURE_BYTES = 1024 * 1024
@@ -198,9 +199,10 @@ def validate_tag(tag: str, version: str) -> str:
 
 
 def validate_repo(repo: str) -> str:
-    if not REPO_RE.fullmatch(repo):
-        raise SystemExit(f"invalid GitHub repository owner/name: {repo}")
-    return repo
+    try:
+        return normalize_repo(repo)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 def infer_channel(version: str) -> str:


### PR DESCRIPTION
Closes #844

## Summary
- reuse shared GitHub repository normalization in package-manager manifest generation
- reuse shared GitHub repository normalization in release update policy generation
- add direct and CLI regressions for malformed repository identifiers

## Validation
- python scripts/check-package-manager-manifests.py
- python scripts/check-release-update-policy.py
- python scripts/check-python-script-compile.py
- python scripts/verify-release-versions.py
- git diff --check
- .\\scripts\\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub repository identifier validation in the release update policy and package-manager manifest generators by reusing shared normalization and adding regression tests. This blocks malformed owner/name values and standardizes CLI error messages.

- **Bug Fixes**
  - Use `normalize_repo` from `github_release_secrets` in `generate-package-manager-manifests.py` and `generate-release-update-policy.py` (remove ad-hoc regex).
  - Add regression tests in `check-package-manager-manifests.py` and `check-release-update-policy.py` for valid/invalid repos, including CLI failure cases with clear messages.

<sup>Written for commit 9a51ad0df0c1252ef7e24f4aef539b67243c232c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

