### PR TITLE
Reject duplicate release manifest keys

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -137,6 +137,25 @@ def main() -> int:
             raise SystemExit(f"rooted manifest target: expected host, got {target}")
 
     with fixture_dir() as root:
+        archive = root / "conu-0.1.0-duplicate-key.zip"
+        secret_target = "secret-npm-target-should-not-print"
+        write_zip(
+            archive,
+            {
+                "manifest.toml": (
+                    f'target = "host"\ntarget = "{secret_target}"\n'
+                    "payload_contents_included = false\n"
+                )
+            },
+        )
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "duplicate key target",
+            "duplicate manifest target key",
+            forbidden=secret_target,
+        )
+
+    with fixture_dir() as root:
         archive = root / "conu-0.1.0-test.zip"
         write_zip(archive, {"conu-9.9.9-test/manifest.toml": 'target = "host"\n'})
         expect_action_failure(
@@ -466,11 +485,19 @@ def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:
     )
 
 
-def expect_action_failure(action, expected: str, label: str) -> None:
+def expect_action_failure(
+    action,
+    expected: str,
+    label: str,
+    *,
+    forbidden: str | None = None,
+) -> None:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
+        if forbidden is not None and forbidden in message:
+            raise SystemExit(f"{label}: error leaked forbidden value: {message}") from exc
         if expected in message:
             return
         raise SystemExit(f"{label}: expected {expected}, got: {message}") from exc

--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -69,6 +69,25 @@ def main() -> int:
             raise SystemExit(f"rooted manifest target: expected host, got {target}")
 
     with fixture_dir() as root:
+        archive = root / "conu-0.1.0-duplicate-key.zip"
+        secret_target = "secret-release-target-should-not-print"
+        write_zip(
+            archive,
+            {
+                "manifest.toml": (
+                    f'target = "host"\ntarget = "{secret_target}"\n'
+                    "payload_contents_included = false\n"
+                )
+            },
+        )
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "duplicate key target",
+            "duplicate manifest target key",
+            forbidden=secret_target,
+        )
+
+    with fixture_dir() as root:
         archive = root / "conu-0.1.0-test.zip"
         write_zip(archive, {"conu-9.9.9-test/manifest.toml": 'target = "host"\n'})
         expect_action_failure(
@@ -385,11 +404,19 @@ def expect_failure(smoke, bin_dir: Path, expected: str, label: str) -> None:
     )
 
 
-def expect_action_failure(action, expected: str, label: str) -> None:
+def expect_action_failure(
+    action,
+    expected: str,
+    label: str,
+    *,
+    forbidden: str | None = None,
+) -> None:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
+        if forbidden is not None and forbidden in message:
+            raise SystemExit(f"{label}: error leaked forbidden value: {message}") from exc
         if expected in message:
             return
         raise SystemExit(f"{label}: expected {expected}, got: {message}") from exc

--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -63,10 +63,16 @@ def write_zip(
     prefix: str | None = None,
 ) -> None:
     prefix = prefix or archive_prefix(path)
+    extra = extra or {}
+    written: set[str] = set()
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
         for name, content in REQUIRED_FILES.items():
-            package.writestr(f"{prefix}/{name}", content)
-        for name, content in (extra or {}).items():
+            archive_name = f"{prefix}/{name}"
+            package.writestr(archive_name, extra.get(archive_name, content))
+            written.add(archive_name)
+        for name, content in extra.items():
+            if name in written:
+                continue
             package.writestr(name, content)
     write_checksum(path)
 
@@ -148,11 +154,21 @@ def verify_archive(verifier, archive: Path) -> None:
     verifier.verify_members(archive, members)
 
 
