### PR TITLE
Reject unsafe GitHub Release asset names

### DIFF
--- a/scripts/check-github-release-assets-published-regression.py
+++ b/scripts/check-github-release-assets-published-regression.py
@@ -196,6 +196,13 @@ def run_audit_tests(module) -> None:
         "forbiddenAssets",
     )
 
+    whitespace_payload = ready_payload(module)
+    whitespace_payload["assets"][0]["name"] = f"{whitespace_payload['assets'][0]['name']} "
+    assert_raises(
+        lambda: module.audit_release_assets("owner/repo", TEST_TAG, whitespace_payload),
+        "whitespace or control",
+    )
+
     unexpected_payload = ready_payload(module)
     unexpected_payload["assets"].append(
         {"name": "conu-0.1.0-extra-notes.txt", "size": 100, "state": "uploaded"}

--- a/scripts/check-github-release-assets-published.py
+++ b/scripts/check-github-release-assets-published.py
@@ -177,9 +177,12 @@ def release_bool(payload: dict[str, Any], api_field: str, view_field: str) -> bo
 
 def asset_name(asset: dict[str, Any]) -> str:
     value = asset.get("name")
-    if not isinstance(value, str) or not value.strip():
+    if not isinstance(value, str) or not value:
         raise ValueError("GitHub Release asset entry did not include a non-empty name")
-    return value.strip()
+    has_control = any(ord(character) <= 32 or ord(character) == 127 for character in value)
+    if value != value.strip() or has_control:
+        raise ValueError("GitHub Release asset names must not contain whitespace or control characters")
+    return value
 
 
 def asset_size_issue(asset: dict[str, Any], name: str) -> str | None:


### PR DESCRIPTION
Closes #848

## Summary
- reject GitHub Release asset names with leading/trailing whitespace or control characters
- stop normalizing asset names before required-asset comparison
- add regression coverage for whitespace-suffixed required asset names

## Validation
- python scripts/check-github-release-assets-published-regression.py
- python scripts/check-github-release-clobber-preflight-regression.py
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- .\\scripts\\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject GitHub Release asset names with leading/trailing whitespace or control characters, and stop trimming names before required-asset checks. Adds regression tests to verify whitespace-suffixed required asset names are rejected.

<sup>Written for commit 9998040a27a2fbb330821a96a663736ccdc0a02c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for release asset names to reject whitespace (including leading/trailing) and control characters with improved error messaging.

* **Tests**
  * Added regression test to verify validation properly rejects invalid asset names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->