### PR TITLE
Redact GPG preflight failure output

### DIFF
--- a/scripts/check-linux-gpg-public-key-export.py
+++ b/scripts/check-linux-gpg-public-key-export.py
@@ -22,14 +22,28 @@ USER_ID = "conU Linux Public Key Regression <noreply@github.com>"
 PUBLIC_KEY_ASSET = "conu-linux-gpg-key.asc"
 WRONG_FINGERPRINT = "F" * 40
 PUBLIC_KEY_FIXTURE = b"-----BEGIN PGP PUBLIC KEY BLOCK-----\nfixture\n"
+SENSITIVE_FAILURE_VALUES = (
+    "npm_fakeLinuxPublicKeyToken1234567890",
+    "ghp_fakeLinuxPublicKeyToken1234567890",
+    "fake-bearer-token-1234567890",
+    "fake-basic-token-1234567890",
+    "fake-node-auth-token-1234567890",
+    "fake-url-password-1234567890",
+    "fake-query-token-1234567890",
+    "fake-private-key-1234567890",
+)
 
 
 def main() -> int:
     run_output_file_preflights()
+    run_command_output_redaction_preflight()
 
     gpg = shutil.which("gpg")
     if gpg is None:
-        print("Linux GPG public-key export regression skipped: gpg is unavailable")
+        print(
+            "Linux GPG public-key export preflight checks passed; "
+            "GPG integration regression skipped: gpg is unavailable"
+        )
         return 0
 
     with tempfile.TemporaryDirectory(prefix="conu-linux-public-key-check-") as temp_text:
@@ -243,6 +257,53 @@ def run_output_file_preflights() -> None:
                 "must not be a symlink",
                 "public-key symlink sidecar output",
             )
+
+
+def run_command_output_redaction_preflight() -> None:
+    exporter = load_exporter()
+    raw = sensitive_command_output()
+    original_subprocess_run = exporter.subprocess.run
+    try:
+
+        def failed_run(*args, **_kwargs):
+            command = args[0] if args else "gpg"
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=command,
+                output=raw.encode("utf-8"),
+                stderr=raw.encode("utf-8"),
+            )
+
+        exporter.subprocess.run = failed_run
+        try:
+            exporter.run_gpg("gpg", {}, ["--fixture"])
+        except SystemExit as exc:
+            rendered = str(exc)
+        else:
+            raise AssertionError("Linux public-key exporter unexpectedly passed")
+    finally:
+        exporter.subprocess.run = original_subprocess_run
+
+    if "gpg failed with output:" not in rendered:
+        raise AssertionError("public-key exporter failure output omitted the command failure label")
+    for value in SENSITIVE_FAILURE_VALUES:
+        if value in rendered:
+            raise AssertionError("public-key exporter failure output leaked a sensitive value")
+
+
+def sensitive_command_output() -> str:
+    return "\n".join(
+        [
+            f"npm ERR! auth token {SENSITIVE_FAILURE_VALUES[0]}",
+            f"gh token {SENSITIVE_FAILURE_VALUES[1]}",
+            f"Authorization: Bearer {SENSITIVE_FAILURE_VALUES[2]}",
+            f"Authorization: Basic {SENSITIVE_FAILURE_VALUES[3]}",
+            f"NODE_AUTH_TOKEN={SENSITIVE_FAILURE_VALUES[4]}",
+            f"https://user:{SENSITIVE_FAILURE_VALUES[5]}@example.invalid/conu",
+            f"https://example.invalid/conu?token={SENSITIVE_FAILURE_VALUES[6]}",
+            f"PRIVATE_KEY={SENSITIVE_FAILURE_VALUES[7]}",
+        ]
+    )
 
 
 def load_exporter():

--- a/scripts/check-linux-signing-secrets-preflight-regression.py
+++ b/scripts/check-linux-signing-secrets-preflight-regression.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -18,15 +19,26 @@ PREFLIGHT = ROOT / "scripts" / "check-linux-signing-secrets-preflight.py"
 PASSPHRASE = "conu-linux-signing-preflight-regression-passphrase"
 USER_ID = "conU Linux Signing Preflight Regression <noreply@github.com>"
 WRONG_FINGERPRINT = "F" * 40