-def expect_failure(description: str, action, expected: str) -> None:
+def expect_failure(
+    description: str,
+    action,
+    expected: str,
+    *,
+    forbidden: str | None = None,
+) -> None:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
+        if forbidden is not None and forbidden in message:
+            raise AssertionError(
+                f"{description} leaked forbidden value in error: {message!r}"
+            ) from exc
         if expected not in message:
             raise AssertionError(
                 f"{description} failed with {message!r}, expected {expected!r}"
@@ -331,6 +347,24 @@ def main() -> int:
             "forbidden secret suffix",
             lambda: verify_archive(verifier, forbidden_secret_suffix),
             "forbidden release archive path",
+        )
+
+        duplicate_payload_manifest = root / "conu-0.1.0-duplicate-payload.zip"
+        duplicate_secret = "secret-payload-flag-should-not-print"
+        write_zip(
+            duplicate_payload_manifest,
+            {
+                f"{archive_prefix(duplicate_payload_manifest)}/manifest.toml": (
+                    b"payload_contents_included = false\n"
+                    + f'payload_contents_included = "{duplicate_secret}"\n'.encode("utf-8")
+                )
+            },
+        )
+        expect_failure(
+            "duplicate payload manifest key",
+            lambda: verify_archive(verifier, duplicate_payload_manifest),
+            "duplicate key payload_contents_included",
+            forbidden=duplicate_secret,
         )
 
         wrong_root = root / "conu-0.1.0-wrong-root.zip"

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -120,15 +120,44 @@ def read_manifest_target(archive: Path) -> str:
     if manifest_bytes is None:
         raise SystemExit(f"{archive.name} missing manifest.toml")
 
-    for raw_line in manifest_bytes.decode("utf-8", errors="replace").splitlines():
-        line = raw_line.strip()
-        if line.startswith("target") and "=" in line:
-            value = line.split("=", 1)[1].strip()
-            if value.startswith('"') and value.endswith('"'):
-                return value[1:-1]
-            return value
+    manifest = parse_manifest_key_values(archive, manifest_bytes)
+    target = manifest.get("target")
+    if target is not None:
+        return target
 
     raise SystemExit(f"{archive.name} manifest.toml missing target")
