### PR TITLE
Reject duplicate local policy keys

### DIFF
--- a/crates/conu-core/src/policy.rs
+++ b/crates/conu-core/src/policy.rs
@@ -282,7 +282,7 @@ fn read_policies(paths: &StatePaths) -> Result<Vec<PeerPolicyRecord>, PolicyErro
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_record_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -290,6 +290,24 @@ fn read_policies(paths: &StatePaths) -> Result<Vec<PeerPolicyRecord>, PolicyErro
     }
 
     Ok(policies)
+}
+
+fn insert_record_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), PolicyError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty key".to_string()
+        } else {
+            format!("duplicate {key}")
+        };
+        return Err(PolicyError::InvalidRecord { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn write_policies(paths: &StatePaths, policies: &[PeerPolicyRecord]) -> Result<(), PolicyError> {
@@ -457,6 +475,22 @@ mod tests {
         assert_eq!(policies.len(), 1);
         assert!(contents.contains("payload_displayed = false"));
         assert!(!contents.contains("private message contents"));
+    }
+
+    #[test]
+    fn peer_policy_duplicate_permission_key_fails_closed_without_payloads() {
+        let home = test_home("duplicate-key");
+        state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            home.join("policy.toml"),
+            "# conU peer policy store\nversion = \"1\"\n\n[[peer_policy]]\npeer_node_id = \"peer.codex\"\nmessages = false\nmessages = true\nstreams = false\nrooms = false\nfiles = false\nmailbox = false\nupdated_at_unix = 1\npayload_displayed = false\nsecret_payload = \"private message contents\"\n",
+        )
+        .expect("policy writes");
+
+        let error = list_peer_policies(Some(home)).expect_err("duplicate key fails closed");
+
+        assert!(error.to_string().contains("duplicate messages"));
+        assert!(!error.to_string().contains("private message contents"));
     }
 
     fn test_home(label: &str) -> PathBuf {

--- a/crates/conu-core/src/rooms.rs
+++ b/crates/conu-core/src/rooms.rs
@@ -1147,7 +1147,7 @@ fn parse_topic_policies(contents: &str) -> Result<Vec<RoomTopicPolicyRecord>, Ro
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_topic_policy_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -1155,6 +1155,24 @@ fn parse_topic_policies(contents: &str) -> Result<Vec<RoomTopicPolicyRecord>, Ro
     }
 
     Ok(policies)
+}
+
+fn insert_topic_policy_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), RoomError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty key".to_string()
+        } else {
+            format!("duplicate {key}")
+        };
+        return Err(RoomError::InvalidRequest { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn room_from_values(values: &HashMap<String, String>) -> Result<RoomRecord, RoomError> {
@@ -1787,6 +1805,23 @@ mod tests {
 
         assert!(error.to_string().contains("not allowed to publish"));
         assert!(!error.to_string().contains("private message contents"));
+    }
+
+    #[test]
+    fn room_topic_policy_duplicate_permission_key_fails_closed_without_payloads() {
+        let home = test_home("topic-policy-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::create_dir_all(&init.paths.rooms_dir).expect("rooms directory creates");
+        fs::write(
+            &init.paths.room_policy,
+            "# conU room topic policy\nversion = \"1\"\n\n[[topic_policy]]\nroom_id = \"room.dev\"\nagent_id = \"agent.codex\"\ntopic = \"build\"\npublish = false\npublish = true\nsubscribe = false\nupdated_at_unix = 1\npayload_displayed = false\nsecret_payload = \"private room contents\"\n",
+        )
+        .expect("topic policy writes");
+
+        let error = list_room_topic_policies(Some(home)).expect_err("duplicate key fails closed");
+
+        assert!(error.to_string().contains("duplicate publish"));
+        assert!(!error.to_string().contains("private room contents"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #896.

## Summary
- Reject duplicate keys in `policy.toml` peer policy records before a later permission value can shadow an earlier one.
- Reject duplicate keys in room topic policy records before publish/subscribe grants can be shadowed.
- Add regression tests for peer and room topic duplicate permission keys, including payload-looking values that must not appear in errors.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- Attempted `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_permission_key`; local executable test linking is blocked because `dlltool.exe` is missing.

## Security Review
- Payload exposure risk: errors include only duplicate field names, not values or payload bytes.
- Trust/permission risk: duplicate peer and topic policy grant keys now fail closed instead of last-write-wins.
- Storage/logging risk: no new persisted payload content or log output is added.
- Relay/network risk: no relay transport or network behavior changed.


___

## **CodeAnt-AI Description**
**Reject duplicate policy keys in local policy files**

### What Changed
- Peer policy files now fail when the same permission key appears twice instead of using the later value
- Room topic policy files now fail when a permission key is duplicated, preventing hidden overrides
- Error checks do not expose payload content when duplicate-key parsing fails

### Impact
`✅ Prevented silent permission overrides`
`✅ Safer policy file loading`
`✅ Fewer leaks in parse errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy and room topic-policy file parsing now validates key uniqueness and rejects duplicate entries instead of silently overwriting them, returning clear error messages when invalid data is encountered.

* **Tests**
  * Added unit tests verifying the system correctly rejects duplicate policy table keys and duplicate room topic-policy fields with appropriate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in local peer and room topic policy files so later values can’t shadow earlier permissions. Parsing now fails closed and errors only show duplicate field names, not payload contents.

- **Bug Fixes**
  - Peer policy parsing (`policy.toml`): duplicate keys now error before any value can be overridden.
  - Room topic policy parsing: duplicate `publish`/`subscribe` keys now error early.
  - Implemented in `conu-core` with helper insert checks and regression tests that ensure no payload data appears in error messages.

<sup>Written for commit 2a2e45b8e7fb21f78ea9fd138fc27f3e1a3085f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