+SENSITIVE_FAILURE_VALUES = (
+    "npm_fakeLinuxSigningToken1234567890",
+    "ghp_fakeLinuxSigningToken1234567890",
+    "fake-bearer-token-1234567890",
+    "fake-basic-token-1234567890",
+    "fake-node-auth-token-1234567890",
+    "fake-url-password-1234567890",
+    "fake-query-token-1234567890",
+    "fake-private-key-1234567890",
+)
 
 
 def main() -> int:
     run_common_output_redaction_tests()
+    run_preflight_output_redaction_tests()
 
     gpg = shutil.which("gpg")
     if gpg is None:
         print(
-            "Linux signing-secret common redaction checks passed; "
+            "Linux signing-secret redaction checks passed; "
             "GPG integration regression skipped: gpg is unavailable"
         )
         return 0
@@ -134,33 +146,63 @@ def run_common_output_redaction_tests() -> None:
         linux_gpg_common.subprocess.run = original_subprocess_run
 
 
+def run_preflight_output_redaction_tests() -> None:
+    preflight = load_preflight()
+    original_subprocess_run = preflight.subprocess.run
+    raw = sensitive_command_output()
+    try:
+
+        def failed_run(*args, **_kwargs):
+            command = args[0] if args else "gpg"
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=command,
+                output=raw.encode("utf-8"),
+            )
+
+        preflight.subprocess.run = failed_run
+        try:
+            preflight.run_gpg("gpg", {}, ["--fixture"])
+        except SystemExit as exc:
+            rendered = str(exc)
+        else:
+            raise AssertionError("Linux signing-secret preflight unexpectedly passed")
+    finally:
+        preflight.subprocess.run = original_subprocess_run
+
+    if "gpg failed with output:" not in rendered:
+        raise AssertionError("preflight failure output omitted the command failure label")
+    for value in SENSITIVE_FAILURE_VALUES:
+        if value in rendered:
+            raise AssertionError("preflight GPG failure output leaked a sensitive value")
+
+
+def load_preflight():
+    sys.path.insert(0, str(SCRIPT_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "check_linux_signing_secrets_preflight",
+            PREFLIGHT,
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load Linux signing-secret preflight")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        try:
+            sys.path.remove(str(SCRIPT_DIR))
+        except ValueError:
+            pass
+
+
 def assert_common_command_output_redacts(linux_gpg_common) -> None:
-    sensitive_values = (
-        "npm_fakeLinuxSigningToken1234567890",
-        "ghp_fakeLinuxSigningToken1234567890",
-        "fake-bearer-token-1234567890",
-        "fake-basic-token-1234567890",
-        "fake-node-auth-token-1234567890",
-        "fake-url-password-1234567890",
-        "fake-query-token-1234567890",
-        "fake-private-key-1234567890",
-    )
-    raw = "\n".join(
-        [
-            f"npm ERR! auth token {sensitive_values[0]}",
-            f"gh token {sensitive_values[1]}",
-            f"Authorization: Bearer {sensitive_values[2]}",
-            f"Authorization: Basic {sensitive_values[3]}",
-            f"NODE_AUTH_TOKEN={sensitive_values[4]}",
-            f"https://user:{sensitive_values[5]}@example.invalid/conu",
-            f"https://example.invalid/conu?token={sensitive_values[6]}",
-            f"PRIVATE_KEY={sensitive_values[7]}",
-        ]
-    )
+    raw = sensitive_command_output()
     redacted = linux_gpg_common.redact_command_output(raw)
     if "[redacted]" not in redacted:
         raise AssertionError("Linux GPG command output redaction did not mark redacted output")
-    for value in sensitive_values:
+    for value in SENSITIVE_FAILURE_VALUES:
         if value in redacted:
             raise AssertionError("Linux GPG command output redaction leaked a sensitive value")
 
@@ -181,9 +223,24 @@ def assert_common_command_output_redacts(linux_gpg_common) -> None:
         raise AssertionError("Linux GPG command output redaction unexpectedly passed")
     if "gpg failed with output:" not in rendered:
         raise AssertionError("Linux GPG failure output omitted the command failure label")
-    for value in sensitive_values:
+    for value in SENSITIVE_FAILURE_VALUES:
         if value in rendered:
             raise AssertionError("Linux GPG failure output leaked a sensitive value")
+
+
+def sensitive_command_output() -> str:
+    return "\n".join(
+        [
+            f"npm ERR! auth token {SENSITIVE_FAILURE_VALUES[0]}",
+            f"gh token {SENSITIVE_FAILURE_VALUES[1]}",
+            f"Authorization: Bearer {SENSITIVE_FAILURE_VALUES[2]}",
+            f"Authorization: Basic {SENSITIVE_FAILURE_VALUES[3]}",
+            f"NODE_AUTH_TOKEN={SENSITIVE_FAILURE_VALUES[4]}",
+            f"https://user:{SENSITIVE_FAILURE_VALUES[5]}@example.invalid/conu",
+            f"https://example.invalid/conu?token={SENSITIVE_FAILURE_VALUES[6]}",
+            f"PRIVATE_KEY={SENSITIVE_FAILURE_VALUES[7]}",
+        ]
+    )
 
 
 def assert_common_failed(

--- a/scripts/check-linux-signing-secrets-preflight.py
+++ b/scripts/check-linux-signing-secrets-preflight.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from linux_gpg_common import (
     add_fingerprint_env_argument,
     read_expected_fingerprint,
+    redact_command_output,
     verify_imported_secret_key_fingerprint,
 )
 
@@ -132,7 +133,7 @@ def run_gpg(
         )
     except subprocess.CalledProcessError as exc:
         output = exc.stdout.decode("utf-8", errors="replace") if exc.stdout else ""
-        raise SystemExit(f"gpg failed with output:\n{output}") from exc
+        raise SystemExit(f"gpg failed with output:\n{redact_command_output(output)}") from exc
     return result.stdout.decode("utf-8", errors="replace")
 
 

--- a/scripts/export-linux-gpg-public-key.py
+++ b/scripts/export-linux-gpg-public-key.py
@@ -19,6 +19,7 @@ from typing import BinaryIO
 from linux_gpg_common import (
     add_fingerprint_env_argument,
     read_expected_fingerprint,
+    redact_command_output,
     verify_imported_secret_key_fingerprint,
 )
 
@@ -409,7 +410,7 @@ def run_gpg(
             output += exc.stdout.decode("utf-8", errors="replace")
         if exc.stderr:
             output += exc.stderr.decode("utf-8", errors="replace")
-        raise SystemExit(f"gpg failed with output:\n{output}") from exc
+        raise SystemExit(f"gpg failed with output:\n{redact_command_output(output)}") from exc
     return result.stdout
 
 


### PR DESCRIPTION
## **User description**
## Summary

- Redact raw GPG subprocess failure output in the Linux signing-secret preflight script.
- Redact raw GPG subprocess failure output in the Linux public-key export script.
- Add direct no-GPG regressions that simulate sensitive command output and verify secrets are not rendered.

Closes #864.

## Validation

- python scripts\\check-linux-signing-secrets-preflight-regression.py
- python scripts\\check-linux-gpg-public-key-export.py
- python scripts\\check-python-script-compile.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts GPG failure output in the Linux signing-secret preflight and public-key export so tokens and secrets never hit logs (closes #864). Adds regression tests that simulate sensitive command output and verify redaction, even when `gpg` is unavailable.

- **Bug Fixes**
  - Use `redact_command_output(...)` in `scripts/check-linux-signing-secrets-preflight.py` and `scripts/export-linux-gpg-public-key.py` error paths.
  - Extend `scripts/check-linux-signing-secrets-preflight-regression.py` to test redaction for preflight and common code with shared sensitive patterns.
  - Add redaction preflight to `scripts/check-linux-gpg-public-key-export.py` and ensure redaction checks run without `gpg`.

<sup>Written for commit 1ce889343da3175f7b6804f0554d77b8502db3a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact sensitive details from GPG failure messages**

### What Changed
- GPG failures in Linux signing-secret preflight and public-key export now hide raw command output before showing the error
- The regression checks now cover those script-specific failure paths, including cases with token-like values, passwords, and private-key strings
- The public-key export checks now still run the redaction test even when GPG is not installed

### Impact
`✅ Fewer secret leaks in build logs`
`✅ Safer GPG error reporting`
`✅ Clearer CI checks for redacted failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved security by implementing automatic output redaction for GPG command failures, preventing accidental exposure of sensitive information in error messages shown to users.

* **Tests**
  * Added comprehensive regression test coverage to verify sensitive data is properly redacted from error output across GPG public key export and signing secret preflight workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->