### PR TITLE
Reject duplicate runtime status metadata keys

### DIFF
--- a/crates/conu-core/src/runtime.rs
+++ b/crates/conu-core/src/runtime.rs
@@ -487,6 +487,9 @@ pub enum RuntimeError {
         path: PathBuf,
         source: io::Error,
     },
+    InvalidStatus {
+        reason: String,
+    },
     AlreadyRunning(Box<RuntimeStatus>),
 }
 
@@ -512,6 +515,7 @@ impl fmt::Display for RuntimeError {
                 path,
                 source,
             } => write!(formatter, "{action} at {}: {source}", path.display()),
+            Self::InvalidStatus { reason } => write!(formatter, "invalid runtime status: {reason}"),
             Self::AlreadyRunning(status) => {
                 let pid = status
                     .pid
@@ -652,7 +656,7 @@ fn read_runtime_from_paths(paths: &StatePaths) -> Result<RuntimeStatus, RuntimeE
     else {
         return Ok(offline_status(paths));
     };
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
     let mut status = RuntimeStatus {
         state: RuntimeState::from_str(value_or_empty(&values, "state")),
         pid: parse_u32(values.get("pid")),
@@ -1195,7 +1199,7 @@ fn remove_file_if_exists(path: &Path) -> Result<(), RuntimeError> {
     }
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, RuntimeError> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -1207,10 +1211,28 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
             continue;
         };
 
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_runtime_value(&mut values, key, value)?;
     }
 
-    values
+    Ok(values)
+}
+
+fn insert_runtime_value(
+    values: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), RuntimeError> {
+    let key = key.trim();
+    if values.contains_key(key) {
+        let reason = if key.is_empty() {
+            "duplicate empty runtime status key".to_string()
+        } else {
+            format!("duplicate runtime status key {key}")
+        };
+        return Err(RuntimeError::InvalidStatus { reason });
+    }
+    values.insert(key.to_string(), clean_value(value));
+    Ok(())
 }
 
 fn clean_value(value: &str) -> String {
@@ -1701,6 +1723,27 @@ mod tests {
         let error = error.to_string();
 
         assert!(error.contains("runtime control file exceeds"));
+        assert!(!error.contains(private_marker));
+    }
+
+    #[test]
+    fn runtime_status_read_rejects_duplicate_key_without_printing_values() {
+        let home = test_home("status-read-duplicate-key");
+        let paths = StatePaths::from_home(home.clone());
+        fs::create_dir_all(&paths.runtime_dir).expect("runtime dir creates");
+        let private_marker = "private-runtime-shadow";
+        fs::write(
+            &paths.runtime_status,
+            format!(
+                "version = \"1\"\nstate = \"running\"\nstate = \"{private_marker}\"\npid = 123\nnode_id = \"node_local\"\nstarted_at_unix = 1\nheartbeat_at_unix = 1\nlocal_endpoint = \"file-ipc:runtime/ipc/inbox\"\n"
+            ),
+        )
+        .expect("status writes");
+
+        let error = read_runtime(Some(home)).expect_err("duplicate key should fail closed");
+        let error = error.to_string();
+
+        assert!(error.contains("duplicate runtime status key state"));
         assert!(!error.contains(private_marker));
     }
 


### PR DESCRIPTION
## **User description**
Closes #924

Summary:
- rejects duplicate runtime status metadata keys before interpreting status values
- adds a runtime status parse error that reports key-only reasons
- adds a regression test proving duplicate status values are not echoed

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript
- python scripts\\check-smoke-output-privacy.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py

Local executable test attempt:
- cargo +stable-x86_64-pc-windows-gnu test -p conu-core runtime_status_read_rejects_duplicate_key_without_printing_values -- --nocapture failed before running tests because dlltool.exe is missing on this workstation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in the runtime status file and fail closed with a clear error. This blocks conflicting metadata from being parsed and prevents sensitive values from leaking into logs.

- **Bug Fixes**
  - Reject duplicate status keys during parsing, before interpreting values.
  - Add `RuntimeError::InvalidStatus` with key-only reasons; no value echoing.
  - Add a regression test verifying duplicates fail and private values are not printed.

<sup>Written for commit 0bfae1baa3296b6dfff3895e1b627c6c831e3373. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate runtime status keys without exposing their values**

### What Changed
- Runtime status parsing now stops when the same key appears more than once
- The error message names the duplicate key and does not print the conflicting value
- Added a test that confirms duplicate status files fail closed and private values stay out of the error output

### Impact
`✅ Fewer invalid runtime status reads`
`✅ Clearer duplicate-key errors`
`✅ Less risk of leaking private values in failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
