### PR TITLE
Redact Linux signing command output

### DIFF
--- a/scripts/check-linux-signing-secrets-preflight-regression.py
+++ b/scripts/check-linux-signing-secrets-preflight-regression.py
@@ -100,10 +100,13 @@ def run_common_output_redaction_tests() -> None:
             pass
 
     original_run_gpg_text = linux_gpg_common.run_gpg_text
+    original_subprocess_run = linux_gpg_common.subprocess.run
     actual = "A" * 40
     other = "B" * 40
     expected = WRONG_FINGERPRINT
     try:
+        assert_common_command_output_redacts(linux_gpg_common)
+
         linux_gpg_common.run_gpg_text = (
             lambda *_args, **_kwargs: f"sec:::::::::\nfpr:::::::::{actual}:\n"
         )
@@ -128,6 +131,59 @@ def run_common_output_redaction_tests() -> None:
         )
     finally:
         linux_gpg_common.run_gpg_text = original_run_gpg_text
+        linux_gpg_common.subprocess.run = original_subprocess_run
+
+
+def assert_common_command_output_redacts(linux_gpg_common) -> None:
+    sensitive_values = (
+        "npm_fakeLinuxSigningToken1234567890",
+        "ghp_fakeLinuxSigningToken1234567890",
+        "fake-bearer-token-1234567890",
+        "fake-basic-token-1234567890",
+        "fake-node-auth-token-1234567890",
+        "fake-url-password-1234567890",
+        "fake-query-token-1234567890",
+        "fake-private-key-1234567890",
+    )
+    raw = "\n".join(
+        [
+            f"npm ERR! auth token {sensitive_values[0]}",
+            f"gh token {sensitive_values[1]}",
+            f"Authorization: Bearer {sensitive_values[2]}",
+            f"Authorization: Basic {sensitive_values[3]}",
+            f"NODE_AUTH_TOKEN={sensitive_values[4]}",
+            f"https://user:{sensitive_values[5]}@example.invalid/conu",
+            f"https://example.invalid/conu?token={sensitive_values[6]}",
+            f"PRIVATE_KEY={sensitive_values[7]}",
+        ]
+    )
+    redacted = linux_gpg_common.redact_command_output(raw)
+    if "[redacted]" not in redacted:
+        raise AssertionError("Linux GPG command output redaction did not mark redacted output")
+    for value in sensitive_values:
+        if value in redacted:
+            raise AssertionError("Linux GPG command output redaction leaked a sensitive value")
+
+    def failed_run(*args, **_kwargs):
+        command = args[0] if args else "gpg"
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=command,
+            output=raw.encode("utf-8"),
+        )
+
+    linux_gpg_common.subprocess.run = failed_run
+    try:
+        linux_gpg_common.run_gpg_text("gpg", {}, ["--fixture"])
+    except SystemExit as exc:
+        rendered = str(exc)
+    else:
+        raise AssertionError("Linux GPG command output redaction unexpectedly passed")
+    if "gpg failed with output:" not in rendered:
+        raise AssertionError("Linux GPG failure output omitted the command failure label")
+    for value in sensitive_values:
+        if value in rendered:
+            raise AssertionError("Linux GPG failure output leaked a sensitive value")
 
 
 def assert_common_failed(

--- a/scripts/linux_gpg_common.py
+++ b/scripts/linux_gpg_common.py
@@ -8,6 +8,20 @@ import subprocess
 
 DEFAULT_FINGERPRINT_ENV = "CONU_LINUX_GPG_KEY_FINGERPRINT"
 FINGERPRINT_RE = re.compile(r"^[0-9A-F]{40}$")
+REDACTED = "[redacted]"
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH)"
+    r"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
+    re.IGNORECASE,
+)
+AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
+NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")
+GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}\b")
+URL_CREDENTIAL_RE = re.compile(r"\b(https?://)([^/\s:@]+):([^@\s/]+)@", re.IGNORECASE)
+URL_SECRET_QUERY_RE = re.compile(
+    r"([?&](?:token|access_token|auth|apikey|api_key|secret|password|pass|key)=)([^&#\s]+)",
+    re.IGNORECASE,
+)
 
 
 def add_fingerprint_env_argument(parser) -> None:
@@ -78,6 +92,16 @@ def primary_secret_fingerprints(colon_listing: str) -> list[str]:
     return fingerprints
 
 
+def redact_command_output(value: str) -> str:
+    value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
+    value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
+    value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
+    value = NPM_TOKEN_RE.sub(REDACTED, value)
+    value = GITHUB_TOKEN_RE.sub(REDACTED, value)
+    value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
+    return value
+
+
 def run_gpg_text(gpg: str, env: dict[str, str], args: list[str]) -> str:
     try:
         result = subprocess.run(
@@ -89,5 +113,5 @@ def run_gpg_text(gpg: str, env: dict[str, str], args: list[str]) -> str:
         )
     except subprocess.CalledProcessError as exc:
         output = exc.stdout.decode("utf-8", errors="replace") if exc.stdout else ""
-        raise SystemExit(f"gpg failed with output:\n{output}") from exc
+        raise SystemExit(f"gpg failed with output:\n{redact_command_output(output)}") from exc
     return result.stdout.decode("utf-8", errors="replace")

