### PR TITLE
Redact S3 publication command failures

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -73,6 +73,15 @@ def main() -> int:
         assert_fake_aws_log(fake_log, confirm_report["fileCount"])
         publisher = load_publisher()
         assert_aws_cli_wrapper_guard(publisher, fake_aws)
+        failing_aws = write_failing_fake_aws(temp)
+        failed_confirm = run_publisher_raw(
+            site_dir,
+            "--confirm",
+            "--json",
+            "--aws-cli",
+            failing_aws,
+        )
+        assert_failed_publication_redacts(failed_confirm, failing_aws)
 
         missing_bucket = run_publisher_raw(site_dir, "--dry-run", "--bucket", "")
         assert_failure("missing bucket", missing_bucket, "S3 bucket is required")
@@ -576,6 +585,25 @@ def write_fake_aws(temp: Path) -> str:
     return subprocess.list2cmdline([sys.executable, str(fake_py)])
 
 
+def write_failing_fake_aws(temp: Path) -> str:
+    fake_py = temp / "failing fake aws.py"
+    fake_py.write_text(
+        "\n".join(
+            [
+                "import sys",
+                f"print('NODE_AUTH_TOKEN={SENSITIVE_SENTINEL}', file=sys.stderr)",
+                f"print('Authorization: Bearer {SENSITIVE_SENTINEL}', file=sys.stderr)",
+                f"print('https://user:{SENSITIVE_SENTINEL}@example.invalid/conu', file=sys.stderr)",
+                "sys.exit(7)",
+            ]
+        )
+        + "\n",
+        encoding="ascii",
+        newline="\n",
+    )
+    return subprocess.list2cmdline([sys.executable, str(fake_py)])
+
+
 def assert_fake_aws_log(log: Path, expected_count: int) -> None:
     if not log.exists():
         raise AssertionError("fake AWS log was not written")
@@ -615,6 +643,26 @@ def assert_failure(description: str, result: subprocess.CompletedProcess[str], e
         raise AssertionError(f"{description} failed with {result.stdout!r}, expected {expected!r}")
 
 
+def assert_failed_publication_redacts(
+    result: subprocess.CompletedProcess[str],
+    fake_aws: str,
+) -> None:
+    if result.returncode == 0:
+        raise AssertionError("failing fake AWS publication unexpectedly passed")
+    if SENSITIVE_SENTINEL in result.stdout:
+        raise AssertionError("failing fake AWS publication leaked a sensitive value")
+    if Path(fake_aws).name in result.stdout or "failing fake aws" in result.stdout:
+        raise AssertionError("failing fake AWS publication leaked the wrapper command path")
+    report = json.loads(result.stdout)
+    if report["published"] is not False or report["endpointChecked"] is not False:
+        raise AssertionError("failed publication report claimed work completed")
+    for guard in ("payloadDisplayed", "tokenDisplayed", "keyMaterialDisplayed"):
+        if report[guard] is not False:
+            raise AssertionError(f"failed publication report expected {guard}=false")
+    if "[redacted]" not in json.dumps(report):
+        raise AssertionError("failed publication report did not include redacted command output")
+
+
 def assert_aws_cli_wrapper_guard(publisher, fake_aws: str) -> None:
     if publisher.parse_aws_cli("aws") != ["aws"]:
         raise AssertionError("plain aws CLI wrapper did not parse")
@@ -630,6 +678,15 @@ def assert_aws_cli_wrapper_guard(publisher, fake_aws: str) -> None:
         ("aws --cache-control public", "publication-owned or unsafe options"),
         ("aws --debug", "publication-owned or unsafe options"),
         ("aws --no-verify-ssl", "publication-owned or unsafe options"),
+        (
+            f"env AWS_SECRET_ACCESS_KEY={SENSITIVE_SENTINEL} aws",
+            "inline credentials or secrets",
+        ),
+        (f"aws --password {SENSITIVE_SENTINEL}", "inline credentials or secrets"),
+        (
+            f"aws https://user:{SENSITIVE_SENTINEL}@example.invalid",
+            "inline credentials or secrets",
+        ),
         ("--profile release", "executable must not be an option"),
     ):
         try:

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Any, BinaryIO
 from urllib.parse import unquote, urlparse, urlunparse
 
+from command_output_redaction import redact_command_output
+
 
 ROOT = Path(__file__).resolve().parents[1]
 ENDPOINT_CHECKER = ROOT / "scripts" / "check-hosted-linux-repository-endpoint.py"
@@ -62,6 +64,10 @@ AWS_CLI_RESERVED_OPTIONS = {
     "--recursive",
     "--region",
 }
