### PR TITLE
Redact package tool failure output

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -19,6 +19,8 @@ import xml.etree.ElementTree as ET
 import zipfile
 from pathlib import Path
 
+from command_output_redaction import redact_command_output
+
 
 ROOT = Path(__file__).resolve().parents[1]
 GENERATOR_PATH = ROOT / "scripts" / "generate-package-manager-manifests.py"
@@ -47,6 +49,16 @@ RPM_ARCHES = {
 }
 RPM_X64_FILENAME = f"conu-{VERSION}-1.x86_64.rpm"
 RPM_ARM64_FILENAME = f"conu-{VERSION}-1.aarch64.rpm"
+SENSITIVE_FAILURE_VALUES = (
+    "npm_fakePackageToolToken1234567890",
+    "ghp_fakePackageToolToken1234567890",
+    "fake-bearer-token-1234567890",
+    "fake-basic-token-1234567890",
+    "fake-node-auth-token-1234567890",
+    "fake-url-password-1234567890",
+    "fake-query-token-1234567890",
+    "fake-private-key-1234567890",
+)
 
 
 def load_generator():
@@ -258,6 +270,22 @@ def expect_failure(description: str, action, expected: str) -> None:
     raise AssertionError(f"{description} unexpectedly passed")
 
 
+def expect_redacted_failure(description: str, action, expected: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+    else:
+        raise AssertionError(f"{description} unexpectedly passed")
+    if expected not in message:
+        raise AssertionError(f"{description} failed with {message!r}, expected {expected!r}")
+    if "[redacted]" not in message:
+        raise AssertionError(f"{description} did not mark redacted output")
+    for value in SENSITIVE_FAILURE_VALUES:
+        if value in message:
+            raise AssertionError(f"{description} leaked a sensitive value")
+
+
 def run_generator_cli(dist: Path, output: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
@@ -340,6 +368,76 @@ def assert_no_forbidden_text(text: str, label: str, temp: Path) -> None:
     for literal in forbidden:
         if literal and literal in normalized:
             raise AssertionError(f"{label} contained forbidden literal {literal!r}")
+
+
+def assert_external_tool_output_redacts(generator) -> None:
+    original_which = generator.shutil.which
+    original_run = generator.subprocess.run
+    raw = sensitive_command_output()
+    try:
+
+        def fake_which(name: str):
+            if name == "rpmbuild":
+                return "rpmbuild"
+            if name == "createrepo_c":
+                return "createrepo_c"
+            if name == "createrepo":
+                return None
+            return original_which(name)
+
+        def failed_run(command, *_args, **_kwargs):
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=command,
+                output=raw,
+            )
+
+        generator.shutil.which = fake_which
+        generator.subprocess.run = failed_run
+        with tempfile.TemporaryDirectory(prefix="conu-package-tool-output-check-") as temp_text:
+            temp = Path(temp_text)
+            dist = temp / "dist"
+            output = temp / "output"
+            dist.mkdir()
+            output.mkdir()
+            spec_path = temp / RPM_SPEC_FILENAME
+            spec_path.write_text("Name: conu\n", encoding="ascii", newline="\n")
+
+            expect_redacted_failure(
+                "rpmbuild failure output",
+                lambda: generator.build_rpm_packages(VERSION, dist, spec_path, output),
+                "rpmbuild failed",
+            )
+
+            package_paths = []
+            for target in RPM_ARCHES:
+                package = output / generator.rpm_filename(VERSION, target)
+                package.write_bytes(b"rpm package fixture\n")
+                write_checksum(package)
+                package_paths.append(package)
+            expect_redacted_failure(
+                "createrepo failure output",
+                lambda: generator.build_rpm_repository_metadata(VERSION, tuple(package_paths)),
+                "createrepo_c failed",
+            )
+    finally:
+        generator.shutil.which = original_which
+        generator.subprocess.run = original_run
+
+
+def sensitive_command_output() -> str:
+    return "\n".join(
+        [
+            f"npm ERR! auth token {SENSITIVE_FAILURE_VALUES[0]}",
+            f"gh token {SENSITIVE_FAILURE_VALUES[1]}",
+            f"Authorization: Bearer {SENSITIVE_FAILURE_VALUES[2]}",
+            f"Authorization: Basic {SENSITIVE_FAILURE_VALUES[3]}",
+            f"NODE_AUTH_TOKEN={SENSITIVE_FAILURE_VALUES[4]}",
+            f"https://user:{SENSITIVE_FAILURE_VALUES[5]}@example.invalid/conu",
+            f"https://example.invalid/conu?token={SENSITIVE_FAILURE_VALUES[6]}",
+            f"PRIVATE_KEY={SENSITIVE_FAILURE_VALUES[7]}",
+        ]
+    )
 
 
 def read_chocolatey_package(path: Path) -> dict[str, str]:
@@ -494,7 +592,8 @@ def assert_rpmbuild_accepts(generator, spec_path: Path, dist: Path) -> None:
                 )
             except subprocess.CalledProcessError as exc:
                 raise AssertionError(
-                    f"rpmbuild failed for {target} with output:\n{exc.stdout}"
+                    f"rpmbuild failed for {target} with output:\n"
+                    f"{redact_command_output(exc.stdout or '')}"
                 ) from exc
             packages = sorted((topdir / "RPMS").rglob("conu-*.rpm"))
             if len(packages) != 1:
@@ -787,6 +886,7 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
 
 def main() -> int:
     generator = load_generator()
+    assert_external_tool_output_redacts(generator)
     if generator.validate_version("1.2.3-rc.1+build.5") != "1.2.3-rc.1+build.5":
         raise AssertionError("package-manager generator rejected semver prerelease plus build metadata")
     if generator.validate_tag("v1.2.3-rc.1+build.5") != "v1.2.3-rc.1+build.5":

