### PR TITLE
Allowlist release readiness variable values

### DIFF
--- a/scripts/check-github-release-secret-readiness-regression.py
+++ b/scripts/check-github-release-secret-readiness-regression.py
@@ -158,15 +158,35 @@ def run_gh_payload_tests(module) -> None:
                 for name in module.REQUIRED_RELEASE_SECRETS
             ]
             return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
-        if args[1:4] == ["variable", "list", "--repo"]:
+        if args[1:] == [
+            "variable",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name",
+        ]:
             payload = [
-                {
-                    "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
-                    "value": "2026-06-03T00:00:01Z",
-                },
-                {"name": "UNRELATED_VARIABLE", "value": SENSITIVE_SENTINEL},
+                {"name": module.NPM_TOKEN_ROTATION_MARKER_VAR},
+                {"name": "UNRELATED_VARIABLE"},
             ]
             return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:] == [
+            "variable",
+            "get",
+            module.NPM_TOKEN_ROTATION_MARKER_VAR,
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name,value",
+        ]:
+            payload = {
+                "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
+                "value": "2026-06-03T00:00:01Z",
+            }
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:3] == ["variable", "get"]:
+            raise AssertionError(f"unexpected variable value request: {args!r}")
         raise AssertionError(f"unexpected gh args: {args!r}")
 
     original_run = subprocess.run
@@ -174,7 +194,11 @@ def run_gh_payload_tests(module) -> None:
     try:
         names = module.load_secret_names("owner/repo", "gh")
         metadata = helper.load_secret_metadata("owner/repo", "gh")
-        variables = module.load_variable_values("owner/repo", "gh")
+        variables = module.load_variable_values(
+            "owner/repo",
+            "gh",
+            module.REQUIRED_VARIABLE_VALUES,
+        )
     finally:
         helper.subprocess.run = original_run
 
@@ -187,6 +211,8 @@ def run_gh_payload_tests(module) -> None:
             raise AssertionError("unexpected updatedAt value in fake metadata payload")
     if variables[module.NPM_TOKEN_ROTATION_MARKER_VAR] != "2026-06-03T00:00:01Z":
         raise AssertionError("loaded variable values did not include the rotation marker")
+    if "UNRELATED_VARIABLE" in variables:
+        raise AssertionError("loaded variable values included an unrelated variable")
     report = module.audit_release_secret_readiness("owner/repo", names, variables)
     assert_safe_report(report)
 
@@ -205,7 +231,11 @@ def run_error_tests(module) -> None:
             "invalid JSON",
         )
         assert_raises(
-            lambda: module.load_variable_values("owner/repo", "gh"),
+            lambda: module.load_variable_values(
+                "owner/repo",
+                "gh",
+                module.REQUIRED_VARIABLE_VALUES,
+            ),
             "invalid JSON",
         )
     finally:
@@ -221,7 +251,11 @@ def run_error_tests(module) -> None:
             "gh secret list failed",
         )
         assert_raises(
-            lambda: module.load_variable_values("owner/repo", "gh"),
+            lambda: module.load_variable_values(
+                "owner/repo",
+                "gh",
+                module.REQUIRED_VARIABLE_VALUES,
+            ),
             "gh variable list failed",
         )
     finally:
@@ -235,15 +269,35 @@ def run_main_tests(module) -> None:
         if args[1:4] == ["secret", "list", "--repo"]:
             payload = [{"name": name} for name in module.REQUIRED_RELEASE_SECRETS]
             return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
-        if args[1:4] == ["variable", "list", "--repo"]:
+        if args[1:] == [
+            "variable",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name",
+        ]:
             payload = [
-                {
-                    "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
-                    "value": "2026-06-03T00:00:01Z",
-                },
-                {"name": "UNRELATED_VARIABLE", "value": SENSITIVE_SENTINEL},
+                {"name": module.NPM_TOKEN_ROTATION_MARKER_VAR},
+                {"name": "UNRELATED_VARIABLE"},
             ]
             return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:] == [
+            "variable",
+            "get",
+            module.NPM_TOKEN_ROTATION_MARKER_VAR,
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name,value",
+        ]:
+            payload = {
+                "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
+                "value": "2026-06-03T00:00:01Z",
+            }
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:3] == ["variable", "get"]:
+            raise AssertionError(f"unexpected variable value request: {args!r}")
         raise AssertionError(f"unexpected gh args: {args!r}")
 
     original_run = subprocess.run