+AWS_CLI_SECRET_ARGUMENT_RE = re.compile(
+    r"(token|secret|password|passwd|private[_-]?key|auth)",
+    re.IGNORECASE,
+)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 FORBIDDEN_SEGMENTS = {
@@ -149,6 +155,7 @@ def main() -> int:
         elif args.post_upload_check:
             raise PublicationError("--post-upload-check requires --confirm")
     except (PublicationError, OSError, subprocess.CalledProcessError, ValueError) as exc:
+        error_message = publication_error_message(exc)
         if args.json:
             print(
                 json.dumps(
@@ -156,7 +163,7 @@ def main() -> int:
                         "schema": "conu.hostedLinuxRepository.s3Publication.v1",
                         "published": False,
                         "endpointChecked": False,
-                        "issues": [str(exc)],
+                        "issues": [error_message],
                         "payloadDisplayed": False,
                         "tokenDisplayed": False,
                         "keyMaterialDisplayed": False,
@@ -166,7 +173,10 @@ def main() -> int:
                 )
             )
         else:
-            print(f"Hosted Linux repository S3 publication failed: {exc}", file=sys.stderr)
+            print(
+                f"Hosted Linux repository S3 publication failed: {error_message}",
+                file=sys.stderr,
+            )
         return 1
 
     if args.json:
@@ -188,6 +198,25 @@ def main() -> int:
             f"{len(plan.files)} files for {plan.base_url}"
         )
     return 0
+
+
+def publication_error_message(exc: Exception) -> str:
+    if not isinstance(exc, subprocess.CalledProcessError):
+        return redact_command_output(str(exc))
+
+    message = f"publication command failed with exit code {exc.returncode}"
+    output = decode_process_output(exc.stdout)
+    if output:
+        message += f"\n{redact_command_output(output)}"
+    return message
+
+
+def decode_process_output(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
 
 
 def parse_args() -> argparse.Namespace:
@@ -886,7 +915,16 @@ def publish_plan(plan: PublishPlan, args: argparse.Namespace) -> None:
                 str(file.size),
                 "--only-show-errors",
             ]
-            subprocess.run(command, stdin=handle, check=True)
+            subprocess.run(
+                command,
+                stdin=handle,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
 
 
 def parse_aws_cli(raw: str) -> list[str]:
@@ -915,12 +953,16 @@ def validate_aws_cli_wrapper(args: list[str]) -> None:
     executable = args[0]
     if executable.startswith("-"):
         raise PublicationError("AWS CLI command executable must not be an option")
-    for item in args:
+    for index, item in enumerate(args):
         if not item or any(ord(character) < 32 or ord(character) == 127 for character in item):
             raise PublicationError("AWS CLI command must not contain empty or control arguments")
 
         normalized = item.lower()
         option_name = normalized.split("=", 1)[0]
+        if redact_command_output(item) != item or (
+            index > 0 and AWS_CLI_SECRET_ARGUMENT_RE.search(option_name)
+        ):
+            raise PublicationError("AWS CLI command must not include inline credentials or secrets")
         if normalized in AWS_CLI_RESERVED_TOKENS:
             raise PublicationError("AWS CLI command must not include S3 service or upload subcommands")
         if normalized.startswith("s3://"):


### PR DESCRIPTION
## **User description**
## Summary

- Capture hosted Linux repository S3 publisher command stdout/stderr so failing AWS CLI output does not stream raw secrets into logs.
- Render generic command failure messages with redacted captured output instead of full command arguments.
- Reject inline secret-looking AWS CLI wrapper arguments.
- Add regression coverage with a failing fake AWS CLI that emits fake token/auth/URL credential output.

Closes #868.

## Validation

- python scripts\\check-hosted-linux-repository-s3-publication.py
- direct one-file publish_plan failure redaction smoke
- python scripts\\check-python-script-compile.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts S3 publication command failures and blocks inline secrets in AWS CLI wrappers to prevent leaking credentials in logs. Captures AWS CLI stdout/stderr and returns sanitized errors in both text and JSON.

- **Bug Fixes**
  - Capture AWS CLI stdout/stderr and pipe into sanitized error messages using `command_output_redaction`.
  - Replace verbose failure prints with a generic exit-code message plus redacted command output; stop echoing command paths/args.
  - Reject AWS CLI wrapper args that include inline credentials (token/secret/password/private key/auth) or control/reserved tokens.
  - Add regression tests with a failing fake AWS CLI to ensure secrets and wrapper paths never appear in logs or JSON reports.

<sup>Written for commit ac1afaae8a3be8db4e8a0569e2f887f7e2b13d71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact S3 publication failures and block inline secrets in AWS CLI wrappers**

### What Changed
- S3 publication now hides command output that may contain secrets when a publish step fails, instead of printing raw failure details.
- Failure reports now show a generic exit-code message with redacted output in both normal text and JSON responses.
- AWS CLI wrapper commands now reject inline credentials, secrets, and secret-like values passed in the command line.
- Added regression coverage for failing AWS CLI output that includes tokens, auth headers, and credentialed URLs.

### Impact
`✅ Fewer secret leaks in publish logs`
`✅ Safer failed publication reports`
`✅ Lower risk of exposing credentials in JSON output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error messages from failed S3 repository publications now properly redact sensitive data, preventing accidental credential exposure in logs.

* **Security**
  * Enhanced validation to block inline credentials and secrets in command arguments during publication workflows.
  * Improved detection of credential patterns to prevent unintended information leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->