### PR TITLE
Hide npm archive preflight local paths

### DIFF
--- a/packaging/npm/conu-cli/lib/archive-preflight.js
+++ b/packaging/npm/conu-cli/lib/archive-preflight.js
@@ -23,8 +23,9 @@ const FORBIDDEN_PARTS = new Set([
 const FORBIDDEN_NAMES = new Set(["node.toml", "runtime.toml", "trust.toml"]);
 
 function validateArchiveMembers(archivePath) {
-  const members = listArchiveMembers(archivePath);
-  assertSafeArchiveMemberList(members, archivePath);
+  const archiveLabel = displayArchiveLabel(archivePath);
+  const members = listArchiveMembers(archivePath, archiveLabel);
+  assertSafeArchiveMemberList(members, archiveLabel);
 }
 
 function assertSafeArchiveMemberList(members, archiveLabel = "archive") {
@@ -90,20 +91,22 @@ function rejectForbiddenArchivePath(normalized, archiveLabel) {
   }
 }
 
-function listArchiveMembers(archivePath) {
-  const tarMembers = listArchiveMembersWithTar(archivePath);
+function listArchiveMembers(archivePath, archiveLabel) {
+  const tarMembers = listArchiveMembersWithTar(archivePath, archiveLabel);
   if (tarMembers) {
     return tarMembers;
   }
 
   if (process.platform === "win32" && archivePath.endsWith(".zip")) {
-    return listZipMembersWithPowerShell(archivePath);
+    return listZipMembersWithPowerShell(archivePath, archiveLabel);
   }
 
-  throw new Error(`could not inspect archive members before extraction: ${archivePath}`);
+  throw new Error(
+    `could not inspect archive members before extraction: ${archiveLabel}; pathDisplayed=false`
+  );
 }
 
-function listArchiveMembersWithTar(archivePath) {
+function listArchiveMembersWithTar(archivePath, archiveLabel) {
   const names = runTool("tar", ["-tf", archivePath]);
   if (names.status !== 0) {
     return null;
@@ -111,7 +114,9 @@ function listArchiveMembersWithTar(archivePath) {
 
   const verbose = runTool("tar", ["-tvf", archivePath]);
   if (verbose.status !== 0) {
-    throw new Error(`could not inspect archive member types before extraction: ${archivePath}`);
+    throw new Error(
+      `could not inspect archive member types before extraction: ${archiveLabel}; pathDisplayed=false`
+    );
   }
 
   const nameLines = splitToolLines(names.stdout);
@@ -139,7 +144,7 @@ function parseTarMemberType(line) {
   return marker ? "other" : "unknown";
 }
 
-function listZipMembersWithPowerShell(archivePath) {
+function listZipMembersWithPowerShell(archivePath, archiveLabel) {
   const script = [
     "Add-Type -AssemblyName System.IO.Compression.FileSystem",
     "$zip = [System.IO.Compression.ZipFile]::OpenRead($args[0])",
@@ -163,7 +168,9 @@ function listZipMembersWithPowerShell(archivePath) {
     archivePath
   ]);
   if (result.status !== 0) {
-    throw new Error(`could not inspect zip archive members before extraction: ${archivePath}`);
+    throw new Error(
+      `could not inspect zip archive members before extraction: ${archiveLabel}; pathDisplayed=false`
+    );
   }
 
   const output = result.stdout.trim();
@@ -172,6 +179,11 @@ function listZipMembersWithPowerShell(archivePath) {
   }
   const parsed = JSON.parse(output);
   return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+function displayArchiveLabel(archivePath) {
+  const baseName = path.basename(String(archivePath || ""));
+  return baseName || "archive";
 }
 
 function runTool(command, args) {

--- a/packaging/npm/conu-cli/scripts/check-archive-preflight.js
+++ b/packaging/npm/conu-cli/scripts/check-archive-preflight.js
@@ -1,8 +1,12 @@
 "use strict";
 
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 const {
   MAX_ARCHIVE_MEMBERS,
-  assertSafeArchiveMemberList
+  assertSafeArchiveMemberList,
+  validateArchiveMembers
 } = require("../lib/archive-preflight");
 
 const SAFE_MEMBERS = [
@@ -34,6 +38,8 @@ function main() {
   expectFail([{ name: "conu-0.1.0/security/identity.key", type: "file" }], "forbidden state path");
   expectFail([{ name: "conu-0.1.0/runtime/node.toml", type: "file" }], "forbidden state path");
   expectFail(makeMemberList(MAX_ARCHIVE_MEMBERS + 1), `more than ${MAX_ARCHIVE_MEMBERS} entries`);
+  expectArchiveInspectionPathRedacted();
+  expectArchiveInspectionFailurePathGuard();
   console.log("archive member preflight check passed");
 }
 
@@ -58,6 +64,53 @@ function makeMemberList(count) {
     name: `conu-0.1.0/docs/file-${index}.txt`,
     type: "file"
   }));
+}
+
+function expectArchiveInspectionPathRedacted() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "conu-secret-local-path-"));
+  try {
+    const archive = path.join(root, "conu-0.1.0-windows-x64.zip");
+    fs.writeFileSync(archive, "not a zip archive\n", "utf8");
+    try {
+      validateArchiveMembers(archive);
+    } catch (error) {
+      if (!error.message.includes(path.basename(archive))) {
+        throw new Error(`expected archive filename in error, got: ${error.message}`);
+      }
+      if (error.message.includes(root) || error.message.includes(archive)) {
+        throw new Error(`archive preflight leaked local path: ${error.message}`);
+      }
+      return;
+    }
+    throw new Error("expected invalid archive inspection failure");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function expectArchiveInspectionFailurePathGuard() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "conu-secret-inspect-path-"));
+  try {
+    const archive = path.join(root, "conu-0.1.0.invalid");
+    fs.writeFileSync(archive, "not an archive\n", "utf8");
+    try {
+      validateArchiveMembers(archive);
+    } catch (error) {
+      if (!error.message.includes("pathDisplayed=false")) {
+        throw new Error(`expected path display guard, got: ${error.message}`);
+      }
+      if (!error.message.includes(path.basename(archive))) {
+        throw new Error(`expected archive filename in error, got: ${error.message}`);
+      }
+      if (error.message.includes(root) || error.message.includes(archive)) {
+        throw new Error(`archive inspection failure leaked local path: ${error.message}`);
+      }
+      return;
+    }
+    throw new Error("expected archive inspection failure");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 }
 
 main();


### PR DESCRIPTION
## **User description**
Closes #874

## Changes
- Report npm archive-preflight errors using archive filenames instead of full temporary archive paths.
- Add path-display guards to generic archive inspection failures.
- Add regressions that create invalid archives under secret-looking temp paths and assert install preflight errors do not expose those paths.

## Validation
- npm run check --prefix packaging/npm/conu-cli
- node packaging/npm/conu-cli/scripts/check-archive-preflight.js
- python scripts\\verify-npm-package-contents.py
- python scripts\\check-python-script-compile.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide local filesystem paths in `conu-cli` npm archive preflight errors to avoid leaking temp directories. Errors now show only the archive filename and include guards on inspection failures.

- Report preflight errors using the archive basename; scrub local paths.
- Add path-display guards to inspection errors (`pathDisplayed=false`) across tar and zip.
- Add regression tests to ensure invalid archives under temp dirs do not leak paths.

<sup>Written for commit d92a4d758d4da640181f105c8e46d1a2acf0432c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide local archive paths in npm preflight errors**

### What Changed
- Archive inspection errors now show only the archive file name instead of the full local path.
- When an archive cannot be inspected, the error now includes a clear `pathDisplayed=false` guard.
- Added checks that invalid archives created in temporary folders do not leak secret local paths in error messages.

### Impact
`✅ Fewer local path leaks in npm install errors`
`✅ Safer archive validation on shared or CI machines`
`✅ Clearer archive failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
