### PR TITLE
Reject malformed agent capability flags

### DIFF
--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -355,11 +355,11 @@ pub fn parse_signed_agent_card_metadata(contents: &str) -> Result<SignedAgentCar
         node_id: validate_identifier(required(&values, "node_id")?, "node id")?,
         kind: validate_kind(required(&values, "kind")?)?,
         capabilities: AgentCapabilities {
-            messages: parse_bool(values.get("cap_messages")).unwrap_or(true),
-            streams: parse_bool(values.get("cap_streams")).unwrap_or(false),
-            rooms: parse_bool(values.get("cap_rooms")).unwrap_or(false),
-            files: parse_bool(values.get("cap_files")).unwrap_or(false),
-            presence: parse_bool(values.get("cap_presence")).unwrap_or(true),
+            messages: parse_capability_bool(&values, "cap_messages", true)?,
+            streams: parse_capability_bool(&values, "cap_streams", false)?,
+            rooms: parse_capability_bool(&values, "cap_rooms", false)?,
+            files: parse_capability_bool(&values, "cap_files", false)?,
+            presence: parse_capability_bool(&values, "cap_presence", true)?,
         },
         signature_algorithm: validate_identifier(
             required(&values, "signature_algorithm")?,
@@ -760,11 +760,11 @@ fn record_from_values(values: &HashMap<String, String>) -> Result<LocalAgentReco
         presence,
         last_seen_unix,
         capabilities: AgentCapabilities {
-            messages: parse_bool(values.get("cap_messages")).unwrap_or(true),
-            streams: parse_bool(values.get("cap_streams")).unwrap_or(false),
-            rooms: parse_bool(values.get("cap_rooms")).unwrap_or(false),
-            files: parse_bool(values.get("cap_files")).unwrap_or(false),
-            presence: parse_bool(values.get("cap_presence")).unwrap_or(true),
+            messages: parse_capability_bool(values, "cap_messages", true)?,
+            streams: parse_capability_bool(values, "cap_streams", false)?,
+            rooms: parse_capability_bool(values, "cap_rooms", false)?,
+            files: parse_capability_bool(values, "cap_files", false)?,
+            presence: parse_capability_bool(values, "cap_presence", true)?,
         },
         signature_algorithm: optional_clean(values.get("signature_algorithm")),
         signature_key_id: optional_clean(values.get("signature_key_id")),
@@ -785,11 +785,11 @@ fn registration_from_values(
             .unwrap_or_else(|| "local-agent".to_string()),
     )?;
     registration.capabilities = AgentCapabilities {
-        messages: parse_bool(values.get("cap_messages")).unwrap_or(true),
-        streams: parse_bool(values.get("cap_streams")).unwrap_or(false),
-        rooms: parse_bool(values.get("cap_rooms")).unwrap_or(false),
-        files: parse_bool(values.get("cap_files")).unwrap_or(false),
-        presence: parse_bool(values.get("cap_presence")).unwrap_or(true),
+        messages: parse_capability_bool(values, "cap_messages", true)?,
+        streams: parse_capability_bool(values, "cap_streams", false)?,
+        rooms: parse_capability_bool(values, "cap_rooms", false)?,
+        files: parse_capability_bool(values, "cap_files", false)?,
+        presence: parse_capability_bool(values, "cap_presence", true)?,
     };
     Ok(registration)
 }
@@ -1135,12 +1135,21 @@ fn value_or_empty<'a>(values: &'a HashMap<String, String>, key: &str) -> &'a str
     values.get(key).map(String::as_str).unwrap_or("")
 }
 
