### PR TITLE
Harden GitHub governance JSON parsing

### DIFF
--- a/scripts/check-github-actions-permissions-regression.py
+++ b/scripts/check-github-actions-permissions-regression.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -71,6 +73,63 @@ def assert_safe_report(report) -> dict[str, object]:
         if parsed.get(field) is not False:
             raise AssertionError(f"expected {field}=false")
     return parsed
+
+
+def assert_raises(func, pattern: str) -> None:
+    try:
+        func()
+    except ValueError as exc:
+        rendered = str(exc)
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("error message leaked a sensitive fixture value") from exc
+        if pattern not in rendered:
+            raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
+        return
+    raise AssertionError(f"expected ValueError containing {pattern!r}")
+
+
+def run_loader_tests(module) -> None:
+    with tempfile.TemporaryDirectory(prefix="conu-actions-json-guard-") as temp_dir:
+        fixture = Path(temp_dir) / "actions.json"
+        fixture.write_text(
+            (
+                '{"enabled":true,'
+                f'"enabled":"{SENSITIVE_SENTINEL}",'
+                '"allowed_actions":"selected"}\n'
+            ),
+            encoding="utf-8",
+        )
+        assert_raises(
+            lambda: module.load_json_fixture(fixture, "Actions permissions fixture JSON"),
+            "duplicate JSON key",
+        )
+
+    original_run = module.subprocess.run
+
+    def duplicate_gh_json(args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '{"enabled":true,'
+                f'"enabled":"{SENSITIVE_SENTINEL}",'
+                '"allowed_actions":"selected"}\n'
+            ),
+            stderr="",
+        )
+
+    module.subprocess.run = duplicate_gh_json
+    try:
+        assert_raises(
+            lambda: module.run_gh_json(
+                "gh",
+                ["api", "repos/owner/repo/actions/permissions"],
+                "gh api GitHub Actions permissions",
+            ),
+            "duplicate JSON key",
+        )
+    finally:
+        module.subprocess.run = original_run
 
 
 def run_ready_tests(module) -> None:
@@ -178,6 +237,7 @@ def run_optional_policy_tests(module) -> None:
 
 def main() -> int:
     module = load_module()
+    run_loader_tests(module)
     run_ready_tests(module)
     run_repository_permission_tests(module)
     run_workflow_permission_tests(module)

--- a/scripts/check-github-actions-permissions.py
+++ b/scripts/check-github-actions-permissions.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from github_release_secrets import find_gh, infer_repo, normalize_repo
+from json_safety import load_json_object, loads_json
 
 
 DEFAULT_REQUIRED_SELECTED_PATTERNS = ("dtolnay/rust-toolchain@stable",)
@@ -79,8 +80,8 @@ def run_gh_json(gh: str, args: list[str], description: str) -> dict[str, Any]:
     if result.returncode != 0:
         raise ValueError(f"{description} failed with exit code {result.returncode}; run gh auth status")
     try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
+        payload = loads_json(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"{description} returned invalid JSON: {exc}") from exc
     if not isinstance(payload, dict):
         raise ValueError(f"{description} returned an unexpected payload")
@@ -89,13 +90,11 @@ def run_gh_json(gh: str, args: list[str], description: str) -> dict[str, Any]:
 
 def load_json_fixture(path: Path, description: str) -> dict[str, Any]:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = load_json_object(path, encoding="utf-8")
     except OSError as exc:
         raise ValueError(f"failed to read {description}: {exc}") from exc
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"{description} was invalid: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise ValueError(f"{description} must contain a JSON object")
     return payload
 
 

--- a/scripts/check-github-main-protection-regression.py
+++ b/scripts/check-github-main-protection-regression.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -63,6 +65,61 @@ def assert_safe_report(report) -> dict[str, object]:
         if parsed.get(field) is not False:
             raise AssertionError(f"expected {field}=false")
     return parsed
