### PR TITLE
Reject duplicate update manifest keys

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -7751,10 +7751,9 @@ impl UpdateArchiveScan {
         let text = String::from_utf8(bytes.to_vec()).map_err(|error| {
             format!("release update archive manifest.toml is invalid UTF-8: {error}")
         })?;
-        self.manifest_target = parse_update_archive_manifest_target(&text);
-        self.manifest_payload_safe = text
-            .lines()
-            .any(|line| line.trim() == "payload_contents_included = false");
+        let manifest = parse_update_archive_manifest(&text)?;
+        self.manifest_target = manifest.target;
+        self.manifest_payload_safe = manifest.payload_contents_included == Some(false);
         Ok(())
     }
 
@@ -7965,20 +7964,57 @@ fn copy_update_binary_with_sha256<R: Read, W: Write>(
     Ok((copied, sha256))
 }
 
-fn parse_update_archive_manifest_target(text: &str) -> Option<String> {
-    text.lines().find_map(|line| {
+#[derive(Default)]
+struct UpdateArchiveManifest {
+    target: Option<String>,
+    payload_contents_included: Option<bool>,
+}
+
+fn parse_update_archive_manifest(text: &str) -> Result<UpdateArchiveManifest, String> {
+    let mut seen = HashSet::new();
+    let mut manifest = UpdateArchiveManifest::default();
+
+    for (line_index, line) in text.lines().enumerate() {
+        let line_number = line_index + 1;
         let trimmed = line.trim();
-        let (key, value) = trimmed.split_once('=')?;
-        if key.trim() != "target" {
-            return None;
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            return Err(format!(
+                "release update archive manifest.toml line {line_number} must include a key"
+            ));
+        }
+        if !seen.insert(key.to_string()) {
+            return Err(format!(
+                "release update archive manifest.toml line {line_number} contains duplicate key {key}"
+            ));
         }
         let value = value.trim();
-        value
-            .strip_prefix('"')
-            .and_then(|value| value.strip_suffix('"'))
-            .filter(|value| !value.trim().is_empty())
-            .map(ToString::to_string)
-    })
+        match key {
+            "target" => {
+                manifest.target = value
+                    .strip_prefix('"')
+                    .and_then(|value| value.strip_suffix('"'))
+                    .filter(|value| !value.trim().is_empty())
+                    .map(ToString::to_string);
+            }
+            "payload_contents_included" => {
+                manifest.payload_contents_included = match value {
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    _ => None,
+                };
+            }
+            _ => {}
+        }
+    }
+
+    Ok(manifest)
 }
 
 fn update_binary_suffix_for_target(target: &str) -> Result<&'static str, String> {
@@ -12519,6 +12555,37 @@ mod tests {
         assert!(!output.stderr.contains("BEGIN PGP SIGNATURE"));
     }
 
+    #[test]
+    fn update_apply_rejects_duplicate_archive_manifest_keys_without_values() {
+        let target = update_apply_test_target();
+        let filename = update_archive_fixture_name(&target);
+        let secret_target = "secret-local-target";
+        let duplicate_target_manifest = format!(
+            "version = \"0.1.0\"\ntarget = \"{target}\"\ntarget = \"{secret_target}\"\npayload_contents_included = false\n"
+        );
+        let duplicate_target_archive =
+            update_archive_fixture_bytes_with_manifest(&target, &duplicate_target_manifest);
+
+        let duplicate_target_error =
+            stage_update_archive_binaries(&filename, &duplicate_target_archive, &target)
+                .expect_err("duplicate manifest target should fail closed");
+
+        assert!(duplicate_target_error.contains("duplicate key target"));
+        assert!(!duplicate_target_error.contains(secret_target));
+
+        let duplicate_payload_manifest = format!(
+            "version = \"0.1.0\"\ntarget = \"{target}\"\npayload_contents_included = false\npayload_contents_included = true\n"
+        );
+        let duplicate_payload_archive =
+            update_archive_fixture_bytes_with_manifest(&target, &duplicate_payload_manifest);
+
+        let duplicate_payload_error =
+            stage_update_archive_binaries(&filename, &duplicate_payload_archive, &target)
+                .expect_err("duplicate payload guard should fail closed");
+
+        assert!(duplicate_payload_error.contains("duplicate key payload_contents_included"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn update_apply_dry_run_rejects_symlinked_install_dir_without_installing() {
@@ -15450,6 +15517,29 @@ mod tests {
     fn update_archive_fixture_bytes(target: &str, unsafe_member: bool) -> Vec<u8> {
         let root = format!("conu-0.1.0-{target}");
         update_archive_fixture_bytes_with_root(target, &root, unsafe_member)
+    }
+
+    fn update_archive_fixture_bytes_with_manifest(target: &str, manifest: &str) -> Vec<u8> {
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        let root = format!("conu-0.1.0-{target}");
+        append_update_archive_fixture_file(
+            &mut builder,
+            &format!("{root}/manifest.toml"),
+            manifest.as_bytes(),
+            0o644,
+        );
+        for name in UPDATE_BINARY_NAMES {
+            append_update_archive_fixture_file(
+                &mut builder,
+                &format!("{root}/bin/{}", update_binary_filename(name)),
+                &update_archive_binary_bytes(name),
+                0o755,
+            );
+        }
+        builder.finish().expect("tar builder finishes");
+        let encoder = builder.into_inner().expect("tar encoder returns");
+        encoder.finish().expect("gzip finishes")
     }
 
     fn update_archive_fixture_bytes_with_root(


### PR DESCRIPTION
## **User description**
Closes #932.

## Summary
- parse release update archive `manifest.toml` through a duplicate-key guard
- reject duplicate `target` and `payload_contents_included` metadata before staging update binaries
- add a regression that uses a secret-looking duplicate target value and asserts it is not echoed

## Validation
- Passed: `cargo fmt --check`
- Passed: `git diff --check`
- Passed: `npm run check` in `packaging/npm/conu-cli`
- Blocked locally: `cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_apply_rejects_duplicate_archive_manifest_keys_without_values` because `dlltool.exe` is missing. The default MSVC toolchain is also missing `link.exe`. CI should run the Rust matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate keys in `manifest.toml` when scanning update archives in `conu-cli`, failing closed and preventing echoing attacker-controlled values. Guards `target` and `payload_contents_included` before staging binaries. Addresses #932.

- **Bug Fixes**
  - Added a manifest parser that rejects duplicate keys with a clear error (includes line number).
  - Ensured duplicate `target` and `payload_contents_included` cause early failure before binaries are staged.
  - Added tests to confirm a secret-looking duplicate `target` is not printed in errors and to cover duplicate payload flags.

<sup>Written for commit 9fa928e3e3493917e2bbac1e38951b5a5fce65a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate keys in update manifests without leaking values**

### What Changed
- Update installation now stops when `manifest.toml` repeats a key such as `target` or `payload_contents_included`
- Duplicate-key errors now report the repeated key and line number instead of accepting the archive
- Secret-looking values from a duplicate `target` entry are no longer echoed back in the error
- Added a regression test that covers duplicate `target` and `payload_contents_included` entries

### Impact
`✅ Safer update archive validation`
`✅ Fewer malformed update installs`
`✅ No secret values echoed in duplicate-key errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
