### PR TITLE
Harden GitHub readiness JSON parsing

### DIFF
--- a/scripts/check-github-pages-readiness-regression.py
+++ b/scripts/check-github-pages-readiness-regression.py
@@ -45,6 +45,8 @@ def assert_raises(func, pattern: str) -> None:
     try:
         func()
     except ValueError as exc:
+        if SENSITIVE_SENTINEL in str(exc):
+            raise AssertionError("error message leaked a sensitive fixture value") from exc
         if pattern not in str(exc):
             raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
         return
@@ -172,6 +174,21 @@ def run_loader_tests(module) -> None:
         payload = module.load_pages_metadata("owner/repo", "gh")
     finally:
         module.run_gh_json = original_run_gh_json
+
+    with tempfile.TemporaryDirectory(prefix="conu-pages-json-guard-") as temp_dir:
+        pages_json = Path(temp_dir) / "pages.json"
+        pages_json.write_text(
+            (
+                '{"html_url":"https://owner.github.io/repo/",'
+                f'"html_url":"{SENSITIVE_SENTINEL}",'
+                '"build_type":"workflow"}\n'
+            ),
+            encoding="utf-8",
+        )
+        assert_raises(
+            lambda: module.load_pages_json(pages_json),
+            "duplicate JSON key",
+        )
     if payload.get("build_type") != "workflow":
         raise AssertionError("loader did not return fixture Pages metadata")
 

--- a/scripts/check-github-pages-readiness.py
+++ b/scripts/check-github-pages-readiness.py
@@ -13,6 +13,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse, urlunparse
 
 from github_release_secrets import find_gh, infer_repo, normalize_repo, run_gh_json
+from json_safety import load_json_object
 from public_host_validation import validate_public_host
 
 
@@ -190,13 +191,11 @@ def load_pages_metadata(repo: str, gh: str) -> dict[str, Any]:
 
 def load_pages_json(path: Path) -> dict[str, Any]:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = load_json_object(path, encoding="utf-8")
     except OSError as exc:
         raise ValueError(f"failed to read Pages fixture JSON: {exc}") from exc
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"Pages fixture JSON was invalid: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise ValueError("Pages fixture JSON must contain an object")
     return payload
 
 

--- a/scripts/check-github-release-assets-published-regression.py
+++ b/scripts/check-github-release-assets-published-regression.py
@@ -58,6 +58,8 @@ def assert_raises(func, pattern: str) -> None:
     try:
         func()
     except ValueError as exc:
+        if SENSITIVE_SENTINEL in str(exc):
+            raise AssertionError("error message leaked a sensitive fixture value") from exc
         if pattern not in str(exc):
             raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
         return
@@ -313,6 +315,21 @@ def run_loader_tests(module) -> None:
         payload = module.load_release_metadata("owner/repo", TEST_TAG, "gh")
     finally:
         module.run_gh_json = original_run_gh_json
+
+    with tempfile.TemporaryDirectory(prefix="conu-release-json-guard-") as temp_dir:
+        release_json = Path(temp_dir) / "release.json"
+        release_json.write_text(
+            (
+                '{"tag_name":"v0.1.0",'
+                f'"tag_name":"{SENSITIVE_SENTINEL}",'
+                '"assets":[]}\n'
+            ),
+            encoding="utf-8",
+        )
+        assert_raises(
+            lambda: module.load_release_json(release_json),
+            "duplicate JSON key",
+        )
     if payload.get("tag_name") != TEST_TAG:
         raise AssertionError("loader did not return fixture release metadata")
     if len(payload.get("assets", [])) != len(module.expected_release_asset_names(TEST_VERSION)):

