### PR TITLE
Reject duplicate security metadata keys

### DIFF
--- a/crates/conu-core/src/security.rs
+++ b/crates/conu-core/src/security.rs
@@ -1750,7 +1750,8 @@ fn local_storage_payload_file(
     path: &Path,
 ) -> Result<Option<LocalStoragePayloadFile>, SecurityError> {
     let contents = read_local_storage_payload_file(path)?;
-    let values = parse_key_values(&contents);
+    let values =
+        parse_key_values(&contents).map_err(|reason| SecurityError::InvalidPayload { reason })?;
     if !values.contains_key("payload_ciphertext_hex") {
         return Ok(None);
     }
@@ -2087,7 +2088,10 @@ fn key_file_is_readable(path: &Path) -> bool {
 
 fn read_key_values(path: &Path) -> Result<HashMap<String, String>, SecurityError> {
     let contents = read_secret_file(path, "read security key")?;
-    Ok(parse_key_values(&contents))
+    parse_key_values(&contents).map_err(|reason| SecurityError::InvalidKey {
+        path: path.to_path_buf(),
+        reason,
+    })
 }
 
 fn secret_bytes<const N: usize>(
@@ -3360,7 +3364,7 @@ fn set_sensitive_file_permissions(_file: &fs::File, _path: &Path) -> Result<(), 
     Ok(())
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, String> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -3372,10 +3376,27 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
             continue;
         };
 
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_security_value(&mut values, key, value)?;
     }
 
-    values
+    Ok(values)
+}
+
+fn insert_security_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), String> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        return if key.is_empty() {
+            Err("duplicate empty security key".to_string())
+        } else {
+            Err(format!("duplicate security key {key}"))
+        };
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn clean_value(value: &str) -> String {
@@ -3545,7 +3566,7 @@ mod tests {
 
         let signing = fs::read_to_string(paths.identity_signing_key).expect("signing key reads");
         if os_secret_protection_available() {
-            let values = parse_key_values(&signing);
+            let values = parse_key_values(&signing).expect("signing key parses");
             assert!(secret_file_uses_os_protection(&values, "secret_key"));
             assert!(!signing.contains("secret_key_hex"));
             assert!(report.secrets_os_protected);
@@ -3694,6 +3715,25 @@ mod tests {
             fs::read_to_string(&target).expect("target reads"),
             "version = \"1\"\nsecret_key_hex = \"outside\"\n"
         );
+    }
+
+    #[test]
+    fn secret_key_duplicate_key_fails_closed_without_values() {
+        let home = test_home("read-secret-duplicate-key");
+        fs::create_dir_all(&home).expect("home directory created");
+        let path = home.join("secret.key");
+        fs::write(
+            &path,
+            "version = \"1\"\nkey_id = \"private-old-key-id\"\nkey_id = \"shadowed-new-key-id\"\n",
+        )
+        .expect("secret key writes");
+
+        let error = read_key_values(&path).expect_err("duplicate security key should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate security key key_id"));
+        assert!(!rendered.contains("private-old-key-id"));
+        assert!(!rendered.contains("shadowed-new-key-id"));
     }
 
     #[test]
@@ -3894,7 +3934,7 @@ mod tests {
         assert_eq!(report.signing_key_id, signing_key_id);
         assert_eq!(storage.key, storage_key);
         if os_secret_protection_available() {
-            let values = parse_key_values(&signing);
+            let values = parse_key_values(&signing).expect("signing key parses");
             assert!(report.secrets_os_protected);
             assert!(secret_file_uses_os_protection(&values, "secret_key"));
             assert!(!signing.contains("secret_key_hex"));
@@ -3922,7 +3962,7 @@ mod tests {
         assert!(contents.contains("contents_displayed = false"));
         assert!(!contents.contains(token));
         if os_secret_protection_available() {
-            let values = parse_key_values(&contents);
+            let values = parse_key_values(&contents).expect("relay credential parses");
             assert!(status.os_protected);
             assert!(secret_file_uses_os_protection(&values, "token"));
             assert!(!contents.contains("token_hex"));
@@ -4197,7 +4237,7 @@ mod tests {
                 (&storage, "key"),
                 (&credential, "token"),
             ] {
-                let values = parse_key_values(contents);
+                let values = parse_key_values(contents).expect("secret metadata parses");
                 assert!(contents.contains(&format!(
                     "secret_protection = \"{}\"",
                     native_test_backend_name()
@@ -4303,8 +4343,8 @@ mod tests {
         let new_key_id = read_storage_key(&paths).expect("new key reads").key_id;
         let request_after = fs::read_to_string(&request_path).expect("request reads");
         let envelope_after = fs::read_to_string(&envelope_path).expect("envelope reads");
-        let request_values = parse_key_values(&request_after);
-        let envelope_values = parse_key_values(&envelope_after);
+        let request_values = parse_key_values(&request_after).expect("request metadata parses");
+        let envelope_values = parse_key_values(&envelope_after).expect("envelope metadata parses");
         let request_rotated = encrypted_payload_from_values(&request_values);
         let envelope_rotated = encrypted_payload_from_values(&envelope_values);
 
@@ -4471,6 +4511,27 @@ mod tests {
         assert!(!error.contains(private_marker));
     }
 
+    #[test]
+    fn storage_payload_duplicate_key_fails_closed_without_payloads() {
+        let home = test_home("storage-payload-duplicate-key");
+        fs::create_dir_all(&home).expect("home creates");
+        let path = home.join("payload.msg");
+        fs::write(
+            &path,
+            "version = \"1\"\ntype = \"send_message\"\nrequest_id = \"req.duplicate\"\nfrom_agent_id = \"agent.sender\"\nto_agent_id = \"agent.receiver\"\npayload_len = 24\npayload_privacy = \"encrypted_at_rest\"\npayload_cipher = \"XChaCha20Poly1305\"\npayload_key_id = \"key.private\"\npayload_nonce_hex = \"nonce.private\"\npayload_ciphertext_hex = \"private encrypted payload contents\"\npayload_ciphertext_hex = \"shadowed encrypted payload contents\"\n",
+        )
+        .expect("payload writes");
+
+        let rendered = match local_storage_payload_file(&path) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("duplicate encrypted payload key should fail closed"),
+        };
+
+        assert!(rendered.contains("duplicate security key payload_ciphertext_hex"));
+        assert!(!rendered.contains("private encrypted payload contents"));
+        assert!(!rendered.contains("shadowed encrypted payload contents"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn storage_payload_rewrite_rejects_symlink_without_touching_target() {
@@ -4548,7 +4609,7 @@ mod tests {
             .expect("stale archived-key request rewrites");
         let second = rotate_storage_key_from_paths(&paths).expect("second rotation succeeds");
         let request_after = fs::read_to_string(&request_path).expect("request reads");
-        let values = parse_key_values(&request_after);
+        let values = parse_key_values(&request_after).expect("request metadata parses");
         let rotated = encrypted_payload_from_values(&values);
 
         assert_eq!(second.files_scanned, 1);
@@ -4580,7 +4641,7 @@ mod tests {
         let retirement =
             retire_unused_storage_keys_from_paths(&paths).expect("retirement succeeds");
         let request_after = fs::read_to_string(&request_path).expect("request reads");
-        let values = parse_key_values(&request_after);
+        let values = parse_key_values(&request_after).expect("request metadata parses");
         let rotated = encrypted_payload_from_values(&values);
 
         assert_eq!(retirement.archived_storage_keys_scanned, 1);


### PR DESCRIPTION
## **User description**
## Summary
- reject duplicate keys in security key/credential metadata instead of allowing later values to overwrite earlier values
- reject duplicate keys in local encrypted-at-rest payload metadata before key ids, lengths, or ciphertext metadata can be shadowed
- add payload-safe regressions that assert rejected duplicate values are not echoed

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript
- python scripts\check-smoke-output-privacy.py
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py

Focused executable Rust tests were attempted with `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_key -- --nocapture`, but local linking failed before tests ran because this workstation is missing `dlltool.exe`.

Closes #920

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate security metadata keys and fail closed to prevent shadowing of key IDs and ciphertext. Tightens parsing in `conu-core` for key, credential, and encrypted-at-rest payload files, with new regression tests.

- **Bug Fixes**
  - Treat duplicate keys as an error when parsing; `parse_key_values` now returns a `Result` and maps to `SecurityError::InvalidKey`/`SecurityError::InvalidPayload`.
  - Guard payload metadata so duplicate fields (e.g., `payload_ciphertext_hex`, `key_id`) cannot override earlier values.
  - Add tests to ensure duplicates are rejected and secret values are not echoed in errors.
  - Extract `insert_security_value` to enforce key uniqueness and preserve value cleaning; update call sites accordingly.

<sup>Written for commit 5ac93d271d8447659f9afda830df3d1e7260bd78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate security metadata keys and fail closed**

### What Changed
- Security key files and encrypted payload files now stop with an error when the same metadata key appears more than once
- Duplicate values can no longer overwrite earlier key IDs, token data, or ciphertext fields
- Error messages stay generic and do not echo the secret values from the file
- Added regressions for duplicate key files and duplicate payload metadata

### Impact
`✅ Fewer secret metadata shadowing attacks`
`✅ Safer key and payload parsing`
`✅ Clearer duplicate-key errors without exposing secrets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of security keys and encrypted payloads now rejects duplicate entries with error messages instead of silent overwrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->