-fn parse_bool(value: Option<&String>) -> Option<bool> {
-    value.and_then(|value| match value.as_str() {
-        "true" => Some(true),
-        "false" => Some(false),
-        _ => None,
-    })
+fn parse_capability_bool(
+    values: &HashMap<String, String>,
+    key: &'static str,
+    default: bool,
+) -> Result<bool, AgentError> {
+    let Some(value) = values.get(key) else {
+        return Ok(default);
+    };
+    match value.as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(AgentError::InvalidRequest {
+            reason: format!("{key} must be true or false"),
+        }),
+    }
 }
 
 fn optional_clean(value: Option<&String>) -> Option<String> {
@@ -1256,6 +1265,71 @@ mod tests {
         );
         assert!(verify_signed_agent_card(&card).expect("signature verifies"));
         assert!(!format!("{card:?}").contains("private message contents"));
+    }
+
+    #[test]
+    fn malformed_registration_capability_is_rejected() {
+        let values = parse_key_values(
+            "agent_id = \"agent.codex\"\n\
+display_name = \"Codex Desktop\"\n\
+kind = \"coding-agent\"\n\
+cap_messages = maybe\n",
+        );
+
+        let error = registration_from_values(&values)
+            .expect_err("malformed registration capability should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("cap_messages must be true or false"));
+        assert!(!rendered.contains("maybe"));
+    }
+
+    #[test]
+    fn malformed_local_agent_record_capability_is_rejected() {
+        let values = parse_key_values(
+            "agent_id = \"agent.codex\"\n\
+display_name = \"Codex Desktop\"\n\
+node_id = \"node.local\"\n\
+kind = \"coding-agent\"\n\
+presence = \"ready\"\n\
+last_seen_unix = 1\n\
+cap_messages = true\n\
+cap_streams = maybe\n",
+        );
+
+        let error =
+            record_from_values(&values).expect_err("malformed local capability should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("cap_streams must be true or false"));
+        assert!(!rendered.contains("maybe"));
+    }
+
+    #[test]
+    fn malformed_signed_agent_card_capability_is_rejected() {
+        let metadata = "version = \"1\"\n\
+type = \"signed_agent_card\"\n\
+agent_id = \"agent.codex\"\n\
+display_name = \"Codex Desktop\"\n\
+node_id = \"node.local\"\n\
+kind = \"coding-agent\"\n\
+cap_messages = maybe\n\
+cap_streams = false\n\
+cap_rooms = false\n\
+cap_files = false\n\
+cap_presence = true\n\
+signature_algorithm = \"ed25519\"\n\
+signature_key_id = \"key.1\"\n\
+signing_public_key_hex = \"aa\"\n\
+signature_hex = \"bb\"\n\
+payload_displayed = false\n";
+
+        let error = parse_signed_agent_card_metadata(metadata)
+            .expect_err("malformed signed card capability should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("cap_messages must be true or false"));
+        assert!(!rendered.contains("maybe"));
     }
 
     #[test]

--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -699,11 +699,11 @@ fn remote_agent_from_values(
         presence,
         last_seen_unix: parse_u64(&required(values, "last_seen_unix")?)?,
         capabilities: AgentCapabilities {
-            messages: parse_bool(values.get("cap_messages")).unwrap_or(true),
-            streams: parse_bool(values.get("cap_streams")).unwrap_or(false),
-            rooms: parse_bool(values.get("cap_rooms")).unwrap_or(false),
-            files: parse_bool(values.get("cap_files")).unwrap_or(false),
-            presence: parse_bool(values.get("cap_presence")).unwrap_or(true),
+            messages: parse_capability_bool(values, "cap_messages", true)?,
+            streams: parse_capability_bool(values, "cap_streams", false)?,
+            rooms: parse_capability_bool(values, "cap_rooms", false)?,
+            files: parse_capability_bool(values, "cap_files", false)?,
+            presence: parse_capability_bool(values, "cap_presence", true)?,
         },
         signature_algorithm: optional_clean(values.get("signature_algorithm")),
         signature_key_id: optional_clean(values.get("signature_key_id")),
@@ -995,11 +995,20 @@ fn parse_usize(value: &str) -> Result<usize, SessionError> {
         })
 }
 
-fn parse_bool(value: Option<&String>) -> Option<bool> {
-    match value?.as_str() {
-        "true" => Some(true),
-        "false" => Some(false),
-        _ => None,
+fn parse_capability_bool(
+    values: &HashMap<String, String>,
+    key: &'static str,
+    default: bool,
+) -> Result<bool, SessionError> {
+    let Some(value) = values.get(key) else {
+        return Ok(default);
+    };
+    match value.as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(SessionError::InvalidRecord {
+            reason: format!("{key} must be true or false"),
+        }),
     }
 }
 
@@ -1343,6 +1352,27 @@ mod tests {
 
         assert!(error.to_string().contains("signing key"));
         assert!(!error.to_string().contains("private message contents"));
+    }
+
+    #[test]
+    fn malformed_remote_agent_capability_is_rejected() {
+        let values = parse_key_values(
+            "agent_id = \"agent.bob\"\n\
+display_name = \"Bob\"\n\
+peer_node_id = \"node.bob\"\n\
+node_id = \"node.bob\"\n\
+kind = \"test-agent\"\n\
+presence = \"ready\"\n\
+last_seen_unix = 1\n\
+cap_messages = maybe\n",
+        );
+
+        let error = remote_agent_from_values(&values)
+            .expect_err("malformed remote capability should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("cap_messages must be true or false"));
+        assert!(!rendered.contains("maybe"));
     }
 
     fn register_agent(home: &Path, agent_id: &str, streams: bool, rooms: bool) {


### PR DESCRIPTION
## **User description**
## Summary

- Reject malformed explicit agent capability booleans instead of silently coercing them to defaults.
- Preserve existing missing-field defaults for compatibility.
- Cover local registration parsing, local agent records, signed agent-card metadata, and remote session agent records.

Fixes #892.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`

Attempted targeted executable tests:

- `cargo +stable-x86_64-pc-windows-gnu test -p conu-core malformed_`

That local executable test run is blocked on this workstation because `dlltool.exe` is missing for the GNU linker. CI should execute the tests.

## Privacy/Security

- No payload, token, token hash, session id, private key, or file-content output added.
- Error messages name only the malformed capability field, not the submitted value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed agent capability flags so bad inputs fail closed instead of silently defaulting. Missing capability keys still use existing defaults for compatibility.

- **Bug Fixes**
  - Enforce strict boolean parsing for `cap_messages`, `cap_streams`, `cap_rooms`, `cap_files`, `cap_presence` in local registration, local/remote agent records, and signed agent-card metadata.
  - Add unit tests for rejection paths; error messages name only the offending field.

<sup>Written for commit b76f64ec6062f59fa03f94c0cccf2eea079dbc1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject malformed agent capability flags instead of accepting them**

### What Changed
- Capability fields now fail closed when they contain values other than `true` or `false` in local registrations, local agent records, signed agent card metadata, and remote agent records
- Missing capability fields still use the existing default values
- Error messages now point to the specific bad field and do not echo the submitted value
- Added checks to cover the rejection path in each affected input source

### Impact
`✅ Fewer bad agent records`
`✅ Clearer capability parsing errors`
`✅ Safer agent imports and sync`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
