### PR TITLE
Include npm marker in release-secret readiness

### DIFF
--- a/scripts/check-github-release-secret-readiness-regression.py
+++ b/scripts/check-github-release-secret-readiness-regression.py
@@ -32,10 +32,30 @@ def assert_raises(func, pattern: str) -> None:
     try:
         func()
     except ValueError as exc:
+        if SENSITIVE_SENTINEL in str(exc):
+            raise AssertionError("error message leaked a secret or variable value") from exc
         if pattern not in str(exc):
             raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
         return
     raise AssertionError(f"expected ValueError containing {pattern!r}")
+
+
+def assert_safe_report(report) -> dict[str, object]:
+    rendered = json.dumps(report.as_json(), sort_keys=True)
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("release secret readiness report leaked a sensitive value")
+    parsed = json.loads(rendered)
+    for field in (
+        "payloadDisplayed",
+        "tokenDisplayed",
+        "tokenHashDisplayed",
+        "keyMaterialDisplayed",
+        "contentsDisplayed",
+        "secretValuesDisplayed",
+    ):
+        if parsed.get(field) is not False:
+            raise AssertionError(f"expected {field}=false")
+    return parsed
 
 
 def run_audit_tests(module) -> None:
@@ -51,6 +71,51 @@ def run_audit_tests(module) -> None:
     not_ready = module.audit_secret_names("owner/repo", configured)
     if not not_ready.missing == (missing_name,):
         raise AssertionError(f"expected only {missing_name} missing, got {not_ready.missing}")
+
+
+def run_rotation_marker_tests(module) -> None:
+    configured = set(module.REQUIRED_RELEASE_SECRETS)
+    ready = module.audit_release_secret_readiness(
+        "owner/repo",
+        configured,
+        {module.NPM_TOKEN_ROTATION_MARKER_VAR: "2026-06-03T00:00:01Z"},
+    )
+    if not ready.ready:
+        raise AssertionError(f"expected ready marker report: {ready.npm_rotation_marker.issues!r}")
+    parsed_ready = assert_safe_report(ready)
+    if parsed_ready["npmTokenRotationMarker"]["rotatedAfter"] != "2026-06-03T00:00:01Z":
+        raise AssertionError("valid marker timestamp was not included in normalized form")
+
+    missing = module.audit_release_secret_readiness("owner/repo", configured, {})
+    if missing.ready:
+        raise AssertionError("missing npm rotation marker should fail readiness")
+    parsed_missing = assert_safe_report(missing)
+    if module.NPM_TOKEN_ROTATION_MARKER_VAR not in json.dumps(parsed_missing):
+        raise AssertionError("missing marker report omitted marker variable name")
+
+    stale = module.audit_release_secret_readiness(
+        "owner/repo",
+        configured,
+        {module.NPM_TOKEN_ROTATION_MARKER_VAR: "2026-06-03T00:00:00Z"},
+    )
+    if stale.ready:
+        raise AssertionError("stale npm rotation marker should fail readiness")
+    parsed_stale = assert_safe_report(stale)
+    if "not after required timestamp" not in json.dumps(parsed_stale):
+        raise AssertionError("stale marker issue was not reported")
+
+    invalid = module.audit_release_secret_readiness(
+        "owner/repo",
+        configured,
+        {module.NPM_TOKEN_ROTATION_MARKER_VAR: SENSITIVE_SENTINEL},
+    )
+    if invalid.ready:
+        raise AssertionError("invalid npm rotation marker should fail readiness")
+    parsed_invalid = assert_safe_report(invalid)
+    if parsed_invalid["npmTokenRotationMarker"]["rotatedAfter"] != "":
+        raise AssertionError("invalid marker value should not be echoed")
+    if "timestamp is invalid" not in json.dumps(parsed_invalid):
+        raise AssertionError("invalid marker issue was not reported")
 
 
 def run_repo_normalization_tests(module) -> None:
@@ -86,20 +151,30 @@ def run_repo_normalization_tests(module) -> None:
 def run_gh_payload_tests(module) -> None:
     helper = sys.modules["github_release_secrets"]
 
