### PR TITLE
Suppress npm pack stderr in package verifier

### DIFF
--- a/scripts/verify-npm-package-contents-regression.py
+++ b/scripts/verify-npm-package-contents-regression.py
@@ -3,14 +3,18 @@
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import importlib.util
+import io
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 SCRIPT = Path(__file__).with_name("verify-npm-package-contents.py")
+SENSITIVE_SENTINEL = "do-not-print-this-npm-token"
 
 
 def load_module():
@@ -97,9 +101,41 @@ def run_public_metadata_tests(module) -> None:
     )
 
 
+def run_npm_pack_privacy_tests(module) -> None:
+    original_run = module.subprocess.run
+
+    def failed_pack(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr=f"npm ERR! auth token {SENSITIVE_SENTINEL}\n",
+        )
+
+    module.subprocess.run = failed_pack
+    stderr = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(stderr):
+            try:
+                module.run_npm_pack("npm", Path("packaging/npm/conu-cli"))
+            except ValueError as exc:
+                rendered = str(exc)
+                if "npm stderr suppressed" not in rendered:
+                    raise AssertionError(f"expected suppressed-stderr error: {rendered}") from exc
+                if SENSITIVE_SENTINEL in rendered:
+                    raise AssertionError("npm pack failure leaked the npm stderr value") from exc
+            else:
+                raise AssertionError("failed npm pack unexpectedly passed")
+    finally:
+        module.subprocess.run = original_run
+
+    if SENSITIVE_SENTINEL in stderr.getvalue():
+        raise AssertionError("npm pack failure printed raw npm stderr")
+
+
 def main() -> int:
     module = load_module()
     run_public_metadata_tests(module)
+    run_npm_pack_privacy_tests(module)
     print("npm package content regression checks passed")
     return 0
 

--- a/scripts/verify-npm-package-contents.py
+++ b/scripts/verify-npm-package-contents.py
@@ -199,9 +199,9 @@ def run_npm_pack(npm: str, package_dir: Path) -> dict[str, Any]:
         stderr=subprocess.PIPE,
     )
     if result.returncode != 0:
-        if result.stderr:
-            print(result.stderr, file=sys.stderr, end="")
-        raise ValueError(f"npm pack dry-run failed in {package_dir}")
+        raise ValueError(
+            f"npm pack dry-run failed in {package_dir}; npm stderr suppressed"
+        )
 
     try:
         report = json.loads(result.stdout)


### PR DESCRIPTION
Closes #858

Summary:
- Stop forwarding raw `npm pack --dry-run --json` stderr from the npm package content verifier.
- Keep the failure actionable with an explicit suppressed-stderr note.
- Add a regression that simulates secret-like npm stderr and verifies it is not printed or included in the error.

Validation:
- `python scripts\verify-npm-package-contents-regression.py`
- `python scripts\verify-npm-package-contents.py`
- `python scripts\check-npm-publish-preflight-regression.py`
- `npm run check --prefix packaging\npm\conu-cli`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-github-workflow-permissions.py`
- `.\scripts\verify-production-readiness.ps1 -SkipRust -SkipPackages -SkipSmokes -CheckGitHubWorkflowPermissions`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress forwarding of raw `npm pack --dry-run --json` stderr in the package verifier to prevent leaking secrets. Failures now raise a clear error noting that npm stderr was suppressed, and a regression test ensures nothing sensitive is printed or included in errors.

- **Bug Fixes**
  - Suppress `stderr` from `npm pack` failures while keeping errors actionable with an explicit "npm stderr suppressed" note.
  - Add regression test that injects a token-like string into npm stderr and verifies it never prints or appears in exceptions.

<sup>Written for commit 429536bdf8839a1564215f74dbb4802381768e5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