--- a/scripts/command_output_redaction.py
+++ b/scripts/command_output_redaction.py
@@ -1,0 +1,31 @@
+"""Redaction helpers for subprocess failure output."""
+
+from __future__ import annotations
+
+import re
+
+
+REDACTED = "[redacted]"
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH)"
+    r"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
+    re.IGNORECASE,
+)
+AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
+NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")
+GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}\b")
+URL_CREDENTIAL_RE = re.compile(r"\b(https?://)([^/\s:@]+):([^@\s/]+)@", re.IGNORECASE)
+URL_SECRET_QUERY_RE = re.compile(
+    r"([?&](?:token|access_token|auth|apikey|api_key|secret|password|pass|key)=)([^&#\s]+)",
+    re.IGNORECASE,
+)
+
+
+def redact_command_output(value: str) -> str:
+    value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
+    value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
+    value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
+    value = NPM_TOKEN_RE.sub(REDACTED, value)
+    value = GITHUB_TOKEN_RE.sub(REDACTED, value)
+    value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
+    return value

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, BinaryIO
 
+from command_output_redaction import redact_command_output
 from github_release_secrets import normalize_repo
 
 
@@ -1471,7 +1472,8 @@ def build_rpm_packages(
                 )
             except subprocess.CalledProcessError as exc:
                 raise SystemExit(
-                    f"rpmbuild failed for {target} with output:\n{exc.stdout}"
+                    f"rpmbuild failed for {target} with output:\n"
+                    f"{redact_command_output(exc.stdout or '')}"
                 ) from exc
 
             packages = sorted((topdir / "RPMS").rglob("conu-*.rpm"))
@@ -1550,7 +1552,10 @@ def build_rpm_repository_metadata(
                 errors="replace",
             )
         except subprocess.CalledProcessError as exc:
-            raise SystemExit(f"createrepo_c failed with output:\n{exc.stdout}") from exc
+            raise SystemExit(
+                f"createrepo_c failed with output:\n"
+                f"{redact_command_output(exc.stdout or '')}"
+            ) from exc
 
         repodata_dir = repo_dir / "repodata"
         if not repodata_dir.is_dir():

--- a/scripts/linux_gpg_common.py
+++ b/scripts/linux_gpg_common.py
@@ -5,23 +5,11 @@ from __future__ import annotations
 import re
 import subprocess
 
+from command_output_redaction import redact_command_output
+
 
 DEFAULT_FINGERPRINT_ENV = "CONU_LINUX_GPG_KEY_FINGERPRINT"
 FINGERPRINT_RE = re.compile(r"^[0-9A-F]{40}$")
-REDACTED = "[redacted]"
-SECRET_ASSIGNMENT_RE = re.compile(
-    r"\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH)"
-    r"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
-    re.IGNORECASE,
-)
-AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
-NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")
-GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}\b")
-URL_CREDENTIAL_RE = re.compile(r"\b(https?://)([^/\s:@]+):([^@\s/]+)@", re.IGNORECASE)
-URL_SECRET_QUERY_RE = re.compile(
-    r"([?&](?:token|access_token|auth|apikey|api_key|secret|password|pass|key)=)([^&#\s]+)",
-    re.IGNORECASE,
-)
 
 
 def add_fingerprint_env_argument(parser) -> None:
@@ -90,16 +78,6 @@ def primary_secret_fingerprints(colon_listing: str) -> list[str]:
         if record_type in {"pub", "ssb", "sub"}:
             waiting_for_primary_fingerprint = False
     return fingerprints
-
-
-def redact_command_output(value: str) -> str:
-    value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
-    value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
-    value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
-    value = NPM_TOKEN_RE.sub(REDACTED, value)
-    value = GITHUB_TOKEN_RE.sub(REDACTED, value)
-    value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
-    return value
 
 
 def run_gpg_text(gpg: str, env: dict[str, str], args: list[str]) -> str:


### PR DESCRIPTION
## **User description**
## Summary

- Add a shared subprocess command-output redaction helper.
- Keep Linux GPG redaction behavior routed through the shared helper.
- Redact pmbuild and createrepo_c failure output in package-manager manifest generation.
- Add no-tool regressions that simulate sensitive external tool output.

Closes #866.

## Validation

- python scripts\\check-package-manager-manifests.py
- python scripts\\check-linux-signing-secrets-preflight-regression.py
- python scripts\\check-linux-gpg-public-key-export.py
- python scripts\\check-python-script-compile.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes subprocess output redaction and applies it to external package tools so failure logs don’t leak secrets. Implements the redaction required by #866 and adds regressions to prove it.

- **Bug Fixes**
  - Redact `rpmbuild` and `createrepo_c` failure output in manifest generation.
  - Ensure manifest checker redacts output when reporting `rpmbuild` failures.
  - Add regressions that simulate secret-filled tool output and verify `[redacted]` is present with no leaks.

- **Refactors**
  - Introduce a shared `redact_command_output` helper and route Linux GPG redaction through it.

<sup>Written for commit 4aeaee70e2765340776bc21ecfe1760bd20250ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact sensitive tool output when package generation fails**

### What Changed
- Failure messages from RPM package and repository generation now hide tokens, passwords, keys, and credentials instead of printing them in full
- Linux GPG error reporting now uses the same redaction rules
- Added regression checks that simulate sensitive tool output and verify the logs are masked

### Impact
`✅ Fewer secret leaks in build logs`
`✅ Safer package release failures`
`✅ Clearer failure messages without exposing credentials`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
