### PR TITLE
Centralize smoke output redaction

### DIFF
--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -8,7 +8,6 @@ import errno
 import json
 import os
 import platform
-import re
 import shutil
 import stat
 import subprocess
@@ -18,6 +17,8 @@ import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
+
+from command_output_redaction import redact_command_output
 
 
 REQUIRED_BINARIES = ("conu", "conud", "conu-relay", "conu-mcp")
@@ -29,20 +30,6 @@ MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 SNIPPET_LIMIT = 2000
-REDACTED = "[redacted]"
-SECRET_ASSIGNMENT_RE = re.compile(
-    r"\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH)"
-    r"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
-    re.IGNORECASE,
-)
-AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
-NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")
-GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}\b")
-URL_CREDENTIAL_RE = re.compile(r"\b(https?://)([^/\s:@]+):([^@\s/]+)@", re.IGNORECASE)
-URL_SECRET_QUERY_RE = re.compile(
-    r"([?&](?:token|access_token|auth|apikey|api_key|secret|password|pass|key)=)([^&#\s]+)",
-    re.IGNORECASE,
-)
 
 
 class ExtractState:
@@ -840,19 +827,9 @@ def run_command(
 
 
 def safe_snippet(value: str) -> str:
-    value = redact_sensitive_output(value).strip()
+    value = redact_command_output(value).strip()
     if len(value) > SNIPPET_LIMIT:
         return value[:SNIPPET_LIMIT] + "\n... truncated ..."
-    return value
-
-
-def redact_sensitive_output(value: str) -> str:
-    value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
-    value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
-    value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
-    value = NPM_TOKEN_RE.sub(REDACTED, value)
-    value = GITHUB_TOKEN_RE.sub(REDACTED, value)
-    value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
     return value
 
 

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -8,7 +8,6 @@ import errno
 import json
 import os
 import platform
-import re
 import shutil
 import stat
 import subprocess
@@ -19,6 +18,8 @@ import zipfile
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 
+from command_output_redaction import redact_command_output
+
 
 REQUIRED_BINARIES = ("conu", "conud", "conu-relay", "conu-mcp")
 MAX_ARCHIVE_BYTES = 1_000_000_000
@@ -28,20 +29,6 @@ MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 SNIPPET_LIMIT = 2000
-REDACTED = "[redacted]"
-SECRET_ASSIGNMENT_RE = re.compile(
-    r"\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH)"
-    r"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
-    re.IGNORECASE,
-)
-AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
-NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")
-GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}\b")
-URL_CREDENTIAL_RE = re.compile(r"\b(https?://)([^/\s:@]+):([^@\s/]+)@", re.IGNORECASE)
-URL_SECRET_QUERY_RE = re.compile(
-    r"([?&](?:token|access_token|auth|apikey|api_key|secret|password|pass|key)=)([^&#\s]+)",
-    re.IGNORECASE,
-)
 
 
 class ExtractState:
@@ -680,19 +667,9 @@ def run_command(
 
 
 def safe_snippet(value: str) -> str:
-    value = redact_sensitive_output(value).strip()
+    value = redact_command_output(value).strip()
     if len(value) > SNIPPET_LIMIT:
         return value[:SNIPPET_LIMIT] + "\n... truncated ..."
-    return value
-
-
-def redact_sensitive_output(value: str) -> str:
-    value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
-    value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
-    value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
-    value = NPM_TOKEN_RE.sub(REDACTED, value)
-    value = GITHUB_TOKEN_RE.sub(REDACTED, value)
-    value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
     return value
 
 


### PR DESCRIPTION
## **User description**
Closes #870

## Changes
- Route release artifact smoke command-output snippets through the shared redaction helper.
- Route npm launcher smoke command-output snippets through the shared redaction helper.
- Remove duplicated token/header/URL redaction regex blocks from both smoke scripts.

## Validation
- python scripts\\check-npm-launcher-local-smoke-preflight.py
- python scripts\\check-release-artifact-smoke-preflight.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\check-python-script-compile.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes smoke command output redaction by using the shared `redact_command_output` helper in both smoke scripts, fulfilling #870 and removing duplicated regex logic.

- **Refactors**
  - Route release artifact and npm launcher smoke output through `redact_command_output` from `command_output_redaction`.
  - Remove local token/header/URL redaction regex blocks from both scripts.

<sup>Written for commit 5832acbd709767994d2c5d8d2c2274573cb0b36e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Centralize smoke command output redaction**

### What Changed
- Smoke test failures now hide sensitive data using the shared redaction rules in both the npm launcher and release artifact checks.
- Removed the separate redaction logic from each script so token, password, auth header, and secret values are handled the same way in both places.
- Failed command output still shows a short snippet, but with sensitive values masked before it is displayed.

### Impact
`✅ Fewer leaked secrets in smoke test logs`
`✅ Consistent redaction across release and npm smoke checks`
`✅ Safer failure output for local and CI runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
