### PR TITLE
Redact secret command flag output

### DIFF
--- a/scripts/check-smoke-output-privacy.py
+++ b/scripts/check-smoke-output-privacy.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from command_output_redaction import redact_command_output
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SMOKE_SCRIPTS = (
@@ -37,6 +39,7 @@ def main() -> int:
 
     check_identity_cleanup(ROOT / "scripts" / "smoke-identity-retirement.ps1", issues)
     check_relay_output_suppression(ROOT / "scripts" / "smoke-relay-daemon.ps1", issues)
+    check_command_output_redaction(issues)
 
     if issues:
         print("smoke output privacy check failed", file=sys.stderr)
@@ -89,6 +92,23 @@ def check_relay_output_suppression(path: Path, issues: list[str]) -> None:
         issues.append(f"{path.relative_to(ROOT)} is missing commandOutputDisplayed=false guard")
     if "$($output -join" in text:
         issues.append(f"{path.relative_to(ROOT)} can echo captured command output on failure")
+
+
+def check_command_output_redaction(issues: list[str]) -> None:
+    sentinel = "do-not-print-this-secret-value"
+    cases = (
+        f"tool --token {sentinel}",
+        f"tool --password='{sentinel} with spaces'",
+        f"tool --security-token \"{sentinel} with spaces\"",
+        f"tool -auth {sentinel}",
+        f"tool --target conu --secret {sentinel} --mode dry-run",
+    )
+    for value in cases:
+        redacted = redact_command_output(value)
+        if sentinel in redacted:
+            issues.append(f"command output redaction leaked secret flag value from {value!r}")
+        if "[redacted]" not in redacted:
+            issues.append(f"command output redaction did not mark secret flag value from {value!r}")
 
 
 if __name__ == "__main__":

--- a/scripts/command_output_redaction.py
+++ b/scripts/command_output_redaction.py
@@ -12,6 +12,14 @@ SECRET_ASSIGNMENT_RE = re.compile(
     re.IGNORECASE,
 )
 AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
+SECRET_FLAG_RE = re.compile(
+    r"(?<!\w)(-{1,2}[A-Z0-9_.-]*(?:"
+    r"TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH|"
+    r"ACCESS[_-]?KEY|SECRET[_-]?KEY|SECURITY[_-]?TOKEN|SESSION[_-]?TOKEN"
+    r")[A-Z0-9_.-]*)(\s*=\s*|\s+)"
+    r"(\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s;&|]+)",
+    re.IGNORECASE,
+)
 NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")
 GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}\b")
 URL_CREDENTIAL_RE = re.compile(r"\b(https?://)([^/\s:@]+):([^@\s/]+)@", re.IGNORECASE)
@@ -31,6 +39,7 @@ def redact_command_output(value: str) -> str:
     value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
     value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
     value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
+    value = SECRET_FLAG_RE.sub(r"\1\2[redacted]", value)
     value = NPM_TOKEN_RE.sub(REDACTED, value)
     value = GITHUB_TOKEN_RE.sub(REDACTED, value)
     value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)


### PR DESCRIPTION
Fixes #876.

## What changed
- Redacts secret-looking command-line flag values in shared release subprocess output sanitization.
- Covers space-separated and quoted values such as `--token value`, `--password 'value'`, and `--security-token "value"`.
- Adds regression coverage through the existing smoke/output privacy check used by CI and release workflows.

## Validation
- `python scripts\check-smoke-output-privacy.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-hosted-linux-repository-s3-publication.py`
- `python scripts\check-package-manager-manifests.py`
- `python scripts\check-npm-launcher-local-smoke-preflight.py`
- `python scripts\check-linux-gpg-public-key-export.py` (GPG integration skipped locally because `gpg` is unavailable)
- `npm run check --prefix packaging/npm/conu-cli`
- `python scripts\verify-npm-package-contents.py`
- `python scripts\check-release-artifact-smoke-preflight.py`
- `python scripts\check-release-artifact-verifier.py`
- `python scripts\check-python-sdk-error-redaction.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts secret-like command-line flag values from subprocess output to prevent leaking tokens and passwords in logs. Fixes #876.

- **Bug Fixes**
  - Added redaction for secret flags (e.g., `--token value`, `--password 'value'`, `--security-token "value"`) including space-separated and quoted values.
  - Extended `scripts/check-smoke-output-privacy.py` with cases to verify flag redaction via `redact_command_output`.

<sup>Written for commit 1ae0ea635866a59486d23d6367ef6a5873eec124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened privacy protection with enhanced detection patterns for secret-related command-line flags, improving redaction of sensitive information in command outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->