### PR TITLE
Use neutral npm temp archive names

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-archive-preflight.js
+++ b/packaging/npm/conu-cli/scripts/check-archive-preflight.js
@@ -178,7 +178,7 @@ function zipEndOfCentralDirectory(entryCount, centralSize, centralOffset) {
 function expectArchiveInspectionPathRedacted() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "conu-secret-local-path-"));
   try {
-    const archive = path.join(root, "conu-0.1.0-windows-x64.zip");
+    const archive = path.join(root, "conu-invalid-archive-fixture.zip");
     fs.writeFileSync(archive, "not a zip archive\n", "utf8");
     try {
       validateArchiveMembers(archive);

--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -13,6 +13,7 @@ const {
   parseContentLength,
   readPositiveIntegerEnv
 } = require("../lib/download-limits");
+const { assetName } = require("../lib/platform");
 
 const packageRoot = path.resolve(__dirname, "..");
 const installScript = path.join(__dirname, "install.js");
@@ -29,6 +30,7 @@ async function main() {
   await expectArchiveLimitFailure();
   await expectChecksumLimitFailure();
   await expectChecksumArchiveNameFailure();
+  await expectInvalidArchiveUsesNeutralTempLabel();
   await expectTimeoutFailure();
   console.log("download limit check passed");
 }
@@ -150,6 +152,28 @@ async function expectChecksumArchiveNameFailure() {
   });
 }
 
+async function expectInvalidArchiveUsesNeutralTempLabel() {
+  const body = Buffer.from("not a release archive");
+  await withServer((request, response) => {
+    if (request.url.includes(".sha256")) {
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+    response.writeHead(200, { "Content-Length": String(body.length) });
+    response.end(body);
+  }, async (baseUrl) => {
+    const result = await runInstall({
+      CONU_NPM_ALLOW_UNVERIFIED: "1",
+      CONU_NPM_DIST_BASE: baseUrl,
+      CONU_NPM_MAX_ARCHIVE_BYTES: "1024"
+    });
+    expectFailedWith(result, "conu-native-archive");
+    expectFailedWithout(result, assetName());
+    expectNoSecretDisplay(result);
+  });
+}
+
 async function expectTimeoutFailure() {
   await withServer((_request, _response) => {}, async (baseUrl) => {
     const result = await runInstall({
@@ -207,6 +231,16 @@ function expectFailedWith(result, expectedMessage) {
   }
   if (!output.includes(expectedMessage)) {
     throw new Error(`expected installer output to include ${expectedMessage}, got: ${output}`);
+  }
+}
+
+function expectFailedWithout(result, unexpectedMessage) {
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  if (result.status === 0) {
+    throw new Error(`expected installer to fail without ${unexpectedMessage}, but it passed`);
+  }
+  if (output.includes(unexpectedMessage)) {
+    throw new Error(`installer output included ${unexpectedMessage}: ${output}`);
   }
 }
 

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -71,7 +71,7 @@ async function main() {
 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "conu-npm-"));
   try {
-    const archivePath = path.join(tempDir, asset);
+    const archivePath = path.join(tempDir, tempArchiveFileName(asset));
     const checksumPath = `${archivePath}.sha256`;
     await downloadFile(`${releaseBase}/${asset}`, archivePath, downloadLimits.maxArchiveBytes);
 
@@ -97,6 +97,16 @@ async function main() {
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+}
+
+function tempArchiveFileName(publicAssetName) {
+  if (publicAssetName.endsWith(".tar.gz")) {
+    return "conu-native-archive.tar.gz";
+  }
+  if (publicAssetName.endsWith(".zip")) {
+    return "conu-native-archive.zip";
+  }
+  throw new Error(`unsupported conU release asset: ${publicAssetName}`);
 }
 
 function installFromLocalDir(sourceDir) {


### PR DESCRIPTION
Closes #914.\n\n## Summary\n- use neutral private temp archive filenames during npm download-backed installs instead of naming temp files like public release assets\n- keep checksum verification pinned to the expected public asset name\n- stop using a real Windows release asset name for the invalid ZIP archive preflight fixture\n- add a regression that invalid archive inspection errors use the neutral temp label and do not show the public asset filename\n\n## Validation\n- npm run check --prefix packaging/npm/conu-cli\n- python scripts\\smoke-npm-launcher-download.py dist\n- python scripts\\check-npm-launcher-local-smoke-preflight.py\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-python-script-compile.py\n- npm run check --prefix sdk/typescript\n- git diff --check\n\n## Security\npayload exposure risk: Reduced. Archive failure output continues to hide local temp paths and now avoids public asset-looking temp labels for private installer files.\n\ntrust/permission risk: Unchanged. This change does not alter trust or permission decisions.\n\nstorage/logging risk: Reduced. Private temporary archive names are less confusing and output remains path-redacted; no local conU state, payloads, or secrets are read or logged.\n\nrelay/network risk: Unchanged. This change is npm packaging/install behavior only.\n\nrequired fixes:\n- Configure the 12 missing live release signing/notarization/GPG secrets tracked by #274.\n- Add CONU_NPM_TOKEN_ROTATED_AFTER after rotating the npm token.\n- NPM_TOKEN is present but must be rotated before publishing because it was pasted in chat.\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the npm installer to use neutral temp archive names so errors/logs don’t look like public release assets, while keeping checksum verification tied to the real asset name. Closes #914.

- **Bug Fixes**
  - Use neutral private temp archive filenames during download-backed installs.
  - Keep checksum verification pinned to the expected public asset name.
  - Update the invalid ZIP preflight fixture and add a regression test to ensure errors use the neutral temp label and never include the public asset filename.

<sup>Written for commit a76dd6a585953b7c3a0a76dbf7fbbcabb96a2ffd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

