### PR TITLE
Reject duplicate relay frame keys

### DIFF
--- a/crates/conu-core/src/relay.rs
+++ b/crates/conu-core/src/relay.rs
@@ -1776,10 +1776,28 @@ fn parse_frame_values(line: &str) -> Result<(&str, HashMap<String, String>), Rel
         let Some((key, value)) = part.split_once('=') else {
             continue;
         };
-        values.insert(key.trim().to_string(), value.trim().to_string());
+        insert_frame_value(&mut values, key, value)?;
     }
 
     Ok((kind, values))
+}
+
+fn insert_frame_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), RelayFrameError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty frame key".to_string()
+        } else {
+            format!("duplicate frame key {key}")
+        };
+        return Err(RelayFrameError::new(reason));
+    }
+    values.insert(key.to_string(), value.trim().to_string());
+    Ok(())
 }
 
 fn required(
@@ -2800,6 +2818,40 @@ mod tests {
 
         assert!(error.to_string().contains("must not include"));
         assert!(!error.to_string().contains("secret"));
+    }
+
+    #[test]
+    fn client_frame_duplicate_key_fails_closed_without_values() {
+        let error = parse_client_frame(
+            "FORWARD to=node.a to=private.message.contents envelope=env.1 bytes=24 payload=opaque",
+        )
+        .expect_err("duplicate client key should fail");
+
+        assert!(error.to_string().contains("duplicate frame key to"));
+        assert!(!error.to_string().contains("private.message.contents"));
+    }
+
+    #[test]
+    fn server_frame_duplicate_key_fails_closed_without_values() {
+        let error = parse_server_frame(
+            "WELCOME session=relay.session.1 resumed=false resumed=true payload=not_observed",
+        )
+        .expect_err("duplicate server key should fail");
+
+        assert!(error.to_string().contains("duplicate frame key resumed"));
+        assert!(!error.to_string().contains("true"));
+    }
+
+    #[test]
+    fn encrypted_forward_duplicate_body_fails_closed_without_values() {
+        let error = parse_server_frame(
+            "ENVELOPE from=node.a to=node.b envelope=env.1 kind=message bytes=24 from_agent=agent.a to_agent=agent.b cipher=xchacha20poly1305 key=key.1 sender_key=abcdef nonce=001122 body=privateciphertext body=private_message_contents payload=peer_encrypted",
+        )
+        .expect_err("duplicate body key should fail");
+
+        assert!(error.to_string().contains("duplicate frame key body"));
+        assert!(!error.to_string().contains("privateciphertext"));
+        assert!(!error.to_string().contains("private_message_contents"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #898.

## Summary
- Reject duplicate key/value fields in shared relay protocol frame parsing before frame-specific validation.
- Keep duplicate-key errors key-only so repeated values, tokens, ciphertext, or payload-looking strings are not echoed.
- Add client, server, and encrypted-forward parser regression tests for duplicate frame keys.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- Attempted `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key`; local executable test linking is blocked because `dlltool.exe` is missing.

## Security Review
- payload exposure risk: Reduced. Ambiguous duplicate frame fields now fail before values can be echoed or interpreted.
- trust/permission risk: Reduced. Relay routing/auth frames no longer accept last-write-wins key shadowing for node, target, envelope, or admin metadata.
- storage/logging risk: Unchanged. No new persisted state or log output is added.
- relay/network risk: Reduced. Wire-frame parsing now rejects ambiguous duplicate keys for client and server relay frames.
- required fixes: Keep CI test execution as the authoritative executable test coverage because this workstation is missing `dlltool.exe`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in relay frame parsing to prevent last-write-wins shadowing and avoid leaking values. Applies to client, server, and encrypted-forward frames.

- **Bug Fixes**
  - Fail fast on duplicate or empty frame keys with key-only errors in the shared parser.
  - Added regression tests for client, server, and encrypted-forward frames.

<sup>Written for commit 0b1e788806e430e0423d59bdc365f517bef957c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate relay frame fields without exposing their values**

### What Changed
- Relay frames now fail when the same field appears more than once, instead of silently using the last value.
- Duplicate-field errors now mention only the field name, so repeated payloads, tokens, or ciphertext are not echoed back.
- Added regression tests for duplicate fields in client frames, server frames, and encrypted forward frames.

### Impact
`✅ Safer relay parsing`
`✅ Fewer routing and auth mistakes from shadowed fields`
`✅ Lower risk of leaking sensitive frame values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
