### PR TITLE
Reject duplicate trust metadata keys

### DIFF
--- a/crates/conu-core/src/trust.rs
+++ b/crates/conu-core/src/trust.rs
@@ -453,7 +453,7 @@ fn read_pairing_invite(paths: &StatePaths, code: &str) -> Result<PairingInvite, 
             reason: "pairing code is not available locally until relay pairing arrives".to_string(),
         });
     };
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
 
     Ok(PairingInvite {
         code: validate_pairing_code(&required(&values, "code")?)?,
@@ -1064,7 +1064,7 @@ fn parse_trust_store(contents: &str) -> Result<Vec<TrustedPeer>, TrustError> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_trust_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -1072,6 +1072,24 @@ fn parse_trust_store(contents: &str) -> Result<Vec<TrustedPeer>, TrustError> {
     }
 
     Ok(peers)
+}
+
+fn insert_trust_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), TrustError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty trust key".to_string()
+        } else {
+            format!("duplicate trust key {key}")
+        };
+        return Err(TrustError::InvalidRequest { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn peer_from_values(values: &HashMap<String, String>) -> Result<TrustedPeer, TrustError> {
@@ -1393,7 +1411,7 @@ fn configured_relay_endpoint(paths: &StatePaths) -> Result<String, TrustError> {
         Some(contents) => contents,
         None => return Ok(DEFAULT_RELAY_ENDPOINT.to_string()),
     };
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
     let endpoint = values
         .get("default_relay")
         .filter(|value| !value.trim().is_empty())
@@ -1410,7 +1428,7 @@ fn configured_direct_quic_endpoint(paths: &StatePaths) -> Result<Option<String>,
     )
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, TrustError> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -1422,10 +1440,10 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
             continue;
         };
 
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_trust_value(&mut values, key, value)?;
     }
 
-    values
+    Ok(values)
 }
 
 fn clean_value(value: &str) -> String {
@@ -1585,6 +1603,52 @@ mod tests {
         assert!(report.changed);
         assert_eq!(report.peer.status, TrustStatus::Revoked);
         assert_eq!(peers[0].status, TrustStatus::Revoked);
+    }
+
+    #[test]
+    fn trust_store_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("trust-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            &init.paths.trust_store,
+            "# conU trust store\nversion = \"1\"\n\n[[peer]]\npeer_node_id = \"peer.safe\"\npeer_node_id = \"private.message.contents\"\ndisplay_name = \"Peer Safe\"\nstatus = \"trusted\"\nsource = \"test\"\npairing_code_hash = \"pair_test\"\nexchange_public_key_hex = \"\"\nrelay_endpoint = \"\"\ndirect_quic_endpoint = \"\"\nsigning_public_key_hex = \"\"\nsignature_algorithm = \"\"\nsignature_key_id = \"\"\nsignature_hex = \"\"\ncreated_at_unix = 1\nupdated_at_unix = 1\npayload_displayed = false\n",
+        )
+        .expect("trust store writes");
+
+        let error = list_peers(Some(home)).expect_err("duplicate trust key fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate trust key peer_node_id")
+        );
+        assert!(!error.to_string().contains("private.message.contents"));
+    }
+
+    #[test]
+    fn pairing_invite_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("invite-duplicate-key");
+        let invite = create_pairing_invite(Some(home.clone())).expect("invite creates");
+        let paths = StatePaths::from_home(home.clone());
+        let invite_path = paths
+            .pairing_invites_dir
+            .join(format!("{}.pair", invite.code));
+        fs::write(
+            invite_path,
+            format!(
+                "version = \"1\"\ncode = \"{}\"\nlocal_node_id = \"node_local\"\npeer_node_id = \"peer_safe\"\ndisplay_name = \"paired-peer-safe\"\ncreated_at_unix = 1\nexpires_at_unix = 601\nstatus = \"pending\"\nstatus = \"private message contents\"\npayload_displayed = false\n",
+                invite.code
+            ),
+        )
+        .expect("invite writes");
+
+        let error = join_pairing_code(Some(home.clone()), &invite.code)
+            .expect_err("duplicate invite key fails closed");
+        let peers = list_peers(Some(home)).expect("peers read");
+
+        assert!(error.to_string().contains("duplicate trust key status"));
+        assert!(!error.to_string().contains("private message contents"));
+        assert!(peers.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #900.

## Summary
- Reject duplicate keys while parsing `trust.toml` peer records before later status, peer id, endpoint, or display metadata can shadow earlier values.
- Reject duplicate keys while parsing trust key/value files such as pairing invitations and trust relay config.
- Add regressions for duplicate trust-store and pairing-invite keys, asserting payload-looking values are not echoed in errors and no peer is trusted after a corrupt invitation.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- Attempted `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key`; local executable test linking is blocked because `dlltool.exe` is missing.

## Security Review
- payload exposure risk: Reduced. Duplicate-key errors include only field names, not values or payload-looking strings.
- trust/permission risk: Reduced. Corrupt trust and pairing metadata now fails closed instead of accepting last-write-wins key shadowing.
- storage/logging risk: Unchanged. No new persisted payload content or log output is added.
- relay/network risk: Reduced for trust-derived relay metadata. Duplicate trust relay config keys now fail before endpoint selection can silently shadow earlier values.
- required fixes: Keep CI test execution as the authoritative executable test coverage because this workstation is missing `dlltool.exe`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in trust metadata parsing to prevent shadowing and data leaks. Corrupt trust or invite files now fail closed with safe error messages.

- **Bug Fixes**
  - Reject duplicate keys in trust store, pairing invites, and relay config.
  - Fail fast to stop last-write-wins shadowing; no partial trust on corrupt files.
  - Error messages include only field names, never payload-like values.
  - Added tests for duplicate-key cases; no peers are trusted after a bad invite.

<sup>Written for commit 72d2a2373565040aa7602888d33d4b9d0bc05e80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate trust metadata keys**

### What Changed
- Trust files now fail when the same key appears more than once, instead of using the last value written.
- Duplicate keys are rejected in trusted peer records, pairing invitations, and trust config files.
- Error messages now name the duplicate field without repeating the file content or payload-like values.
- Corrupt pairing invites no longer create a trusted peer.

### Impact
`✅ Fewer trust-file parsing mistakes`
`✅ Safer error messages`
`✅ Fewer accidental trust changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
