### PR TITLE
Reject duplicate room metadata keys

### DIFF
--- a/crates/conu-core/src/rooms.rs
+++ b/crates/conu-core/src/rooms.rs
@@ -1091,7 +1091,7 @@ fn parse_rooms(contents: &str) -> Result<Vec<RoomRecord>, RoomError> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_room_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -1119,7 +1119,7 @@ fn parse_events(contents: &str) -> Result<Vec<RoomEvent>, RoomError> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        current.insert(key.trim().to_string(), clean_value(value));
+        insert_room_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -1147,7 +1147,7 @@ fn parse_topic_policies(contents: &str) -> Result<Vec<RoomTopicPolicyRecord>, Ro
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        insert_topic_policy_value(&mut current, key, value)?;
+        insert_room_value(&mut current, key, value)?;
     }
 
     if !current.is_empty() {
@@ -1157,7 +1157,7 @@ fn parse_topic_policies(contents: &str) -> Result<Vec<RoomTopicPolicyRecord>, Ro
     Ok(policies)
 }
 
-fn insert_topic_policy_value(
+fn insert_room_value(
     values: &mut HashMap<String, String>,
     key: &str,
     value: &str,
@@ -1822,6 +1822,43 @@ mod tests {
 
         assert!(error.to_string().contains("duplicate publish"));
         assert!(!error.to_string().contains("private room contents"));
+    }
+
+    #[test]
+    fn room_registry_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("room-registry-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::create_dir_all(&init.paths.rooms_dir).expect("rooms directory creates");
+        fs::write(
+            &init.paths.room_registry,
+            "# conU room registry\nversion = \"1\"\n\n[[room]]\nroom_id = \"room.safe\"\ndisplay_name = \"Safe Room\"\nstate = \"open\"\ncreated_by_agent_id = \"agent.codex\"\nparticipants = \"agent.codex:local:1\"\nparticipants = \"private room contents\"\ntopics = \"build\"\nevents_published = 0\nbytes_published = 0\ncreated_at_unix = 1\nupdated_at_unix = 1\npayload_displayed = false\n",
+        )
+        .expect("duplicate room registry writes");
+
+        let error = list_rooms(Some(home)).expect_err("duplicate room key fails closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate participants"));
+        assert!(!rendered.contains("private room contents"));
+    }
+
+    #[test]
+    fn room_event_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("room-event-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        fs::create_dir_all(&init.paths.rooms_dir).expect("rooms directory creates");
+        fs::write(
+            &init.paths.room_events,
+            "# conU room event bus\nversion = \"1\"\n\n[[event]]\nevent_id = \"event.safe\"\nroom_id = \"room.safe\"\ntopic = \"build\"\nfrom_agent_id = \"agent.codex\"\nevent_type = \"message\"\nroute = \"room-local\"\npayload_bytes = 10\npayload_bytes = \"private room contents\"\ncreated_at_unix = 1\npayload_displayed = false\n",
+        )
+        .expect("duplicate room event writes");
+
+        let error =
+            list_room_events(Some(home)).expect_err("duplicate room event key fails closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate payload_bytes"));
+        assert!(!rendered.contains("private room contents"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
Closes #912.

What changed:
- Room registry parsing now rejects duplicate keys instead of accepting last-write-wins shadowing.
- Room event parsing now rejects duplicate keys before event ids, route labels, topics, byte counts, or timestamps can be shadowed.
- The existing room topic-policy duplicate-key guard now shares the same room metadata insert helper.
- Added payload-safe regressions that assert duplicate room/event key errors include only key names, not payload-looking duplicate values.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings`
- `npm run check --prefix packaging/npm/conu-cli`
- `npm run check --prefix sdk/typescript`
- `python scripts/check-smoke-output-privacy.py`
- `python scripts/check-python-script-compile.py`
- `python scripts/check-production-readiness-toolchain.py`

Local executable test note:
- `cargo +stable-x86_64-pc-windows-gnu test -p conu-core room_ -- --nocapture` was attempted but this workstation is missing `dlltool.exe`; CI should cover executable Rust tests on hosted runners.

Security review:
- payload exposure risk: Reduced. Duplicate room metadata errors include key names only and do not echo payload-looking duplicate values.
- trust/permission risk: Reduced. Room participants, topics, and event route metadata now fail closed instead of accepting shadowed fields.
- storage/logging risk: Reduced. Persisted room registry and room event readers reject duplicate metadata before continuing; no new payload storage or logging was added.
- relay/network risk: Reduced. Relay-backed room-event route metadata can no longer be shadowed through duplicate stored keys.
- required fixes: CI executable tests must pass before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate room and event metadata keys to prevent shadowing and fail closed. Error messages show only key names, never payload values.

- **Bug Fixes**
  - Room registry parser now rejects duplicate keys (no last-write-wins).
  - Room event parser rejects duplicate keys before IDs, routes, topics, counts, or timestamps can be shadowed.
  - Tests assert errors include only key names, not payload-like values.

- **Refactors**
  - Introduced a shared `insert_room_value` helper used by room registry, events, and topic policies for consistent duplicate-key handling.

<sup>Written for commit 36476f0e878214c9f65179924dae65197183ae4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate room metadata keys and keep error details safe**

### What Changed
- Room registry and room event files now stop loading when the same key appears more than once, instead of silently using the last value.
- Duplicate keys are also blocked in room topic policy files, so shadowed room settings no longer slip through.
- Duplicate-key errors now mention the repeated field name only and do not echo payload-like values.

### Impact
`✅ Fewer hidden room metadata overrides`
`✅ Safer duplicate-key error messages`
`✅ More reliable room and event loading`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Room metadata configuration files with duplicate keys are now properly rejected with validation errors, preventing potential data integrity issues and configuration inconsistencies.

* **Tests**
  * Added validation tests for duplicate key detection in metadata file parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->