### PR TITLE
Reject special IP ranges in update host guard

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -9879,8 +9879,12 @@ fn is_public_ipv6(ip: Ipv6Addr) -> bool {
         || is_ipv6_link_local(ip)
         || is_ipv6_site_local(ip)
         || is_ipv6_documentation(ip)
+        || is_ipv6_3fff_documentation(ip)
         || is_ipv6_discard_only(ip)
+        || is_ipv6_dummy_prefix(ip)
         || is_ipv6_protocol_assignment(ip)
+        || is_ipv6_nat64_local_use(ip)
+        || is_ipv6_segment_routing_sid(ip)
         || is_ipv6_6to4(ip)
     {
         return false;
@@ -9891,6 +9895,9 @@ fn is_public_ipv6(ip: Ipv6Addr) -> bool {
     }
     if let Some(compatible) = ipv4_compatible_address(ip) {
         return is_public_ipv4(compatible);
+    }
+    if let Some(well_known_nat64) = ipv6_well_known_nat64_address(ip) {
+        return is_public_ipv4(well_known_nat64);
     }
 
     true
@@ -9913,9 +9920,19 @@ fn is_ipv6_documentation(ip: Ipv6Addr) -> bool {
     segments[0] == 0x2001 && segments[1] == 0x0db8
 }
 
+fn is_ipv6_3fff_documentation(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x3fff && (segments[1] & 0xf000) == 0
+}
+
 fn is_ipv6_discard_only(ip: Ipv6Addr) -> bool {
     let segments = ip.segments();
     segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0
+}
+
+fn is_ipv6_dummy_prefix(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 1
 }
 
 fn is_ipv6_protocol_assignment(ip: Ipv6Addr) -> bool {
@@ -9923,8 +9940,30 @@ fn is_ipv6_protocol_assignment(ip: Ipv6Addr) -> bool {
     segments[0] == 0x2001 && segments[1] <= 0x01ff
 }
 
+fn is_ipv6_nat64_local_use(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2] == 1
+}
+
+fn is_ipv6_segment_routing_sid(ip: Ipv6Addr) -> bool {
+    ip.segments()[0] == 0x5f00
+}
+
 fn is_ipv6_6to4(ip: Ipv6Addr) -> bool {
     ip.segments()[0] == 0x2002
+}
+
+fn ipv6_well_known_nat64_address(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    let segments = ip.segments();
+    if segments[..6] != [0x0064, 0xff9b, 0, 0, 0, 0] {
+        return None;
+    }
+    Some(Ipv4Addr::new(
+        (segments[6] >> 8) as u8,
+        segments[6] as u8,
+        (segments[7] >> 8) as u8,
+        segments[7] as u8,
+    ))
 }
 
 fn ipv4_compatible_address(ip: Ipv6Addr) -> Option<Ipv4Addr> {
@@ -11995,8 +12034,14 @@ mod tests {
             "fe80::1",
             "fec0::1",
             "100::1",
+            "100:0:0:1::1",
             "2001::1",
             "2001:db8::1",
+            "3fff::1",
+            "3fff:0fff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "5f00::1",
+            "64:ff9b:1::1",
+            "64:ff9b::10.0.0.1",
             "2002::1",
             "::ffff:127.0.0.1",
             "::ffff:10.0.0.1",
@@ -12012,6 +12057,7 @@ mod tests {
             "2606:4700:4700::1111",
             "2001:4860:4860::8888",
             "::ffff:8.8.8.8",
+            "64:ff9b::8.8.8.8",
             "::8.8.8.8",
         ] {
             let ip = value.parse::<IpAddr>().expect("test IP parses");


### PR DESCRIPTION
## **User description**
## Summary
- extend the Rust release update public-host guard for newer IPv6 special-purpose ranges
- reject `3fff::/20`, `5f00::/16`, `64:ff9b:1::/48`, `100:0:0:1::/64`, and well-known NAT64 mappings to non-public IPv4
- preserve public well-known NAT64 mappings such as `64:ff9b::8.8.8.8`
- add focused unit coverage to the update public IP filter

Closes #888

## Validation
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-cli --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

Local caveat: executable `cargo test` could not run on this Windows workstation because `link.exe` is unavailable for MSVC and `dlltool.exe` is unavailable for the GNU test link step. The focused test target compiles via `cargo check --tests`; PR CI should run the actual Rust tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the release update public-host guard in `conu-cli` to reject newer IPv6 special-purpose ranges and correctly handle NAT64. Prevents updates from resolving to private/special addresses while allowing valid public NAT64 targets. Addresses #888.

- **Bug Fixes**
  - Rejects `3fff::/20`, `5f00::/16`, `64:ff9b:1::/48`, `100:0:0:1::/64`, and NAT64 embeddings that map to non-public IPv4.
  - Allows well-known NAT64 `64:ff9b::/96` when the mapped IPv4 is public (e.g., `64:ff9b::8.8.8.8`).
  - Adds focused unit tests for IPv6 special ranges, NAT64 handling, and IPv4/IPv6 public checks.

<sup>Written for commit 5304852e8b3025b57ca6b5c625bee63c881ed93e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject more special IPv6 addresses when checking update hosts**

### What Changed
- Update hosts now reject additional IPv6 special-use ranges, including documentation, dummy, NAT64 local-use, and segment-routing addresses
- Well-known NAT64 addresses are now treated as public only when they map to a public IPv4 address, and rejected when they point to private IPs
- Added coverage for the newly blocked ranges and for allowed public NAT64 addresses

### Impact
`✅ Fewer update links to private or reserved hosts`
`✅ Safer release downloads through NAT64`
`✅ Clearer blocking of invalid IPv6 addresses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