+
+
+def parse_manifest_key_values(archive: Path, manifest_bytes: bytes) -> dict[str, str]:
+    try:
+        manifest_text = manifest_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise SystemExit(f"{archive.name} manifest.toml is invalid UTF-8") from exc
+
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(manifest_text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise SystemExit(
+                f"{archive.name} manifest.toml line {line_number} must include a key"
+            )
+        if key in values:
+            raise SystemExit(
+                f"{archive.name} manifest.toml line {line_number} contains duplicate key {key}"
+            )
+        values[key] = parse_manifest_value(raw_value)
+    return values
+
+
+def parse_manifest_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    return value
 
 
 def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -76,15 +76,44 @@ def read_manifest_target(archive: Path) -> str:
     if manifest_bytes is None:
         raise SystemExit(f"{archive.name} missing manifest.toml")
 
-    for raw_line in manifest_bytes.decode("utf-8", errors="replace").splitlines():
-        line = raw_line.strip()
-        if line.startswith("target") and "=" in line:
-            value = line.split("=", 1)[1].strip()
-            if value.startswith('"') and value.endswith('"'):
-                return value[1:-1]
-            return value
+    manifest = parse_manifest_key_values(archive, manifest_bytes)
+    target = manifest.get("target")
+    if target is not None:
+        return target
 
     raise SystemExit(f"{archive.name} manifest.toml missing target")
+
+
+def parse_manifest_key_values(archive: Path, manifest_bytes: bytes) -> dict[str, str]:
+    try:
+        manifest_text = manifest_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise SystemExit(f"{archive.name} manifest.toml is invalid UTF-8") from exc
+
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(manifest_text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise SystemExit(
+                f"{archive.name} manifest.toml line {line_number} must include a key"
+            )
+        if key in values:
+            raise SystemExit(
+                f"{archive.name} manifest.toml line {line_number} contains duplicate key {key}"
+            )
+        values[key] = parse_manifest_value(raw_value)
+    return values
+
+
+def parse_manifest_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    return value
 
 
 def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -510,8 +510,8 @@ def verify_members(archive: Path, members: ArchiveMembers) -> None:
 
     if members.manifest is None:
         raise SystemExit(f"{archive.name} missing manifest.toml")
-    manifest_text = members.manifest.decode("utf-8", errors="replace")
-    if "payload_contents_included = false" not in manifest_text:
+    manifest = parse_manifest_key_values(archive, members.manifest)
+    if manifest.get("payload_contents_included") != "false":
         raise SystemExit(
             f"{archive.name} manifest does not declare payload_contents_included = false"
         )
@@ -526,6 +526,38 @@ def required_binary_paths(paths: set[str]) -> set[str]:
     if windows_bins <= paths:
         return windows_bins
     return {f"bin/{binary}" for binary in REQUIRED_BINARIES}
+
+
+def parse_manifest_key_values(archive: Path, manifest_bytes: bytes) -> dict[str, str]:
+    try:
+        manifest_text = manifest_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise SystemExit(f"{archive.name} manifest.toml is invalid UTF-8") from exc
+
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(manifest_text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise SystemExit(
+                f"{archive.name} manifest.toml line {line_number} must include a key"
+            )
+        if key in values:
+            raise SystemExit(
+                f"{archive.name} manifest.toml line {line_number} contains duplicate key {key}"
+            )
+        values[key] = parse_manifest_value(raw_value)
+    return values
+
+
+def parse_manifest_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    return value
 
 
 def is_forbidden_release_path(path: str) -> bool:


### PR DESCRIPTION
## **User description**
Closes #934.

## Summary
- parse release archive `manifest.toml` files into explicit key/value maps in release smoke paths
- reject duplicate manifest keys with key-only errors before accepting `target` metadata
- require parsed `payload_contents_included = false` in the release verifier instead of accepting a substring
- add regressions that use secret-looking duplicate values and assert those values are not echoed

## Validation
- `python scripts\check-release-artifact-smoke-preflight.py`
- `python scripts\check-npm-launcher-local-smoke-preflight.py`
- `python scripts\check-release-artifact-verifier.py`
- `python -m compileall -q scripts`
- `python scripts\verify-release-versions.py`
- `python scripts\check-release-update-policy.py`
- `python scripts\check-production-readiness-toolchain.py`
- `npm run check` in `packaging/npm/conu-cli`
- `cargo fmt --check`
- `git diff --check`

## Live readiness
- `NPM_TOKEN` rotation marker is now set and npm rotation readiness no longer appears in live readiness failures.
- Release readiness still fails only on missing platform signing/notary/Linux GPG secrets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in release `manifest.toml` across smoke and verifier paths. Tightens parsing to block secret-like value leakage and require `payload_contents_included = false`.

- **Bug Fixes**
  - Parse `manifest.toml` into key/value maps with duplicate-key detection.
  - Fail on duplicate `target` and require exact `payload_contents_included = false`.
  - Add regressions to ensure error messages never echo secret-like values.

<sup>Written for commit acb2796eba825e5ef8ac22f44679b39f24e940d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate release manifest keys and stop echoing secret values**

### What Changed
- Release checks now read `manifest.toml` as key/value entries, which lets them reject duplicate keys instead of accepting the first match.
- A release now fails when `target` or `payload_contents_included` appears more than once in the manifest.
- Manifest parsing now requires valid UTF-8 and a real key name on each parsed line.
- Error checks in the release smoke tests now verify that sensitive-looking values are not included in failure messages.

### Impact
`✅ Fewer releases accepted with tampered manifests`
`✅ Clearer release manifest errors`
`✅ Lower risk of secret values appearing in release failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest file validation to detect and properly reject duplicate keys.
  * Enhanced error handling to prevent sensitive values from appearing in error messages.

* **Tests**
  * Added regression tests for manifest parsing edge cases, including duplicate key scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->