### PR TITLE
Redact release smoke command snippets

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -14,6 +14,7 @@ from unittest import mock
 def main() -> int:
     smoke = load_smoke_helpers()
     download_smoke = load_download_smoke_helpers()
+    assert_safe_snippet_redacts(smoke)
 
     with fixture_dir() as root:
         with mock.patch.object(Path, "is_symlink", return_value=True):
@@ -424,6 +425,37 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+def assert_safe_snippet_redacts(smoke) -> None:
+    sensitive_values = (
+        "npm_fakeNpmSmokeOutputToken1234567890",
+        "ghp_fakeNpmSmokeOutputToken1234567890",
+        "fake-bearer-token-1234567890",
+        "fake-basic-token-1234567890",
+        "fake-node-auth-token-1234567890",
+        "fake-url-password-1234567890",
+        "fake-query-token-1234567890",
+        "fake-private-key-1234567890",
+    )
+    raw = "\n".join(
+        [
+            f"npm ERR! auth token {sensitive_values[0]}",
+            f"gh token {sensitive_values[1]}",
+            f"Authorization: Bearer {sensitive_values[2]}",
+            f"Authorization: Basic {sensitive_values[3]}",
+            f"NODE_AUTH_TOKEN={sensitive_values[4]}",
+            f"https://user:{sensitive_values[5]}@example.invalid/conu",
+            f"https://example.invalid/conu?token={sensitive_values[6]}",
+            f"PRIVATE_KEY={sensitive_values[7]}",
+        ]
+    )
+    rendered = smoke.safe_snippet(raw)
+    if "[redacted]" not in rendered:
+        raise SystemExit("npm smoke safe snippet did not mark redacted output")
+    for value in sensitive_values:
+        if value in rendered:
+            raise SystemExit("npm smoke safe snippet leaked sensitive command output")
 
 
 def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:

--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -13,6 +13,7 @@ from unittest import mock
 
 def main() -> int:
     smoke = load_smoke_helpers()
+    assert_safe_snippet_redacts(smoke)
 
     with fixture_dir() as root:
         with mock.patch.object(Path, "is_symlink", return_value=True):
@@ -343,6 +344,37 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+def assert_safe_snippet_redacts(smoke) -> None:
+    sensitive_values = (
+        "npm_fakeSmokeOutputToken1234567890",
+        "ghp_fakeSmokeOutputToken1234567890",
+        "fake-bearer-token-1234567890",
+        "fake-basic-token-1234567890",
+        "fake-node-auth-token-1234567890",
+        "fake-url-password-1234567890",
+        "fake-query-token-1234567890",
+        "fake-private-key-1234567890",
+    )
+    raw = "\n".join(
+        [
+            f"npm ERR! auth token {sensitive_values[0]}",
+            f"gh token {sensitive_values[1]}",
+            f"Authorization: Bearer {sensitive_values[2]}",
+            f"Authorization: Basic {sensitive_values[3]}",
+            f"NODE_AUTH_TOKEN={sensitive_values[4]}",
+            f"https://user:{sensitive_values[5]}@example.invalid/conu",
+            f"https://example.invalid/conu?token={sensitive_values[6]}",
+            f"PRIVATE_KEY={sensitive_values[7]}",
+        ]
+    )
+    rendered = smoke.safe_snippet(raw)
+    if "[redacted]" not in rendered:
+        raise SystemExit("release smoke safe snippet did not mark redacted output")
+    for value in sensitive_values:
+        if value in rendered:
+            raise SystemExit("release smoke safe snippet leaked sensitive command output")
 
 
 def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -8,6 +8,7 @@ import errno
 import json
 import os
 import platform
+import re
 import shutil
 import stat
 import subprocess
@@ -27,6 +28,21 @@ MAX_MEMBER_COUNT = 10_000
 MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
+SNIPPET_LIMIT = 2000
+REDACTED = "[redacted]"
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH)"
+    r"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
+    re.IGNORECASE,
+)
+AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
+NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")
+GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}\b")
+URL_CREDENTIAL_RE = re.compile(r"\b(https?://)([^/\s:@]+):([^@\s/]+)@", re.IGNORECASE)
+URL_SECRET_QUERY_RE = re.compile(
+    r"([?&](?:token|access_token|auth|apikey|api_key|secret|password|pass|key)=)([^&#\s]+)",
+    re.IGNORECASE,
+)
 
 
 class ExtractState:
