### PR TITLE
Reject duplicate relay policy keys

### DIFF
--- a/crates/conu-relay/src/main.rs
+++ b/crates/conu-relay/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::io::{self, Read};
@@ -7040,6 +7041,7 @@ fn parse_abuse_threshold_policy_file(contents: &str) -> Result<AbuseThresholds, 
     let mut version = None::<String>;
     let mut thresholds = AbuseThresholds::default();
     let mut guards = AbuseThresholdPolicyGuards::default();
+    let mut keys = ConfigKeyTracker::default();
 
     for (line_index, raw_line) in contents.lines().enumerate() {
         let line_number = line_index + 1;
@@ -7057,6 +7059,7 @@ fn parse_abuse_threshold_policy_file(contents: &str) -> Result<AbuseThresholds, 
                 "abuse threshold policy file line {line_number} must include a key"
             ));
         }
+        keys.record(key, "abuse threshold policy file", line_number)?;
 
         if key == "version" {
             version = Some(value);
@@ -7521,6 +7524,7 @@ fn parse_mailbox_retention_policy_file(contents: &str) -> Result<MailboxRetentio
     let mut version = None::<String>;
     let mut policy = MailboxRetentionPolicy::default();
     let mut guards = MailboxRetentionPolicyGuards::default();
+    let mut keys = ConfigKeyTracker::default();
 
     for (line_index, raw_line) in contents.lines().enumerate() {
         let line_number = line_index + 1;
@@ -7538,6 +7542,7 @@ fn parse_mailbox_retention_policy_file(contents: &str) -> Result<MailboxRetentio
                 "mailbox retention policy file line {line_number} must include a key"
             ));
         }
