### PR TITLE
Align relay localhost bind readiness

### DIFF
--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -7666,7 +7666,8 @@ fn bind_addr_is_public(bind_addr: &str) -> bool {
     if host.is_empty() || host == "*" {
         return true;
     }
-    if host.eq_ignore_ascii_case("localhost") {
+    if host.eq_ignore_ascii_case("localhost") || host.eq_ignore_ascii_case("localhost.localdomain")
+    {
         return false;
     }
 
@@ -8035,6 +8036,21 @@ mod tests {
             RelayConfig::new("127.0.0.1:0", "local-dev-token").expect("loopback dev token ok");
 
         assert!(config.auth.authorize("node.local", "local-dev-token"));
+    }
+
+    #[test]
+    fn loopback_hostname_aliases_allow_dev_token() {
+        for bind_addr in [
+            "localhost:0",
+            "LOCALHOST:0",
+            "localhost.localdomain:0",
+            "LOCALHOST.LOCALDOMAIN:0",
+        ] {
+            let config =
+                RelayConfig::new(bind_addr, "local-dev-token").expect("loopback dev token ok");
+
+            assert!(config.auth.authorize("node.local", "local-dev-token"));
+        }
     }
 
     #[test]
@@ -12349,7 +12365,7 @@ token_displayed = true\n",
                 .expect("alice relay sync");
         let bob_report = bob_sync.join().expect("bob thread joins");
         let inbox =
-            messages::list_agent_inbox(Some(bob_home.clone()), "agent.bob").expect("inbox reads");
+            wait_for_agent_inbox_count(bob_home.clone(), "agent.bob", 1, Duration::from_secs(2));
         let receipts = messages::list_receipts(Some(bob_home.clone())).expect("receipts read");
         let received =
             messages::read_message_payload(Some(bob_home), "agent.bob", &inbox[0].envelope_id)
@@ -12419,7 +12435,7 @@ token_displayed = true\n",
                 .expect("alice relay sync");
         let bob_report = bob_sync.join().expect("bob thread joins");
         let inbox =
-            messages::list_agent_inbox(Some(bob_home.clone()), "agent.bob").expect("inbox reads");
+            wait_for_agent_inbox_count(bob_home.clone(), "agent.bob", 1, Duration::from_secs(2));
         let room_events = rooms::list_room_events(Some(bob_home.clone())).expect("events read");
         let received = messages::read_message_payload(
             Some(bob_home.clone()),
@@ -12904,6 +12920,29 @@ token_displayed = false\n"
         .expect("remote message valid");
         relay_delivery::submit_remote_message(Some(alice_home.to_path_buf()), remote)
             .expect("remote message queues");
+    }
+
+    fn wait_for_agent_inbox_count(
+        home: PathBuf,
+        agent_id: &str,
+        count: usize,
+        timeout: Duration,
+    ) -> Vec<messages::InboxEntry> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let inbox =
+                messages::list_agent_inbox(Some(home.clone()), agent_id).expect("inbox reads");
+            if inbox.len() >= count {
+                return inbox;
+            }
+            if Instant::now() >= deadline {
+                panic!(
+                    "agent inbox did not reach expected metadata count: expected={count} actual={}",
+                    inbox.len()
+                );
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
     }
 
     fn write_remote_agent(home: &Path, agent_id: &str, peer_node_id: &str) {

--- a/crates/conu-relay/src/main.rs
+++ b/crates/conu-relay/src/main.rs
@@ -1329,7 +1329,8 @@ impl HostedReadinessReport {
 
 fn readiness_bind_addr_is_public(bind_addr: &str) -> bool {
     let host = readiness_bind_host(bind_addr);
-    if host == "localhost" || host.eq_ignore_ascii_case("localhost.localdomain") {
+    if host.eq_ignore_ascii_case("localhost") || host.eq_ignore_ascii_case("localhost.localdomain")
+    {
         return false;
     }
     if host == "*" {
@@ -1347,12 +1348,14 @@ fn readiness_bind_host(bind_addr: &str) -> String {
             .split_once(']')
             .map(|(host, _)| host)
             .unwrap_or(rest)
+            .trim()
             .to_string();
     }
     bind_addr
         .rsplit_once(':')
         .map(|(host, _)| host)
         .unwrap_or(bind_addr)
+        .trim()
         .to_string()
 }
 
@@ -13411,6 +13414,29 @@ mod tests {
         assert!(error.contains("unknown option"));
         assert!(error.contains("contentsDisplayed=false"));
         assert!(!error.contains(secret_marker));
+    }
+
+    #[test]
+    fn readiness_bind_classifies_loopback_hostname_aliases() {
+        for bind_addr in [
+            "localhost:8787",
+            "LOCALHOST:8787",
+            "localhost.localdomain:8787",
+            "LOCALHOST.LOCALDOMAIN:8787",
+            " [::1]:8787 ",
+        ] {
+            assert!(
+                !readiness_bind_addr_is_public(bind_addr),
+                "{bind_addr} should be treated as loopback"
+            );
+        }
+
+        for bind_addr in ["*:8787", "0.0.0.0:8787", "localhost.evil.test:8787"] {
+            assert!(
+                readiness_bind_addr_is_public(bind_addr),
+                "{bind_addr} should require public-bind credentials"
+            );
+        }
     }
 
     fn abuse_threshold_policy_contents(thresholds: &str) -> String {


### PR DESCRIPTION
## **User description**
## Summary

- Align relay runtime token-validation bind classification with hosted readiness for `localhost.localdomain`.
- Treat `localhost` readiness checks case-insensitively and trim parsed bind hosts.
- Add focused runtime/readiness tests for loopback hostname aliases while preserving wildcard/non-loopback credential warnings.

Fixes #890.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-relay --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`

Attempted focused executable test:

- `cargo +stable-x86_64-pc-windows-gnu test -p conu-relay loopback_hostname_aliases_allow_dev_token -- --exact`

That local executable test is blocked on this workstation because `dlltool.exe` is missing for the GNU linker. CI should cover executable Rust tests.

## Privacy/Security

- No payload, token, token hash, session id, local file content, or private material output added.
- Non-loopback and wildcard binds still require custom relay credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align runtime and hosted readiness handling for localhost binds. Hostnames are now trimmed and matched case-insensitively (including `localhost.localdomain` and `[::1]`), so loopback binds allow the dev token while public/wildcard binds still require credentials. Fixes #890.

- **Bug Fixes**
  - Readiness parsing now trims hosts, handles bracketed IPv6, and treats `localhost`/`localhost.localdomain` case-insensitively to match runtime.
  - Stabilized message receipt tests by waiting for the expected inbox count.

<sup>Written for commit 1defdc94be4363f162a5cf188ff2bc38846fae9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loopback address detection to recognize additional hostname aliases as local (case-insensitive matching).
  * Enhanced hostname parsing with whitespace trimming in bind address validation.

* **Tests**
  * Added unit tests to verify correct loopback classification for hostname variants and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Treat localhost aliases as loopback for relay readiness and token access**

### What Changed
- Relay readiness now treats `localhost`, `localhost.localdomain`, and bracketed loopback addresses as local binds, even when written with different casing or extra spaces.
- Loopback hostnames now allow the development token, while public and wildcard binds still require relay credentials.
- Added coverage for localhost aliases to keep readiness and runtime behavior aligned.

### Impact
`✅ Fewer false credential warnings on local relay setups`
`✅ Reliable dev token use on localhost aliases`
`✅ Clearer readiness checks for loopback binds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
