### PR TITLE
Reject duplicate agent metadata keys

### DIFF
--- a/crates/conu-core/src/agents.rs
+++ b/crates/conu-core/src/agents.rs
@@ -340,7 +340,7 @@ pub fn render_signed_agent_card_metadata(card: &SignedAgentCard) -> String {
 
 /// Parse a signed agent card exchanged as encrypted control-plane metadata.
 pub fn parse_signed_agent_card_metadata(contents: &str) -> Result<SignedAgentCard, AgentError> {
-    let values = parse_key_values(contents);
+    let values = parse_key_values(contents)?;
     if value_or_empty(&values, "version") != "1"
         || value_or_empty(&values, "type") != "signed_agent_card"
     {
@@ -421,7 +421,7 @@ fn process_one_request(
         "inspect IPC request",
         "read IPC request",
     )?;
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
 
     if value_or_empty(&values, "version") != REQUEST_VERSION {
         return Err(AgentError::InvalidRequest {
@@ -726,7 +726,7 @@ fn parse_registry(contents: &str) -> Result<Vec<LocalAgentRecord>, AgentError> {
             continue;
         };
 
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_agent_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -734,6 +734,24 @@ fn parse_registry(contents: &str) -> Result<Vec<LocalAgentRecord>, AgentError> {
     }
 
     Ok(records)
+}
+
+fn insert_agent_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), AgentError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty agent key".to_string()
+        } else {
+            format!("duplicate agent key {key}")
+        };
+        return Err(AgentError::InvalidRequest { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn record_from_values(values: &HashMap<String, String>) -> Result<LocalAgentRecord, AgentError> {
@@ -1104,7 +1122,7 @@ fn validate_hex_value(
     Ok(value)
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, AgentError> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -1116,10 +1134,10 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
             continue;
         };
 
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_agent_value(&mut values, key, value)?;
     }
 
-    values
+    Ok(values)
 }
 
 fn clean_value(value: &str) -> String {
@@ -1274,7 +1292,8 @@ mod tests {
 display_name = \"Codex Desktop\"\n\
 kind = \"coding-agent\"\n\
 cap_messages = maybe\n",
-        );
+        )
+        .expect("metadata parses");
 
         let error = registration_from_values(&values)
             .expect_err("malformed registration capability should fail closed");
@@ -1295,7 +1314,8 @@ presence = \"ready\"\n\
 last_seen_unix = 1\n\
 cap_messages = true\n\
 cap_streams = maybe\n",
-        );
+        )
+        .expect("metadata parses");
 
         let error =
             record_from_values(&values).expect_err("malformed local capability should fail closed");
@@ -1330,6 +1350,79 @@ payload_displayed = false\n";
 
         assert!(rendered.contains("cap_messages must be true or false"));
         assert!(!rendered.contains("maybe"));
+    }
+
+    #[test]
+    fn agent_registry_duplicate_capability_key_fails_closed_without_payloads() {
+        let home = test_home("registry-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            &init.paths.agent_registry,
+            "# conU local agent registry\nversion = \"1\"\n\n[[agent]]\nagent_id = \"agent.codex\"\ndisplay_name = \"Codex Desktop\"\nnode_id = \"node.local\"\nkind = \"coding-agent\"\npresence = \"ready\"\nlast_seen_unix = 1\ncap_messages = true\ncap_streams = false\ncap_rooms = false\ncap_rooms = \"private.message.contents\"\ncap_files = false\ncap_presence = true\n",
+        )
+        .expect("registry writes");
+
+        let error = list_local_agents(Some(home)).expect_err("duplicate registry key fails closed");
+
+        assert!(error.to_string().contains("duplicate agent key cap_rooms"));
+        assert!(!error.to_string().contains("private.message.contents"));
+    }
+
+    #[test]
+    fn gateway_request_duplicate_type_key_fails_closed_without_payloads() {
+        let home = test_home("request-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let request = init.paths.ipc_inbox_dir.join("duplicate.req");
+        fs::write(
+            &request,
+            "version = \"1\"\ntype = \"register_agent\"\ntype = \"private message contents\"\nrequest_id = \"duplicate\"\nagent_id = \"agent.codex\"\ndisplay_name = \"Codex Desktop\"\nkind = \"coding-agent\"\ncap_messages = true\ncap_streams = false\ncap_rooms = false\ncap_files = false\ncap_presence = true\n",
+        )
+        .expect("request writes");
+
+        let report = process_gateway_requests(Some(home.clone())).expect("requests process");
+        let error_text = fs::read_to_string(
+            StatePaths::from_home(home.clone())
+                .ipc_rejected_dir
+                .join("duplicate.error"),
+        )
+        .expect("rejection reason reads");
+        let agents = list_local_agents(Some(home)).expect("agents list");
+
+        assert_eq!(report.rejected, 1);
+        assert!(agents.is_empty());
+        assert!(error_text.contains("duplicate agent key type"));
+        assert!(!error_text.contains("private message contents"));
+    }
+
+    #[test]
+    fn signed_agent_card_duplicate_capability_key_fails_closed_without_payloads() {
+        let metadata = "version = \"1\"\n\
+type = \"signed_agent_card\"\n\
+agent_id = \"agent.codex\"\n\
+display_name = \"Codex Desktop\"\n\
+node_id = \"node.local\"\n\
+kind = \"coding-agent\"\n\
+cap_messages = true\n\
+cap_messages = \"private_message_contents\"\n\
+cap_streams = false\n\
+cap_rooms = false\n\
+cap_files = false\n\
+cap_presence = true\n\
+signature_algorithm = \"ed25519\"\n\
+signature_key_id = \"key.1\"\n\
+signing_public_key_hex = \"aa\"\n\
+signature_hex = \"bb\"\n\
+payload_displayed = false\n";
+
+        let error = parse_signed_agent_card_metadata(metadata)
+            .expect_err("duplicate signed card key fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate agent key cap_messages")
+        );
+        assert!(!error.to_string().contains("private_message_contents"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #902.

## Summary
- Reject duplicate keys while parsing local agent registry records before later capability or signature metadata can shadow earlier values.
- Reject duplicate keys while parsing gateway request and signed agent-card metadata before request type, agent id, or capability fields can be shadowed.
- Add regressions for duplicate registry capability keys, duplicate gateway request type keys, and duplicate signed-card capability keys, asserting payload-looking values are not echoed.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- Attempted `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key`; local executable test linking is blocked because `dlltool.exe` is missing.

## Security Review
- payload exposure risk: Reduced. Duplicate-key errors include only field names, not repeated values or payload-looking strings.
- trust/permission risk: Reduced. Local agent capability metadata now fails closed instead of accepting last-write-wins key shadowing.
- storage/logging risk: Unchanged. No new persisted payload content or log output is added.
- relay/network risk: Reduced for signed agent-card control metadata that can be exchanged over encrypted relay paths.
- required fixes: Keep CI test execution as the authoritative executable test coverage because this workstation is missing `dlltool.exe`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in agent metadata to prevent shadowing and reduce payload exposure across registry records, gateway requests, and signed agent cards. Aligns with #902; errors fail closed and only include field names.

- **Bug Fixes**
  - Added `insert_agent_value` to detect duplicate keys; `parse_key_values` now returns `Result` and is used by all parsing paths.
  - Registry parsing rejects repeated capability keys; gateway requests reject duplicate `type`/`agent_id`/capability keys; signed-agent-card parsing rejects duplicate capability keys.
  - Added regression tests ensuring duplicates are rejected and payload-like values are not echoed in errors.

<sup>Written for commit 08f9bc5b7761f5591454380c1d030d8e11ed2047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate metadata keys in agent records, requests, and signed cards**

### What Changed
- Agent registry records now fail if the same key appears twice, instead of accepting the last value and continuing.
- Gateway requests and signed agent cards now also fail on duplicate keys before parsing the rest of the metadata.
- Duplicate-key errors only name the repeated field, so payload-like values are not echoed back in rejection messages.

### Impact
`✅ Fewer agent metadata shadowing bugs`
`✅ Safer request and card parsing`
`✅ Less payload data exposed in error messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