+        keys.record(key, "mailbox retention policy file", line_number)?;
 
         match key {
             "version" => version = Some(value),
@@ -8412,6 +8417,20 @@ fn hosted_fleet_abuse_response_plan_exit(
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct ConfigKeyTracker {
+    seen: HashSet<String>,
+}
+
+impl ConfigKeyTracker {
+    fn record(&mut self, key: &str, label: &str, line: usize) -> Result<(), String> {
+        if !self.seen.insert(key.to_string()) {
+            return Err(format!("{label} line {line} contains duplicate key {key}"));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 struct HostedFleetDashboardArgs {
     fleet_file: PathBuf,
@@ -8460,10 +8479,12 @@ struct HostedFleetRelayConfigBuilder {
     mailbox_ttl_seconds: Option<u64>,
     accounting_dir: Option<PathBuf>,
     abuse_dir: Option<PathBuf>,
+    keys: ConfigKeyTracker,
 }
 
 impl HostedFleetRelayConfigBuilder {
     fn set(&mut self, base_dir: &Path, key: &str, value: &str, line: usize) -> Result<(), String> {
+        self.keys.record(key, "hosted fleet dashboard file", line)?;
         match key {
             "name" => {
                 self.name = Some(validate_dashboard_filter_id(
@@ -9150,6 +9171,7 @@ fn parse_hosted_fleet_dashboard_file(path: &Path) -> Result<Vec<HostedFleetRelay
         .unwrap_or_else(|| Path::new("."));
     let mut version_seen = false;
     let mut guards = HostedFleetDashboardFileGuards::default();
+    let mut top_level_keys = ConfigKeyTracker::default();
     let mut relays = Vec::<HostedFleetRelayConfig>::new();
     let mut current = None::<HostedFleetRelayConfigBuilder>;
 
@@ -9173,12 +9195,18 @@ fn parse_hosted_fleet_dashboard_file(path: &Path) -> Result<Vec<HostedFleetRelay
         };
         let key = key.trim();
         let value = clean_config_value(value);
+        if key.is_empty() {
+            return Err(format!(
+                "hosted fleet dashboard file line {line_number} must include a key"
+            ));
+        }
 
         if let Some(builder) = current.as_mut() {
             builder.set(base_dir, key, &value, line_number)?;
             continue;
         }
 
+        top_level_keys.record(key, "hosted fleet dashboard file", line_number)?;
         if key == "version" {
             if value != HOSTED_FLEET_DASHBOARD_FILE_VERSION {
                 return Err(format!(
@@ -15597,6 +15625,21 @@ token_displayed = false\n",
         .expect_err("secret-bearing unknown key should fail");
         assert!(unknown_secret.contains("unsupported key token"));
         assert!(!unknown_secret.contains(secret_value));
+
+        let duplicate_secret = "relay-duplicate-secret";
+        let duplicate_threshold =
+            parse_abuse_threshold_policy_file(&abuse_threshold_policy_contents(&format!(
+                "max_admin_unauthorized = 5\nmax_admin_unauthorized = \"{duplicate_secret}\"\n"
+            )))
+            .expect_err("duplicate threshold key should fail closed");
+        assert!(duplicate_threshold.contains("duplicate key max_admin_unauthorized"));
+        assert!(!duplicate_threshold.contains(duplicate_secret));
+
+        let duplicate_guard = parse_abuse_threshold_policy_file(&abuse_threshold_policy_contents(
+            "payload_displayed = false\n",
+        ))
+        .expect_err("duplicate display guard should fail closed");
+        assert!(duplicate_guard.contains("duplicate key payload_displayed"));
     }
 
     #[test]
@@ -15794,6 +15837,21 @@ token_displayed = false\n",
         .expect_err("invalid node id should fail");
         assert!(invalid_node.contains("node id"));
         assert!(!invalid_node.contains(secret_value));
+
+        let duplicate_secret = "relay-duplicate-secret";
+        let duplicate_ttl =
+            parse_mailbox_retention_policy_file(&mailbox_retention_policy_contents(&format!(
+                "ttl_seconds = 3600\nttl_seconds = \"{duplicate_secret}\"\n"
+            )))
+            .expect_err("duplicate ttl key should fail closed");
+        assert!(duplicate_ttl.contains("duplicate key ttl_seconds"));
+        assert!(!duplicate_ttl.contains(duplicate_secret));
+
+        let duplicate_guard = parse_mailbox_retention_policy_file(
+            &mailbox_retention_policy_contents("contents_displayed = false\n"),
+        )
+        .expect_err("duplicate display guard should fail closed");
+        assert!(duplicate_guard.contains("duplicate key contents_displayed"));
     }
 
     #[test]
@@ -17410,6 +17468,27 @@ abuse_dir = "abuse"
             .expect_err("missing guards should fail closed");
         assert!(error.contains("requires"));
         assert!(!error.contains("relay-secret-token"));
+
+        let duplicate_secret = "relay-duplicate-secret";
+        let duplicate_top_level = write_hosted_fleet_dashboard_file(
+            &hosted_fleet_dashboard_file_contents(&format!(
+                "version = \"{duplicate_secret}\"\n[[relay]]\nname = \"relay-east\"\nabuse_dir = \"abuse\"\n"
+            )),
+        );
+        let duplicate_top_error = parse_hosted_fleet_dashboard_file(&duplicate_top_level)
+            .expect_err("duplicate top-level fleet key should fail closed");
+        assert!(duplicate_top_error.contains("duplicate key version"));
+        assert!(!duplicate_top_error.contains(duplicate_secret));
+
+        let duplicate_relay = write_hosted_fleet_dashboard_file(
+            &hosted_fleet_dashboard_file_contents(&format!(
+                "[[relay]]\nname = \"relay-east\"\nname = \"{duplicate_secret}\"\nabuse_dir = \"abuse\"\n"
+            )),
+        );
+        let duplicate_relay_error = parse_hosted_fleet_dashboard_file(&duplicate_relay)
+            .expect_err("duplicate relay fleet key should fail closed");
+        assert!(duplicate_relay_error.contains("duplicate key name"));
+        assert!(!duplicate_relay_error.contains(duplicate_secret));
 
         let relay = HostedFleetRelaySnapshot {
             config: HostedFleetRelayConfig {


### PR DESCRIPTION
## **User description**
Closes #928.

## Summary
- reject duplicate keys in relay abuse threshold policy files
- reject duplicate keys in mailbox retention policy files
- reject duplicate top-level and per-relay keys in hosted fleet dashboard files
- add regressions that use secret-looking duplicate values and assert they are not echoed

## Validation
- Passed: cargo fmt --check
- Passed: git diff --check
- Passed: npm run check (packaging/npm/conu-cli)
- Blocked locally: cargo test -p conu-relay abuse_threshold_policy_file_parser_is_metadata_only, mailbox_retention_policy_file_parser_is_metadata_only, hosted_fleet_dashboard_parser_and_renderers_are_metadata_only because the local Windows MSVC toolchain is missing link.exe and the installed GNU toolchain is missing dlltool.exe. CI should run the Rust matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in relay policy and hosted fleet dashboard files to prevent ambiguous configs and avoid leaking secrets in error messages. Adds strict key tracking and tests for secure failures.

- **Bug Fixes**
  - Error on duplicate keys in abuse threshold, mailbox retention, and hosted fleet dashboard files (top-level and per-relay).
  - Introduced ConfigKeyTracker to track seen keys and enforce uniqueness.
  - Tests ensure secret-like values in duplicates are not echoed in errors.

<sup>Written for commit 430d64e4a9b031d2260f11aa215e5e457ece3dc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate policy keys in relay configuration files**

### What Changed
- Relay abuse threshold, mailbox retention, and hosted fleet dashboard files now fail when the same key appears more than once
- Duplicate keys are blocked both at the top level and inside each relay entry in hosted fleet dashboard files
- New checks keep duplicate-key errors from echoing secret-like values back in the message

### Impact
`✅ Fewer misread relay policy files`
`✅ Safer handling of secret-like config values`
`✅ Clearer config errors for duplicate keys`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration file validation now detects and rejects duplicate keys in abuse threshold policies, mailbox retention policies, and hosted fleet dashboard files, preventing configuration errors and unexpected behavior.
  * Enhanced error handling catches malformed configuration entries during file parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->