### PR TITLE
Reject duplicate npm manifest JSON keys

### DIFF
--- a/scripts/json_safety.py
+++ b/scripts/json_safety.py
@@ -1,0 +1,31 @@
+"""Small JSON parsing helpers for release and packaging checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in values:
+            raise ValueError(f"duplicate JSON key: {key}")
+        values[key] = value
+    return values
+
+
+def loads_json(text: str) -> Any:
+    return json.loads(text, object_pairs_hook=reject_duplicate_json_keys)
+
+
+def load_json(path: Path, *, encoding: str = "utf-8") -> Any:
+    return loads_json(path.read_text(encoding=encoding))
+
+
+def load_json_object(path: Path, *, encoding: str = "utf-8") -> dict[str, Any]:
+    value = load_json(path, encoding=encoding)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value

--- a/scripts/verify-npm-package-contents-regression.py
+++ b/scripts/verify-npm-package-contents-regression.py
@@ -7,8 +7,8 @@ import contextlib
 import copy
 import importlib.util
 import io
-import json
 import sys
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -37,9 +37,9 @@ def assert_raises(func, pattern: str) -> None:
     raise AssertionError(f"expected ValueError containing {pattern!r}")
 
 
-def manifest_for(rule) -> dict[str, object]:
+def manifest_for(module, rule) -> dict[str, object]:
     repo = Path(__file__).resolve().parents[1]
-    return json.loads((repo / rule.directory / "package.json").read_text(encoding="utf-8"))
+    return module.load_json(repo / rule.directory / "package.json")
 
 
 def rule_by_name(module, name: str):
@@ -51,7 +51,7 @@ def rule_by_name(module, name: str):
 
 def run_public_metadata_tests(module) -> None:
     cli_rule = rule_by_name(module, "@conu/cli")
-    cli_manifest = manifest_for(cli_rule)
+    cli_manifest = manifest_for(module, cli_rule)
     module.validate_manifest_public_surface(cli_rule, cli_manifest)
 
     broken_bin = copy.deepcopy(cli_manifest)
@@ -83,7 +83,7 @@ def run_public_metadata_tests(module) -> None:
     )
 
     sdk_rule = rule_by_name(module, "@conu/sdk")
-    sdk_manifest = manifest_for(sdk_rule)
+    sdk_manifest = manifest_for(module, sdk_rule)
     module.validate_manifest_public_surface(sdk_rule, sdk_manifest)
 
     broken_exports = copy.deepcopy(sdk_manifest)
@@ -99,6 +99,40 @@ def run_public_metadata_tests(module) -> None:
         lambda: module.validate_manifest_public_surface(sdk_rule, broken_engine),
         "engines.node",
     )
+
+
+def run_json_duplicate_key_tests(module) -> None:
+    with tempfile.TemporaryDirectory(prefix="conu-npm-json-") as temp_text:
+        temp = Path(temp_text)
+        duplicate = temp / "package.json"
+        duplicate.write_text(
+            '{"name":"@conu/cli","version":"0.1.0","version":"'
+            + SENSITIVE_SENTINEL
+            + '"}\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        try:
+            module.load_json(duplicate)
+        except ValueError as exc:
+            rendered = str(exc)
+            if "duplicate JSON key: version" not in rendered:
+                raise AssertionError(f"unexpected duplicate-key error: {rendered!r}") from exc
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("duplicate-key error leaked the shadow value") from exc
+        else:
+            raise AssertionError("duplicate top-level package JSON key unexpectedly passed")
+
+        nested = temp / "nested-package.json"
+        nested.write_text(
+            '{"name":"@conu/cli","scripts":{"postinstall":"node scripts/install.js",'
+            + '"postinstall":"'
+            + SENSITIVE_SENTINEL
+            + '"}}\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        assert_raises(lambda: module.load_json(nested), "duplicate JSON key: postinstall")
 
 
 def run_npm_pack_privacy_tests(module) -> None:
@@ -135,6 +169,7 @@ def run_npm_pack_privacy_tests(module) -> None:
 def main() -> int:
     module = load_module()
     run_public_metadata_tests(module)
+    run_json_duplicate_key_tests(module)
     run_npm_pack_privacy_tests(module)
     print("npm package content regression checks passed")
     return 0

--- a/scripts/verify-npm-package-contents.py
+++ b/scripts/verify-npm-package-contents.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from json_safety import load_json_object, loads_json
+
 
 MAX_ENTRY_BYTES = 1_000_000
 MAX_PACKAGE_BYTES = 1_000_000
@@ -154,11 +156,7 @@ def find_npm() -> str:
 
 
 def load_json(path: Path) -> dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        value = json.load(handle)
-    if not isinstance(value, dict):
-        raise ValueError(f"{path} must contain a JSON object")
-    return value
+    return load_json_object(path, encoding="utf-8")
 
 
 def normalize_pack_path(raw_path: Any) -> str:
@@ -204,7 +202,7 @@ def run_npm_pack(npm: str, package_dir: Path) -> dict[str, Any]:
         )
 
     try:
-        report = json.loads(result.stdout)
+        report = loads_json(result.stdout)
     except json.JSONDecodeError as exc:
         raise ValueError(f"npm pack dry-run did not return JSON for {package_dir}: {exc}") from exc
 

--- a/scripts/verify-release-versions.py
+++ b/scripts/verify-release-versions.py
@@ -9,6 +9,8 @@ import re
 import sys
 from pathlib import Path
 
+from json_safety import load_json_object
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - CI uses Python 3.11+.
@@ -38,8 +40,7 @@ def read_toml(path: Path) -> dict:
 
 
 def read_json(path: Path) -> dict:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
+    return load_json_object(path, encoding="utf-8")
 
 
 def package_version(manifest: Path) -> str:


### PR DESCRIPTION
## **User description**
Closes #938.

## What changed

- Added `scripts/json_safety.py` to reject duplicate JSON object keys without echoing values.
- Updated npm package content verification to use duplicate-key-safe parsing for `package.json` and `npm pack --json` output.
- Updated release version checks to use duplicate-key-safe parsing for npm manifests.
- Added regression coverage for top-level and nested duplicate manifest keys, including a shadow value that must not appear in the error.

## Why

Python's default JSON parser accepts duplicate keys and keeps the last value. For package and release metadata checks, that can make ambiguous package manifests pass with shadowed fields. This closes that gap for the npm/release readiness path.

## Validation

- `python -m py_compile scripts/json_safety.py scripts/verify-npm-package-contents.py scripts/verify-npm-package-contents-regression.py scripts/verify-release-versions.py`
- `python scripts/verify-npm-package-contents-regression.py`
- `python scripts/verify-release-versions.py`
- `python scripts/verify-npm-package-contents.py`
- `npm run check --prefix packaging/npm/conu-cli`
- `npm run check --prefix sdk/typescript`
- `python -m compileall -q scripts`
- `python scripts/check-production-readiness-toolchain.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in npm manifest JSON to prevent shadowed fields and ambiguous metadata. All packaging and release checks now parse `package.json` and `npm pack --json` output with a duplicate-key-safe loader.

- **Bug Fixes**
  - Added `scripts/json_safety.py` with a loader that raises on duplicate keys.
  - Switched `verify-npm-package-contents.py` to use it for `package.json` and `npm pack --json`.
  - Switched `verify-release-versions.py` to use it when reading npm manifests.
  - Added regression tests for top-level and nested duplicates, ensuring shadow values do not leak in errors.

<sup>Written for commit e70e317ab5c65bebe2351b3c715bb890789b4fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate keys in npm manifest JSON**

### What Changed
- npm package and release checks now fail when a manifest contains the same JSON key more than once
- Duplicate keys are rejected in both top-level and nested manifest sections, so hidden values can no longer pass validation
- Added regression coverage to confirm duplicate-key errors are raised without exposing the shadowed value

### Impact
`✅ Safer package metadata checks`
`✅ Fewer release checks accepting hidden manifest values`
`✅ Clearer duplicate-manifest errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
