### PR TITLE
Reject duplicate stream metadata keys

### DIFF
--- a/crates/conu-core/src/streams.rs
+++ b/crates/conu-core/src/streams.rs
@@ -601,7 +601,7 @@ fn parse_streams(contents: &str) -> Result<Vec<StreamRecord>, StreamError> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_stream_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -629,7 +629,7 @@ fn parse_events(contents: &str) -> Result<Vec<StreamEvent>, StreamError> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_stream_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -735,6 +735,24 @@ fn required(values: &HashMap<String, String>, key: &'static str) -> Result<Strin
         .ok_or_else(|| StreamError::InvalidRequest {
             reason: format!("missing {key}"),
         })
+}
+
+fn insert_stream_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), StreamError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty stream key".to_string()
+        } else {
+            format!("duplicate stream key {key}")
+        };
+        return Err(StreamError::InvalidRequest { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn validate_identifier(value: String, field: &'static str) -> Result<String, StreamError> {
@@ -884,6 +902,42 @@ mod tests {
         assert_eq!(closed.stream.state, StreamState::Closed);
         assert_eq!(events.len(), 3);
         assert!(stream_log.is_dir());
+    }
+
+    #[test]
+    fn stream_registry_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("stream-registry-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            &init.paths.stream_registry,
+            "# conU stream registry\nversion = \"1\"\n\n[[stream]]\nstream_id = \"stream.safe\"\nstream_id = \"secret private stream contents\"\nfrom_agent_id = \"agent.a\"\nto_agent_id = \"agent.b\"\nkind = \"message\"\nstate = \"open\"\nroute = \"local\"\nchunks_written = 0\nbytes_written = 0\nbackpressure_window = 65536\nopened_at_unix = 1\nupdated_at_unix = 1\npayload_displayed = false\n",
+        )
+        .expect("duplicate stream registry writes");
+
+        let error = list_streams(Some(home)).expect_err("duplicate stream key fails closed");
+
+        assert!(error.to_string().contains("duplicate stream key stream_id"));
+        assert!(!error.to_string().contains("secret private stream contents"));
+    }
+
+    #[test]
+    fn stream_event_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("stream-event-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            &init.paths.stream_events,
+            "# conU stream event bus\nversion = \"1\"\n\n[[event]]\nevent_id = \"event.safe\"\nstream_id = \"stream.safe\"\nevent_type = \"chunk\"\nfrom_agent_id = \"agent.a\"\nto_agent_id = \"agent.b\"\nroute = \"local\"\npayload_bytes = 10\npayload_bytes = \"secret private stream contents\"\ncreated_at_unix = 1\npayload_displayed = false\n",
+        )
+        .expect("duplicate stream event writes");
+
+        let error = list_events(Some(home)).expect_err("duplicate stream event key fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate stream key payload_bytes")
+        );
+        assert!(!error.to_string().contains("secret private stream contents"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #906

## Summary
- reject duplicate keys while parsing stream registry records and stream event metadata
- preserve generated stream metadata format while failing closed on malformed repeated fields
- add regressions covering duplicate stream id and payload byte-count keys without exposing payload-looking values

## Local validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `npm run check --prefix packaging/npm/conu-cli`
- `npm run check --prefix sdk/typescript`
- `python scripts/check-smoke-output-privacy.py`
- `python scripts/check-python-script-compile.py`
- `python scripts/check-production-readiness-toolchain.py`

Focused local executable test attempt:
- `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key` is still blocked locally by missing `dlltool.exe`; PR CI should cover executable tests on GitHub-hosted runners.

## Security notes
payload exposure risk: Reduced. Duplicate stream metadata errors name only the repeated key and do not include repeated values or payload-looking text.

trust/permission risk: Reduced. Stream registry and event metadata now fail closed instead of accepting last-write-wins shadowing of stream ids, route/state fields, event type, and byte counters.

storage/logging risk: Reduced. Stream metadata reads reject duplicate keys before continuing; no new payload storage or log output is added.

relay/network risk: Reduced for relay-backed stream event metadata because malformed local stream records can no longer shadow route/event counters.

required fixes: CI must pass before merge; #274 release secret configuration remains required for production publishing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys when parsing stream registry and event metadata so malformed records fail closed and cannot shadow IDs, routes, or counters. Error messages now name only the repeated key and never include payload-looking values.

- **Bug Fixes**
  - Added a duplicate-key guard in `conu-core` parsing (`insert_stream_value`) and applied it to both stream and event parsers.
  - Added tests that confirm rejection of duplicate `stream_id` and `payload_bytes` and verify no payload contents appear in errors.

<sup>Written for commit c1c504d2b995ab52bae0284a627cfadf50beb027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate stream metadata keys without exposing stored values**

### What Changed
- Stream registry and event files now stop loading when the same key appears twice in a record.
- Duplicate key errors now name only the repeated field, and do not include the duplicate value or payload-like text.
- Added checks covering duplicate `stream_id` and `payload_bytes` entries.

### Impact
`✅ Fewer malformed stream records accepted`
`✅ Clearer stream metadata error messages`
`✅ Lower risk of sensitive data appearing in errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