+
+
+def assert_raises(func, pattern: str) -> None:
+    try:
+        func()
+    except ValueError as exc:
+        rendered = str(exc)
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("error message leaked a sensitive fixture value") from exc
+        if pattern not in rendered:
+            raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
+        return
+    raise AssertionError(f"expected ValueError containing {pattern!r}")
+
+
+def run_loader_tests(module) -> None:
+    with tempfile.TemporaryDirectory(prefix="conu-protection-json-guard-") as temp_dir:
+        fixture = Path(temp_dir) / "protection.json"
+        fixture.write_text(
+            (
+                '{"required_status_checks":{"strict":true},'
+                f'"required_status_checks":"{SENSITIVE_SENTINEL}"}}\n'
+            ),
+            encoding="utf-8",
+        )
+        assert_raises(
+            lambda: module.load_protection_json(fixture),
+            "duplicate JSON key",
+        )
+
+    original_run = module.subprocess.run
+
+    def duplicate_gh_json(args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '{"required_status_checks":{"strict":true},'
+                f'"required_status_checks":"{SENSITIVE_SENTINEL}"}}\n'
+            ),
+            stderr="",
+        )
+
+    module.subprocess.run = duplicate_gh_json
+    try:
+        assert_raises(
+            lambda: module.run_gh_json_or_none(
+                "gh",
+                ["api", "repos/owner/repo/branches/main/protection"],
+                "gh api branch protection",
+            ),
+            "duplicate JSON key",
+        )
+    finally:
+        module.subprocess.run = original_run
 
 
 def audit(module, payload, **kwargs):
@@ -171,6 +228,7 @@ def run_optional_admin_tests(module) -> None:
 
 def main() -> int:
     module = load_module()
+    run_loader_tests(module)
     run_ready_tests(module)
     run_unprotected_tests(module)
     run_status_check_tests(module)

--- a/scripts/check-github-main-protection.py
+++ b/scripts/check-github-main-protection.py
@@ -13,6 +13,7 @@ from typing import Any
 from urllib.parse import quote
 
 from github_release_secrets import find_gh, infer_repo, normalize_repo
+from json_safety import load_json, loads_json
 
 
 DEFAULT_BRANCH = "main"
@@ -79,8 +80,8 @@ def run_gh_json_or_none(gh: str, args: list[str], description: str) -> Any | Non
     )
     if result.returncode == 0:
         try:
-            return json.loads(result.stdout)
-        except json.JSONDecodeError as exc:
+            return loads_json(result.stdout)
+        except (json.JSONDecodeError, ValueError) as exc:
             raise ValueError(f"{description} returned invalid JSON: {exc}") from exc
     stderr = result.stderr.lower()
     if "http 404" in stderr or "branch not protected" in stderr:
@@ -106,10 +107,10 @@ def load_branch_protection(repo: str, branch: str, gh: str) -> dict[str, Any] | 
 
 def load_protection_json(path: Path) -> dict[str, Any] | None:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = load_json(path, encoding="utf-8")
     except OSError as exc:
         raise ValueError(f"failed to read protection fixture JSON: {exc}") from exc
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"protection fixture JSON was invalid: {exc}") from exc
     if payload is None:
         return None

--- a/scripts/check-github-release-clobber-preflight-regression.py
+++ b/scripts/check-github-release-clobber-preflight-regression.py
@@ -49,7 +49,10 @@ def assert_raises(func, pattern: str) -> None:
     try:
         func()
     except ValueError as exc:
-        if pattern not in str(exc):
+        rendered = str(exc)
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("error message leaked a sensitive fixture value") from exc
+        if pattern not in rendered:
             raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
         return
     raise AssertionError(f"expected ValueError containing {pattern!r}")
@@ -180,6 +183,47 @@ def run_loader_tests(module) -> None:
     if payload is None or payload.get("tag_name") != TEST_TAG:
         raise AssertionError("expected loader to return release metadata")
 
+    def fake_duplicate_release_json_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=(
+                '{"tag_name":"v0.1.0",'
+                f'"tag_name":"{SENSITIVE_SENTINEL}",'
+                '"draft":false,"prerelease":false,"assets":[]}\n'
+            ),
+            stderr="",
+        )
+
+    module.subprocess.run = fake_duplicate_release_json_run
+    try:
+        assert_raises(
+            lambda: module.load_release_metadata("owner/repo", TEST_TAG, "gh"),
+            "duplicate JSON key",
+        )
+    finally:
+        module.subprocess.run = original_run
+
+    def fake_duplicate_repo_json_run(args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '{"full_name":"owner/repo",'
+                f'"full_name":"{SENSITIVE_SENTINEL}"}}\n'
+            ),
+            stderr="",
+        )
+
+    module.subprocess.run = fake_duplicate_repo_json_run
+    try:
+        assert_raises(
+            lambda: module.verify_repo_access("owner/repo", "gh"),
+            "duplicate JSON key",
+        )
+    finally:
+        module.subprocess.run = original_run
+
     def fake_failure_run(*_args, **_kwargs):
         return subprocess.CompletedProcess(
             args=["gh"],
@@ -223,6 +267,20 @@ def run_fixture_tests(module) -> None:
         existing_payload = module.load_release_json(existing_path)
         if existing_payload is None:
             raise AssertionError("expected existing release fixture to load")
+
+        duplicate_path = Path(temp_dir) / "duplicate.json"
+        duplicate_path.write_text(
+            (
+                '{"tag_name":"v0.1.0",'
+                f'"tag_name":"{SENSITIVE_SENTINEL}",'
+                '"draft":false,"prerelease":false,"assets":[]}\n'
+            ),
+            encoding="utf-8",
+        )
+        assert_raises(
+            lambda: module.load_release_json(duplicate_path),
+            "duplicate JSON key",
+        )
 
 
 def run_main_tests(module) -> None:

--- a/scripts/check-github-release-clobber-preflight.py
+++ b/scripts/check-github-release-clobber-preflight.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from github_release_secrets import find_gh, infer_repo, normalize_repo
+from json_safety import load_json, loads_json
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
@@ -147,8 +148,8 @@ def verify_repo_access(repo: str, gh: str) -> None:
             f"exit code {result.returncode}; run gh auth status or check repository access"
         )
     try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
