### PR TITLE
Defer npm marker metadata in full dry runs

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -1108,6 +1108,46 @@ def run_rotation_marker_main_tests(module) -> None:
                 raise AssertionError("combined dry-run omitted marker setup output")
             if SENSITIVE_SENTINEL in rendered:
                 raise AssertionError("combined marker dry-run leaked a secret value")
+
+            original_loader = module.load_secret_metadata
+            try:
+                module.load_secret_metadata = (
+                    lambda _repo, _gh: (_ for _ in ()).throw(
+                        AssertionError(
+                            "full dry-run should not read existing NPM_TOKEN metadata"
+                        )
+                    )
+                )
+                exit_code, rendered = call_main(
+                    module,
+                    [
+                        "set-github-release-secrets.py",
+                        "--repo",
+                        "owner/repo",
+                        "--gh",
+                        "gh",
+                        "--env-file",
+                        str(env_file),
+                        "--env-file-only",
+                        "--set-npm-token-rotation-marker-from-secret-updated-at",
+                        "--confirm-npm-token-rotated",
+                        "--dry-run",
+                    ],
+                )
+            finally:
+                module.load_secret_metadata = original_loader
+            if exit_code != 0:
+                raise AssertionError(
+                    f"expected env-file plus updatedAt marker dry-run to pass: {rendered}"
+                )
+            if "release secret setup" not in rendered:
+                raise AssertionError("updatedAt dry-run omitted release secret setup output")
+            if module.NPM_TOKEN_ROTATION_MARKER_VAR not in rendered:
+                raise AssertionError("updatedAt dry-run omitted marker setup output")
+            if module.DRY_RUN_NPM_TOKEN_ROTATION_MARKER_FROM_UPDATED_AT not in rendered:
+                raise AssertionError("updatedAt dry-run omitted deferred marker text")
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("updatedAt marker dry-run leaked a secret value")
     finally:
         restore_env(original)
 

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -30,6 +30,9 @@ MAX_ENV_FILE_BYTES = 128 * 1024
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 POSIX_ENV_FILE_FORBIDDEN_MODE = stat.S_IRWXG | stat.S_IRWXO
+DRY_RUN_NPM_TOKEN_ROTATION_MARKER_FROM_UPDATED_AT = (
+    "from NPM_TOKEN updatedAt after upload"
+)
 
 
 def render_env_template(names: tuple[str, ...]) -> str:
@@ -361,6 +364,18 @@ def require_npm_rotation_marker_for_token_write(
     )
 
 
+def should_defer_npm_rotation_marker_updated_at(
+    *,
+    dry_run: bool,
+    derive_from_secret_updated_at: bool,
+    secret_setup_requested: bool,
+    values: Mapping[str, str],
+) -> bool:
+    if not (dry_run and derive_from_secret_updated_at and secret_setup_requested):
+        return False
+    return values.get(NPM_TOKEN_SECRET_NAME, "").strip() != ""
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -608,17 +623,29 @@ def main() -> int:
             configured = configure_release_secrets(repo, gh, values, args.dry_run)
         if marker_requested:
             if args.set_npm_token_rotation_marker_from_secret_updated_at:
-                marker_timestamp = load_npm_rotation_marker_timestamp_from_secret_metadata(
+                if should_defer_npm_rotation_marker_updated_at(
+                    dry_run=args.dry_run,
+                    derive_from_secret_updated_at=True,
+                    secret_setup_requested=secret_setup_requested,
+                    values=values,
+                ):
+                    marker_timestamp = DRY_RUN_NPM_TOKEN_ROTATION_MARKER_FROM_UPDATED_AT
+                else:
+                    marker_timestamp = load_npm_rotation_marker_timestamp_from_secret_metadata(
+                        repo,
+                        gh,
+                    )
+            if marker_timestamp == DRY_RUN_NPM_TOKEN_ROTATION_MARKER_FROM_UPDATED_AT:
+                if not args.dry_run:
+                    raise ValueError("internal error: deferred npm rotation marker requires --dry-run")
+            else:
+                marker_timestamp = configure_npm_rotation_marker(
                     repo,
                     gh,
+                    marker_timestamp or args.set_npm_token_rotation_marker,
+                    args.confirm_npm_token_rotated,
+                    args.dry_run,
                 )
-            marker_timestamp = configure_npm_rotation_marker(
-                repo,
-                gh,
-                marker_timestamp or args.set_npm_token_rotation_marker,
-                args.confirm_npm_token_rotated,
-                args.dry_run,
-            )
     except (OSError, ValueError) as exc:
         action = (
             "GitHub release secret env file check failed"


### PR DESCRIPTION
Closes #854

Summary:
- Defer the `CONU_NPM_TOKEN_ROTATED_AFTER` updatedAt marker during full release-secret dry-runs when the dry-run includes a local `NPM_TOKEN` upload.
- Keep marker-only dry-runs reading existing GitHub metadata, matching the real marker-only flow.
- Add regression coverage that proves full dry-runs do not read stale existing `NPM_TOKEN` metadata and do not print secret values.

Validation:
- `python scripts\set-github-release-secrets-regression.py`
- `python scripts\check-release-secret-rotation-gate-regression.py`
- `python scripts\check-github-release-secret-readiness-regression.py`
- `python scripts\check-tagged-release-readiness-regression.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-github-workflow-permissions.py`
- `.\scripts\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer reading and setting the NPM token rotation marker during full release-secret dry runs that upload a local `NPM_TOKEN`, preventing stale metadata reads and any secret output. Marker-only dry runs still read GitHub metadata to mirror real runs. Closes #854.

- **Bug Fixes**
  - Skip existing metadata read in full dry runs with a local token via `should_defer_npm_rotation_marker_updated_at`.
  - Add sentinel `DRY_RUN_NPM_TOKEN_ROTATION_MARKER_FROM_UPDATED_AT` and guard to ensure it’s only used with `--dry-run`.
  - Keep marker-only dry runs using `load_npm_rotation_marker_timestamp_from_secret_metadata`.
  - Add regression tests to verify no stale reads and no secret leakage.

<sup>Written for commit 4ce12099f508c47252dcd5c27a356d60e7c328cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

