### PR TITLE
Reject duplicate relay delivery metadata keys

### DIFF
--- a/crates/conu-core/src/relay_delivery.rs
+++ b/crates/conu-core/src/relay_delivery.rs
@@ -1250,7 +1250,7 @@ fn read_relay_request(path: &Path) -> Result<RelayRequest, RelayDeliveryError> {
         "inspect relay outbox request",
         "read relay outbox request",
     )?;
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
 
     if value_or_empty(&values, "version") != RELAY_REQUEST_VERSION {
         return Err(RelayDeliveryError::InvalidRequest {
@@ -1557,7 +1557,7 @@ fn configured_default_relay(paths: &StatePaths) -> Result<Option<String>, RelayD
         Some(contents) => contents,
         None => return Ok(None),
     };
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
     Ok(values
         .get("default_relay")
         .map(|value| value.trim().to_string())
@@ -1573,7 +1573,7 @@ fn relay_auto_sync_enabled(paths: &StatePaths) -> Result<bool, RelayDeliveryErro
         Some(contents) => contents,
         None => return Ok(true),
     };
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
     let value = values
         .get("relay_auto_sync")
         .map(|value| value.trim().to_ascii_lowercase())
@@ -1947,7 +1947,7 @@ fn validate_relay_kind_stream(
     }
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, RelayDeliveryError> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -1957,10 +1957,28 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_relay_delivery_value(&mut values, key, value)?;
     }
 
-    values
+    Ok(values)
+}
+
+fn insert_relay_delivery_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), RelayDeliveryError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty relay delivery key".to_string()
+        } else {
+            format!("duplicate relay delivery key {key}")
+        };
+        return Err(RelayDeliveryError::InvalidRequest { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn clean_value(value: &str) -> String {
@@ -2180,6 +2198,27 @@ mod tests {
         let error = read_relay_request(&path).expect_err("mismatched request fails");
 
         assert!(error.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn relay_request_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("relay-request-duplicate-key");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        fs::create_dir_all(&init.paths.relay_outbox_dir).expect("relay outbox");
+        let path = init.paths.relay_outbox_dir.join("duplicate.relay");
+        fs::write(
+            &path,
+            "version = \"1\"\ntype = \"relay_message\"\nkind = \"message\"\nrequest_id = \"relayreq.1\"\nenvelope_id = \"env.1\"\nfrom_node_id = \"node.a\"\nto_node_id = \"node.b\"\nfrom_agent_id = \"agent.a\"\nto_agent_id = \"agent.b\"\npayload_len = 32\npayload_cipher = \"xchacha20poly1305\"\npayload_key_id = \"key.1\"\nsender_exchange_public_key_hex = \"aa\"\npayload_nonce_hex = \"bb\"\npayload_ciphertext_hex = \"private relay ciphertext contents\"\npayload_ciphertext_hex = \"shadowed relay ciphertext\"\n",
+        )
+        .expect("request writes");
+
+        let error =
+            read_relay_request(&path).expect_err("duplicate relay request key should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate relay delivery key payload_ciphertext_hex"));
+        assert!(!rendered.contains("private relay ciphertext contents"));
+        assert!(!rendered.contains("shadowed relay ciphertext"));
     }
 
     #[cfg(unix)]
@@ -2548,6 +2587,26 @@ mod tests {
 
         assert!(rendered.contains("relay endpoint is invalid"));
         assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains("token=private"));
+    }
+
+    #[test]
+    fn relay_config_duplicate_key_fails_closed_without_values() {
+        let home = test_home("runtime-duplicate-relay-config");
+        let init = state::init_state(Some(home)).expect("state initializes");
+        fs::write(
+            &init.paths.config,
+            "version = \"1\"\ndefault_relay = \"wss://relay.example.com/conu\"\ndefault_relay = \"wss://user:secret@relay.example.com/conu?token=private#fragment\"\nrelay_auto_sync = true\n",
+        )
+        .expect("config writes");
+
+        let error =
+            configured_relay_endpoint(&init.paths).expect_err("duplicate relay config key fails");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate relay delivery key default_relay"));
+        assert!(!rendered.contains("wss://relay.example.com/conu"));
+        assert!(!rendered.contains("user:secret"));
         assert!(!rendered.contains("token=private"));
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- reject duplicate relay delivery metadata keys instead of allowing later values to overwrite earlier values
- apply the guard to relay outbox requests and relay config parsing
- add payload-safe regressions for duplicated ciphertext/config keys

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript
- python scripts\check-smoke-output-privacy.py
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py

Focused executable Rust tests were attempted with `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key -- --nocapture`, but local linking failed before tests ran because this workstation is missing `dlltool.exe`.

Closes #918

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate relay delivery metadata keys to prevent silent overwrites. Applies to relay outbox request parsing and relay config; duplicates now return a clear error and fail closed without leaking payload contents.

- **Bug Fixes**
  - Enforced unique keys in parsing: `parse_key_values` now returns `Result` and uses `insert_relay_delivery_value` to reject duplicates.
  - Applied to `read_relay_request`, `configured_default_relay`, and `relay_auto_sync_enabled`.
  - Error messages include the offending key (e.g., “duplicate relay delivery key payload_ciphertext_hex”).
  - Added tests to ensure duplicate ciphertext/config keys are rejected and sensitive values do not appear in errors.

<sup>Written for commit 6419ce76dbe851b525603747f7f947a45ce187ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate relay request and config keys**

### What Changed
- Relay outbox requests and relay config files now fail when the same key appears twice instead of silently using the last value
- Duplicate relay keys now return a clear error that names the repeated key
- Errors no longer expose relay ciphertext or other config values when duplicate-key parsing fails
- Added checks covering duplicate relay request payload keys and duplicate relay config keys

### Impact
`✅ Fewer silent relay misconfigurations`
`✅ Clearer relay parsing errors`
`✅ Lower risk of leaking relay payload data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
