### PR TITLE
Reject duplicate node identity metadata keys

### DIFF
--- a/crates/conu-core/src/state.rs
+++ b/crates/conu-core/src/state.rs
@@ -495,7 +495,7 @@ fn write_new_file_with_actions(
 
 fn read_node_identity(path: &Path) -> Result<NodeIdentity, StateError> {
     let contents = read_existing_state_file(path, "inspect node identity", "read node identity")?;
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(path, &contents)?;
 
     let node_id = required_field(path, &values, "node_id")?;
     let display_name = required_field(path, &values, "display_name")?;
@@ -1202,7 +1202,7 @@ fn required_field(
         })
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(path: &Path, contents: &str) -> Result<HashMap<String, String>, StateError> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -1214,10 +1214,32 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
             continue;
         };
 
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_node_identity_value(path, &mut values, key, value)?;
     }
 
-    values
+    Ok(values)
+}
+
+fn insert_node_identity_value(
+    path: &Path,
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), StateError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty node identity key".to_string()
+        } else {
+            format!("duplicate node identity key {key}")
+        };
+        return Err(StateError::InvalidNodeIdentity {
+            path: path.to_path_buf(),
+            reason,
+        });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn clean_value(value: &str) -> String {
@@ -1820,6 +1842,26 @@ mod tests {
             fs::read_to_string(&outside).expect("outside reads"),
             outside_contents
         );
+    }
+
+    #[test]
+    fn read_state_rejects_duplicate_node_identity_key_without_values() {
+        let home = test_home("node-identity-duplicate-key");
+        fs::create_dir_all(&home).expect("home creates");
+        let paths = StatePaths::from_home(home.clone());
+        fs::write(
+            &paths.node_identity,
+            "# conU node identity\nversion = \"1\"\nnode_id = \"node_private_old\"\nnode_id = \"node_shadowed_new\"\ndisplay_name = \"local node\"\ncreated_at_unix = 1\nprotocol_version = \"1\"\n",
+        )
+        .expect("node identity writes");
+
+        let error =
+            read_state(Some(home)).expect_err("duplicate node identity key should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate node identity key node_id"));
+        assert!(!rendered.contains("node_private_old"));
+        assert!(!rendered.contains("node_shadowed_new"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## **User description**
## Summary
- reject duplicate node identity metadata keys instead of allowing later values to overwrite earlier values
- keep node identity parse failures payload-safe by reporting only the duplicated key name
- add a regression for duplicate `node_id` entries that verifies submitted values are not echoed

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript
- python scripts\check-smoke-output-privacy.py
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py

Focused executable Rust test attempt: `cargo +stable-x86_64-pc-windows-gnu test -p conu-core duplicate_node_identity -- --nocapture` failed before tests ran because this workstation is missing `dlltool.exe`.

Closes #922

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate node identity metadata keys in `conu-core` state parsing to prevent silent overwrites. Errors are payload-safe and only include the duplicated key name.

- **Bug Fixes**
  - Parser now fails on duplicate keys with `StateError::InvalidNodeIdentity`.
  - Error messages include only the key name; values are not echoed.
  - Added a regression test for duplicate `node_id` entries.

<sup>Written for commit ccab41193404ecb428ff17a562f2bd1171a1ea01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate node identity keys and keep the error payload-safe**

### What Changed
- Reading node identity data now fails when the same key appears more than once, instead of silently using the later value
- The error message names only the duplicated key and does not echo any submitted values
- Added a regression test to verify duplicate `node_id` entries are rejected and their values are not exposed

### Impact
`✅ Fewer silent node identity mismatches`
`✅ Clearer node identity validation errors`
`✅ Lower risk of leaking submitted identity values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
