### PR TITLE
Reject trailing data in release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         run: python scripts/check-smoke-output-privacy.py
       - name: Release version consistency
         run: python scripts/verify-release-versions.py
+      - name: Release version regression
+        run: python scripts/check-release-version-regression.py
       - name: Release artifact verifier regression
         run: python scripts/check-release-artifact-verifier.py
       - name: Release artifact smoke preflight regression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,8 @@ jobs:
         run: python scripts/check-smoke-output-privacy.py
       - name: Release version consistency
         run: python scripts/verify-release-versions.py
+      - name: Release version regression
+        run: python scripts/check-release-version-regression.py
       - name: Release artifact verifier regression
         run: python scripts/check-release-artifact-verifier.py
       - name: Release artifact smoke preflight regression

--- a/scripts/check-npm-publish-preflight-regression.py
+++ b/scripts/check-npm-publish-preflight-regression.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from urllib.error import HTTPError
@@ -81,6 +83,29 @@ def run_version_consistency_tests(module) -> None:
         lambda: module.validate_package_version_consistency(mismatched),
         "versions must match",
     )
+
+
+def run_manifest_version_tests(module) -> None:
+    with tempfile.TemporaryDirectory(prefix="conu-npm-publish-preflight-") as temp_text:
+        repo = Path(temp_text)
+        package_dir = repo / "packaging" / "npm" / "conu-cli"
+        package_dir.mkdir(parents=True)
+        manifest = {
+            "name": "@conu/cli",
+            "version": "0.1.0\n",
+        }
+        (package_dir / "package.json").write_text(
+            json.dumps(manifest),
+            encoding="utf-8",
+            newline="\n",
+        )
+        assert_raises(
+            lambda: module.validate_manifest(
+                repo,
+                module.PackageRule("@conu/cli", Path("packaging/npm/conu-cli")),
+            ),
+            "version is not semver-like",
+        )
 
 
 def run_token_tests(module) -> None:
@@ -202,6 +227,7 @@ def main() -> int:
     try:
         run_registry_tests(module)
         run_version_consistency_tests(module)
+        run_manifest_version_tests(module)
         run_token_tests(module)
         run_token_auth_tests(module)
     finally:

--- a/scripts/check-npm-publish-preflight.py
+++ b/scripts/check-npm-publish-preflight.py
@@ -74,7 +74,7 @@ def validate_manifest(repo: Path, rule: PackageRule) -> PackageInfo:
         raise ValueError(f"{manifest_path} name must be {rule.name}")
 
     version = require_string(manifest, "version", manifest_path)
-    if not SEMVER_RE.match(version):
+    if not SEMVER_RE.fullmatch(version):
         raise ValueError(f"{manifest_path} version is not semver-like: {version}")
 
     if manifest.get("private") is True:

--- a/scripts/check-release-version-regression.py
+++ b/scripts/check-release-version-regression.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Regression checks for release version validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify-release-versions.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("verify_release_versions", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load release version verifier module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    module = load_module()
+    for version in ("0.1.0", "1.2.3-rc.1", "1.2.3+build.5", "1.2.3-rc.1+build.5"):
+        if not module.is_semver_like(version):
+            raise AssertionError(f"valid release version was rejected: {version!r}")
+    for version in ("0.1.0\n", "0.1.0 extra", "v0.1.0", "latest"):
+        if module.is_semver_like(version):
+            raise AssertionError(f"invalid release version was accepted: {version!r}")
+    print("release version regression checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-production-readiness.ps1
+++ b/scripts/verify-production-readiness.ps1
@@ -300,6 +300,9 @@ try {
         Invoke-ReadinessStep "release version consistency" {
             & python scripts/verify-release-versions.py
         }
+        Invoke-ReadinessStep "release version regression" {
+            & python scripts/check-release-version-regression.py
+        }
         Invoke-ReadinessStep "release artifact verifier regression" {
             & python scripts/check-release-artifact-verifier.py
         }

--- a/scripts/verify-release-versions.py
+++ b/scripts/verify-release-versions.py
@@ -76,6 +76,10 @@ def expected_tag_version() -> str | None:
     return version
 
 
+def is_semver_like(version: str) -> bool:
+    return SEMVER_RE.fullmatch(version) is not None
+
+
 def main() -> int:
     try:
         repo = Path(__file__).resolve().parents[1]
@@ -95,7 +99,7 @@ def main() -> int:
             return 1
 
         release_version = unique_versions[0]
-        if not SEMVER_RE.match(release_version):
+        if not is_semver_like(release_version):
             print(f"release version is not semver-like: {release_version}", file=sys.stderr)
             return 1
 


### PR DESCRIPTION
Closes #846

## Summary
- require release and npm publish semver checks to match the full string
- add release-version regression coverage for trailing data
- wire the release-version regression into CI, release self-checks, and production-readiness verification

## Validation
- python scripts/check-release-version-regression.py
- python scripts/verify-release-versions.py
- python scripts/check-npm-publish-preflight.py
- python scripts/check-npm-publish-preflight-regression.py
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- .\\scripts\\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require exact semver matches for release tags and `package.json` versions, and add regression checks to block trailing data. Prevents cases like `0.1.0\n`, `0.1.0 extra`, or `v0.1.0` from passing validation.

- **Bug Fixes**
  - Enforce exact semver using `SEMVER_RE.fullmatch` and new `is_semver_like` helper.
  - Add `scripts/check-release-version-regression.py` with valid/invalid cases; extend npm preflight regression to catch trailing newline in `@conu/cli` manifest.
  - Wire regression checks into CI, release workflow, and production-readiness verification.

<sup>Written for commit 1fdfd3445e21e03ec13f09b37fb212de29ed6a23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