--- a/scripts/check-github-release-secret-readiness.py
+++ b/scripts/check-github-release-secret-readiness.py
@@ -22,9 +22,12 @@ from github_release_secrets import (
     find_gh,
     infer_repo,
     load_secret_names,
+    load_variable_values,
     normalize_repo,
-    run_gh_json,
 )
+
+
+REQUIRED_VARIABLE_VALUES = (NPM_TOKEN_ROTATION_MARKER_VAR,)
 
 
 @dataclass(frozen=True)
@@ -62,28 +65,6 @@ def load_script_module(filename: str, module_name: str):
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
-
-
-def load_variable_values(repo: str, gh: str) -> dict[str, str]:
-    payload = run_gh_json(
-        gh,
-        ["variable", "list", "--repo", repo, "--json", "name,value"],
-        "gh variable list",
-    )
-    if not isinstance(payload, list):
-        raise ValueError("gh variable list returned an unexpected payload")
-    values: dict[str, str] = {}
-    for item in payload:
-        if not isinstance(item, dict):
-            raise ValueError("gh variable list returned a non-object variable entry")
-        name = item.get("name")
-        value = item.get("value", "")
-        if not isinstance(name, str) or not name.strip():
-            raise ValueError("gh variable list returned a variable entry without a name")
-        if not isinstance(value, str):
-            raise ValueError(f"gh variable list returned a non-string value for {name}")
-        values[name.strip()] = value.strip()
-    return values
 
 
 def audit_release_secret_readiness(
@@ -163,7 +144,7 @@ def main() -> int:
         report = audit_release_secret_readiness(
             repo,
             load_secret_names(repo, gh),
-            load_variable_values(repo, gh),
+            load_variable_values(repo, gh, REQUIRED_VARIABLE_VALUES),
         )
     except (OSError, ValueError) as exc:
         print(f"GitHub release secret readiness failed: {exc}", file=sys.stderr)

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -8,6 +8,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 SCRIPT = Path(__file__).with_name("check-tagged-release-readiness.py")
@@ -1086,6 +1087,82 @@ def run_custom_repository_tests(module) -> None:
         raise AssertionError("explicit loopback endpoint allowance should normalize URL")
 
 
+def run_variable_loader_tests(module) -> None:
+    helper = sys.modules["github_release_secrets"]
+
+    def fake_gh(args, **_kwargs):
+        if args[1:] == [
+            "variable",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name",
+        ]:
+            payload = [
+                {"name": module.NPM_TOKEN_ROTATION_MARKER_VAR},
+                {"name": module.CUSTOM_REPOSITORY_BASE_URL_VAR},
+                {"name": "UNRELATED_VARIABLE"},
+            ]
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:] == [
+            "variable",
+            "get",
+            module.NPM_TOKEN_ROTATION_MARKER_VAR,
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name,value",
+        ]:
+            payload = {
+                "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
+                "value": "2026-06-03T00:00:01Z",
+            }
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:] == [
+            "variable",
+            "get",
+            module.CUSTOM_REPOSITORY_BASE_URL_VAR,
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name,value",
+        ]:
+            payload = {
+                "name": module.CUSTOM_REPOSITORY_BASE_URL_VAR,
+                "value": "https://packages.example.com/conu/",
+            }
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        if args[1:3] == ["variable", "get"]:
+            raise AssertionError(f"unexpected variable value request: {args!r}")
+        raise AssertionError(f"unexpected gh args: {args!r}")
+
+    original_run = helper.subprocess.run
+    helper.subprocess.run = fake_gh
+    try:
+        values = module.load_variable_values(
+            "owner/repo",
+            "gh",
+            module.REQUIRED_VARIABLE_VALUES,
+        )
+    finally:
+        helper.subprocess.run = original_run
+
+    if values[module.NPM_TOKEN_ROTATION_MARKER_VAR] != "2026-06-03T00:00:01Z":
+        raise AssertionError("variable loader omitted the npm rotation marker")
+    if (
+        values[module.CUSTOM_REPOSITORY_BASE_URL_VAR]
+        != "https://packages.example.com/conu/"
+    ):
+        raise AssertionError("variable loader omitted the custom repository base URL")
+    if module.CUSTOM_REPOSITORY_BUCKET_VAR in values:
+        raise AssertionError("variable loader should omit absent allowlisted variables")
+    if "UNRELATED_VARIABLE" in values:
+        raise AssertionError("variable loader included an unrelated variable")
+    if SENSITIVE_SENTINEL in json.dumps(values):
+        raise AssertionError("variable loader leaked unrelated sensitive text")
+
+
 def run_safe_failure_tests(module) -> None:
     invalid = module.audit_tagged_release_readiness(
         repo="owner/repo",
@@ -1159,6 +1236,7 @@ def main() -> int:
     run_secret_rotation_tests(module)
     run_secret_rotation_marker_tests(module)
     run_custom_repository_tests(module)
+    run_variable_loader_tests(module)
     run_safe_failure_tests(module)
     print("Tagged release readiness regression checks passed")
     return 0

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -26,6 +26,7 @@ from github_release_secrets import (
     infer_repo,
     load_secret_metadata,
     load_secret_names,
+    load_variable_values,
     normalize_repo,
     run_gh_json,
 )
@@ -44,6 +45,14 @@ CUSTOM_REPOSITORY_REGION_VAR = "CONU_LINUX_REPOSITORY_AWS_REGION"
 CUSTOM_REPOSITORY_REQUIRED_SECRETS = (
     "CONU_LINUX_REPOSITORY_AWS_ACCESS_KEY_ID",
     "CONU_LINUX_REPOSITORY_AWS_SECRET_ACCESS_KEY",
+)
+REQUIRED_VARIABLE_VALUES = (
+    NPM_TOKEN_ROTATION_MARKER_VAR,
+    CUSTOM_REPOSITORY_BASE_URL_VAR,
+    CUSTOM_REPOSITORY_BUCKET_VAR,
+    CUSTOM_REPOSITORY_PREFIX_VAR,
+    CUSTOM_REPOSITORY_ENDPOINT_VAR,
+    CUSTOM_REPOSITORY_REGION_VAR,
 )
 CRATE_MANIFESTS = (
     Path("crates/conu-cli/Cargo.toml"),
@@ -477,28 +486,6 @@ def audit_secret_rotation_markers(
         markers=tuple(markers),
         issues=tuple(issues),
     )
-
-
-def load_variable_values(repo: str, gh: str) -> dict[str, str]:
-    payload = run_gh_json(
-        gh,
-        ["variable", "list", "--repo", repo, "--json", "name,value"],
-        "gh variable list",
-    )
-    if not isinstance(payload, list):
-        raise ValueError("gh variable list returned an unexpected payload")
-    values: dict[str, str] = {}
-    for item in payload:
-        if not isinstance(item, dict):
-            raise ValueError("gh variable list returned a non-object variable entry")
-        name = item.get("name")
-        value = item.get("value", "")
-        if not isinstance(name, str) or not name.strip():
-            raise ValueError("gh variable list returned a variable entry without a name")
-        if not isinstance(value, str):
-            raise ValueError(f"gh variable list returned a non-string value for {name}")
-        values[name.strip()] = value.strip()
-    return values
 
 
 def normalize_custom_base_url(raw: str) -> str:
@@ -1376,7 +1363,7 @@ def main() -> int:
             }
         else:
             secret_names = load_secret_names(repo, gh)
-        variable_values = load_variable_values(repo, gh)
+        variable_values = load_variable_values(repo, gh, REQUIRED_VARIABLE_VALUES)
         ci_head_sha = args.ci_head.strip()
         release_target_sha = args.release_target_head.strip()
         if (

--- a/scripts/github_release_secrets.py
+++ b/scripts/github_release_secrets.py
@@ -158,6 +158,54 @@ def load_secret_names(repo: str, gh: str) -> set[str]:
     return set(load_secret_metadata(repo, gh))
 
 
+def load_variable_names(repo: str, gh: str) -> set[str]:
+    repo = normalize_repo(repo)
+    payload = run_gh_json(
+        gh,
+        ["variable", "list", "--repo", repo, "--json", "name"],
+        "gh variable list",
+    )
+    if not isinstance(payload, list):
+        raise ValueError("gh variable list returned an unexpected payload")
+
+    names: set[str] = set()
+    for item in payload:
+        if not isinstance(item, dict):
+            raise ValueError("gh variable list returned a non-object variable entry")
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("gh variable list returned a variable entry without a name")
+        names.add(name.strip())
+    return names
+
+
+def load_variable_values(repo: str, gh: str, names: tuple[str, ...]) -> dict[str, str]:
+    repo = normalize_repo(repo)
+    requested = tuple(dict.fromkeys(name.strip() for name in names if name.strip()))
+    available = load_variable_names(repo, gh)
+    values: dict[str, str] = {}
+    for name in requested:
+        if name not in available:
+            continue
+        payload = run_gh_json(
+            gh,
+            ["variable", "get", name, "--repo", repo, "--json", "name,value"],
+            f"gh variable get {name}",
+        )
+        if not isinstance(payload, dict):
+            raise ValueError(f"gh variable get {name} returned an unexpected payload")
+        returned_name = payload.get("name")
+        value = payload.get("value", "")
+        if not isinstance(returned_name, str) or not returned_name.strip():
+            raise ValueError(f"gh variable get {name} returned a variable without a name")
+        if returned_name.strip() != name:
+            raise ValueError(f"gh variable get {name} returned a different variable name")
+        if not isinstance(value, str):
+            raise ValueError(f"gh variable get {name} returned a non-string value")
+        values[name] = value.strip()
+    return values
+
+
 def audit_secret_names(repo: str, configured_names: set[str]) -> SecretReadiness:
     repo = normalize_repo(repo)
     present = tuple(name for name in REQUIRED_RELEASE_SECRETS if name in configured_names)


### PR DESCRIPTION
Closes #856

Summary:
- Move repository variable value loading into the shared GitHub release helper.
- List repository variable names without values, then fetch only the explicit non-secret allowlist needed by release readiness checks.
- Keep `check-github-release-secret-readiness.py` limited to `CONU_NPM_TOKEN_ROTATED_AFTER`.
- Keep `check-tagged-release-readiness.py` limited to `CONU_NPM_TOKEN_ROTATED_AFTER` plus hosted Linux repository variables.
- Add regressions proving unrelated variable values are not requested or leaked.

Validation:
- `python scripts\check-github-release-secret-readiness-regression.py`
- `python scripts\check-tagged-release-readiness-regression.py`
- `python scripts\check-release-secret-rotation-gate-regression.py`
- `python scripts\set-github-release-secrets-regression.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-github-workflow-permissions.py`
- `.\scripts\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

Live readiness checks were re-run and still fail only for the existing #274 missing release secrets and missing `CONU_NPM_TOKEN_ROTATED_AFTER` marker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened release readiness checks to only fetch allowlisted GitHub variable values and moved variable loading into the shared helper. This prevents leaking unrelated variable values and reduces API calls.

- **Refactors**
  - Centralized variable loading in `github_release_secrets.py` with `load_variable_names` and `load_variable_values` (lists names, then gets values for an explicit allowlist).
  - `check-github-release-secret-readiness.py` now requests only `CONU_NPM_TOKEN_ROTATED_AFTER`.
  - `check-tagged-release-readiness.py` now requests `CONU_NPM_TOKEN_ROTATED_AFTER` plus hosted Linux repository variables.
  - Added regression tests to ensure unrelated variables are not requested or leaked.

<sup>Written for commit 1886b0fbd6f55dc9f69e2589088df0265c6ab351. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate GitHub variable-loading logic into a shared utility function for cleaner code reuse across release readiness checks.

* **Tests**
  * Expanded regression coverage for GitHub variable retrieval, including validation that only required variables are loaded and unrelated variables are properly filtered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->