### PR TITLE
Fail release-secret dry runs without npm marker

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -520,9 +520,17 @@ def run_dry_run_tests(module) -> None:
         if calls:
             raise AssertionError("dry run must not call gh secret set")
 
+        assert_raises(
+            lambda: module.require_npm_rotation_marker_for_token_write(
+                values=values,
+                marker_requested=False,
+                dry_run=True,
+            ),
+            module.NPM_TOKEN_ROTATION_MARKER_VAR,
+        )
         module.require_npm_rotation_marker_for_token_write(
             values=values,
-            marker_requested=False,
+            marker_requested=True,
             dry_run=True,
         )
         module.require_npm_rotation_marker_for_token_write(
@@ -564,10 +572,10 @@ def run_env_file_main_tests(module) -> None:
                     "--dry-run",
                 ]
             )
-            if exit_code != 0:
-                raise AssertionError(f"expected env-file dry run to pass: {rendered}")
+            if exit_code == 0 or module.NPM_TOKEN_ROTATION_MARKER_VAR not in rendered:
+                raise AssertionError(f"expected env-file dry run without marker to fail: {rendered}")
             if SENSITIVE_SENTINEL in rendered:
-                raise AssertionError("env-file dry-run output leaked a secret value")
+                raise AssertionError("env-file dry-run marker error leaked a secret value")
 
             exit_code, rendered = call_main(
                 module,
@@ -583,10 +591,37 @@ def run_env_file_main_tests(module) -> None:
                     "--dry-run",
                 ]
             )
-            if exit_code != 0:
-                raise AssertionError(f"expected env-file-only dry run to pass: {rendered}")
+            if exit_code == 0 or module.NPM_TOKEN_ROTATION_MARKER_VAR not in rendered:
+                raise AssertionError(
+                    f"expected env-file-only dry run without marker to fail: {rendered}"
+                )
             if SENSITIVE_SENTINEL in rendered:
-                raise AssertionError("env-file-only dry-run output leaked a secret value")
+                raise AssertionError("env-file-only dry-run marker error leaked a secret value")
+
+            exit_code, rendered = call_main(
+                module,
+                [
+                    "set-github-release-secrets.py",
+                    "--repo",
+                    "owner/repo",
+                    "--gh",
+                    "gh",
+                    "--env-file",
+                    str(env_file),
+                    "--env-file-only",
+                    "--dry-run",
+                    "--set-npm-token-rotation-marker",
+                    "2026-06-03T00:00:01Z",
+                    "--allow-unverified-npm-token-rotation-marker",
+                    "--confirm-npm-token-rotated",
+                ]
+            )
+            if exit_code != 0:
+                raise AssertionError(f"expected env-file-only dry run with marker to pass: {rendered}")
+            if module.NPM_TOKEN_ROTATION_MARKER_VAR not in rendered:
+                raise AssertionError("env-file-only dry run with marker omitted marker variable")
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("env-file-only dry-run with marker leaked a secret value")
 
             exit_code, rendered = call_main(
                 module,
@@ -764,10 +799,14 @@ def run_env_file_main_tests(module) -> None:
                         "--dry-run",
                     ]
                 )
-                if exit_code != 0:
-                    raise AssertionError("normal env-file mode should allow environment fallback")
+                if exit_code == 0 or module.NPM_TOKEN_ROTATION_MARKER_VAR not in rendered:
+                    raise AssertionError(
+                        "normal env-file fallback should still require the npm rotation marker"
+                    )
+                if "missing local release secret values" in rendered:
+                    raise AssertionError("normal env-file fallback should load environment values")
                 if SENSITIVE_SENTINEL in rendered:
-                    raise AssertionError("normal env-file fallback output leaked a secret value")
+                    raise AssertionError("normal env-file fallback marker error leaked a secret value")
             finally:
                 restore_env(original_with_env)
     finally:

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -348,12 +348,13 @@ def require_npm_rotation_marker_for_token_write(
     marker_requested: bool,
     dry_run: bool,
 ) -> None:
-    if dry_run or marker_requested:
+    # Dry-run must fail like the real write so setup checks cannot bless a stale token.
+    if marker_requested:
         return
     if (value := values.get(NPM_TOKEN_SECRET_NAME)) is None or value.strip() == "":
         return
     raise ValueError(
-        f"{NPM_TOKEN_SECRET_NAME} upload requires "
+        f"{NPM_TOKEN_SECRET_NAME} setup requires "
         f"{NPM_TOKEN_ROTATION_MARKER_VAR}; add "
         "--set-npm-token-rotation-marker-from-secret-updated-at "
         "--confirm-npm-token-rotated after rotating the token"


### PR DESCRIPTION
Closes #850.

## Summary
- require the NPM token rotation marker during release-secret setup dry-runs, matching the real write path
- extend release-secret setup regression coverage for dry-run failure without the marker and success with an explicit rotated-token marker
- keep setup output payload-safe and secret-value-free

## Validation
- python scripts\set-github-release-secrets-regression.py
- python scripts\check-release-secret-rotation-gate-regression.py
- python scripts\check-tagged-release-readiness-regression.py
- python scripts\check-python-script-compile.py
- python scripts\check-github-workflow-permissions.py
- .\scripts\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make release-secret dry runs fail unless the NPM token rotation marker is provided, matching real write behavior and preventing approval of stale tokens. Adds regression tests and keeps dry-run output free of secret values.

- **Bug Fixes**
  - Dry-run now requires the rotation marker when `NPM_TOKEN` is set; errors mention `NPM_TOKEN_ROTATION_MARKER`.
  - Added regression coverage for failure without the marker and success with an explicit marker in env-file and env-file-only modes.
  - Ensured environment fallback still loads values but enforces the marker; dry-run errors never print secret values.

<sup>Written for commit 61f2debb42d622d22127fc19920167e232ec5746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