--- a/scripts/check-github-release-assets-published.py
+++ b/scripts/check-github-release-assets-published.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from github_release_secrets import find_gh, infer_repo, normalize_repo, run_gh_json
+from json_safety import load_json_object
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
@@ -361,13 +362,11 @@ def load_release_assets(repo: str, release_id: int, gh: str) -> list[dict[str, A
 
 def load_release_json(path: Path) -> dict[str, Any]:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = load_json_object(path, encoding="utf-8")
     except OSError as exc:
         raise ValueError(f"failed to read release fixture JSON: {exc}") from exc
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"release fixture JSON was invalid: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise ValueError("release fixture JSON must contain an object")
     return payload
 
 

--- a/scripts/check-github-release-secret-readiness-regression.py
+++ b/scripts/check-github-release-secret-readiness-regression.py
@@ -241,6 +241,25 @@ def run_error_tests(module) -> None:
     finally:
         helper.subprocess.run = original_run
 
+    def duplicate_json(*_args, **_kwargs):
+        payload = (
+            '[{"name":"'
+            + module.REQUIRED_RELEASE_SECRETS[0]
+            + '","name":"'
+            + SENSITIVE_SENTINEL
+            + '"}]'
+        )
+        return SimpleNamespace(returncode=0, stdout=payload, stderr="")
+
+    helper.subprocess.run = duplicate_json
+    try:
+        assert_raises(
+            lambda: module.load_secret_names("owner/repo", "gh"),
+            "duplicate JSON key",
+        )
+    finally:
+        helper.subprocess.run = original_run
+
     def failed_command(*_args, **_kwargs):
         return SimpleNamespace(returncode=1, stdout="", stderr=SENSITIVE_SENTINEL)
 

--- a/scripts/github_release_secrets.py
+++ b/scripts/github_release_secrets.py
@@ -11,6 +11,8 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
+from json_safety import loads_json
+
 
 NPM_TOKEN_SECRET_NAME = "NPM_TOKEN"
 NPM_TOKEN_ROTATION_MARKER_VAR = "CONU_NPM_TOKEN_ROTATED_AFTER"
@@ -103,8 +105,8 @@ def run_gh_json(gh: str, args: list[str], description: str) -> Any:
             f"{description} failed with exit code {result.returncode}; run gh auth status"
         )
     try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
+        return loads_json(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"{description} returned invalid JSON: {exc}") from exc
 
 


### PR DESCRIPTION
## **User description**
## Summary
- reject duplicate JSON keys in the shared GitHub CLI JSON helper used by release readiness gates
- reject duplicate keys in local GitHub Release asset and GitHub Pages readiness fixture JSON
- add regressions proving duplicate shadow values fail closed without leaking those values

## Validation
- `python -m py_compile scripts/github_release_secrets.py scripts/check-github-release-secret-readiness-regression.py scripts/check-github-release-assets-published.py scripts/check-github-release-assets-published-regression.py scripts/check-github-pages-readiness.py scripts/check-github-pages-readiness-regression.py scripts/json_safety.py`
- `python scripts/check-github-release-secret-readiness-regression.py`
- `python scripts/check-github-release-assets-published-regression.py`
- `python scripts/check-github-pages-readiness-regression.py`
- `python scripts/check-tagged-release-readiness-regression.py`
- `python scripts/check-github-workflow-permissions.py`
- `python -m compileall -q scripts`
- `python scripts/check-production-readiness-toolchain.py`
- `python scripts/check-github-pages-readiness.py --repo imthegoodboy/conU`
- `git diff --check`

Security review:
- payload exposure risk: no payload route or runtime output changed; duplicate-key fixture values are asserted not to leak
- trust/permission risk: no trust or permission behavior changed
- storage/logging risk: readiness errors stay sanitized and do not print GitHub secret values, fixture shadow values, or release body/download URL contents
- relay/network risk: relay and runtime networking are untouched
- required fixes: none for this PR

Closes #944

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened JSON parsing in GitHub readiness scripts to reject duplicate keys and sanitize errors. Prevents shadowed values from bypassing checks in `gh` output and local fixtures.

- **Bug Fixes**
  - Use `json_safety.loads_json` in `run_gh_json` to reject duplicate keys.
  - Use `json_safety.load_json_object` for release and pages fixture loaders.
  - Add regression tests to assert duplicate-key failures and prevent sensitive value leakage.
  - Unified error messages when JSON is invalid or not an object.

Closes #944

<sup>Written for commit 26c1367b4ff2a281d9b9ee6c32b2f273162a008e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate JSON keys in GitHub readiness checks**

### What Changed
- GitHub readiness checks now fail when GitHub CLI output contains duplicate JSON keys, instead of accepting shadowed values
- Local JSON fixture files for GitHub release assets and GitHub Pages now also reject duplicate keys
- Error messages stay sanitized and do not print sensitive fixture values when parsing fails

### Impact
`✅ Fewer false-ready GitHub checks`
`✅ Safer handling of malformed release and Pages JSON`
`✅ Clearer parse failures without exposing secret values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
