### PR TITLE
Reject duplicate session relay config keys

### DIFF
--- a/crates/conu-core/src/sessions.rs
+++ b/crates/conu-core/src/sessions.rs
@@ -808,7 +808,7 @@ fn relay_endpoint(paths: &StatePaths) -> Result<String, SessionError> {
         Some(contents) => contents,
         None => return Ok(DEFAULT_RELAY_ENDPOINT.to_string()),
     };
-    let values = parse_key_values(&contents);
+    let values = parse_key_values(&contents)?;
     let endpoint = values
         .get("default_relay")
         .filter(|value| !value.trim().is_empty())
@@ -849,7 +849,7 @@ fn record_session_log(paths: &StatePaths, sessions: &[RemoteSession], remote_age
     let _ = append_session_log(paths, sessions, remote_agents);
 }
 
-fn parse_key_values(contents: &str) -> HashMap<String, String> {
+fn parse_key_values(contents: &str) -> Result<HashMap<String, String>, SessionError> {
     let mut values = HashMap::new();
 
     for line in contents.lines().map(str::trim) {
@@ -859,10 +859,10 @@ fn parse_key_values(contents: &str) -> HashMap<String, String> {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        values.insert(key.trim().to_string(), clean_value(value));
+        insert_session_value(&mut values, key, value)?;
     }
 
-    values
+    Ok(values)
 }
 
 fn clean_value(value: &str) -> String {
@@ -1140,6 +1140,27 @@ mod tests {
         assert!(rendered.contains("relay endpoint is invalid"));
         assert!(!rendered.contains("secret"));
         assert!(!rendered.contains("token=private"));
+    }
+
+    #[test]
+    fn session_relay_config_duplicate_key_fails_closed_without_echoing_value() {
+        let home = test_home("session-relay-config-duplicate-key");
+        let init = state::init_state(Some(home.clone())).expect("state initializes");
+        let private_marker = "private-relay-shadow";
+        fs::write(
+            &init.paths.config,
+            format!(
+                "version = \"1\"\ndefault_relay = \"wss://relay.example.com\"\ndefault_relay = \"wss://{private_marker}.example.com\"\n"
+            ),
+        )
+        .expect("config writes");
+
+        let error =
+            relay_endpoint(&init.paths).expect_err("duplicate relay config key should fail closed");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("duplicate session key default_relay"));
+        assert!(!rendered.contains(private_marker));
     }
 
     #[test]
@@ -1429,7 +1450,8 @@ kind = \"test-agent\"\n\
 presence = \"ready\"\n\
 last_seen_unix = 1\n\
 cap_messages = maybe\n",
-        );
+        )
+        .expect("metadata parses");
 
         let error = remote_agent_from_values(&values)
             .expect_err("malformed remote capability should fail closed");


### PR DESCRIPTION
## **User description**
Closes #926

Summary:
- rejects duplicate keys while reading session relay config metadata
- reuses the existing session duplicate-key error path so duplicate reasons are key-only
- adds a regression test proving a shadowed relay endpoint value is not echoed

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-core --tests
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- npm run check --prefix packaging/npm/conu-cli
- npm run check --prefix sdk/typescript
- python scripts\\check-smoke-output-privacy.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py

Local executable test attempt:
- cargo +stable-x86_64-pc-windows-gnu test -p conu-core session_sync_rejects_duplicate_relay_config_key_without_echoing_value -- --nocapture failed before running tests because dlltool.exe is missing on this workstation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in session relay config and fail closed when duplicates are found. Prevents leaking shadowed `default_relay` values and aligns with Linear #926.

- Bug Fixes
  - `parse_key_values` now returns a `Result` and rejects duplicate keys via the existing duplicate-key error path; `relay_endpoint` propagates the error.
  - Error messages include only the key (no value), so a shadowed relay endpoint is not echoed.
  - Added regression test: `session_relay_config_duplicate_key_fails_closed_without_echoing_value`.

<sup>Written for commit 623fdc2c1efcf79c7bf687f04234e877f6339a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Reject duplicate session relay config keys without exposing the replaced value**

### What Changed
- Session relay config now fails when the same key appears more than once instead of silently using one value
- Duplicate-key errors now show only the key name, so a hidden relay endpoint value is not revealed
- Added a regression test covering duplicate `default_relay` entries and confirming the shadowed value is not echoed

### Impact
`✅ Safer relay config handling`
`✅ Fewer silent config mistakes`
`✅ Lower risk of leaking hidden relay values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
