### PR TITLE
Harden npm publish preflight JSON parsing

### DIFF
--- a/scripts/check-npm-publish-preflight-regression.py
+++ b/scripts/check-npm-publish-preflight-regression.py
@@ -15,6 +15,7 @@ from urllib.error import HTTPError
 
 
 SCRIPT = Path(__file__).with_name("check-npm-publish-preflight.py")
+SENSITIVE_SENTINEL = "sensitive-json-shadow-value"
 
 
 def load_module():
@@ -33,6 +34,19 @@ def assert_raises(func, pattern: str) -> None:
     except ValueError as exc:
         if pattern not in str(exc):
             raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
+        return
+    raise AssertionError(f"expected ValueError containing {pattern!r}")
+
+
+def assert_raises_without_leak(func, pattern: str) -> None:
+    try:
+        func()
+    except ValueError as exc:
+        rendered = str(exc)
+        if pattern not in rendered:
+            raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("validation error leaked a shadow JSON value") from exc
         return
     raise AssertionError(f"expected ValueError containing {pattern!r}")
 
@@ -56,6 +70,24 @@ def run_registry_tests(module) -> None:
     assert_raises(
         lambda: module.check_registry_availability("npm", packages),
         "already exists",
+    )
+
+    def duplicate_registry_json_run(args, **_kwargs):
+        package_id = args[2]
+        version = package_id.rsplit("@", 1)[1]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                f'{{"version":"{version}",'
+                f'"version":"{SENSITIVE_SENTINEL}"}}\n'
+            ),
+            stderr="",
+        )
+
+    module.subprocess.run = duplicate_registry_json_run
+    assert_raises_without_leak(
+        lambda: module.check_registry_availability("npm", packages),
+        "invalid JSON",
     )
 
     def network_error_run(*_args, **_kwargs):
@@ -105,6 +137,22 @@ def run_manifest_version_tests(module) -> None:
                 module.PackageRule("@conu/cli", Path("packaging/npm/conu-cli")),
             ),
             "version is not semver-like",
+        )
+
+        (package_dir / "package.json").write_text(
+            (
+                '{"name":"@conu/cli","version":"0.1.0",'
+                f'"version":"{SENSITIVE_SENTINEL}"}}\n'
+            ),
+            encoding="utf-8",
+            newline="\n",
+        )
+        assert_raises_without_leak(
+            lambda: module.validate_manifest(
+                repo,
+                module.PackageRule("@conu/cli", Path("packaging/npm/conu-cli")),
+            ),
+            "duplicate JSON key",
         )
 
 
@@ -180,6 +228,22 @@ def run_token_auth_tests(module) -> None:
 
         module.urlopen = successful_urlopen
         module.validate_token_authentication(env_name)
+
+        def duplicate_username_urlopen(*_args, **_kwargs):
+            return FakeResponse(
+                200,
+                (
+                    b'{"username":"imthegoodboy",'
+                    + f'"username":"{SENSITIVE_SENTINEL}"'.encode("utf-8")
+                    + b"}"
+                ),
+            )
+
+        module.urlopen = duplicate_username_urlopen
+        assert_raises_without_leak(
+            lambda: module.validate_token_authentication(env_name),
+            "returned invalid JSON",
+        )
 
         def unauthorized_urlopen(*_args, **_kwargs):
             raise HTTPError(module.NPM_WHOAMI_URL, 401, "Unauthorized", {}, None)

--- a/scripts/check-npm-publish-preflight.py
+++ b/scripts/check-npm-publish-preflight.py
@@ -16,6 +16,8 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from json_safety import load_json_object, loads_json
+
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 NPM_WHOAMI_URL = "https://registry.npmjs.org/-/whoami"
@@ -51,11 +53,7 @@ def find_npm() -> str:
 
 
 def load_json(path: Path) -> dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        value = json.load(handle)
-    if not isinstance(value, dict):
-        raise ValueError(f"{path} must contain a JSON object")
-    return value
+    return load_json_object(path)
 
 
 def require_string(manifest: dict[str, Any], field: str, context: Path) -> str:
@@ -146,10 +144,12 @@ def validate_token_authentication(env_name: str | None) -> None:
         raise ValueError(f"npm token authentication check response was too large for {env_name}")
 
     try:
-        parsed = json.loads(body.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        parsed = loads_json(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"npm token authentication check returned invalid JSON for {env_name}") from exc
 
+    if not isinstance(parsed, dict):
+        raise ValueError(f"npm token authentication check did not return an npm username for {env_name}")
     username = parsed.get("username")
     if not isinstance(username, str) or not is_single_line_token_value(username):
         raise ValueError(f"npm token authentication check did not return an npm username for {env_name}")
@@ -166,8 +166,8 @@ def npm_version_exists(npm: str, package: PackageInfo) -> bool:
     )
     if result.returncode == 0:
         try:
-            reported = json.loads(result.stdout)
-        except json.JSONDecodeError as exc:
+            reported = loads_json(result.stdout)
+        except (json.JSONDecodeError, ValueError) as exc:
             raise ValueError(
                 f"npm registry returned invalid JSON for {package.name}@{package.version}: {exc}"
             ) from exc


### PR DESCRIPTION
## **User description**
## Summary
- route npm publish preflight JSON parsing through the duplicate-key rejecting helper
- reject duplicate-key JSON from local package manifests, npm token-auth responses, and npm registry output before publish checks proceed
- add regressions proving duplicate shadow values are rejected without leaking those values

## Validation
- `python -m py_compile scripts/check-npm-publish-preflight.py scripts/check-npm-publish-preflight-regression.py scripts/json_safety.py`
- `python scripts/check-npm-publish-preflight-regression.py`
- `python scripts/check-npm-publish-preflight.py`
- `python scripts/verify-npm-package-contents.py`
- `python scripts/verify-release-versions.py`
- `python -m compileall -q scripts`
- `python scripts/check-production-readiness-toolchain.py`
- `python scripts/check-github-workflow-permissions.py`
- `git diff --check`

Closes #942

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the npm publish preflight by rejecting duplicate-key JSON and failing fast on bad data from `package.json`, npm `whoami`, and registry responses. Prevents poisoned JSON and avoids leaking sensitive values in errors.

- **Bug Fixes**
  - Parse all JSON via `load_json_object`/`loads_json`; reject duplicate keys and non-object `whoami` responses.
  - Added regressions for duplicate keys in local manifests, registry output, and token auth; verify no shadow value leaks.
  - Clearer errors and broader exception handling for invalid JSON.

<sup>Written for commit 7ce9d0b417ba3fa9a9f5a230afd1e1e712a09e58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject malformed npm JSON before publish checks continue**

### What Changed
- Npm publish preflight now rejects JSON objects with duplicate keys in package manifests, registry checks, and token-auth responses
- If npm returns invalid JSON, the preflight stops with a clear validation error instead of using a shadowed value
- Token-auth results are still checked for a valid username after parsing

### Impact
`✅ Fewer publish checks using hidden JSON values`
`✅ Clearer npm preflight errors`
`✅ Safer release checks for malformed registry responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests & Quality Assurance**
  * Enhanced npm publish preflight validation with additional regression tests to verify sensitive data is not leaked in error messages.
  * Improved JSON parsing robustness for npm registry and token authentication responses with proper error handling for malformed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->