-    def fake_secret_list(args, **_kwargs):
-        if args[1:4] != ["secret", "list", "--repo"]:
-            raise AssertionError(f"unexpected gh args: {args!r}")
-        payload = [
-            {"name": name, "value": SENSITIVE_SENTINEL}
-            for name in module.REQUIRED_RELEASE_SECRETS
-        ]
-        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+    def fake_gh_list(args, **_kwargs):
+        if args[1:4] == ["secret", "list", "--repo"]:
+            payload = [
+                {"name": name, "value": SENSITIVE_SENTINEL}
+                for name in module.REQUIRED_RELEASE_SECRETS
+            ]
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:4] == ["variable", "list", "--repo"]:
+            payload = [
+                {
+                    "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
+                    "value": "2026-06-03T00:00:01Z",
+                },
+                {"name": "UNRELATED_VARIABLE", "value": SENSITIVE_SENTINEL},
+            ]
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        raise AssertionError(f"unexpected gh args: {args!r}")
 
     original_run = subprocess.run
-    helper.subprocess.run = fake_secret_list
+    helper.subprocess.run = fake_gh_list
     try:
         names = module.load_secret_names("owner/repo", "gh")
         metadata = helper.load_secret_metadata("owner/repo", "gh")
+        variables = module.load_variable_values("owner/repo", "gh")
     finally:
         helper.subprocess.run = original_run
 
@@ -110,10 +185,10 @@ def run_gh_payload_tests(module) -> None:
     for record in metadata.values():
         if record.updated_at != "":
             raise AssertionError("unexpected updatedAt value in fake metadata payload")
-    report = module.audit_secret_names("owner/repo", names)
-    rendered = json.dumps(report.as_json())
-    if SENSITIVE_SENTINEL in rendered:
-        raise AssertionError("secret readiness report included a secret value")
+    if variables[module.NPM_TOKEN_ROTATION_MARKER_VAR] != "2026-06-03T00:00:01Z":
+        raise AssertionError("loaded variable values did not include the rotation marker")
+    report = module.audit_release_secret_readiness("owner/repo", names, variables)
+    assert_safe_report(report)
 
 
 def run_error_tests(module) -> None:
@@ -129,6 +204,10 @@ def run_error_tests(module) -> None:
             lambda: module.load_secret_names("owner/repo", "gh"),
             "invalid JSON",
         )
+        assert_raises(
+            lambda: module.load_variable_values("owner/repo", "gh"),
+            "invalid JSON",
+        )
     finally:
         helper.subprocess.run = original_run
 
@@ -141,6 +220,10 @@ def run_error_tests(module) -> None:
             lambda: module.load_secret_names("owner/repo", "gh"),
             "gh secret list failed",
         )
+        assert_raises(
+            lambda: module.load_variable_values("owner/repo", "gh"),
+            "gh variable list failed",
+        )
     finally:
         helper.subprocess.run = original_run
 
@@ -148,17 +231,26 @@ def run_error_tests(module) -> None:
 def run_main_tests(module) -> None:
     helper = sys.modules["github_release_secrets"]
 
-    def fake_secret_list(args, **_kwargs):
-        if args[1:4] != ["secret", "list", "--repo"]:
-            raise AssertionError(f"unexpected gh args: {args!r}")
-        payload = [{"name": name} for name in module.REQUIRED_RELEASE_SECRETS]
-        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+    def fake_gh_list(args, **_kwargs):
+        if args[1:4] == ["secret", "list", "--repo"]:
+            payload = [{"name": name} for name in module.REQUIRED_RELEASE_SECRETS]
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:4] == ["variable", "list", "--repo"]:
+            payload = [
+                {
+                    "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
+                    "value": "2026-06-03T00:00:01Z",
+                },
+                {"name": "UNRELATED_VARIABLE", "value": SENSITIVE_SENTINEL},
+            ]
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        raise AssertionError(f"unexpected gh args: {args!r}")
 
     original_run = subprocess.run
     original_argv = sys.argv
     stdout = io.StringIO()
     stderr = io.StringIO()
