### PR TITLE
Reject duplicate direct transport metadata keys

### DIFF
--- a/crates/conu-core/src/direct_transport.rs
+++ b/crates/conu-core/src/direct_transport.rs
@@ -621,7 +621,7 @@ fn receive_direct_frame(
         std::str::from_utf8(bytes).map_err(|_| DirectTransportError::InvalidRequest {
             reason: "direct frame metadata is not UTF-8".to_string(),
         })?;
-    let values = parse_key_values(contents);
+    let values = parse_key_values(contents)?;
     if value_or_empty(&values, "version") != DIRECT_VERSION {
         return Err(DirectTransportError::InvalidRequest {
             reason: "unsupported direct frame version".to_string(),
@@ -890,7 +890,7 @@ fn read_config(paths: &StatePaths) -> Result<HashMap<String, String>, DirectTran
         Some(contents) => contents,
         None => return Ok(HashMap::new()),
     };
-    Ok(parse_key_values(&contents))
+    parse_key_values(&contents)
 }
 
 fn direct_endpoint_for_peer(
@@ -1092,7 +1092,7 @@ fn render_direct_response(
 }
 
 fn parse_direct_response(response: &str) -> Result<HashMap<String, String>, DirectTransportError> {
-    let values = parse_key_values(response);
+    let values = parse_key_values(response)?;
     if value_or_empty(&values, "version") != DIRECT_VERSION {
         return Err(DirectTransportError::InvalidRequest {
             reason: "unsupported direct response version".to_string(),
@@ -1472,7 +1472,7 @@ fn config_key_suffix(value: &str) -> String {
         .collect()
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, DirectTransportError> {
     let mut values = HashMap::new();
     for line in contents.lines().map(str::trim) {
         if line.is_empty() || line.starts_with('#') {
@@ -1481,9 +1481,27 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_direct_value(&mut values, key, value)?;
     }
-    values
+    Ok(values)
+}
+
+fn insert_direct_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), DirectTransportError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty direct key".to_string()
+        } else {
+            format!("duplicate direct key {key}")
+        };
+        return Err(DirectTransportError::InvalidRequest { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn clean_value(value: &str) -> String {
@@ -1647,6 +1665,59 @@ mod tests {
                 .file_type()
                 .is_symlink()
         );
+    }
+
+    #[test]
+    fn direct_config_duplicate_key_fails_closed_without_values() {
+        let home = test_home("direct-config-duplicate-key");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        fs::write(
+            &init.paths.config,
+            "version = \"1\"\ndirect_quic_endpoint = \"quic://127.0.0.1:9443\"\ndirect_quic_endpoint = \"private direct endpoint contents\"\n",
+        )
+        .expect("config writes");
+
+        let error = configured_direct_quic_endpoint_from_paths(&init.paths)
+            .expect_err("duplicate direct config key should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate direct key direct_quic_endpoint"));
+        assert!(!rendered.contains("quic://127.0.0.1:9443"));
+        assert!(!rendered.contains("private direct endpoint contents"));
+    }
+
+    #[test]
+    fn direct_frame_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("direct-frame-duplicate-key");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        let frame = format!(
+            "version = \"{}\"\ntype = \"direct_message\"\nkind = \"message\"\npayload_ciphertext_hex = \"private direct frame contents\"\npayload_ciphertext_hex = \"shadowed ciphertext\"\n",
+            DIRECT_VERSION
+        );
+
+        let error = receive_direct_frame(&init.paths, &init.node.node_id, frame.as_bytes())
+            .expect_err("duplicate direct frame key should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate direct key payload_ciphertext_hex"));
+        assert!(!rendered.contains("private direct frame contents"));
+        assert!(!rendered.contains("shadowed ciphertext"));
+    }
+
+    #[test]
+    fn direct_response_duplicate_key_fails_closed_without_payloads() {
+        let response = format!(
+            "version = \"{}\"\ntype = \"direct_ack\"\nenvelope_id = \"private direct ack contents\"\nenvelope_id = \"shadowed envelope\"\n",
+            DIRECT_VERSION
+        );
+
+        let error = parse_direct_response(&response)
+            .expect_err("duplicate direct response key should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate direct key envelope_id"));
+        assert!(!rendered.contains("private direct ack contents"));
+        assert!(!rendered.contains("shadowed envelope"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #916.\n\n## Summary\n- reject duplicate direct transport metadata keys instead of accepting last-write-wins inserts\n- apply the guard to direct config reads, incoming direct frames, and direct probe/ACK response parsing\n- add regressions proving duplicate config, frame, and response keys fail closed without echoing endpoint, payload-looking, or shadowed values\n\n## Validation\n- cargo fmt --all -- --check\n- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests\n- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets\n- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings\n- npm run check --prefix packaging/npm/conu-cli\n- npm run check --prefix sdk/typescript\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- git diff --check\n\nLocal executable test attempt: cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key -- --nocapture could not run because this workstation is missing dlltool.exe; CI covers Rust tests on Windows, Ubuntu, and macOS.\n\n## Security\npayload exposure risk: Reduced. Duplicate direct metadata errors include only repeated key names, not endpoint values, ciphertext, payload-looking text, or shadowed values.\n\ntrust/permission risk: Reduced. Direct config, frame, and response metadata now fail closed before duplicate keys can shadow peer, endpoint, envelope, payload length, or encrypted payload metadata.\n\nstorage/logging risk: Reduced. Config and direct metadata readers reject ambiguous records before continuing, and the change adds no payload storage or log output.\n\nrelay/network risk: Reduced. Authenticated direct QUIC probing and direct message/stream delivery no longer accept last-write-wins shadowing in direct transport metadata.\n\nrequired fixes:\n- Configure the 12 missing live release signing/notarization/GPG secrets tracked by #274.\n- Add CONU_NPM_TOKEN_ROTATED_AFTER after rotating the npm token.\n- NPM_TOKEN is present but must be rotated before publishing because it was pasted in chat.\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate direct transport metadata keys to prevent shadowing and last-write-wins behavior. Errors redact values to reduce exposure risk.

- **Bug Fixes**
  - `parse_key_values` now returns an error on duplicate keys via `insert_direct_value`.
  - Applied to `read_config`, `receive_direct_frame`, and `parse_direct_response`.
  - Added regression tests to ensure duplicates fail closed without echoing endpoint, ciphertext, or payload-looking values.

- **Migration**
  - Senders must ensure each direct metadata key is unique; duplicates now cause request/response/config parsing to fail.

<sup>Written for commit ea4046a70d053116818c867841f5d14c3a6ab14b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate direct transport metadata keys and fail closed on ambiguous input**

### What Changed
- Direct transport config, incoming frames, and direct responses now reject repeated keys instead of using the last value found.
- Duplicate metadata errors stop processing immediately and only name the repeated key, without echoing endpoint, payload, or shadowed values.
- Added checks that duplicate config, frame, and response records all fail closed.

### Impact
`✅ Safer direct transport parsing`
`✅ Fewer shadowed metadata mistakes`
`✅ Clearer duplicate-key errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
