### PR TITLE
Reject non-public release repository URLs

### DIFF
--- a/scripts/check-github-pages-readiness-regression.py
+++ b/scripts/check-github-pages-readiness-regression.py
@@ -130,6 +130,16 @@ def run_audit_tests(module) -> None:
         ),
         "encoded separators",
     )
+    for bad_url in (
+        "https://127.0.0.1/conu",
+        "https://10.0.0.1/conu",
+        "https://[fc00::1]/conu",
+        "https://packages.local/conu",
+    ):
+        assert_raises(
+            lambda bad_url=bad_url: module.audit_pages_readiness("owner/repo", None, bad_url),
+            "host must be public",
+        )
     default_custom = module.audit_pages_readiness(
         "owner/repo",
         None,

--- a/scripts/check-github-pages-readiness.py
+++ b/scripts/check-github-pages-readiness.py
@@ -13,6 +13,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse, urlunparse
 
 from github_release_secrets import find_gh, infer_repo, normalize_repo, run_gh_json
+from public_host_validation import validate_public_host
 
 
 @dataclass(frozen=True)
@@ -54,6 +55,7 @@ def normalize_https_url(value: str, field_name: str) -> str:
     if parsed.params or parsed.query or parsed.fragment:
         raise ValueError(f"{field_name} must not contain params, query, or fragment")
     netloc = normalize_url_netloc(parsed, field_name)
+    validate_public_host(parsed.hostname or "", field_name)
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise ValueError(f"{field_name} path must not contain dot segments")

--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -83,6 +83,10 @@ def main() -> int:
                 ("https://packages.example.com%40evil.test/conu", "authority"),
                 ("https://packages.example.com\\evil.test/conu", "authority"),
                 (f"{base_url}/%00", "whitespace or control characters"),
+                ("https://127.0.0.1/conu", "host must be public"),
+                ("https://10.0.0.1/conu", "host must be public"),
+                ("https://[fc00::1]/conu", "host must be public"),
+                ("https://packages.local/conu", "host must be public"),
             ):
                 run_checker_expect_failure(
                     bad_url,

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -7,13 +7,14 @@ import argparse
 import fnmatch
 import json
 import os
-import socket
 import sys
 from dataclasses import dataclass
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urljoin, urlparse, urlunparse
 from urllib.request import Request, urlopen
+
+from public_host_validation import is_loopback_host, validate_public_host
 
 
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
@@ -23,7 +24,6 @@ MAX_JSON_BYTES = 1024 * 1024
 MAX_TEXT_BYTES = 1024 * 1024
 MAX_HEAD_BYTES = 0
 DEFAULT_TIMEOUT_SECONDS = 15.0
-LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 FORBIDDEN_TEXT = (
     "BEGIN PGP PRIVATE KEY BLOCK",
     "BEGIN PRIVATE KEY",
@@ -269,6 +269,12 @@ def normalize_base_url(raw_value: str, *, allow_loopback_http: bool) -> str:
             raise EndpointReadinessError(
                 "hosted Linux repository base URL must be an absolute HTTPS URL"
             )
+    else:
+        validate_public_host(
+            host_lower,
+            "hosted Linux repository base URL",
+            error_factory=EndpointReadinessError,
+        )
     port = validate_url_port(parsed, "hosted Linux repository base URL")
     path_parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in path_parts):
@@ -305,15 +311,6 @@ def normalize_netloc(host: str, port: int | None) -> str:
     if port is None:
         return host
     return f"{host}:{port}"
-
-
-def is_loopback_host(host: str) -> bool:
-    if host in LOOPBACK_HOSTS:
-        return True
-    try:
-        return socket.gethostbyname(host).startswith("127.")
-    except OSError:
-        return False
 
 
 def has_url_authority_control(value: str) -> bool:

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -164,6 +164,24 @@ def main() -> int:
             "whitespace or control characters",
         )
 