-    helper.subprocess.run = fake_secret_list
+    helper.subprocess.run = fake_gh_list
     sys.argv = [
         "check-github-release-secret-readiness.py",
         "--repo",
@@ -176,8 +268,10 @@ def run_main_tests(module) -> None:
     if exit_code != 0:
         raise AssertionError(f"expected main() to pass, got {exit_code}: {stderr.getvalue()}")
     rendered = stdout.getvalue() + stderr.getvalue()
+    if module.NPM_TOKEN_ROTATION_MARKER_VAR not in rendered:
+        raise AssertionError("main() output omitted the rotation marker variable")
     if SENSITIVE_SENTINEL in rendered:
-        raise AssertionError("main() output leaked a secret value")
+        raise AssertionError("main() output leaked a secret or variable value")
 
     sys.argv = [
         "check-github-release-secret-readiness.py",
@@ -210,6 +304,7 @@ def run_main_tests(module) -> None:
 def main() -> int:
     module = load_module()
     run_audit_tests(module)
+    run_rotation_marker_tests(module)
     run_repo_normalization_tests(module)
     run_gh_payload_tests(module)
     run_error_tests(module)

--- a/scripts/check-github-release-secret-readiness.py
+++ b/scripts/check-github-release-secret-readiness.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
-"""Audit GitHub Actions release secret names before creating a release tag."""
+"""Audit GitHub Actions release secrets before creating a release tag."""
 
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from github_release_secrets import (
+    NPM_TOKEN_ROTATION_MARKER_VAR,
+    NPM_TOKEN_ROTATION_REQUIRED_AFTER,
+    NPM_TOKEN_SECRET_NAME,
     REQUIRED_RELEASE_SECRETS,
     SecretReadiness,
     audit_secret_names,
@@ -17,26 +23,113 @@ from github_release_secrets import (
     infer_repo,
     load_secret_names,
     normalize_repo,
+    run_gh_json,
 )
 
 
-def print_text_report(report: SecretReadiness) -> None:
+@dataclass(frozen=True)
+class ReleaseSecretReadiness:
+    repo: str
+    secrets: SecretReadiness
+    npm_rotation_marker: Any
+
+    @property
+    def ready(self) -> bool:
+        return self.secrets.ready and self.npm_rotation_marker.ready
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "schema": "conu.githubReleaseSecretReadiness.v1",
+            "repo": self.repo,
+            "ready": self.ready,
+            "releaseSecrets": self.secrets.as_json(),
+            "npmTokenRotationMarker": self.npm_rotation_marker.as_json(),
+            "payloadDisplayed": False,
+            "tokenDisplayed": False,
+            "tokenHashDisplayed": False,
+            "keyMaterialDisplayed": False,
+            "contentsDisplayed": False,
+            "secretValuesDisplayed": False,
+        }
+
+
+def load_script_module(filename: str, module_name: str):
+    path = Path(__file__).with_name(filename)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"could not load {filename}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_variable_values(repo: str, gh: str) -> dict[str, str]:
+    payload = run_gh_json(
+        gh,
+        ["variable", "list", "--repo", repo, "--json", "name,value"],
+        "gh variable list",
+    )
+    if not isinstance(payload, list):
+        raise ValueError("gh variable list returned an unexpected payload")
+    values: dict[str, str] = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            raise ValueError("gh variable list returned a non-object variable entry")
+        name = item.get("name")
+        value = item.get("value", "")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("gh variable list returned a variable entry without a name")
+        if not isinstance(value, str):
+            raise ValueError(f"gh variable list returned a non-string value for {name}")
+        values[name.strip()] = value.strip()
+    return values
+
+
+def audit_release_secret_readiness(
+    repo: str,
+    secret_names: set[str],
+    variable_values: dict[str, str],
+) -> ReleaseSecretReadiness:
+    repo = normalize_repo(repo)
+    secrets = audit_secret_names(repo, secret_names)
+    gate_module = load_script_module(
+        "check-release-secret-rotation-gate.py",
+        "check_release_secret_rotation_gate_for_secret_readiness",
+    )
+    npm_rotation_marker = gate_module.audit_rotation_marker(
+        secret_name=NPM_TOKEN_SECRET_NAME,
+        marker_env=NPM_TOKEN_ROTATION_MARKER_VAR,
+        required_after=NPM_TOKEN_ROTATION_REQUIRED_AFTER,
+        rotated_after=variable_values.get(NPM_TOKEN_ROTATION_MARKER_VAR, ""),
+    )
+    return ReleaseSecretReadiness(
+        repo=repo,
+        secrets=secrets,
+        npm_rotation_marker=npm_rotation_marker,
+    )
+
+
+def print_text_report(report: ReleaseSecretReadiness) -> None:
     if report.ready:
         print(
             "GitHub release secret readiness passed: "
-            f"{len(report.present)}/{len(report.required)} required secret names configured "
+            f"{len(report.secrets.present)}/{len(report.secrets.required)} required secret names "
+            f"and {report.npm_rotation_marker.marker_env} configured "
             f"for {report.repo}"
         )
         return
 
     print(
         "GitHub release secret readiness failed: "
-        f"{len(report.missing)}/{len(report.required)} required secret names missing "
+        f"{len(report.secrets.missing)}/{len(report.secrets.required)} required secret names missing "
         f"for {report.repo}",
         file=sys.stderr,
     )
-    for name in report.missing:
+    for name in report.secrets.missing:
         print(f"missing: {name}", file=sys.stderr)
+    for issue in report.npm_rotation_marker.issues:
+        print(f"marker: {issue}", file=sys.stderr)
 
 
 def parse_args() -> argparse.Namespace:
@@ -49,7 +142,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--json",
         action="store_true",
-        help="print a machine-readable report containing secret names only",
+        help="print a machine-readable report containing secret names and non-secret marker status",
     )
     parser.add_argument(
         "--gh",
@@ -67,7 +160,11 @@ def main() -> int:
 
         gh = args.gh or find_gh()
         repo = normalize_repo(args.repo.strip() or infer_repo(gh))
-        report = audit_secret_names(repo, load_secret_names(repo, gh))
+        report = audit_release_secret_readiness(
+            repo,
+            load_secret_names(repo, gh),
+            load_variable_values(repo, gh),
+        )
     except (OSError, ValueError) as exc:
         print(f"GitHub release secret readiness failed: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
Closes #852.

## Summary
- make the live release-secret readiness audit validate the non-secret NPM token rotation marker
- report missing/stale/invalid CONU_NPM_TOKEN_ROTATED_AFTER without printing secret values or invalid marker values
- extend regression coverage for secret names, GitHub variable loading, marker readiness, and payload-safe output

## Validation
- python scripts\check-github-release-secret-readiness.py --repo imthegoodboy/conU (expected fail: missing signing secrets and marker)
- python scripts\check-github-release-secret-readiness-regression.py
- python scripts\check-release-secret-rotation-gate-regression.py
- python scripts\check-tagged-release-readiness-regression.py
- python scripts\check-python-script-compile.py
- python scripts\check-github-workflow-permissions.py
- .\scripts\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the release-secret readiness audit to also verify the non-secret NPM token rotation marker, blocking releases when the marker is missing, stale, or invalid. Adds safe GitHub Variable loading and reporting without leaking secret or variable values.

- **New Features**
  - Combine secret name checks with NPM rotation marker readiness using `CONU_NPM_TOKEN_ROTATED_AFTER`.
  - Load GitHub Variables via `gh variable list` and include marker status in reports.
  - Update JSON output to schema `conu.githubReleaseSecretReadiness.v1` with explicit “no sensitive data displayed” flags.
  - Text report now shows missing secrets and marker issues; JSON report includes normalized marker timestamp when valid.
  - Add regression tests for marker readiness, gh payload parsing, error handling, and output safety.

<sup>Written for commit 610bb911ac569ba496bbe3d822cae69de5ea53c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

