### PR TITLE
Reject duplicate route metadata keys

### DIFF
--- a/crates/conu-core/src/routes.rs
+++ b/crates/conu-core/src/routes.rs
@@ -607,7 +607,7 @@ fn read_config(paths: &StatePaths) -> Result<HashMap<String, String>, RouteError
         Some(contents) => contents,
         None => return Ok(HashMap::new()),
     };
-    Ok(parse_key_values(&contents))
+    parse_key_values(&contents)
 }
 
 fn relay_endpoint(config: &HashMap<String, String>) -> Result<String, RouteError> {
@@ -823,7 +823,7 @@ fn parse_routes(contents: &str) -> Result<Vec<RouteRecord>, RouteError> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_route_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -851,7 +851,7 @@ fn parse_probes(contents: &str) -> Result<Vec<RouteProbe>, RouteError> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_route_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -926,7 +926,7 @@ fn probe_from_values(values: &HashMap<String, String>) -> Result<RouteProbe, Rou
     })
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, RouteError> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -936,10 +936,28 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_route_value(&mut values, key, value)?;
     }
 
-    values
+    Ok(values)
+}
+
+fn insert_route_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), RouteError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty route key".to_string()
+        } else {
+            format!("duplicate route key {key}")
+        };
+        return Err(RouteError::InvalidRecord { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn clean_value(value: &str) -> String {
@@ -1597,6 +1615,63 @@ mod tests {
         assert_eq!(report.peers, 1);
         assert_eq!(selected.transport, RouteTransport::RelayWebSocket);
         assert!(route_log.is_dir());
+    }
+
+    #[test]
+    fn route_config_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("route-config-duplicate-key");
+        trusted_peer(&home);
+        let secret_endpoint = "wss://relay.example.com/private-message-contents?token=secret";
+        fs::write(
+            StatePaths::from_home(home.clone()).config,
+            format!(
+                "version = \"1\"\ndefault_relay = \"ws://127.0.0.1:8787\"\ndefault_relay = \"{secret_endpoint}\"\n"
+            ),
+        )
+        .expect("duplicate route config writes");
+
+        let error = sync_routes(Some(home)).expect_err("duplicate route config key fails closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate route key default_relay"));
+        assert!(!rendered.contains(secret_endpoint));
+        assert!(!rendered.contains("private-message-contents"));
+        assert!(!rendered.contains("token=secret"));
+    }
+
+    #[test]
+    fn route_registry_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("route-registry-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            init.paths.route_registry,
+            "# conU route registry\nversion = \"1\"\n\n[[route]]\nroute_id = \"route.safe\"\npeer_node_id = \"node.safe\"\ndisplay_name = \"Safe Peer\"\ntransport = \"relay-websocket\"\nendpoint = \"ws://127.0.0.1:8787\"\nendpoint = \"secret private route contents\"\nstate = \"selected\"\nscore = 80\nlatency_ms = 80\ndirect_attempted = false\nrelay_fallback = true\nnat_profile = \"unknown\"\ncandidate_source = \"none\"\ncandidate_kind = \"none\"\nrendezvous_state = \"not_configured\"\nfailure_reason = \"\"\nupdated_at_unix = 1\npayload_displayed = false\n",
+        )
+        .expect("duplicate route registry writes");
+
+        let error = list_routes(Some(home)).expect_err("duplicate route key fails closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate route key endpoint"));
+        assert!(!rendered.contains("secret private route contents"));
+    }
+
+    #[test]
+    fn route_probe_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("route-probe-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::write(
+            init.paths.route_probes,
+            "# conU route probes\nversion = \"1\"\n\n[[probe]]\nprobe_id = \"probe.safe\"\nroute_id = \"route.safe\"\npeer_node_id = \"node.safe\"\ntransport = \"relay-websocket\"\nendpoint = \"ws://127.0.0.1:8787\"\noutcome = \"selected\"\noutcome = \"secret private probe contents\"\nscore = 80\nlatency_ms = 80\ncandidate_source = \"none\"\ncandidate_kind = \"none\"\nrendezvous_state = \"not_configured\"\ncreated_at_unix = 1\npayload_displayed = false\n",
+        )
+        .expect("duplicate route probe writes");
+
+        let error =
+            list_route_probes(Some(home)).expect_err("duplicate route probe key fails closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate route key outcome"));
+        assert!(!rendered.contains("secret private probe contents"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #910.

What changed:
- Route config parsing now rejects duplicate keys instead of accepting last-write-wins shadowing.
- Route registry records now reject duplicate route metadata keys before selected route, endpoint, transport, NAT, latency, or fallback metadata can be shadowed.
- Route probe records now reject duplicate probe metadata keys before outcome, endpoint, latency, or candidate metadata can be shadowed.
- Added payload-safe regressions that assert duplicate-key errors include only the key name, not payload-looking duplicate values.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `npm run check --prefix packaging/npm/conu-cli`
- `npm run check --prefix sdk/typescript`
- `python scripts/check-smoke-output-privacy.py`
- `python scripts/check-python-script-compile.py`
- `python scripts/check-production-readiness-toolchain.py`

Local executable test note:
- `cargo +stable-x86_64-pc-windows-gnu test -p conu-core route_ -- --nocapture` was attempted but this workstation is missing `dlltool.exe`; CI should cover executable Rust tests on hosted runners.

Security review:
- payload exposure risk: Reduced. Duplicate route metadata errors include key names only and do not echo endpoint, probe, or payload-looking duplicate values.
- trust/permission risk: Reduced. Direct/relay route choice metadata now fails closed on duplicate keys instead of allowing shadowed endpoint, state, transport, NAT, or fallback fields.
- storage/logging risk: Reduced. Persisted route registry and route probe readers reject duplicate metadata before continuing; no new payload storage or logging was added.
- relay/network risk: Reduced. Relay/direct route metadata and probe outcomes can no longer be shadowed through duplicate stored keys.
- required fixes: CI executable tests must pass before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate route metadata keys in config, registry, and probe files to prevent shadowing and reduce payload exposure. Parsing now fails closed and returns clear errors like "duplicate route key <key>".

- **Bug Fixes**
  - Parsing now errors on duplicate keys across config, route registry, and route probes.
  - Errors include only the key name; no endpoint, token, or payload-looking values.
  - Added tests to verify fail-closed behavior and privacy.

- **Migration**
  - Remove duplicate keys in state files (config, route registry, probe logs).
  - Ensure each record defines a given key (e.g., endpoint, outcome) only once.

<sup>Written for commit 9003e4fb489335a39f81fbb900a3a8cbf1175865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate route metadata keys and stop hidden values from slipping through**

### What Changed
- Route config, route records, and route probe records now fail when the same key appears more than once instead of accepting the last value.
- Duplicate-key errors now report only the repeated key name, without exposing endpoint or payload-like values.
- Added checks that confirm duplicate route and probe entries are rejected before they can be loaded.

### Impact
`✅ Fewer hidden route overrides`
`✅ Clearer route file errors`
`✅ Lower risk of leaking sensitive values in error messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
