### PR TITLE
Harden relay test frame reads

### DIFF
--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -8018,6 +8018,10 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::process;
 
+    const TEST_HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(3);
+    const TEST_SERVER_FRAME_POLL: Duration = Duration::from_millis(500);
+    const TEST_SERVER_FRAME_WAIT: Duration = Duration::from_secs(10);
+
     #[test]
     fn websocket_accept_key_matches_rfc_example() {
         let accept = websocket_accept_key("dGhlIHNhbXBsZSBub25jZQ==");
@@ -12786,7 +12790,7 @@ token_displayed = false\n"
     fn connect_client(addr: SocketAddr) -> TcpStream {
         let mut stream = TcpStream::connect(addr).expect("client connects");
         stream
-            .set_read_timeout(Some(Duration::from_secs(3)))
+            .set_read_timeout(Some(TEST_HANDSHAKE_READ_TIMEOUT))
             .expect("timeout set");
         let request = "GET /relay HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
         stream
@@ -12800,6 +12804,9 @@ token_displayed = false\n"
         }
         let response = String::from_utf8(response).expect("handshake utf8");
         assert!(response.contains("101 Switching Protocols"));
+        stream
+            .set_read_timeout(Some(TEST_SERVER_FRAME_POLL))
+            .expect("frame timeout set");
         stream
     }
 
@@ -12822,9 +12829,16 @@ token_displayed = false\n"
     }
 
     fn read_server_text(stream: &mut TcpStream) -> String {
-        read_text_frame(stream)
-            .expect("server frame reads")
-            .expect("server frame exists")
+        let deadline = Instant::now() + TEST_SERVER_FRAME_WAIT;
+        loop {
+            if let Some(frame) = read_text_frame(stream).expect("server frame reads") {
+                return frame;
+            }
+            if Instant::now() >= deadline {
+                panic!("server frame exists");
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
     }
 
     fn send_admin_text(addr: SocketAddr, request: RelayAdminRequest) -> String {


### PR DESCRIPTION
## **User description**
Fixes #880.

## What changed
- Keeps the test WebSocket handshake read timeout at 3 seconds.
- Uses a shorter frame-read poll timeout after handshake.
- Retries missing/timeout server-frame reads within a bounded 10-second window before panicking.

This is test-only hardening for the Windows main-CI failure in run 26928811699, where three relay file-backed tests timed out at the helper panic `server frame exists` even though the same PR CI had passed.

## Validation
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-relay --lib`
- `git diff --check`

Local targeted `cargo test -p conu-relay ...` was attempted but this workstation is missing the MSVC `link.exe`, so the PR CI Windows test job is the authoritative validation for the failing path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened relay test frame reads to reduce flaky Windows CI timeouts by adding bounded retries for server text frames. Fixes #880.

**Bug Fixes**
- Keep WebSocket handshake read timeout at 3s.
- After handshake, use a 500ms read timeout to poll for frames.
- Retry missing/timeout server-frame reads for up to 10s (25ms sleep between polls) before failing.

<sup>Written for commit 4688f5fdf03a1ae99e4f8d5c20ca0e6fd67ec98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make relay frame tests wait longer for server responses**

### What Changed
- Relay test connections now use a short timeout while waiting for the WebSocket handshake, then switch to a shorter polling timeout for server frames.
- When a server frame is not ready yet, the test now keeps retrying for up to 10 seconds before failing instead of stopping at the first miss.
- This reduces flaky Windows test failures caused by slow frame reads.

### Impact
`✅ Fewer flaky relay test failures`
`✅ More stable Windows CI`
`✅ Fewer false test timeouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
