### PR TITLE
Use native ZIP preflight reader

### DIFF
--- a/packaging/npm/conu-cli/lib/archive-preflight.js
+++ b/packaging/npm/conu-cli/lib/archive-preflight.js
@@ -1,10 +1,16 @@
 "use strict";
 
+const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const MAX_ARCHIVE_LIST_BYTES = 2 * 1024 * 1024;
 const MAX_ARCHIVE_MEMBERS = 10000;
+const MAX_ZIP_EOCD_SEARCH_BYTES = 22 + 65535;
+const ZIP_EOCD_SIGNATURE = 0x06054b50;
+const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const ZIP64_ENTRY_COUNT = 0xffff;
+const ZIP64_FIELD = 0xffffffff;
 const SUPPORTED_MEMBER_TYPES = new Set(["file", "directory"]);
 const FORBIDDEN_PARTS = new Set([
   ".conu",
@@ -92,13 +98,13 @@ function rejectForbiddenArchivePath(normalized, archiveLabel) {
 }
 
 function listArchiveMembers(archivePath, archiveLabel) {
+  if (archivePath.endsWith(".zip")) {
+    return listZipMembersWithNode(archivePath, archiveLabel);
+  }
+
   const tarMembers = listArchiveMembersWithTar(archivePath, archiveLabel);
   if (tarMembers) {
     return tarMembers;
-  }
-
-  if (process.platform === "win32" && archivePath.endsWith(".zip")) {
-    return listZipMembersWithPowerShell(archivePath, archiveLabel);
   }
 
   throw new Error(
@@ -144,41 +150,141 @@ function parseTarMemberType(line) {
   return marker ? "other" : "unknown";
 }
 
-function listZipMembersWithPowerShell(archivePath, archiveLabel) {
-  const script = [
-    "Add-Type -AssemblyName System.IO.Compression.FileSystem",
-    "$zip = [System.IO.Compression.ZipFile]::OpenRead($args[0])",
-    "try {",
-    "  $zip.Entries | ForEach-Object {",
-    "    $mode = ($_.ExternalAttributes -shr 16) -band 61440",
-    "    $type = if ($_.FullName.EndsWith('/') -or $_.FullName.EndsWith('\\')) { 'directory' } elseif ($mode -eq 40960) { 'symlink' } elseif ($mode -eq 32768 -or $mode -eq 0) { 'file' } else { 'other' }",
-    "    [pscustomobject]@{ name = $_.FullName; type = $type }",
-    "  } | ConvertTo-Json -Compress",
-    "} finally {",
-    "  $zip.Dispose()",
-    "}"
-  ].join("; ");
+function listZipMembersWithNode(archivePath, archiveLabel) {
+  let fd = null;
+  try {
+    fd = fs.openSync(archivePath, "r");
+    const size = fs.fstatSync(fd).size;
+    const { centralDirectory, entryCount } = readZipCentralDirectory(fd, size, archiveLabel);
+    return parseZipCentralDirectory(centralDirectory, entryCount, archiveLabel);
+  } catch (error) {
+    if (error && error.zipInspectionError) {
+      throw error;
+    }
+    throw zipInspectionError(archiveLabel);
+  } finally {
+    if (fd !== null) {
+      fs.closeSync(fd);
+    }
+  }
+}
 
-  const result = runTool("powershell", [
-    "-NoProfile",
-    "-ExecutionPolicy",
-    "Bypass",
-    "-Command",
-    script,
-    archivePath
-  ]);
-  if (result.status !== 0) {
-    throw new Error(
-      `could not inspect zip archive members before extraction: ${archiveLabel}; pathDisplayed=false`
-    );
+function readZipCentralDirectory(fd, size, archiveLabel) {
+  if (!Number.isSafeInteger(size) || size < 22) {
+    throw zipInspectionError(archiveLabel);
   }
 
-  const output = result.stdout.trim();
-  if (!output) {
-    return [];
+  const searchLength = Math.min(size, MAX_ZIP_EOCD_SEARCH_BYTES);
+  const searchStart = size - searchLength;
+  const eocd = Buffer.alloc(searchLength);
+  if (fs.readSync(fd, eocd, 0, searchLength, searchStart) !== searchLength) {
+    throw zipInspectionError(archiveLabel);
   }
-  const parsed = JSON.parse(output);
-  return Array.isArray(parsed) ? parsed : [parsed];
+
+  for (let offset = searchLength - 22; offset >= 0; offset -= 1) {
+    if (eocd.readUInt32LE(offset) !== ZIP_EOCD_SIGNATURE) {
+      continue;
+    }
+
+    const commentLength = eocd.readUInt16LE(offset + 20);
+    if (offset + 22 + commentLength !== searchLength) {
+      continue;
+    }
+
+    const diskNumber = eocd.readUInt16LE(offset + 4);
+    const centralDisk = eocd.readUInt16LE(offset + 6);
+    const diskEntries = eocd.readUInt16LE(offset + 8);
+    const entryCount = eocd.readUInt16LE(offset + 10);
+    const centralSize = eocd.readUInt32LE(offset + 12);
+    const centralOffset = eocd.readUInt32LE(offset + 16);
+
+    if (diskNumber !== 0 || centralDisk !== 0 || diskEntries !== entryCount) {
+      throw zipInspectionError(archiveLabel);
+    }
+    if (
+      entryCount === ZIP64_ENTRY_COUNT ||
+      centralSize === ZIP64_FIELD ||
+      centralOffset === ZIP64_FIELD
+    ) {
+      throw zipInspectionError(archiveLabel);
+    }
+    if (entryCount > MAX_ARCHIVE_MEMBERS) {
+      throw new Error(`${archiveLabel} contains more than ${MAX_ARCHIVE_MEMBERS} entries`);
+    }
+    if (centralSize > MAX_ARCHIVE_LIST_BYTES) {
+      throw zipInspectionError(archiveLabel);
+    }
+    if (centralOffset + centralSize > size) {
+      throw zipInspectionError(archiveLabel);
+    }
+
+    const centralDirectory = Buffer.alloc(centralSize);
+    if (fs.readSync(fd, centralDirectory, 0, centralSize, centralOffset) !== centralSize) {
+      throw zipInspectionError(archiveLabel);
+    }
+    return { centralDirectory, entryCount };
+  }
+
+  throw zipInspectionError(archiveLabel);
+}
+
+function parseZipCentralDirectory(centralDirectory, entryCount, archiveLabel) {
+  const members = [];
+  let offset = 0;
+  while (offset < centralDirectory.length) {
+    if (
+      offset + 46 > centralDirectory.length ||
+      centralDirectory.readUInt32LE(offset) !== ZIP_CENTRAL_DIRECTORY_SIGNATURE
+    ) {
+      throw zipInspectionError(archiveLabel);
+    }
+
+    const flags = centralDirectory.readUInt16LE(offset + 8);
+    const nameLength = centralDirectory.readUInt16LE(offset + 28);
+    const extraLength = centralDirectory.readUInt16LE(offset + 30);
+    const commentLength = centralDirectory.readUInt16LE(offset + 32);
+    const externalAttributes = centralDirectory.readUInt32LE(offset + 38);
+    const entryLength = 46 + nameLength + extraLength + commentLength;
+    if (offset + entryLength > centralDirectory.length) {
+      throw zipInspectionError(archiveLabel);
+    }
+
+    const name = centralDirectory.subarray(offset + 46, offset + 46 + nameLength).toString("utf8");
+    members.push({
+      name,
+      type: zipMemberType(name, flags, externalAttributes)
+    });
+    offset += entryLength;
+  }
+  if (members.length !== entryCount) {
+    throw zipInspectionError(archiveLabel);
+  }
+  return members;
+}
+
+function zipMemberType(name, flags, externalAttributes) {
+  if (name.endsWith("/") || name.endsWith("\\")) {
+    return "directory";
+  }
+  if ((flags & 1) !== 0) {
+    return "encrypted";
+  }
+  const mode = (externalAttributes >>> 16) & 0xf000;
+  if (mode === 0xa000) {
+    return "symlink";
+  }
+  if (mode === 0x8000 || mode === 0) {
+    return "file";
+  }
+  return "other";
+}
+
+function zipInspectionError(archiveLabel) {
+  const error = new Error(
+    `could not inspect zip archive members before extraction: ${archiveLabel}; pathDisplayed=false`
+  );
+  error.zipInspectionError = true;
+  return error;
 }
 
 function displayArchiveLabel(archivePath) {

--- a/packaging/npm/conu-cli/scripts/check-archive-preflight.js
+++ b/packaging/npm/conu-cli/scripts/check-archive-preflight.js
@@ -38,6 +38,7 @@ function main() {
   expectFail([{ name: "conu-0.1.0/security/identity.key", type: "file" }], "forbidden state path");
   expectFail([{ name: "conu-0.1.0/runtime/node.toml", type: "file" }], "forbidden state path");
   expectFail(makeMemberList(MAX_ARCHIVE_MEMBERS + 1), `more than ${MAX_ARCHIVE_MEMBERS} entries`);
+  expectNativeZipInspection();
   expectArchiveInspectionPathRedacted();
   expectArchiveInspectionFailurePathGuard();
   console.log("archive member preflight check passed");
@@ -64,6 +65,114 @@ function makeMemberList(count) {
     name: `conu-0.1.0/docs/file-${index}.txt`,
     type: "file"
   }));
+}
+
+function expectNativeZipInspection() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "conu-native-zip-preflight-"));
+  try {
+    const safeArchive = path.join(root, "conu-0.1.0-windows-x64.zip");
+    writeZipFixture(safeArchive, [
+      { name: "conu-0.1.0-windows-x64/bin/conu.exe", mode: 0o100644 },
+      { name: "conu-0.1.0-windows-x64/docs/", mode: 0o040755 }
+    ]);
+    validateArchiveMembers(safeArchive);
+
+    const traversalArchive = path.join(root, "conu-0.1.0-windows-x64-traversal.zip");
+    writeZipFixture(traversalArchive, [
+      { name: "conu-0.1.0-windows-x64/../conu.exe", mode: 0o100644 }
+    ]);
+    expectValidateArchiveFail(traversalArchive, "parent-traversal archive path");
+
+    const symlinkArchive = path.join(root, "conu-0.1.0-windows-x64-symlink.zip");
+    writeZipFixture(symlinkArchive, [
+      { name: "conu-0.1.0-windows-x64/bin/conu.exe", mode: 0o120777 }
+    ]);
+    expectValidateArchiveFail(symlinkArchive, "unsupported symlink member");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function expectValidateArchiveFail(archive, expectedMessage) {
+  try {
+    validateArchiveMembers(archive);
+  } catch (error) {
+    if (error.message.includes(expectedMessage)) {
+      return;
+    }
+    throw new Error(`expected ${expectedMessage}, got: ${error.message}`);
+  }
+  throw new Error(`expected archive inspection failure: ${expectedMessage}`);
+}
+
+function writeZipFixture(archive, entries) {
+  const localHeaders = [];
+  const centralHeaders = [];
+  let localOffset = 0;
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, "utf8");
+    const localHeader = zipLocalHeader(name);
+    localHeaders.push(localHeader);
+    centralHeaders.push(zipCentralHeader(name, localOffset, entry));
+    localOffset += localHeader.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralHeaders);
+  const eocd = zipEndOfCentralDirectory(entries.length, centralDirectory.length, localOffset);
+  fs.writeFileSync(archive, Buffer.concat([...localHeaders, centralDirectory, eocd]));
+}
+
+function zipLocalHeader(name) {
+  const header = Buffer.alloc(30 + name.length);
+  header.writeUInt32LE(0x04034b50, 0);
+  header.writeUInt16LE(20, 4);
+  header.writeUInt16LE(0x0800, 6);
+  header.writeUInt16LE(0, 8);
+  header.writeUInt32LE(0, 10);
+  header.writeUInt32LE(0, 14);
+  header.writeUInt32LE(0, 18);
+  header.writeUInt32LE(0, 22);
+  header.writeUInt16LE(name.length, 26);
+  header.writeUInt16LE(0, 28);
+  name.copy(header, 30);
+  return header;
+}
+
+function zipCentralHeader(name, localOffset, entry) {
+  const header = Buffer.alloc(46 + name.length);
+  const mode = entry.mode === undefined ? 0o100644 : entry.mode;
+  const externalAttributes = (mode << 16) >>> 0;
+  header.writeUInt32LE(0x02014b50, 0);
+  header.writeUInt16LE(0x0314, 4);
+  header.writeUInt16LE(20, 6);
+  header.writeUInt16LE(0x0800, 8);
+  header.writeUInt16LE(0, 10);
+  header.writeUInt32LE(0, 12);
+  header.writeUInt32LE(0, 16);
+  header.writeUInt32LE(0, 20);
+  header.writeUInt32LE(0, 24);
+  header.writeUInt16LE(name.length, 28);
+  header.writeUInt16LE(0, 30);
+  header.writeUInt16LE(0, 32);
+  header.writeUInt16LE(0, 34);
+  header.writeUInt16LE(0, 36);
+  header.writeUInt32LE(externalAttributes, 38);
+  header.writeUInt32LE(localOffset, 42);
+  name.copy(header, 46);
+  return header;
+}
+
+function zipEndOfCentralDirectory(entryCount, centralSize, centralOffset) {
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(entryCount, 8);
+  eocd.writeUInt16LE(entryCount, 10);
+  eocd.writeUInt32LE(centralSize, 12);
+  eocd.writeUInt32LE(centralOffset, 16);
+  eocd.writeUInt16LE(0, 20);
+  return eocd;
 }
 
 function expectArchiveInspectionPathRedacted() {


### PR DESCRIPTION
## **User description**
Fixes #878.

## What changed
- Replaces ZIP member preflight inspection with a native Node central-directory reader for `.zip` archives.
- Removes the PowerShell ZIP member-list fallback from npm archive preflight so malformed ZIPs fail in-process instead of reaching Windows shell/archive UI.
- Keeps existing path redaction behavior: malformed archives report the archive filename and `pathDisplayed=false`, not the local temp path.
- Adds native ZIP fixture regressions for safe members, traversal rejection, and symlink rejection.

## Validation
- `node packaging\npm\conu-cli\scripts\check-archive-preflight.js`
- `npm run check --prefix packaging/npm/conu-cli`
- `python scripts\verify-npm-package-contents.py`
- `python scripts\check-python-script-compile.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces ZIP preflight in `conu-cli` with a native Node central-directory reader and removes the PowerShell fallback on Windows. `.zip` inspection now runs in-process, applies consistent safety checks, and keeps path redaction for malformed archives.

- **Refactors**
  - Use Node-based ZIP reader; rejects multi-disk, ZIP64, oversized listings, and encrypted entries.
  - Remove PowerShell ZIP listing; malformed `.zip` files fail before extraction on Windows.
  - Enforce rules: block traversal and symlink members; cap member count and listing size.
  - Add native ZIP fixtures and script checks for safe, traversal, and symlink cases.

<sup>Written for commit a49de224c5deabd8327ea14e040560d445adc969. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Inspect ZIP archives in-process before extraction**

### What Changed
- ZIP archives are now checked directly in the app instead of relying on a Windows shell fallback.
- Malformed ZIP files fail early with a redacted error message, so the local temp path is not exposed.
- ZIP validation still blocks unsafe members such as parent-traversal paths, symlinks, and archives with too many entries.
- Added ZIP fixture checks to cover safe archives and rejected traversal and symlink cases.

### Impact
`✅ Fewer Windows ZIP extraction failures`
`✅ Clearer archive safety errors`
`✅ Less risk from unsafe ZIP contents`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
