### PR TITLE
Reject duplicate session metadata keys

### DIFF
--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -620,7 +620,7 @@ fn parse_sessions(contents: &str) -> Result<Vec<RemoteSession>, SessionError> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_session_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -648,7 +648,7 @@ fn parse_remote_agents(contents: &str) -> Result<Vec<RemoteAgentRecord>, Session
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_session_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -888,6 +888,24 @@ fn required(values: &HashMap<String, String>, key: &'static str) -> Result<Strin
         .ok_or_else(|| SessionError::InvalidRecord {
             reason: format!("missing {key}"),
         })
+}
+
+fn insert_session_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), SessionError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty session key".to_string()
+        } else {
+            format!("duplicate session key {key}")
+        };
+        return Err(SessionError::InvalidRecord { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn validate_identifier(value: String, field: &'static str) -> Result<String, SessionError> {
@@ -1165,6 +1183,52 @@ mod tests {
         assert_eq!(report.connected, 1);
         assert_eq!(sessions[0].peer_node_id, joined.peer.peer_node_id);
         assert!(session_log.is_dir());
+    }
+
+    #[test]
+    fn session_registry_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("session-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            &init.paths.session_registry,
+            "# conU remote session registry\nversion = \"1\"\n\n[[session]]\npeer_node_id = \"node.safe\"\npeer_node_id = \"secret private session contents\"\ndisplay_name = \"Safe Peer\"\nstate = \"connected\"\nroute = \"relay-websocket\"\nrelay_endpoint = \"wss://relay.example.com\"\nreconnect_attempts = 0\nremote_agent_count = 1\nlast_seen_unix = 1\nupdated_at_unix = 1\npayload_displayed = false\n",
+        )
+        .expect("duplicate session registry writes");
+
+        let error =
+            list_remote_sessions(Some(home)).expect_err("duplicate session key fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate session key peer_node_id")
+        );
+        assert!(
+            !error
+                .to_string()
+                .contains("secret private session contents")
+        );
+    }
+
+    #[test]
+    fn remote_agent_registry_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("remote-agent-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            &init.paths.remote_agent_registry,
+            "# conU remote agent registry\nversion = \"1\"\n\n[[remote_agent]]\nagent_id = \"agent.safe\"\ndisplay_name = \"Safe Agent\"\npeer_node_id = \"node.safe\"\nnode_id = \"node.safe\"\nkind = \"test-agent\"\npresence = \"ready\"\nlast_seen_unix = 1\ncap_messages = true\ncap_messages = \"secret private agent contents\"\ncap_streams = false\ncap_rooms = false\ncap_files = false\ncap_presence = true\npayload_displayed = false\n",
+        )
+        .expect("duplicate remote agent registry writes");
+
+        let error =
+            list_remote_agents(Some(home)).expect_err("duplicate remote agent key fails closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate session key cap_messages")
+        );
+        assert!(!error.to_string().contains("secret private agent contents"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #908

## Summary
- reject duplicate keys while parsing remote session registry records and remote-agent registry records
- preserve generated session metadata format while failing closed on malformed repeated fields
- add regressions covering duplicate peer id and remote capability keys without exposing payload-looking values

## Local validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `npm run check --prefix packaging/npm/conu-cli`
- `npm run check --prefix sdk/typescript`
- `python scripts/check-smoke-output-privacy.py`
- `python scripts/check-python-script-compile.py`
- `python scripts/check-production-readiness-toolchain.py`

Focused local executable test attempt:
- `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key` is still blocked locally by missing `dlltool.exe`; PR CI should cover executable tests on GitHub-hosted runners.

## Security notes
payload exposure risk: Reduced. Duplicate session metadata errors name only the repeated key and do not include repeated values or payload-looking text.

trust/permission risk: Reduced. Remote session and remote-agent metadata now fail closed instead of accepting last-write-wins shadowing of peer ids, session state, endpoint metadata, signature fields, and capability booleans.

storage/logging risk: Reduced. Session registry and remote-agent registry reads reject duplicate keys before continuing; no new payload storage or log output is added.

relay/network risk: Reduced. Relay-backed session/discovery metadata can no longer be locally shadowed through duplicate stored keys.

required fixes: CI must pass before merge; #274 release secret configuration remains required for production publishing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in remote session and remote-agent registries to prevent shadowing; parsing now fails closed with key-only errors. Adds targeted tests to block payload leakage.

- **Bug Fixes**
  - Added `insert_session_value` in `conu-core` to reject duplicate keys in `parse_sessions` and `parse_remote_agents`.
  - Errors include only the repeated key name, preserving the current metadata format.
  - Regression tests cover duplicate `peer_node_id` and `cap_messages`.

<sup>Written for commit 64fad286cb8a145ac9d5de5fef37803f9de0ac28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate keys in session and agent records**

### What Changed
- Session and remote agent records now stop loading when the same field appears twice in one entry
- Error messages name the repeated key and do not expose the repeated value
- Added coverage for duplicate session and agent records to ensure they fail closed

### Impact
`✅ Fewer corrupted session loads`
`✅ Safer error messages`
`✅ Less chance of hidden metadata shadowing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
