### PR TITLE
Reject IPv6 documentation hosts in release guards

### DIFF
--- a/scripts/check-github-pages-readiness-regression.py
+++ b/scripts/check-github-pages-readiness-regression.py
@@ -134,6 +134,7 @@ def run_audit_tests(module) -> None:
         "https://127.0.0.1/conu",
         "https://10.0.0.1/conu",
         "https://[fc00::1]/conu",
+        "https://[2001:db8:1::1]/conu",
         "https://packages.local/conu",
     ):
         assert_raises(

--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -86,6 +86,7 @@ def main() -> int:
                 ("https://127.0.0.1/conu", "host must be public"),
                 ("https://10.0.0.1/conu", "host must be public"),
                 ("https://[fc00::1]/conu", "host must be public"),
+                ("https://[2001:db8:1::1]/conu", "host must be public"),
                 ("https://packages.local/conu", "host must be public"),
             ):
                 run_checker_expect_failure(

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -168,6 +168,7 @@ def main() -> int:
             "https://127.0.0.1/conu",
             "https://10.0.0.1/conu",
             "https://[fc00::1]/conu",
+            "https://[2001:db8:1::1]/conu",
             "https://packages.local/conu",
         ):
             non_public_base = run_publisher_raw(

--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -272,6 +272,7 @@ def main() -> int:
             "https://[fc00::1]/imthegoodboy/conU/releases/download/v0.1.0",
             "https://[fec0::1]/imthegoodboy/conU/releases/download/v0.1.0",
             "https://[2001:db8::1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[2001:db8:1::1]/imthegoodboy/conU/releases/download/v0.1.0",
             "https://[::ffff:127.0.0.1]/imthegoodboy/conU/releases/download/v0.1.0",
             "https://release.local/imthegoodboy/conU/releases/download/v0.1.0",
         ):

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -924,6 +924,7 @@ def run_custom_repository_tests(module) -> None:
         "https://[fc00::1]/conu",
         "https://[fec0::1]/conu",
         "https://[2001:db8::1]/conu",
+        "https://[2001:db8:1::1]/conu",
         "https://[::ffff:127.0.0.1]/conu",
         "https://packages.local/conu",
     ):

--- a/scripts/public_host_validation.py
+++ b/scripts/public_host_validation.py
@@ -101,7 +101,7 @@ def is_ipv6_site_local(ip: ipaddress.IPv6Address) -> bool:
 
 
 def is_ipv6_documentation(ip: ipaddress.IPv6Address) -> bool:
-    return int(ip) >> 32 == int(ipaddress.IPv6Address("2001:db8::")) >> 32
+    return int(ip) >> 96 == int(ipaddress.IPv6Address("2001:db8::")) >> 96
 
 
 def is_ipv6_discard_only(ip: ipaddress.IPv6Address) -> bool:


### PR DESCRIPTION
## **User description**
## Summary
- fix public-host validation to reject the full `2001:db8::/32` IPv6 documentation block
- add regressions across release update policy, tagged release readiness, GitHub Pages readiness, hosted endpoint readiness, and S3 publication checks

## Validation
- `python scripts\check-release-update-policy.py`
- `python scripts\check-tagged-release-readiness-regression.py`
- `python scripts\check-github-pages-readiness-regression.py`
- `python scripts\check-hosted-linux-repository-endpoint-regression.py`
- `python scripts\check-hosted-linux-repository-s3-publication.py`
- `python scripts\check-python-script-compile.py`
- `git diff --check`

Closes #884

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject IPv6 documentation hosts (2001:db8::/32) in public-host validation and all release guards, closing #884. Adds regression tests across release update policy, tagged release readiness, GitHub Pages readiness, hosted endpoint readiness, and S3 publication checks.

- **Bug Fixes**
  - Fix `is_ipv6_documentation` to compare the top 32 bits (`>> 96`) so the entire 2001:db8::/32 block is rejected.
  - Add failing samples like `https://[2001:db8:1::1]/...` to ensure guards correctly block documentation IPv6 hosts.

<sup>Written for commit a2f52d3e802bde695e47a7d84626c5bfa7de5bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject IPv6 documentation hosts in release and publication checks**

### What Changed
- Release and publication checks now reject the full IPv6 documentation range, not just a single address
- Added coverage for `2001:db8:1::1` across release update policy, tagged release readiness, GitHub Pages readiness, hosted endpoint readiness, and S3 publication checks
- Public-host validation now treats IPv6 documentation hosts as non-public so they are blocked consistently

### Impact
`✅ Fewer release checks accepting fake public hosts`
`✅ Safer custom repository URLs`
`✅ Clearer failure handling for IPv6 documentation addresses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IPv6 documentation address range detection to accurately classify and identify non-public hosts in validation checks.

* **Tests**
  * Expanded regression test coverage across multiple validation suites with additional IPv6 address test cases to ensure consistent and correct handling of non-public host addresses in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->