+        payload = loads_json(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"gh api repository lookup returned invalid JSON: {exc}") from exc
     if not isinstance(payload, dict):
         raise ValueError("gh api repository lookup returned an unexpected payload")
@@ -172,8 +173,8 @@ def load_release_metadata(repo: str, tag: str, gh: str) -> dict[str, Any] | None
             f"exit code {result.returncode}; run gh auth status or check repository access"
         )
     try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
+        payload = loads_json(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"gh api GitHub Release lookup returned invalid JSON: {exc}") from exc
     if not isinstance(payload, dict):
         raise ValueError("gh api GitHub Release lookup returned an unexpected payload")
@@ -182,10 +183,10 @@ def load_release_metadata(repo: str, tag: str, gh: str) -> dict[str, Any] | None
 
 def load_release_json(path: Path) -> dict[str, Any] | None:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = load_json(path, encoding="utf-8")
     except OSError as exc:
         raise ValueError(f"failed to read release fixture JSON: {exc}") from exc
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"release fixture JSON was invalid: {exc}") from exc
     if payload is None:
         return None

--- a/scripts/check-github-repository-security-regression.py
+++ b/scripts/check-github-repository-security-regression.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -66,6 +68,88 @@ def assert_safe_report(report) -> dict[str, object]:
         if parsed.get(field) is not False:
             raise AssertionError(f"expected {field}=false")
     return parsed
+
+
+def assert_raises(func, pattern: str) -> None:
+    try:
+        func()
+    except ValueError as exc:
+        rendered = str(exc)
+        if SENSITIVE_SENTINEL in rendered:
+            raise AssertionError("error message leaked a sensitive fixture value") from exc
+        if pattern not in rendered:
+            raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
+        return
+    raise AssertionError(f"expected ValueError containing {pattern!r}")
+
+
+def run_loader_tests(module) -> None:
+    with tempfile.TemporaryDirectory(prefix="conu-repository-security-json-guard-") as temp_dir:
+        fixture = Path(temp_dir) / "repo.json"
+        fixture.write_text(
+            (
+                '{"visibility":"public",'
+                f'"visibility":"{SENSITIVE_SENTINEL}",'
+                '"archived":false}\n'
+            ),
+            encoding="utf-8",
+        )
+        assert_raises(
+            lambda: module.load_json_fixture(fixture, "repository metadata fixture JSON"),
+            "duplicate JSON key",
+        )
+
+    original_run = module.subprocess.run
+
+    def duplicate_repo_json(args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '{"visibility":"public",'
+                f'"visibility":"{SENSITIVE_SENTINEL}",'
+                '"archived":false}\n'
+            ),
+            stderr="",
+        )
+
+    module.subprocess.run = duplicate_repo_json
+    try:
+        assert_raises(
+            lambda: module.run_gh_json(
+                "gh",
+                ["api", "repos/owner/repo"],
+                "gh api repository metadata",
+            ),
+            "duplicate JSON key",
+        )
+    finally:
+        module.subprocess.run = original_run
+
+    def duplicate_alert_json(args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                '[{"state":"open",'
+                f'"state":"{SENSITIVE_SENTINEL}"}}]\n'
+            ),
+            stderr="",
+        )
+
+    module.subprocess.run = duplicate_alert_json
+    try:
+        assert_raises(
+            lambda: module.load_alerts(
+                "owner/repo",
+                "gh",
+                "dependabot/alerts",
+                "gh api Dependabot alerts",
+            ),
+            "duplicate JSON key",
+        )
+    finally:
+        module.subprocess.run = original_run
 
 
 def run_ready_tests(module) -> None:
