### PR TITLE
Reject non-public npm download hosts

### DIFF
--- a/packaging/npm/conu-cli/lib/download-policy.js
+++ b/packaging/npm/conu-cli/lib/download-policy.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const net = require("node:net");
+
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
 function validateDownloadUrl(rawUrl) {
@@ -8,11 +10,12 @@ function validateDownloadUrl(rawUrl) {
     throw new Error("download URL must not include embedded credentials");
   }
 
+  const hostClass = classifyDownloadHost(parsed.hostname);
   if (parsed.protocol === "https:") {
     return parsed;
   }
 
-  if (parsed.protocol === "http:" && isLoopbackHost(parsed.hostname)) {
+  if (parsed.protocol === "http:" && hostClass === "loopback") {
     return parsed;
   }
 
@@ -64,7 +67,212 @@ function parseDownloadUrl(rawUrl) {
 }
 
 function isLoopbackHost(hostname) {
-  return LOOPBACK_HOSTS.has(hostname.toLowerCase().replace(/^\[|\]$/g, ""));
+  const host = normalizeHostname(hostname);
+  if (LOOPBACK_HOSTS.has(host) || host.endsWith(".localhost")) {
+    return true;
+  }
+  const ipVersion = net.isIP(host);
+  if (ipVersion === 4) {
+    return ipv4Octets(host)[0] === 127;
+  }
+  if (ipVersion === 6) {
+    const parsed = parseIpv6(host);
+    return parsed !== null && parsed === 1n;
+  }
+  return false;
+}
+
+function classifyDownloadHost(hostname) {
+  const host = normalizeHostname(hostname);
+  if (!host || host === "local" || host.endsWith(".local")) {
+    throw new Error("download URL host must be public or loopback");
+  }
+  if (isLoopbackHost(host)) {
+    return "loopback";
+  }
+
+  const ipVersion = net.isIP(host);
+  if (ipVersion === 4 && isPublicIpv4(host)) {
+    return "public";
+  }
+  if (ipVersion === 6 && isPublicIpv6(host)) {
+    return "public";
+  }
+  if (ipVersion !== 0) {
+    throw new Error("download URL host must be public or loopback");
+  }
+
+  return "public";
+}
+
+function normalizeHostname(hostname) {
+  return String(hostname || "")
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.+$/g, "");
+}
+
+function isPublicIpv4(host) {
+  const octets = ipv4Octets(host);
+  const [first, second, third] = octets;
+  return !(
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    first === 169 && second === 254 ||
+    first === 172 && second >= 16 && second <= 31 ||
+    first === 192 && second === 168 ||
+    first >= 224 ||
+    first === 255 ||
+    first === 100 && second >= 64 && second <= 127 ||
+    first === 192 && second === 0 && third === 0 ||
+    first === 192 && second === 0 && third === 2 ||
+    first === 192 && second === 88 && third === 99 ||
+    first === 198 && (second === 18 || second === 19) ||
+    first === 198 && second === 51 && third === 100 ||
+    first === 203 && second === 0 && third === 113
+  );
+}
+
+function ipv4Octets(host) {
+  return host.split(".").map((part) => Number.parseInt(part, 10));
+}
+
+function isPublicIpv6(host) {
+  const value = parseIpv6(host);
+  if (value === null) {
+    throw new Error("download URL host must be public or loopback");
+  }
+
+  if (
+    value === 0n ||
+    value === 1n ||
+    hasIpv6Prefix(value, "ff00::", 8) ||
+    hasIpv6Prefix(value, "fc00::", 7) ||
+    hasIpv6Prefix(value, "fe80::", 10) ||
+    hasIpv6Prefix(value, "fec0::", 10) ||
+    hasIpv6Prefix(value, "2001:db8::", 32) ||
+    hasIpv6Prefix(value, "3fff::", 20) ||
+    hasIpv6Prefix(value, "100::", 64) ||
+    hasIpv6Prefix(value, "100:0:0:1::", 64) ||
+    hasIpv6Prefix(value, "2001::", 23) ||
+    hasIpv6Prefix(value, "64:ff9b:1::", 48) ||
+    hasIpv6Prefix(value, "5f00::", 16) ||
+    hasIpv6Prefix(value, "2002::", 16)
+  ) {
+    return false;
+  }
+
+  const mapped = ipv4MappedAddress(value);
+  if (mapped !== null) {
+    return isPublicIpv4(mapped);
+  }
+  const compatible = ipv4CompatibleAddress(value);
+  if (compatible !== null) {
+    return isPublicIpv4(compatible);
+  }
+  const wellKnownNat64 = wellKnownNat64Address(value);
+  if (wellKnownNat64 !== null) {
+    return isPublicIpv4(wellKnownNat64);
+  }
+  return true;
+}
+
+function hasIpv6Prefix(value, prefix, bits) {
+  const prefixValue = parseIpv6(prefix);
+  if (prefixValue === null) {
+    throw new Error(`invalid IPv6 policy prefix: ${prefix}`);
+  }
+  const shift = BigInt(128 - bits);
+  return value >> shift === prefixValue >> shift;
+}
+
+function ipv4MappedAddress(value) {
+  if (value >> 32n !== 0xffffn) {
+    return null;
+  }
+  return ipv4FromNumber(Number(value & 0xffffffffn));
+}
+
+function ipv4CompatibleAddress(value) {
+  if (value >> 32n !== 0n || value === 0n || value === 1n) {
+    return null;
+  }
+  return ipv4FromNumber(Number(value & 0xffffffffn));
+}
+
+function wellKnownNat64Address(value) {
+  const prefix = parseIpv6("64:ff9b::");
+  if (prefix === null || value >> 32n !== prefix >> 32n) {
+    return null;
+  }
+  return ipv4FromNumber(Number(value & 0xffffffffn));
+}
+
+function ipv4FromNumber(value) {
+  return [
+    Math.floor(value / 256 ** 3) % 256,
+    Math.floor(value / 256 ** 2) % 256,
+    Math.floor(value / 256) % 256,
+    value % 256
+  ].join(".");
+}
+
+function parseIpv6(host) {
+  let normalized = host.toLowerCase();
+  if (normalized.includes("%")) {
+    return null;
+  }
+
+  if (normalized.includes(".")) {
+    const lastColon = normalized.lastIndexOf(":");
+    if (lastColon === -1) {
+      return null;
+    }
+    const ipv4 = normalized.slice(lastColon + 1);
+    if (net.isIP(ipv4) !== 4) {
+      return null;
+    }
+    const [a, b, c, d] = ipv4Octets(ipv4);
+    normalized = `${normalized.slice(0, lastColon)}:${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`;
+  }
+
+  const halves = normalized.split("::");
+  if (halves.length > 2) {
+    return null;
+  }
+
+  const left = splitIpv6Half(halves[0]);
+  const right = halves.length === 2 ? splitIpv6Half(halves[1]) : [];
+  if (left === null || right === null) {
+    return null;
+  }
+
+  const missing = 8 - left.length - right.length;
+  if ((halves.length === 1 && missing !== 0) || missing < 0) {
+    return null;
+  }
+
+  const parts = [...left, ...Array(missing).fill("0"), ...right];
+  let value = 0n;
+  for (const part of parts) {
+    if (!/^[0-9a-f]{1,4}$/.test(part)) {
+      return null;
+    }
+    value = (value << 16n) + BigInt(Number.parseInt(part, 16));
+  }
+  return value;
+}
+
+function splitIpv6Half(value) {
+  if (value === "") {
+    return [];
+  }
+  const parts = value.split(":");
+  if (parts.some((part) => part.length === 0)) {
+    return null;
+  }
+  return parts;
 }
 
 module.exports = {

--- a/packaging/npm/conu-cli/scripts/check-download-policy.js
+++ b/packaging/npm/conu-cli/scripts/check-download-policy.js
@@ -9,12 +9,24 @@ const {
 
 function main() {
   expectPass("https://github.com/imthegoodboy/conU/releases/download/v0.1.0/conu.zip");
+  expectPass("https://[64:ff9b::808:808]/conu.zip");
   expectPass("http://127.0.0.1:50123/conu.zip");
   expectPass("http://localhost:50123/conu.zip");
   expectPass("http://[::1]:50123/conu.zip");
   expectFail("http://example.com/conu.zip", "download URL must use HTTPS");
   expectFail("ftp://example.com/conu.zip", "unsupported download URL protocol");
   expectFail("https://user:pass@example.com/conu.zip", "embedded credentials");
+  expectFail("https://10.0.0.1/conu.zip", "host must be public or loopback");
+  expectFail("https://169.254.169.254/conu.zip", "host must be public or loopback");
+  expectFail("https://[fc00::1]/conu.zip", "host must be public or loopback");
+  expectFail("https://[fec0::1]/conu.zip", "host must be public or loopback");
+  expectFail("https://[2001:db8:1::1]/conu.zip", "host must be public or loopback");
+  expectFail("https://[3fff::1]/conu.zip", "host must be public or loopback");
+  expectFail("https://[5f00::1]/conu.zip", "host must be public or loopback");
+  expectFail("https://[64:ff9b:1::1]/conu.zip", "host must be public or loopback");
+  expectFail("https://[64:ff9b::a00:1]/conu.zip", "host must be public or loopback");
+  expectFail("https://[100:0:0:1::1]/conu.zip", "host must be public or loopback");
+  expectFail("https://release.local/conu.zip", "host must be public or loopback");
   expectFail("http://localhost.evil.test/conu.zip", "download URL must use HTTPS");
   expectFail("not a url", "invalid download URL");
   expectUnverifiedPass("http://127.0.0.1:50123/releases");
@@ -33,6 +45,11 @@ function main() {
     "https://github.com/imthegoodboy/conU/releases/download/v0.1.0/conu.zip",
     "http://127.0.0.1:50123/conu.zip?token=secret",
     "public and loopback"
+  );
+  expectRedirectFail(
+    "https://github.com/imthegoodboy/conU/releases/download/v0.1.0/conu.zip",
+    "https://[3fff::1]/conu.zip?token=secret",
+    "host must be public or loopback"
   );
   expectRedirectFail(
     "http://127.0.0.1:50123/conu.zip",

--- a/scripts/check-github-pages-readiness-regression.py
+++ b/scripts/check-github-pages-readiness-regression.py
@@ -135,6 +135,11 @@ def run_audit_tests(module) -> None:
         "https://10.0.0.1/conu",
         "https://[fc00::1]/conu",
         "https://[2001:db8:1::1]/conu",
+        "https://[3fff::1]/conu",
+        "https://[5f00::1]/conu",
+        "https://[64:ff9b:1::1]/conu",
+        "https://[64:ff9b::a00:1]/conu",
+        "https://[100:0:0:1::1]/conu",
         "https://packages.local/conu",
     ):
         assert_raises(

--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -87,6 +87,11 @@ def main() -> int:
                 ("https://10.0.0.1/conu", "host must be public"),
                 ("https://[fc00::1]/conu", "host must be public"),
                 ("https://[2001:db8:1::1]/conu", "host must be public"),
+                ("https://[3fff::1]/conu", "host must be public"),
+                ("https://[5f00::1]/conu", "host must be public"),
+                ("https://[64:ff9b:1::1]/conu", "host must be public"),
+                ("https://[64:ff9b::a00:1]/conu", "host must be public"),
+                ("https://[100:0:0:1::1]/conu", "host must be public"),
                 ("https://packages.local/conu", "host must be public"),
             ):
                 run_checker_expect_failure(

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -169,6 +169,11 @@ def main() -> int:
             "https://10.0.0.1/conu",
             "https://[fc00::1]/conu",
             "https://[2001:db8:1::1]/conu",
+            "https://[3fff::1]/conu",
+            "https://[5f00::1]/conu",
+            "https://[64:ff9b:1::1]/conu",
+            "https://[64:ff9b::a00:1]/conu",
+            "https://[100:0:0:1::1]/conu",
             "https://packages.local/conu",
         ):
             non_public_base = run_publisher_raw(

--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -273,6 +273,11 @@ def main() -> int:
             "https://[fec0::1]/imthegoodboy/conU/releases/download/v0.1.0",
             "https://[2001:db8::1]/imthegoodboy/conU/releases/download/v0.1.0",
             "https://[2001:db8:1::1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[3fff::1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[5f00::1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[64:ff9b:1::1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[64:ff9b::a00:1]/imthegoodboy/conU/releases/download/v0.1.0",
+            "https://[100:0:0:1::1]/imthegoodboy/conU/releases/download/v0.1.0",
             "https://[::ffff:127.0.0.1]/imthegoodboy/conU/releases/download/v0.1.0",
             "https://release.local/imthegoodboy/conU/releases/download/v0.1.0",
         ):

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -925,6 +925,11 @@ def run_custom_repository_tests(module) -> None:
         "https://[fec0::1]/conu",
         "https://[2001:db8::1]/conu",
         "https://[2001:db8:1::1]/conu",
+        "https://[3fff::1]/conu",
+        "https://[5f00::1]/conu",
+        "https://[64:ff9b:1::1]/conu",
+        "https://[64:ff9b::a00:1]/conu",
+        "https://[100:0:0:1::1]/conu",
         "https://[::ffff:127.0.0.1]/conu",
         "https://packages.local/conu",
     ):

--- a/scripts/public_host_validation.py
+++ b/scripts/public_host_validation.py
@@ -75,8 +75,12 @@ def is_public_ipv6(ip: ipaddress.IPv6Address) -> bool:
         or is_ipv6_link_local(ip)
         or is_ipv6_site_local(ip)
         or is_ipv6_documentation(ip)
+        or is_ipv6_3fff_documentation(ip)
         or is_ipv6_discard_only(ip)
+        or is_ipv6_dummy_prefix(ip)
         or is_ipv6_protocol_assignment(ip)
+        or is_ipv6_nat64_local_use(ip)
+        or is_ipv6_segment_routing_sid(ip)
         or is_ipv6_6to4(ip)
     ):
         return False
@@ -85,6 +89,9 @@ def is_public_ipv6(ip: ipaddress.IPv6Address) -> bool:
     compatible = ipv4_compatible_address(ip)
     if compatible is not None:
         return is_public_ipv4(compatible)
+    well_known_nat64 = ipv6_well_known_nat64_address(ip)
+    if well_known_nat64 is not None:
+        return is_public_ipv4(well_known_nat64)
     return True
 
 
@@ -104,8 +111,16 @@ def is_ipv6_documentation(ip: ipaddress.IPv6Address) -> bool:
     return int(ip) >> 96 == int(ipaddress.IPv6Address("2001:db8::")) >> 96
 
 
+def is_ipv6_3fff_documentation(ip: ipaddress.IPv6Address) -> bool:
+    return int(ip) >> 108 == int(ipaddress.IPv6Address("3fff::")) >> 108
+
+
 def is_ipv6_discard_only(ip: ipaddress.IPv6Address) -> bool:
     return int(ip) >> 64 == int(ipaddress.IPv6Address("100::")) >> 64
+
+
+def is_ipv6_dummy_prefix(ip: ipaddress.IPv6Address) -> bool:
+    return int(ip) >> 64 == int(ipaddress.IPv6Address("100:0:0:1::")) >> 64
 
 
 def is_ipv6_protocol_assignment(ip: ipaddress.IPv6Address) -> bool:
@@ -113,8 +128,25 @@ def is_ipv6_protocol_assignment(ip: ipaddress.IPv6Address) -> bool:
     return int(segments[0], 16) == 0x2001 and int(segments[1], 16) <= 0x01FF
 
 
+def is_ipv6_nat64_local_use(ip: ipaddress.IPv6Address) -> bool:
+    return int(ip) >> 80 == int(ipaddress.IPv6Address("64:ff9b:1::")) >> 80
+
+
+def is_ipv6_segment_routing_sid(ip: ipaddress.IPv6Address) -> bool:
+    return int(ip) >> 112 == int(ipaddress.IPv6Address("5f00::")) >> 112
+
+
 def is_ipv6_6to4(ip: ipaddress.IPv6Address) -> bool:
     return ip.exploded.startswith("2002:")
+
+
+def ipv6_well_known_nat64_address(
+    ip: ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | None:
+    value = int(ip)
+    if value >> 32 != int(ipaddress.IPv6Address("64:ff9b::")) >> 32:
+        return None
+    return ipaddress.IPv4Address(value & 0xFFFFFFFF)
 
 
 def ipv4_compatible_address(ip: ipaddress.IPv6Address) -> ipaddress.IPv4Address | None:


### PR DESCRIPTION
## **User description**
## Summary
- add npm installer host classification so HTTPS download URLs reject private, local-use, documentation, and reserved IP-literal hosts unless they are loopback test hosts
- extend the shared Python public-host guard for newer IPv6 special-purpose ranges: 3fff::/20, 5f00::/16, 64:ff9b:1::/48, and 100:0:0:1::/64
- keep well-known NAT64 mappings to public IPv4 allowed while rejecting NAT64 mappings to non-public IPv4
- add regressions across npm download policy, release update policy, tagged readiness, Pages readiness, hosted repository endpoint, and S3 publication URL checks

Closes #886

## Validation
- `node packaging\npm\conu-cli\scripts\check-download-policy.js`
- `npm --prefix packaging\npm\conu-cli run check`
- `python scripts\check-release-update-policy.py`
- `python scripts\check-github-pages-readiness-regression.py`
- `python scripts\check-tagged-release-readiness-regression.py`
- `python scripts\check-hosted-linux-repository-endpoint-regression.py`
- `python scripts\check-python-script-compile.py`
- `git diff --check`
- direct `publish-hosted-linux-repository-s3.py validate_base_url` probe for the new special-purpose ranges
- direct `check-tagged-release-readiness.py normalize_custom_base_url` probe for the new special-purpose ranges

Local caveat: `python scripts\check-hosted-linux-repository-s3-publication.py` exceeded the Windows local tool timeout; the targeted S3 base URL validation paths were exercised directly, and PR CI should run the full workflow check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non‑public npm download hosts in `conu-cli`. Requires HTTPS for public hosts and allows HTTP only for loopback test hosts. Closes #886.

- **New Features**
  - Add host classification to reject private, local-use, documentation, reserved, and `.local` hosts; treat `localhost`, `*.localhost`, `127.0.0.0/8`, and `::1` as loopback.
  - Expand IPv6 guard: add `3fff::/20`, `5f00::/16`, `64:ff9b:1::/48`, and `100:0:0:1::/64`; keep well-known NAT64 (`64:ff9b::/96`) to public IPv4 allowed; block NAT64, IPv4‑mapped, and compatible addresses that resolve to non‑public IPv4.
  - Extend regression coverage for download policy, release update policy, tagged release readiness, GitHub Pages readiness, hosted repository endpoint, and S3 publication URLs.

<sup>Written for commit c64321cb108e5c9b95f47f53f81f3a9953b76843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject more private and special-use download hosts**

### What Changed
- Download URLs now reject additional private, reserved, and special-use IPv4 and IPv6 hosts, including newer IPv6 ranges and loopback-like local hosts.
- NAT64-style IPv6 addresses are only allowed when they map to a public IPv4 address; local-use mappings are rejected.
- Existing download checks, release update checks, Pages readiness, tagged release readiness, and S3 publication checks now cover the same blocked host set.

### Impact
`✅ Fewer unsafe download URLs`
`✅ Consistent host validation across release and publication checks`
`✅ Clearer errors for private or special-use hosts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
