### PR TITLE
Extend release JSON manifest guards

### DIFF
--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -171,6 +171,26 @@ def expect_failure(description: str, action, expected: str) -> None:
     raise AssertionError(f"{description} unexpectedly passed")
 
 
+def expect_failure_without_leak(
+    description: str,
+    action,
+    expected: str,
+    forbidden: str,
+) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+        if expected not in message:
+            raise AssertionError(
+                f"{description} failed with {message!r}, expected {expected!r}"
+            ) from exc
+        if forbidden in message:
+            raise AssertionError(f"{description} leaked forbidden value: {message!r}") from exc
+        return
+    raise AssertionError(f"{description} unexpectedly passed")
+
+
 def expect_failure_with_limit(
     module,
     limit_name: str,
@@ -252,6 +272,21 @@ def main() -> int:
         second = assert_bundle(preparer, generated, repeat_output)
         if first.read_bytes() != second.read_bytes():
             raise AssertionError("package-manager submission bundle was not deterministic")
+
+        expect_failure_without_leak(
+            "duplicate Scoop manifest JSON key",
+            lambda: preparer.validate_structured_manifest(
+                (
+                    '{"version":"0.1.0","version":"'
+                    + SENSITIVE_SENTINEL
+                    + '","architecture":{},"bin":[]}\n'
+                ),
+                preparer.BundleEntry("conu.json", "scoop-bucket/bucket/conu.json", "scoop"),
+                generated / "conu.json",
+            ),
+            "not valid JSON",
+            SENSITIVE_SENTINEL,
+        )
 
         symlink_dist = temp / "symlink-dist"
         if try_symlink(generated, symlink_dist, target_is_directory=True):

--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -493,6 +494,44 @@ def run_missing_secret_tests(module) -> None:
     parsed = assert_safe_report(report)
     if "NPM_TOKEN" not in parsed["releaseSecrets"]["missing"]:
         raise AssertionError("missing release secret name was not reported")
+
+
+def run_repo_version_json_duplicate_tests(module) -> None:
+    original_root = module.ROOT
+    original_crates = module.CRATE_MANIFESTS
+    original_npm = module.NPM_MANIFESTS
+    with tempfile.TemporaryDirectory(prefix="conu-tagged-version-json-") as temp_text:
+        temp = Path(temp_text)
+        (temp / "Cargo.toml").write_text(
+            "[package]\nname = \"conu-fixture\"\nversion = \"0.1.0\"\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        (temp / "package.json").write_text(
+            '{"version":"0.1.0","version":"' + SENSITIVE_SENTINEL + '"}\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        try:
+            module.ROOT = temp
+            module.CRATE_MANIFESTS = (Path("Cargo.toml"),)
+            module.NPM_MANIFESTS = (Path("package.json"),)
+            try:
+                module.read_repo_version()
+            except ValueError as exc:
+                rendered = str(exc)
+                if "duplicate JSON key: version" not in rendered:
+                    raise AssertionError(
+                        f"unexpected duplicate package version error: {rendered!r}"
+                    ) from exc
+                if SENSITIVE_SENTINEL in rendered:
+                    raise AssertionError("duplicate package version error leaked shadow value") from exc
+            else:
+                raise AssertionError("duplicate package version JSON key unexpectedly passed")
+        finally:
+            module.ROOT = original_root
+            module.CRATE_MANIFESTS = original_crates
+            module.NPM_MANIFESTS = original_npm
 
 
 def run_secret_rotation_tests(module) -> None:
@@ -1265,6 +1304,7 @@ def main() -> int:
     run_ci_readiness_tests(module)
     run_release_branch_readiness_tests(module)
     run_missing_secret_tests(module)
+    run_repo_version_json_duplicate_tests(module)
     run_secret_rotation_tests(module)
     run_secret_rotation_marker_tests(module)
     run_custom_repository_tests(module)

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -30,6 +30,7 @@ from github_release_secrets import (
     normalize_repo,
     run_gh_json,
 )
+from json_safety import load_json_object
 from public_host_validation import is_loopback_host, validate_public_host
 
 
@@ -293,7 +294,7 @@ def read_repo_version() -> str:
         versions[str(manifest)] = version.strip()
 
     for manifest in NPM_MANIFESTS:
-        payload = json.loads((ROOT / manifest).read_text(encoding="utf-8"))
+        payload = load_json_object(ROOT / manifest, encoding="utf-8")
         version = payload.get("version")
         if not isinstance(version, str) or not version.strip():
             raise ValueError(f"{manifest} does not contain version")

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -25,6 +25,7 @@ from typing import Any, BinaryIO
 
 from command_output_redaction import redact_command_output
 from github_release_secrets import normalize_repo
+from json_safety import load_json_object
 
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
@@ -244,8 +245,7 @@ def parse_args() -> argparse.Namespace:
 
 def read_repo_version() -> str:
     package_json = Path(__file__).resolve().parents[1] / "packaging/npm/conu-cli/package.json"
-    with package_json.open("r", encoding="utf-8") as handle:
-        package = json.load(handle)
+    package = load_json_object(package_json, encoding="utf-8")
     version = package.get("version")
     if not isinstance(version, str) or not version:
         raise SystemExit(f"{package_json} does not contain a non-empty version")

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -17,6 +17,7 @@ from typing import Any, BinaryIO
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
 from github_release_secrets import normalize_repo
+from json_safety import load_json_object
 from public_host_validation import validate_public_host
 
 
@@ -165,8 +166,7 @@ def parse_args() -> argparse.Namespace:
 
 def read_package_version(relative_path: str) -> str:
     path = Path(__file__).resolve().parents[1] / relative_path
-    with path.open("r", encoding="utf-8") as handle:
-        package = json.load(handle)
+    package = load_json_object(path, encoding="utf-8")
     version = package.get("version")
     if not isinstance(version, str) or not version:
         raise SystemExit(f"{path} does not contain a non-empty version")

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, BinaryIO
 
+from json_safety import load_json_object, loads_json
+
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
@@ -140,8 +142,7 @@ def parse_args() -> argparse.Namespace:
 
 def read_repo_version() -> str:
     package_json = Path(__file__).resolve().parents[1] / "packaging/npm/conu-cli/package.json"
-    with package_json.open("r", encoding="utf-8") as handle:
-        package = json.load(handle)
+    package = load_json_object(package_json, encoding="utf-8")
     version = package.get("version")
     if not isinstance(version, str) or not version:
         raise SystemExit(f"{package_json} does not contain a non-empty version")
@@ -397,8 +398,8 @@ def validate_structured_manifest(text: str, entry: BundleEntry, source: Path) ->
                 raise SystemExit(f"{entry.source_name} is missing expected Homebrew field: {required}")
     elif entry.kind == "scoop":
         try:
-            payload = json.loads(text)
-        except json.JSONDecodeError as exc:
+            payload = loads_json(text)
+        except (json.JSONDecodeError, ValueError) as exc:
             raise SystemExit(f"{entry.source_name} is not valid JSON") from exc
         if not isinstance(payload, dict):
             raise SystemExit(f"{entry.source_name} must contain a JSON object")

--- a/scripts/smoke-npm-launcher-download.py
+++ b/scripts/smoke-npm-launcher-download.py
@@ -7,13 +7,14 @@ import argparse
 import functools
 import http.server
 import importlib.util
-import json
 import os
 import socketserver
 import sys
 import tempfile
 import threading
 from pathlib import Path
+
+from json_safety import load_json_object
 
 
 DEFAULT_PACKAGE_DIR = Path("packaging/npm/conu-cli")
@@ -112,7 +113,7 @@ def load_local_smoke_helpers():
 
 
 def npm_asset_name(package_dir: Path, local_smoke) -> str:
-    manifest = json.loads(package_dir.joinpath("package.json").read_text(encoding="utf-8"))
+    manifest = load_json_object(package_dir.joinpath("package.json"), encoding="utf-8")
     version = manifest.get("version")
     if not isinstance(version, str) or not version:
         raise SystemExit(f"{package_dir / 'package.json'} missing package version")


### PR DESCRIPTION
## **User description**
Closes #940.

## What changed

- Reused `json_safety.load_json_object` for package version reads in:
  - release update-policy generation
  - package-manager manifest generation
  - package-manager submission preparation
  - live tagged-release readiness
  - npm launcher download smoke asset selection
- Reused `json_safety.loads_json` for generated Scoop manifest validation.
- Added regressions for duplicate package-version JSON keys and duplicate Scoop JSON keys, with shadow-value leak checks.

## Why

These scripts are part of the tag/publish readiness path. Python's default JSON parser accepts duplicate keys and keeps the last value, so ambiguous release/package metadata should fail closed instead.

## Validation

- `python -m py_compile scripts/generate-release-update-policy.py scripts/generate-package-manager-manifests.py scripts/prepare-package-manager-submissions.py scripts/check-package-manager-submissions.py scripts/check-tagged-release-readiness.py scripts/check-tagged-release-readiness-regression.py scripts/smoke-npm-launcher-download.py`
- `python scripts/check-tagged-release-readiness-regression.py`
- `python scripts/check-package-manager-submissions.py`
- `python scripts/check-package-manager-manifests.py`
- `python scripts/check-release-update-policy.py`
- `python scripts/verify-release-versions.py`
- `python scripts/verify-npm-package-contents-regression.py`
- `python scripts/verify-npm-package-contents.py`
- `python -m compileall -q scripts`
- `python scripts/check-production-readiness-toolchain.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened JSON parsing across release and packaging scripts to reject duplicate keys and fail closed, preventing ambiguous metadata and sensitive value leaks.

- **Bug Fixes**
  - Switched to `json_safety.load_json_object`/`loads_json` for package version reads and Scoop manifest validation in update-policy generation, manifest generation, submissions, tagged-release readiness, and npm smoke.
  - Added regression tests for duplicate JSON keys and ensured errors do not leak shadow values.

<sup>Written for commit c3f352ed37b48a7be904c4fbbe8e6d1067083e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate keys in release and packaging JSON files**

### What Changed
- Release and package metadata reads now fail when a JSON file contains duplicate keys instead of silently using the last value.
- Scoop submission checks now reject malformed JSON with duplicate keys and avoid printing hidden replacement values in the error message.
- Release readiness regression checks now cover duplicate version entries in package manifests and confirm secret-like values are not leaked.

### Impact
`✅ Safer release metadata checks`
`✅ Fewer bad package submissions`
`✅ Lower risk of leaking hidden values in validation errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