@@ -189,6 +273,7 @@ def run_optional_secret_scanning_tests(module) -> None:
 
 def main() -> int:
     module = load_module()
+    run_loader_tests(module)
     run_ready_tests(module)
     run_disabled_feature_tests(module)
     run_repository_state_tests(module)

--- a/scripts/check-github-repository-security.py
+++ b/scripts/check-github-repository-security.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from github_release_secrets import find_gh, infer_repo, normalize_repo
+from json_safety import load_json, loads_json
 
 
 @dataclass(frozen=True)
@@ -69,8 +70,8 @@ def run_gh_json(gh: str, args: list[str], description: str) -> Any:
     if result.returncode != 0:
         raise ValueError(f"{description} failed with exit code {result.returncode}; run gh auth status")
     try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
+        return loads_json(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"{description} returned invalid JSON: {exc}") from exc
 
 
@@ -95,10 +96,10 @@ def run_gh_status(gh: str, args: list[str], description: str) -> int | None:
 
 def load_json_fixture(path: Path, description: str) -> Any:
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        return load_json(path, encoding="utf-8")
     except OSError as exc:
         raise ValueError(f"failed to read {description}: {exc}") from exc
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"{description} was invalid: {exc}") from exc
 
 
@@ -134,8 +135,8 @@ def load_alerts(repo: str, gh: str, endpoint: str, description: str) -> list[Any
     if result.returncode != 0:
         return None
     try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
+        payload = loads_json(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise ValueError(f"{description} returned invalid JSON: {exc}") from exc
     if not isinstance(payload, list):
         raise ValueError(f"{description} returned an unexpected payload")


### PR DESCRIPTION
## **User description**
## Summary

- Harden GitHub governance/release readiness parsers to reject duplicate JSON keys from live `gh` output and fixture files.
- Cover Actions permissions, main branch protection, repository security, and GitHub Release clobber preflight checks.
- Add regressions that verify shadow values are rejected and sentinel values are not leaked through duplicate-key errors.

## Validation

- `python -m py_compile scripts/check-github-actions-permissions.py scripts/check-github-actions-permissions-regression.py scripts/check-github-main-protection.py scripts/check-github-main-protection-regression.py scripts/check-github-repository-security.py scripts/check-github-repository-security-regression.py scripts/check-github-release-clobber-preflight.py scripts/check-github-release-clobber-preflight-regression.py scripts/json_safety.py`
- `python scripts/check-github-actions-permissions-regression.py`
- `python scripts/check-github-main-protection-regression.py`
- `python scripts/check-github-repository-security-regression.py`
- `python scripts/check-github-release-clobber-preflight-regression.py`
- `git diff --check`

## Security Review

payload exposure risk: No runtime payload handling changed; this is GitHub metadata parser hardening only.

trust/permission risk: Governance checks now fail closed on duplicate-key API data; no peer trust or runtime permission rules changed.

storage/logging risk: Duplicate-key errors expose duplicate key names only, not shadow values or raw API bodies.

relay/network risk: No relay or runtime networking behavior changed.

required fixes: None for this PR after the included parser conversions and regressions.

Closes #946


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate JSON keys across GitHub governance and release preflight checks, failing closed on malformed `gh` output or fixtures. Adds regression tests to catch duplicate-key cases without leaking sensitive values.

- **Bug Fixes**
  - Switched to `json_safety` helpers (`load_json`, `load_json_object`, `loads_json`) in Actions permissions, main branch protection, repository security, and release clobber preflight scripts.
  - Guarded fixture and `gh` API parsing to raise clear “duplicate JSON key” errors and validate payload types.
  - Added regression tests that simulate duplicate-key fixtures and `gh` responses; verify error messages do not include sentinel values.

- **Migration**
  - Update any local fixtures or mocked `gh` outputs with duplicate keys; checks now reject them.

<sup>Written for commit da24d93a7e28ddc1d7ae02664bc858d408b6b65f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject malformed GitHub JSON with duplicate keys**

### What Changed
- GitHub governance checks now fail when API output or fixture files contain duplicate JSON keys instead of using a shadowed value
- The branch protection, repository security, Actions permissions, and release clobber checks all use the stricter JSON handling
- Error messages no longer expose sensitive fixture values when malformed JSON is rejected
- Regression checks now cover duplicate-key cases for live `gh` output and saved fixtures

### Impact
`✅ Safer GitHub governance checks`
`✅ Fewer false passes from malformed JSON`
`✅ Less risk of leaking sensitive fixture values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
