### PR TITLE
Reject duplicate relay manifest keys

### DIFF
--- a/crates/conu-relay/src/lib.rs
+++ b/crates/conu-relay/src/lib.rs
@@ -1505,6 +1505,7 @@ pub fn parse_scoped_credentials_file(contents: &str) -> Result<Vec<RelayCredenti
 fn parse_credential_file_records(contents: &str) -> Result<Vec<CredentialFileRecord>, RelayError> {
     let mut version = None::<String>;
     let mut current = None::<CredentialFileRecord>;
+    let mut top_level_keys = ConfigKeyTracker::default();
     let mut records = Vec::new();
 
     for (line_index, raw_line) in contents.lines().enumerate() {
@@ -1528,12 +1529,18 @@ fn parse_credential_file_records(contents: &str) -> Result<Vec<CredentialFileRec
         })?;
         let key = key.trim();
         let value = clean_config_value(value);
+        if key.is_empty() {
+            return Err(RelayError::InvalidConfigValue(format!(
+                "relay credential file line {line_number} must include a key"
+            )));
+        }
 
         if let Some(record) = current.as_mut() {
             record.set(key, &value, line_number)?;
             continue;
         }
 
+        top_level_keys.record(key, "relay credential file", line_number)?;
         match key {
             "version" => version = Some(value),
             _ => {
@@ -1584,6 +1591,7 @@ fn parse_admin_tokens_file(
 ) -> Result<RelayAdminTokenManifest, RelayError> {
     let mut version = None::<String>;
     let mut current = None::<AdminTokenFileRecord>;
+    let mut top_level_keys = ConfigKeyTracker::default();
     let mut records = Vec::new();
 
     for (line_index, raw_line) in contents.lines().enumerate() {
@@ -1607,12 +1615,18 @@ fn parse_admin_tokens_file(
         })?;
         let key = key.trim();
         let value = clean_config_value(value);
+        if key.is_empty() {
+            return Err(RelayError::InvalidConfigValue(format!(
+                "relay admin tokens file line {line_number} must include a key"
+            )));
+        }
 
         if let Some(record) = current.as_mut() {
             record.set(key, &value, line_number)?;
             continue;
         }
 
+        top_level_keys.record(key, "relay admin tokens file", line_number)?;
         match key {
             "version" => version = Some(value),
             _ => {
@@ -3608,6 +3622,7 @@ fn load_hosted_tenant_manifest_or_empty(path: &Path) -> Result<HostedTenantManif
 
 fn parse_hosted_tenant_manifest(contents: &str) -> Result<HostedTenantManifest, RelayError> {
     let mut version = None::<String>;
+    let mut top_level_keys = ConfigKeyTracker::default();
     let mut section = None::<HostedTenantManifestSection>;
     let mut tenants = Vec::new();
     let mut nodes = Vec::new();
@@ -3641,6 +3656,11 @@ fn parse_hosted_tenant_manifest(contents: &str) -> Result<HostedTenantManifest, 
         })?;
         let key = key.trim();
         let value = clean_config_value(value);
+        if key.is_empty() {
+            return Err(RelayError::InvalidConfigValue(format!(
+                "hosted tenant file line {line_number} must include a key"
+            )));
+        }
 
         match section.as_mut() {
             Some(HostedTenantManifestSection::Tenant(record)) => {
@@ -3650,8 +3670,12 @@ fn parse_hosted_tenant_manifest(contents: &str) -> Result<HostedTenantManifest, 
                 record.set(key, &value, line_number)?;
             }
             None => match key {
-                "version" => version = Some(value),
+                "version" => {
+                    top_level_keys.record(key, "hosted tenant file", line_number)?;
+                    version = Some(value);
+                }
                 _ => {
+                    top_level_keys.record(key, "hosted tenant file", line_number)?;
                     return Err(RelayError::InvalidConfigValue(format!(
                         "hosted tenant file line {line_number} has key before a section"
                     )));
@@ -4064,6 +4088,22 @@ impl fmt::Debug for RelayAdminTokenRecord {
 }
 
 #[derive(Clone, Default)]
+struct ConfigKeyTracker {
+    seen: HashSet<String>,
+}
+
+impl ConfigKeyTracker {
+    fn record(&mut self, key: &str, label: &str, line_number: usize) -> Result<(), RelayError> {
+        if !self.seen.insert(key.to_string()) {
+            return Err(RelayError::InvalidConfigValue(format!(
+                "{label} line {line_number} contains duplicate key {key}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
 struct AdminTokenFileRecord {
     account_id: Option<String>,
     token_sha256_hex: Option<String>,
@@ -4071,10 +4111,13 @@ struct AdminTokenFileRecord {
     status: Option<RelayCredentialStatus>,
     expires_at_unix: Option<u64>,
     scopes: RelayAdminTokenScopes,
+    keys: ConfigKeyTracker,
 }
 
 impl AdminTokenFileRecord {
     fn set(&mut self, key: &str, value: &str, line_number: usize) -> Result<(), RelayError> {
+        self.keys
+            .record(key, "relay admin tokens file", line_number)?;
         match key {
             "account_id" => self.account_id = Some(validate_account_id(value.to_string())?),
             "token_sha256_hex" => self.token_sha256_hex = Some(value.to_string()),
@@ -4166,10 +4209,13 @@ struct CredentialFileRecord {
     expires_at_unix: Option<u64>,
     created_at_unix: Option<u64>,
     updated_at_unix: Option<u64>,
+    keys: ConfigKeyTracker,
 }
 
 impl CredentialFileRecord {
     fn set(&mut self, key: &str, value: &str, line_number: usize) -> Result<(), RelayError> {
+        self.keys
+            .record(key, "relay credential file", line_number)?;
         match key {
             "account_id" => self.account_id = Some(validate_account_id(value.to_string())?),
             "node_id" => self.node_id = Some(value.to_string()),
@@ -4230,6 +4276,7 @@ impl CredentialFileRecord {
             expires_at_unix: credential.expires_at_unix,
             created_at_unix: Some(credential.created_at_unix),
             updated_at_unix: Some(updated_at_unix),
+            keys: ConfigKeyTracker::default(),
         }
     }
 
@@ -4250,6 +4297,7 @@ impl CredentialFileRecord {
             expires_at_unix,
             created_at_unix: Some(created_at_unix),
             updated_at_unix: Some(created_at_unix),
+            keys: ConfigKeyTracker::default(),
         })
     }
 
@@ -4369,6 +4417,7 @@ struct HostedTenantFileRecord {
     status: Option<HostedTenantStatus>,
     created_at_unix: Option<u64>,
     updated_at_unix: Option<u64>,
+    keys: ConfigKeyTracker,
 }
 
 #[derive(Clone, Default)]
@@ -4385,10 +4434,12 @@ struct HostedTenantNodeFileRecord {
     exchange_key_id: Option<String>,
     created_at_unix: Option<u64>,
     updated_at_unix: Option<u64>,
+    keys: ConfigKeyTracker,
 }
 
 impl HostedTenantFileRecord {
     fn set(&mut self, key: &str, value: &str, line_number: usize) -> Result<(), RelayError> {
+        self.keys.record(key, "hosted tenant file", line_number)?;
         match key {
             "account_id" => self.account_id = Some(validate_account_id(value.to_string())?),
             "status" => self.status = Some(HostedTenantStatus::parse(value)?),
@@ -4431,6 +4482,7 @@ impl HostedTenantFileRecord {
 
 impl HostedTenantNodeFileRecord {
     fn set(&mut self, key: &str, value: &str, line_number: usize) -> Result<(), RelayError> {
+        self.keys.record(key, "hosted tenant file", line_number)?;
         match key {
             "account_id" => self.account_id = Some(validate_account_id(value.to_string())?),
             "node_id" => self.node_id = Some(validate_node_id(value.to_string())?),
@@ -10678,6 +10730,137 @@ token_displayed = true\n",
         assert!(error.to_string().contains("token_displayed must be false"));
         assert!(!error.to_string().contains(token));
         assert!(!error.to_string().contains(&hash));
+    }
+
+    #[test]
+    fn relay_manifest_parsers_reject_duplicate_keys_without_secret_values() {
+        let secret = "relay-duplicate-secret";
+        let token = "duplicate-manifest-token-1234567890";
+        let hash = relay_token_sha256_hex(token).expect("hash");
+        let duplicate_message = |error: RelayError, key: &str| {
+            let message = error.to_string();
+            assert!(message.contains(&format!("duplicate key {key}")));
+            assert!(!message.contains(secret));
+            assert!(!message.contains(&hash));
+        };
+
+        let credential_top_level = format!(
+            "version = \"1\"\nversion = \"{secret}\"\n\n\
+[[credential]]\n\
+node_id = \"node.a\"\n\
+token_sha256_hex = \"{hash}\"\n\
+token_length = {}\n\
+payload_displayed = false\n\
+token_displayed = false\n",
+            token.len()
+        );
+        duplicate_message(
+            parse_scoped_credentials_file(&credential_top_level)
+                .expect_err("duplicate credential version should fail closed"),
+            "version",
+        );
+
+        let credential_entry = format!(
+            "version = \"1\"\n\n\
+[[credential]]\n\
+node_id = \"node.a\"\n\
+node_id = \"{secret}\"\n\
+token_sha256_hex = \"{hash}\"\n\
+token_length = {}\n\
+payload_displayed = false\n\
+token_displayed = false\n",
+            token.len()
+        );
+        duplicate_message(
+            parse_scoped_credentials_file(&credential_entry)
+                .expect_err("duplicate credential entry key should fail closed"),
+            "node_id",
+        );
+
+        let admin_top_level = format!(
+            "version = \"1\"\nversion = \"{secret}\"\n\n\
+[[admin_token]]\n\
+token_sha256_hex = \"{hash}\"\n\
+token_length = {}\n\
+scope_dashboard = true\n\
+token_hash_displayed = false\n",
+            token.len()
+        );
+        duplicate_message(
+            parse_admin_tokens_file(&admin_top_level, "127.0.0.1:0")
+                .expect_err("duplicate admin-token version should fail closed"),
+            "version",
+        );
+
+        let admin_entry = format!(
+            "version = \"1\"\n\n\
+[[admin_token]]\n\
+token_sha256_hex = \"{hash}\"\n\
+token_sha256_hex = \"{secret}\"\n\
+token_length = {}\n\
+scope_dashboard = true\n\
+token_hash_displayed = false\n",
+            token.len()
+        );
+        duplicate_message(
+            parse_admin_tokens_file(&admin_entry, "127.0.0.1:0")
+                .expect_err("duplicate admin-token entry key should fail closed"),
+            "token_sha256_hex",
+        );
+
+        let tenant_top_level = format!(
+            "version = \"1\"\nversion = \"{secret}\"\n\n\
+[[tenant]]\n\
+account_id = \"account.prod\"\n\
+payload_displayed = false\n\
+token_displayed = false\n\
+key_material_displayed = false\n\
+contents_displayed = false\n"
+        );
+        duplicate_message(
+            parse_hosted_tenant_manifest(&tenant_top_level)
+                .expect_err("duplicate hosted-tenant version should fail closed"),
+            "version",
+        );
+
+        let tenant_entry = format!(
+            "version = \"1\"\n\n\
+[[tenant]]\n\
+account_id = \"account.prod\"\n\
+account_id = \"{secret}\"\n\
+payload_displayed = false\n\
+token_displayed = false\n\
+key_material_displayed = false\n\
+contents_displayed = false\n"
+        );
+        duplicate_message(
+            parse_hosted_tenant_manifest(&tenant_entry)
+                .expect_err("duplicate hosted-tenant entry key should fail closed"),
+            "account_id",
+        );
+
+        let tenant_node_entry = format!(
+            "version = \"1\"\n\n\
+[[tenant]]\n\
+account_id = \"account.prod\"\n\
+payload_displayed = false\n\
+token_displayed = false\n\
+key_material_displayed = false\n\
+contents_displayed = false\n\n\
+[[tenant_node]]\n\
+account_id = \"account.prod\"\n\
+node_id = \"node.a\"\n\
+node_id = \"{secret}\"\n\
+payload_displayed = false\n\
+token_displayed = false\n\
+key_material_displayed = false\n\
+contents_displayed = false\n"
+        );
+        duplicate_message(
+            parse_hosted_tenant_manifest(&tenant_node_entry)
+                .expect_err("duplicate hosted-tenant node key should fail closed"),
+            "node_id",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
Closes #930.

## Summary
- reject duplicate top-level keys in relay credential, admin-token, and hosted-tenant manifests
- reject duplicate keys inside credential, admin-token, tenant, and tenant-node sections
- add metadata-only regressions that use secret-looking duplicate values and assert they are not echoed

## Validation
- Passed: cargo fmt --check
- Passed: git diff --check
- Passed: npm run check (packaging/npm/conu-cli)
- Blocked locally: cargo +stable-x86_64-pc-windows-gnu test -p conu-relay relay_manifest_parsers_reject_duplicate_keys_without_secret_values because dlltool.exe is missing. The default MSVC toolchain is also missing link.exe. CI should run the Rust matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in relay manifest parsers to fail closed and prevent ambiguous configs. Error messages now avoid leaking secret-like values.

- **Bug Fixes**
  - Reject duplicate top-level keys in credential, admin-token, and hosted-tenant manifest files.
  - Reject duplicate keys within `credential`, `admin_token`, `tenant`, and `tenant_node` sections.
  - Validate non-empty keys and include line numbers in errors.
  - Add regression tests to ensure secrets and token hashes aren’t echoed.

<sup>Written for commit 88b4eff6c60261ef0760e2d4fd289539486a64b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate keys in relay manifest files**

### What Changed
- Relay credential, admin token, and hosted tenant manifests now fail when the same key appears more than once
- Empty keys are now rejected with a clear error instead of being accepted silently
- Duplicate-key errors are covered for both top-level manifest fields and fields inside each record or section
- Error messages no longer echo secret-like values from the file

### Impact
`✅ Safer relay manifest parsing`
`✅ Fewer misconfigured credential files`
`✅ Clearer duplicate-key errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