@@ -824,9 +840,19 @@ def run_command(
 
 
 def safe_snippet(value: str) -> str:
-    value = value.strip()
-    if len(value) > 2000:
-        return value[:2000] + "\n... truncated ..."
+    value = redact_sensitive_output(value).strip()
+    if len(value) > SNIPPET_LIMIT:
+        return value[:SNIPPET_LIMIT] + "\n... truncated ..."
+    return value
+
+
+def redact_sensitive_output(value: str) -> str:
+    value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
+    value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
+    value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
+    value = NPM_TOKEN_RE.sub(REDACTED, value)
+    value = GITHUB_TOKEN_RE.sub(REDACTED, value)
+    value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
     return value
 
 

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -8,6 +8,7 @@ import errno
 import json
 import os
 import platform
+import re
 import shutil
 import stat
 import subprocess
@@ -26,6 +27,21 @@ MAX_MEMBER_COUNT = 10_000
 MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
+SNIPPET_LIMIT = 2000
+REDACTED = "[redacted]"
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH)"
+    r"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
+    re.IGNORECASE,
+)
+AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
+NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")
+GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}\b")
+URL_CREDENTIAL_RE = re.compile(r"\b(https?://)([^/\s:@]+):([^@\s/]+)@", re.IGNORECASE)
+URL_SECRET_QUERY_RE = re.compile(
+    r"([?&](?:token|access_token|auth|apikey|api_key|secret|password|pass|key)=)([^&#\s]+)",
+    re.IGNORECASE,
+)
 
 
 class ExtractState:
@@ -664,9 +680,19 @@ def run_command(
 
 
 def safe_snippet(value: str) -> str:
-    value = value.strip()
-    if len(value) > 2000:
-        return value[:2000] + "\n... truncated ..."
+    value = redact_sensitive_output(value).strip()
+    if len(value) > SNIPPET_LIMIT:
+        return value[:SNIPPET_LIMIT] + "\n... truncated ..."
+    return value
+
+
+def redact_sensitive_output(value: str) -> str:
+    value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
+    value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
+    value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
+    value = NPM_TOKEN_RE.sub(REDACTED, value)
+    value = GITHUB_TOKEN_RE.sub(REDACTED, value)
+    value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
     return value
 
 


### PR DESCRIPTION
## **User description**
Closes #860\n\nSummary:\n- redact sensitive command output before release smoke failure snippets are printed\n- cover npm/GitHub token patterns, bearer/basic auth, URL credentials, secret query parameters, and secret-like assignments\n- add focused regression checks for direct release smoke and npm smoke helpers\n\nValidation:\n- python scripts/check-release-artifact-smoke-preflight.py\n- python scripts/check-npm-launcher-local-smoke-preflight.py\n- python scripts/check-python-script-compile.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts sensitive values in release and npm smoke command output before printing failure snippets to prevent token leaks in logs. Redaction runs before truncation and marks secrets as "[redacted]".

- **Bug Fixes**
  - Added redaction in `safe_snippet()` with patterns for Authorization headers, `npm_` and `gh*`/`github_pat_` tokens, URL credentials, secret query params, and secret-like assignments (e.g., `NODE_AUTH_TOKEN`, `PRIVATE_KEY`).
  - Set `SNIPPET_LIMIT=2000`; redact first, then truncate.
  - Added regression checks in `check-release-artifact-smoke-preflight.py` and `check-npm-launcher-local-smoke-preflight.py` to verify masking and prevent leaks.

<sup>Written for commit 371b6708a554e9c9dfdc32a02f901cd5954c9aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide secrets from release and npm smoke failure output**

### What Changed
- Failure snippets now redact likely secrets before they are shown in release and npm smoke logs.
- Redaction covers auth headers, npm and GitHub tokens, credentials embedded in URLs, secret values in query strings, and secret-style environment assignments.
- Snippets are still shortened after redaction so logged output stays limited in size.
- Added checks that confirm sensitive values are replaced with `[redacted]` and do not appear in regression output.

### Impact
`✅ Fewer secret leaks in smoke test logs`
`✅ Safer release failure output`
`✅ Safer npm launcher failure output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
