### PR TITLE
Reject duplicate message metadata keys

### DIFF
--- a/crates/conu-core/src/messages.rs
+++ b/crates/conu-core/src/messages.rs
@@ -290,7 +290,7 @@ pub fn read_message_payload(
         "inspect local message",
         "read local message",
     )?;
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
     let payload =
         payload_from_values(&paths, &values, &message_envelope_aad_from_values(&values)?)?;
 
@@ -439,7 +439,7 @@ fn process_one_message_request(
         "inspect message IPC request",
         "read message IPC request",
     )?;
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
 
     if value_or_empty(&values, "version") != REQUEST_VERSION {
         return Err(MessageError::InvalidRequest {
@@ -874,7 +874,7 @@ fn read_inbox_entry(path: &Path) -> Result<InboxEntry, MessageError> {
         "inspect inbox metadata",
         "read inbox metadata",
     )?;
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
 
     Ok(InboxEntry {
         envelope_id: validate_identifier(required(&values, "envelope_id")?, "envelope id")?,
@@ -903,7 +903,7 @@ fn read_receipt(path: &Path) -> Result<DeliveryReceipt, MessageError> {
         "inspect message receipt",
         "read message receipt",
     )?;
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
 
     Ok(DeliveryReceipt {
         receipt_id: validate_identifier(required(&values, "receipt_id")?, "receipt id")?,
@@ -1198,7 +1198,7 @@ fn validate_payload_size(bytes: usize) -> Result<(), MessageError> {
     Ok(())
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, MessageError> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -1210,10 +1210,28 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
             continue;
         };
 
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_message_value(&mut values, key, value)?;
     }
 
-    values
+    Ok(values)
+}
+
+fn insert_message_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), MessageError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty message key".to_string()
+        } else {
+            format!("duplicate message key {key}")
+        };
+        return Err(MessageError::InvalidRequest { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn clean_value(value: &str) -> String {
@@ -1470,6 +1488,78 @@ mod tests {
 
         assert_eq!(report.delivered, 1);
         assert_eq!(report.rejected, 1);
+    }
+
+    #[test]
+    fn message_request_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("request-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let request = init.paths.message_ipc_inbox_dir.join("duplicate.msg");
+        fs::write(
+            &request,
+            "version = \"1\"\ntype = \"send_message\"\ntype = \"secret private message contents\"\nrequest_id = \"duplicate\"\nfrom_agent_id = \"agent.sender\"\nto_agent_id = \"agent.receiver\"\npayload_len = 31\npayload_hex = \"7365637265742070726976617465206d65737361676520636f6e74656e7473\"\n",
+        )
+        .expect("duplicate request writes");
+
+        let report = process_message_requests(Some(home.clone())).expect("request rejects safely");
+        let error_text =
+            fs::read_to_string(init.paths.message_ipc_rejected_dir.join("duplicate.error"))
+                .expect("rejection reason reads");
+
+        assert_eq!(report.delivered, 0);
+        assert_eq!(report.rejected, 1);
+        assert!(error_text.contains("duplicate message key type"));
+        assert!(!error_text.contains("secret private message contents"));
+        assert!(!error_text.contains("736563726574"));
+        assert!(!request.exists());
+    }
+
+    #[test]
+    fn inbox_envelope_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("inbox-envelope-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let inbox = init.paths.message_inbox_dir.join("agent.receiver");
+        fs::create_dir_all(&inbox).expect("agent inbox creates");
+        fs::write(
+            inbox.join("duplicate.env"),
+            "version = \"1\"\nenvelope_id = \"env.safe\"\nenvelope_id = \"secret private message contents\"\nfrom_agent_id = \"agent.sender\"\nto_agent_id = \"agent.receiver\"\nreceipt_id = \"rcpt.safe\"\ndelivered_at_unix = 1\npayload_len = 31\npayload_hex = \"7365637265742070726976617465206d65737361676520636f6e74656e7473\"\n",
+        )
+        .expect("duplicate envelope writes");
+
+        let error = list_agent_inbox(Some(home), "agent.receiver")
+            .expect_err("duplicate inbox key fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate message key envelope_id")
+        );
+        assert!(
+            !error
+                .to_string()
+                .contains("secret private message contents")
+        );
+        assert!(!error.to_string().contains("736563726574"));
+    }
+
+    #[test]
+    fn delivery_receipt_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("delivery-receipt-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            init.paths.message_receipts_dir.join("duplicate.receipt"),
+            "version = \"1\"\nreceipt_id = \"rcpt.safe\"\nenvelope_id = \"env.safe\"\nfrom_agent_id = \"agent.sender\"\nto_agent_id = \"agent.receiver\"\nstatus = \"delivered_local\"\nstatus = \"secret private message contents\"\ndelivered_at_unix = 1\npayload_len = 31\npayload_displayed = false\n",
+        )
+        .expect("duplicate receipt writes");
+
+        let error = list_receipts(Some(home)).expect_err("duplicate receipt key fails closed");
+
+        assert!(error.to_string().contains("duplicate message key status"));
+        assert!(
+            !error
+                .to_string()
+                .contains("secret private message contents")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #904

## Summary
- reject duplicate keys while parsing local message IPC requests, inbox envelope metadata, and delivery receipts
- preserve generated message metadata format while failing closed on malformed repeated fields
- add regressions covering request, envelope, and receipt duplicate-key errors without payload-looking values in output

## Local validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `npm run check --prefix packaging/npm/conu-cli`
- `npm run check --prefix sdk/typescript`
- `python scripts/check-smoke-output-privacy.py`
- `python scripts/check-python-script-compile.py`
- `python scripts/check-production-readiness-toolchain.py`

Focused local executable test attempt:
- `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key` is still blocked locally by missing `dlltool.exe`; PR CI should cover executable tests on GitHub-hosted runners.

## Security notes
payload exposure risk: Reduced. Duplicate-key errors name only the repeated key and do not include repeated values or payload-looking bytes.

trust/permission risk: Reduced. Message request sender/recipient/request metadata now fails closed instead of accepting last-write-wins shadowing.

storage/logging risk: Reduced. Inbox envelope and delivery receipt metadata reject duplicate keys before metadata reads continue; no new payload storage or log output is added.

relay/network risk: Unchanged. This change is local message metadata parsing only.

required fixes: CI must pass before merge; #274 release secret configuration remains required for production publishing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys when parsing message metadata for IPC requests, inbox envelopes, and delivery receipts. This fails closed to prevent hidden overwrites, and error messages exclude payload-like values.

- **Bug Fixes**
  - Updated `parse_key_values` to return `Result` and added `insert_message_value` to enforce unique keys; duplicates yield `InvalidRequest`.
  - Added regression tests for duplicate keys and verified errors only include the repeated key (no payload hex or contents).

<sup>Written for commit 973a9da7bd3f5ed720b94b99451570c03fbe6b27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate keys in local message metadata**

### What Changed
- Local message requests, inbox envelopes, and delivery receipts now fail if the same metadata key appears more than once
- Duplicate-key errors now mention only the repeated key, not any message contents or encoded payload data
- Malformed duplicate metadata is rejected before the message is processed or shown in inbox and receipt views

### Impact
`✅ Fewer messages accepted with conflicting metadata`
`✅ Clearer duplicate-key errors`
`✅ Lower risk of leaking message contents in error output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message parsing to detect and reject messages with duplicate keys, providing meaningful error feedback instead of silent failures.

* **Tests**
  * Added comprehensive tests verifying rejection of duplicate keys in message requests, inbox entries, and delivery receipts, ensuring sensitive payload information is protected in error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->