--- a/scripts/sign-linux-release-assets.py
+++ b/scripts/sign-linux-release-assets.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from linux_gpg_common import (
     add_fingerprint_env_argument,
     read_expected_fingerprint,
+    redact_command_output,
     verify_imported_secret_key_fingerprint,
 )
 
@@ -335,7 +336,7 @@ def run_gpg(
         )
     except subprocess.CalledProcessError as exc:
         output = exc.stdout.decode("utf-8", errors="replace") if exc.stdout else ""
-        raise SystemExit(f"gpg failed with output:\n{output}") from exc
+        raise SystemExit(f"gpg failed with output:\n{redact_command_output(output)}") from exc
     return result.stdout.decode("utf-8", errors="replace")
 
 

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -22,6 +22,7 @@ from typing import BinaryIO
 from linux_gpg_common import (
     add_fingerprint_env_argument,
     read_expected_fingerprint,
+    redact_command_output,
     verify_imported_secret_key_fingerprint,
 )
 
@@ -679,7 +680,7 @@ def run_gpg(
         )
     except subprocess.CalledProcessError as exc:
         output = exc.stdout.decode("utf-8", errors="replace") if exc.stdout else ""
-        raise SystemExit(f"gpg failed with output:\n{output}") from exc
+        raise SystemExit(f"gpg failed with output:\n{redact_command_output(output)}") from exc
     return result.stdout.decode("utf-8", errors="replace")
 
 

--- a/scripts/sign-rpm-packages.py
+++ b/scripts/sign-rpm-packages.py
@@ -21,6 +21,7 @@ from typing import BinaryIO
 from linux_gpg_common import (
     add_fingerprint_env_argument,
     read_expected_fingerprint,
+    redact_command_output,
     verify_imported_secret_key_fingerprint,
 )
 
@@ -489,9 +490,15 @@ def verify_rpm_signature(
     )
     lowered = output.lower()
     if "nokey" in lowered or "not ok" in lowered or "missing" in lowered:
-        raise SystemExit(f"RPM signature verification was not trusted for {package.name}:\n{output}")
+        raise SystemExit(
+            f"RPM signature verification was not trusted for {package.name}:\n"
+            f"{redact_command_output(output)}"
+        )
     if SIGNATURE_OUTPUT_RE.search(output) is None:
-        raise SystemExit(f"RPM signature verification did not report a package signature for {package.name}:\n{output}")
+        raise SystemExit(
+            "RPM signature verification did not report a package signature for "
+            f"{package.name}:\n{redact_command_output(output)}"
+        )
     return output
 
 
@@ -518,7 +525,7 @@ def run_gpg(
             output += exc.stdout.decode("utf-8", errors="replace")
         if exc.stderr:
             output += exc.stderr.decode("utf-8", errors="replace")
-        raise SystemExit(f"gpg failed with output:\n{output}") from exc
+        raise SystemExit(f"gpg failed with output:\n{redact_command_output(output)}") from exc
     return result.stdout
 
 
@@ -541,7 +548,7 @@ def run_tool(
             env=env,
         )
     except subprocess.CalledProcessError as exc:
-        raise SystemExit(f"{label}:\n{exc.stdout}") from exc
+        raise SystemExit(f"{label}:\n{redact_command_output(exc.stdout or '')}") from exc
     return result.stdout
 
 


### PR DESCRIPTION
## **User description**
Closes #862\n\nSummary:\n- add shared external-tool output redaction for Linux signing helpers\n- redact GPG/RPM failure output before printing it in release signing scripts\n- add regression coverage for token-like values, auth headers, URL credentials, secret query parameters, and secret-like assignments\n\nValidation:\n- python scripts/check-linux-signing-secrets-preflight-regression.py\n- python scripts/check-linux-release-signing.py (local GPG unavailable, integration skipped)\n- python scripts/check-linux-repository-signing.py (local GPG unavailable, integration skipped)\n- python scripts/check-rpm-package-signing.py (local GPG/RPM tools unavailable, integration skipped)\n- python scripts/check-python-script-compile.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts sensitive values from GPG/RPM command output in Linux signing scripts to prevent secret leaks in logs. Adds a shared redaction helper and applies it to all relevant error paths.

- **Bug Fixes**
  - Added `redact_command_output` in `linux_gpg_common` to scrub tokens, auth headers, URL credentials, secret query params, and secret-like assignments.
  - Applied redaction to GPG failures in `sign-linux-release-assets.py`, `sign-linux-repository-metadata.py`, and `sign-rpm-packages.py`, and to RPM verification errors.
  - Added regression tests to cover npm/GitHub tokens, Bearer/Basic headers, URL passwords, query tokens, and PRIVATE_KEY/TOKEN-style variables.

<sup>Written for commit ea7c8ff46bc508768bff44b9831351b77fa1dbd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact sensitive data from Linux signing errors**

### What Changed
- GPG and RPM signing failures now hide secret-like values before showing command output in logs and error messages.
- Redaction covers tokens, authorization headers, URL passwords, secret query values, and secret-style environment assignments.
- Added regression checks to confirm sensitive values do not appear in redacted output or failure messages.

### Impact
`✅ Fewer secret leaks in signing logs`
`✅ Safer Linux release and repository signing failures`
`✅ Clearer error messages without exposing credentials`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