+        for bad_url in (
+            "https://127.0.0.1/conu",
+            "https://10.0.0.1/conu",
+            "https://[fc00::1]/conu",
+            "https://packages.local/conu",
+        ):
+            non_public_base = run_publisher_raw(
+                site_dir,
+                "--dry-run",
+                "--base-url",
+                bad_url,
+            )
+            assert_failure(
+                "non-public repository base URL",
+                non_public_base,
+                "repository base URL host must be public",
+            )
+
         query_download_url = temp / "query-download-url-site"
         shutil.copytree(site_dir, query_download_url)
         repository_path = query_download_url / "repository.json"

--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -264,6 +264,24 @@ def main() -> int:
             release_base_url="https://github.com/imthegoodboy/conU/releases/download/v0.1.0/%00",
         )
 
+        for bad_url in (
+            "https://127.0.0.1/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://10.0.0.1/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://100.64.0.1/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://192.88.99.1/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[fc00::1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[fec0::1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[2001:db8::1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[::ffff:127.0.0.1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://release.local/imthegoodboy/conU/releases/download/v0.1.0",
+        ):
+            expect_failure(
+                "non-public release base URL",
+                dist,
+                "host must be public",
+                release_base_url=bad_url,
+            )
+
         expect_failure(
             "tag mismatch",
             dist,

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -916,6 +916,32 @@ def run_custom_repository_tests(module) -> None:
     else:
         raise AssertionError("custom base URL with encoded control path unexpectedly passed")
 
+    for bad_base_url in (
+        "https://127.0.0.1/conu",
+        "https://10.0.0.1/conu",
+        "https://100.64.0.1/conu",
+        "https://192.88.99.1/conu",
+        "https://[fc00::1]/conu",
+        "https://[fec0::1]/conu",
+        "https://[2001:db8::1]/conu",
+        "https://[::ffff:127.0.0.1]/conu",
+        "https://packages.local/conu",
+    ):
+        try:
+            module.normalize_custom_base_url(bad_base_url)
+        except ValueError as exc:
+            if "custom repository base URL host must be public" not in str(exc):
+                raise AssertionError(f"unexpected custom base URL host failure: {exc}")
+        else:
+            raise AssertionError(f"non-public custom base URL unexpectedly passed: {bad_base_url}")
+
+    for good_base_url in (
+        "https://1.1.1.1/conu",
+        "https://[2606:4700:4700::1111]/conu",
+        "https://[::ffff:8.8.8.8]/conu",
+    ):
+        module.normalize_custom_base_url(good_base_url)
+
     invalid_endpoint_paths = module.audit_tagged_release_readiness(
         repo="owner/repo",
         tag=TAG,

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -30,6 +30,7 @@ from github_release_secrets import (
     normalize_repo,
     run_gh_json,
 )
+from public_host_validation import is_loopback_host, validate_public_host
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -498,6 +499,7 @@ def normalize_custom_base_url(raw: str) -> str:
     if parsed.params or parsed.query or parsed.fragment:
         raise ValueError("custom repository base URL must not include params, query, or fragment")
     netloc = normalize_url_netloc(parsed, "custom repository base URL")
+    validate_public_host(parsed.hostname or "", "custom repository base URL")
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise ValueError("custom repository base URL path must not contain dot segments")
@@ -550,10 +552,6 @@ def validate_prefix(raw: str) -> str:
     if any(has_url_path_control(part) for part in decoded_parts):
         raise ValueError("custom repository S3 prefix must not contain whitespace or control characters")
     return "/".join(parts)
-
-
-def is_loopback_host(host: str) -> bool:
-    return host in {"localhost", "127.0.0.1", "::1"} or host.startswith("127.")
 
 
 def validate_endpoint_url(raw: str, *, allow_loopback_http: bool = False) -> str:

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -17,6 +17,7 @@ from typing import Any, BinaryIO
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
 from github_release_secrets import normalize_repo
+from public_host_validation import validate_public_host
 
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
@@ -231,6 +232,11 @@ def validate_release_base_url(raw: str, repo: str, tag: str) -> str:
     if parsed.params or parsed.query or parsed.fragment:
         raise SystemExit("release update policy base URL must not include params, query, or fragment")
     netloc = normalize_url_netloc(parsed, "release update policy base URL")
+    validate_public_host(
+        parsed.hostname or "",
+        "release update policy base URL",
+        error_factory=SystemExit,
+    )
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise SystemExit("release update policy base URL path must not contain dot segments")

--- a/scripts/public_host_validation.py
+++ b/scripts/public_host_validation.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Public-host validation helpers for release and hosted-repository tooling."""
+
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Callable
+
+
+ErrorFactory = Callable[[str], BaseException]
+
+
+def is_loopback_host(host: str) -> bool:
+    trimmed = host.strip(".").lower()
+    if trimmed in {"localhost", "127.0.0.1", "::1"} or trimmed.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(trimmed).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_public_host(
+    host: str,
+    label: str,
+    *,
+    error_factory: ErrorFactory = ValueError,
+) -> None:
+    trimmed = host.strip(".").lower()
+    if (
+        not trimmed
+        or trimmed == "localhost"
+        or trimmed.endswith(".localhost")
+        or trimmed.endswith(".local")
+    ):
+        raise error_factory(f"{label} host must be public")
+    try:
+        ip = ipaddress.ip_address(trimmed)
+    except ValueError:
+        return
+    if not is_public_ip(ip):
+        raise error_factory(f"{label} host must be public")
+
+
+def is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if isinstance(ip, ipaddress.IPv4Address):
+        return is_public_ipv4(ip)
+    return is_public_ipv6(ip)
+
+
+def is_public_ipv4(ip: ipaddress.IPv4Address) -> bool:
+    first, second, third, _fourth = ip.packed
+    return not (
+        first == 0
+        or ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_unspecified
+        or first == 255
+        or (first == 100 and 64 <= second <= 127)
+        or (first == 192 and second == 0 and third == 0)
+        or (first == 192 and second == 88 and third == 99)
+        or (first == 198 and second in {18, 19})
+        or first >= 240
+    )
+
+
+def is_public_ipv6(ip: ipaddress.IPv6Address) -> bool:
+    if (
+        ip.is_loopback
+        or ip.is_unspecified
+        or ip.is_multicast
+        or is_ipv6_unique_local(ip)
+        or is_ipv6_link_local(ip)
+        or is_ipv6_site_local(ip)
+        or is_ipv6_documentation(ip)
+        or is_ipv6_discard_only(ip)
+        or is_ipv6_protocol_assignment(ip)
+        or is_ipv6_6to4(ip)
+    ):
+        return False
+    if ip.ipv4_mapped is not None:
+        return is_public_ipv4(ip.ipv4_mapped)
+    compatible = ipv4_compatible_address(ip)
+    if compatible is not None:
+        return is_public_ipv4(compatible)
+    return True
+
+
+def is_ipv6_unique_local(ip: ipaddress.IPv6Address) -> bool:
+    return (int(ip) >> 121) == 0b1111110
+
+
+def is_ipv6_link_local(ip: ipaddress.IPv6Address) -> bool:
+    return (int(ip) >> 118) == 0b1111111010
+
+
+def is_ipv6_site_local(ip: ipaddress.IPv6Address) -> bool:
+    return (int(ip) >> 118) == 0b1111111011
+
+
+def is_ipv6_documentation(ip: ipaddress.IPv6Address) -> bool:
+    return int(ip) >> 32 == int(ipaddress.IPv6Address("2001:db8::")) >> 32
+
+
+def is_ipv6_discard_only(ip: ipaddress.IPv6Address) -> bool:
+    return int(ip) >> 64 == int(ipaddress.IPv6Address("100::")) >> 64
+
+
+def is_ipv6_protocol_assignment(ip: ipaddress.IPv6Address) -> bool:
+    segments = ip.exploded.split(":")
+    return int(segments[0], 16) == 0x2001 and int(segments[1], 16) <= 0x01FF
+
+
+def is_ipv6_6to4(ip: ipaddress.IPv6Address) -> bool:
+    return ip.exploded.startswith("2002:")
+
+
+def ipv4_compatible_address(ip: ipaddress.IPv6Address) -> ipaddress.IPv4Address | None:
+    value = int(ip)
+    if value >> 32 != 0:
+        return None
+    if value in {0, 1}:
+        return None
+    return ipaddress.IPv4Address(value & 0xFFFFFFFF)

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -22,6 +22,7 @@ from typing import Any, BinaryIO
 from urllib.parse import unquote, urlparse, urlunparse
 
 from command_output_redaction import redact_command_output
+from public_host_validation import is_loopback_host, validate_public_host
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -411,10 +412,6 @@ def validate_endpoint_url(raw: str, *, allow_loopback_http: bool = False) -> str
     return urlunparse((scheme, netloc, path, "", "", ""))
 
 
-def is_loopback_host(host: str) -> bool:
-    return host in {"localhost", "127.0.0.1", "::1"} or host.startswith("127.")
-
-
 def validate_base_url(raw: str) -> str:
     value = raw.strip()
     parsed = urlparse(value)
@@ -425,6 +422,11 @@ def validate_base_url(raw: str) -> str:
     if parsed.params or parsed.query or parsed.fragment:
         raise PublicationError("repository base URL must not include params, query, or fragment")
     netloc = normalize_url_netloc(parsed, "repository base URL")
+    validate_public_host(
+        parsed.hostname or "",
+        "repository base URL",
+        error_factory=PublicationError,
+    )
     parts = [part for part in parsed.path.split("/") if part]
     if any(part in {".", ".."} for part in parts):
         raise PublicationError("repository base URL path must not contain dot segments")


### PR DESCRIPTION
## **User description**
## Summary
- add a shared Python public-host validator for release and hosted repository tooling
- reject localhost, `.localhost`, `.local`, private/non-global IPv4, special IPv4, unique-local/link-local/site-local IPv6, documentation IPv6, and IPv4-mapped private hosts for public release/repository base URLs
- keep hidden loopback HTTP allowances scoped to true loopback test endpoints and leave private HTTPS S3 upload endpoints valid

Fixes #882

## Validation
- `python scripts\check-python-script-compile.py`
- `python scripts\check-hosted-linux-repository-endpoint-regression.py`
- `python scripts\check-tagged-release-readiness-regression.py`
- `python scripts\check-github-pages-readiness-regression.py`
- `python scripts\check-release-update-policy.py`
- `python scripts\check-release-update-download-gate.py`
- targeted S3 publication public-host validation import check
- custom repository publication preflight fixture failed as expected for `https://127.0.0.1/conu` with payload/token/secret display guards false
- `git diff --check`

Local note: the full `python scripts\check-hosted-linux-repository-s3-publication.py` fixture was attempted but timed out on this workstation; PR CI should cover the full hosted repository publication regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-public hosts for release and repository base URLs to prevent accidental local or private endpoints from being used. Adds a shared validator and applies it across release and hosted-repository tooling.

- **New Features**
  - Added `public_host_validation.py` with `validate_public_host` and `is_loopback_host`.
  - Enforced public-host checks in release update policy generation, tagged release readiness, GitHub Pages readiness, hosted Linux repository endpoint checks, and S3 repository publication.
  - Blocks `localhost`, `.localhost`, `.local`, private/special IPv4 (e.g., RFC1918, CGNAT, 192.88.99.0/24), non-public IPv6 (ULA, link-local, site-local, documentation, 6to4), and IPv4-mapped non-public addresses.
  - Keeps loopback HTTP allowances for true local test endpoints; private HTTPS S3 upload endpoints remain valid.

- **Migration**
  - If any base URL uses a non-public host, switch it to a public host. No changes needed for private S3 upload endpoints.

<sup>Written for commit cc641f76d1ad954b6143de03f64a0bebd440bc92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject non-public hosts in release and repository URLs**

### What Changed
- Release, repository, and hosted-site URL checks now reject private, loopback, and local-only hosts such as `127.0.0.1`, `10.0.0.1`, `fc00::1`, and `.local`
- Public-host checks also cover tricky IPv4 and IPv6 cases, including mapped or special-purpose addresses that should not be accepted for public release links
- Existing loopback-only HTTP allowances stay limited to local test endpoints
- Regression coverage was added for rejected private URLs and for a few valid public IP hosts that should still pass

### Impact
`✅ Fewer unsafe release links`
`✅ Safer hosted repository setup`
`✅ Clearer errors for private or local URLs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
