### PR TITLE
Harden hosted repository JSON metadata parsing

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -33,6 +33,7 @@ RPM_PACKAGES = (
     f"conu-{VERSION}-1.aarch64.rpm",
 )
 ZIP_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
+SENSITIVE_SENTINEL = "do-not-print-this-shadow-value"
 
 
 def main() -> int:
@@ -54,6 +55,21 @@ def main() -> int:
         run_generator(dist, repeat)
         if bundle.read_bytes() != (repeat / HOSTED_BUNDLE).read_bytes():
             raise AssertionError("hosted Linux repository bundle was not deterministic")
+
+        generator = load_generator()
+        message = expect_action_failure(
+            lambda: generator.parse_package_version(
+                Path("package.json"),
+                (
+                    '{"version":"0.1.0",'
+                    f'"version":"{SENSITIVE_SENTINEL}"}}\n'
+                ).encode("utf-8"),
+                "hosted Linux repositories regression",
+            ),
+            "not valid UTF-8 JSON",
+            "duplicate package metadata JSON",
+        )
+        assert_no_sentinel(message, "duplicate package metadata JSON output")
 
         missing_signature = temp / "missing-signature"
         shutil.copytree(dist, missing_signature)
@@ -333,15 +349,20 @@ def expect_zip_bound_failure(
         setattr(generator, constant_name, original)
 
 
-def expect_action_failure(action, expected: str, label: str) -> None:
+def expect_action_failure(action, expected: str, label: str) -> str:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
         if expected in message:
-            return
+            return message
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_no_sentinel(output: str, label: str) -> None:
+    if SENSITIVE_SENTINEL in output:
+        raise AssertionError(f"{label} leaked duplicate-key shadow value")
 
 
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:

--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -26,6 +26,7 @@ PLACEHOLDER_BASE_URL = "https://packages.example.com/conu"
 PUBLIC_KEY = "conu-linux-gpg-key.asc"
 HOSTED_BUNDLE = f"conu-{VERSION}-hosted-linux-repositories.zip"
 SITE_BUNDLE = f"conu-{VERSION}-hosted-linux-repository-site.zip"
+SENSITIVE_SENTINEL = "do-not-print-this-shadow-value"
 
 
 def main() -> int:
@@ -137,6 +138,41 @@ def main() -> int:
         with serve_site(bad_cache_policy, mode="good") as base_url:
             rewrite_base_url(bad_cache_policy, PLACEHOLDER_BASE_URL, base_url)
             run_checker_expect_failure(base_url, "tokenDisplayed=false", "--expected-version", VERSION)
+
+        duplicate_repository = temp / "duplicate-repository-json"
+        shutil.copytree(site_root, duplicate_repository)
+        (duplicate_repository / "repository.json").write_text(
+            '{"schema":"conu.hostedLinuxRepository.site.v1",'
+            f'"version":"{VERSION}","version":"{SENSITIVE_SENTINEL}"}}\n',
+            encoding="ascii",
+            newline="\n",
+        )
+        with serve_site(duplicate_repository, mode="good") as base_url:
+            output = run_checker_expect_failure(
+                base_url,
+                "repository.json is not valid JSON",
+                "--expected-version",
+                VERSION,
+            )
+            assert_no_sentinel(output, "duplicate repository JSON output")
+
+        duplicate_cache_policy = temp / "duplicate-cache-policy-json"
+        shutil.copytree(site_root, duplicate_cache_policy)
+        (duplicate_cache_policy / "cache-policy.json").write_text(
+            '{"schema":"conu.hostedLinuxRepository.cachePolicy.v1",'
+            f'"version":"{VERSION}","version":"{SENSITIVE_SENTINEL}"}}\n',
+            encoding="ascii",
+            newline="\n",
+        )
+        with serve_site(duplicate_cache_policy, mode="good") as base_url:
+            rewrite_base_url(duplicate_cache_policy, PLACEHOLDER_BASE_URL, base_url)
+            output = run_checker_expect_failure(
+                base_url,
+                "cache-policy.json is not valid JSON",
+                "--expected-version",
+                VERSION,
+            )
+            assert_no_sentinel(output, "duplicate cache policy JSON output")
 
         unsafe_cache_path = temp / "unsafe-cache-path"
         shutil.copytree(site_root, unsafe_cache_path)
@@ -405,6 +441,11 @@ def run_checker_expect_failure(
             f"endpoint check failed with {completed.stdout!r}, expected {expected!r}"
         )
     return completed.stdout
+
+
+def assert_no_sentinel(output: str, label: str) -> None:
+    if SENSITIVE_SENTINEL in output:
+        raise AssertionError(f"{label} leaked duplicate-key shadow value")
 
 
 if __name__ == "__main__":

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -14,6 +14,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urljoin, urlparse, urlunparse
 from urllib.request import Request, urlopen
 
+from json_safety import loads_json
 from public_host_validation import is_loopback_host, validate_public_host
 
 
@@ -395,8 +396,8 @@ def decode_json(data: bytes, label: str) -> dict[str, Any]:
     text = decode_ascii(data, label)
     assert_no_forbidden_text(text, label)
     try:
-        value = json.loads(text)
-    except json.JSONDecodeError as exc:
+        value = loads_json(text)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise EndpointReadinessError(f"{label} is not valid JSON") from exc
     if not isinstance(value, dict):
         raise EndpointReadinessError(f"{label} must be a JSON object")

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -26,6 +26,7 @@ SITE_BUNDLE = f"conu-{VERSION}-hosted-linux-repository-site.zip"
 PUBLIC_KEY = "conu-linux-gpg-key.asc"
 ZIP_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
+SENSITIVE_SENTINEL = "do-not-print-this-shadow-value"
 
 
 def main() -> int:
@@ -240,6 +241,46 @@ def main() -> int:
             temp / "missing-cache-policy-pages",
             "missing Pages member",
         )
+
+        duplicate_repository = temp / "duplicate-repository"
+        shutil.copytree(dist, duplicate_repository)
+        rewrite_site_zip(
+            duplicate_repository / SITE_BUNDLE,
+            {
+                "repository.json": (
+                    '{"schema":"conu.hostedLinuxRepository.site.v1",'
+                    f'"version":"{VERSION}","version":"{SENSITIVE_SENTINEL}"}}\n'
+                ).encode("ascii")
+            },
+        )
+        sign_site(duplicate_repository / SITE_BUNDLE)
+        output = expect_failure(
+            "duplicate repository JSON",
+            duplicate_repository / SITE_BUNDLE,
+            temp / "duplicate-repository-pages",
+            "repository.json is not ASCII JSON",
+        )
+        assert_no_sentinel(output, "duplicate repository JSON output")
+
+        duplicate_cache_policy = temp / "duplicate-cache-policy"
+        shutil.copytree(dist, duplicate_cache_policy)
+        rewrite_site_zip(
+            duplicate_cache_policy / SITE_BUNDLE,
+            {
+                "cache-policy.json": (
+                    '{"schema":"conu.hostedLinuxRepository.cachePolicy.v1",'
+                    f'"version":"{VERSION}","version":"{SENSITIVE_SENTINEL}"}}\n'
+                ).encode("ascii")
+            },
+        )
+        sign_site(duplicate_cache_policy / SITE_BUNDLE)
+        output = expect_failure(
+            "duplicate cache policy JSON",
+            duplicate_cache_policy / SITE_BUNDLE,
+            temp / "duplicate-cache-policy-pages",
+            "cache-policy.json is not ASCII JSON",
+        )
+        assert_no_sentinel(output, "duplicate cache policy JSON output")
 
         bad_cache_policy = temp / "bad-cache-policy"
         shutil.copytree(dist, bad_cache_policy)
@@ -475,7 +516,7 @@ def run_preparer(site: Path, output_dir: Path) -> str:
     ).stdout
 
 
-def expect_failure(description: str, site: Path, output_dir: Path, expected: str) -> None:
+def expect_failure(description: str, site: Path, output_dir: Path, expected: str) -> str:
     failed = subprocess.run(
         [
             sys.executable,
@@ -494,6 +535,7 @@ def expect_failure(description: str, site: Path, output_dir: Path, expected: str
         raise AssertionError(
             f"{description} failed with {failed.stdout!r}, expected {expected!r}"
         )
+    return failed.stdout
 
 
 def expect_zip_bound_failure(
@@ -525,6 +567,11 @@ def expect_action_failure(action, expected: str, label: str) -> None:
             return
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_no_sentinel(output: str, label: str) -> None:
+    if SENSITIVE_SENTINEL in output:
+        raise AssertionError(f"{label} leaked duplicate-key shadow value")
 
 
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -105,6 +105,38 @@ def main() -> int:
         )
         assert_failure("base URL mismatch", mismatch, "repository.json baseUrl does not match")
 
+        duplicate_repository = temp / "duplicate-repository-json-site"
+        shutil.copytree(site_dir, duplicate_repository)
+        (duplicate_repository / "repository.json").write_text(
+            '{"schema":"conu.hostedLinuxRepository.site.v1",'
+            f'"version":"{VERSION}","version":"{SENSITIVE_SENTINEL}"}}\n',
+            encoding="ascii",
+            newline="\n",
+        )
+        duplicate_repository_result = run_publisher_raw(duplicate_repository, "--dry-run")
+        assert_failure(
+            "duplicate repository JSON",
+            duplicate_repository_result,
+            "repository.json is not valid JSON",
+        )
+        assert_no_sentinel(duplicate_repository_result.stdout, "duplicate repository JSON output")
+
+        duplicate_cache_policy = temp / "duplicate-cache-policy-json-site"
+        shutil.copytree(site_dir, duplicate_cache_policy)
+        (duplicate_cache_policy / "cache-policy.json").write_text(
+            '{"schema":"conu.hostedLinuxRepository.cachePolicy.v1",'
+            f'"version":"{VERSION}","version":"{SENSITIVE_SENTINEL}"}}\n',
+            encoding="ascii",
+            newline="\n",
+        )
+        duplicate_cache_policy_result = run_publisher_raw(duplicate_cache_policy, "--dry-run")
+        assert_failure(
+            "duplicate cache policy JSON",
+            duplicate_cache_policy_result,
+            "cache-policy.json is not valid JSON",
+        )
+        assert_no_sentinel(duplicate_cache_policy_result.stdout, "duplicate cache policy JSON output")
+
         encoded_base_result = run_publisher_raw(
             site_dir,
             "--dry-run",
@@ -669,6 +701,11 @@ def assert_fake_aws_log(log: Path, expected_count: int) -> None:
 def assert_failure(description: str, result: subprocess.CompletedProcess[str], expected: str) -> None:
     if result.returncode == 0 or expected not in result.stdout:
         raise AssertionError(f"{description} failed with {result.stdout!r}, expected {expected!r}")
+
+
+def assert_no_sentinel(output: str, label: str) -> None:
+    if SENSITIVE_SENTINEL in output:
+        raise AssertionError(f"{label} leaked duplicate-key shadow value")
 
 
 def assert_failed_publication_redacts(

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -26,6 +26,7 @@ SITE_BUNDLE = f"conu-{VERSION}-hosted-linux-repository-site.zip"
 PUBLIC_KEY = "conu-linux-gpg-key.asc"
 ZIP_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
+SENSITIVE_SENTINEL = "do-not-print-this-shadow-value"
 CACHE_CONTROL_RULES = (
     {
         "kind": "mutable-site-metadata",
@@ -148,6 +149,20 @@ def main() -> int:
         run_generator(dist, repeat, BASE_URL)
         if site.read_bytes() != (repeat / SITE_BUNDLE).read_bytes():
             raise AssertionError("hosted Linux repository site artifact was not deterministic")
+
+        message = expect_action_failure(
+            lambda: site_generator.parse_package_version(
+                Path("package.json"),
+                (
+                    '{"version":"0.1.0",'
+                    f'"version":"{SENSITIVE_SENTINEL}"}}\n'
+                ).encode("utf-8"),
+                "hosted Linux repository site regression",
+            ),
+            "not valid UTF-8 JSON",
+            "duplicate package metadata JSON",
+        )
+        assert_no_sentinel(message, "duplicate package metadata JSON output")
 
         missing_signature = temp / "missing-signature"
         shutil.copytree(dist, missing_signature)
@@ -457,15 +472,20 @@ def expect_zip_bound_failure(
         setattr(site_generator, constant_name, original)
 
 
-def expect_action_failure(action, expected: str, label: str) -> None:
+def expect_action_failure(action, expected: str, label: str) -> str:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
         if expected in message:
-            return
+            return message
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_no_sentinel(output: str, label: str) -> None:
+    if SENSITIVE_SENTINEL in output:
+        raise AssertionError(f"{label} leaked duplicate-key shadow value")
 
 
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -18,6 +18,8 @@ from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 import xml.etree.ElementTree as ET
 
+from json_safety import loads_json
+
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
@@ -99,13 +101,17 @@ def read_repo_version() -> str:
         "npm package metadata",
         max_bytes=MAX_PACKAGE_JSON_BYTES,
     )
+    return parse_package_version(package_json, package_data, "hosted Linux repositories")
+
+
+def parse_package_version(package_json: Path, package_data: bytes, context: str) -> str:
     try:
-        package = json.loads(package_data.decode("utf-8"))
-    except UnicodeDecodeError as exc:
-        raise SystemExit(f"{package_json} is not valid UTF-8") from exc
+        package = loads_json(package_data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise SystemExit(f"{package_json} is not valid UTF-8 JSON") from exc
     version = package.get("version")
     if not isinstance(version, str) or not version:
-        raise SystemExit(f"{package_json} does not contain a non-empty version")
+        raise SystemExit(f"{package_json} does not contain a non-empty version for {context}")
     return version
 
 

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -16,6 +16,8 @@ from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 from urllib.parse import unquote, urlparse, urlunparse
 
+from json_safety import loads_json
+
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
@@ -161,13 +163,17 @@ def read_repo_version() -> str:
         "npm package metadata",
         max_bytes=MAX_PACKAGE_JSON_BYTES,
     )
+    return parse_package_version(package_json, package_data, "hosted Linux repository site")
+
+
+def parse_package_version(package_json: Path, package_data: bytes, context: str) -> str:
     try:
-        package = json.loads(package_data.decode("utf-8"))
-    except UnicodeDecodeError as exc:
-        raise SystemExit(f"{package_json} is not valid UTF-8") from exc
+        package = loads_json(package_data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise SystemExit(f"{package_json} is not valid UTF-8 JSON") from exc
     version = package.get("version")
     if not isinstance(version, str) or not version:
-        raise SystemExit(f"{package_json} does not contain a non-empty version")
+        raise SystemExit(f"{package_json} does not contain a non-empty version for {context}")
     return version
 
 

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -16,6 +16,8 @@ from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 from urllib.parse import unquote, urlparse, urlunparse
 
+from json_safety import loads_json
+
 
 CHECKSUM_RE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+([^ \t\r\n]+)(?:\r?\n)?$")
 SITE_RE = re.compile(
@@ -435,8 +437,8 @@ def validate_allowed_path(site_name: str, version: str, name: str) -> None:
 
 def validate_repository_json(version: str, data: bytes) -> str:
     try:
-        repository = json.loads(data.decode("ascii"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        repository = loads_json(data.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         raise SystemExit("repository.json is not ASCII JSON") from exc
     if repository.get("schema") != "conu.hostedLinuxRepository.site.v1":
         raise SystemExit("repository.json has unexpected schema")
@@ -621,8 +623,8 @@ def has_url_path_control(value: str) -> bool:
 
 def validate_cache_policy_json(version: str, base_url: str, data: bytes) -> None:
     try:
-        policy = json.loads(data.decode("ascii"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        policy = loads_json(data.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         raise SystemExit("cache-policy.json is not ASCII JSON") from exc
     if policy.get("schema") != CACHE_POLICY_SCHEMA:
         raise SystemExit("cache-policy.json has unexpected schema")

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -22,6 +22,7 @@ from typing import Any, BinaryIO
 from urllib.parse import unquote, urlparse, urlunparse
 
 from command_output_redaction import redact_command_output
+from json_safety import loads_json
 from public_host_validation import is_loopback_host, validate_public_host
 
 
@@ -489,8 +490,8 @@ def read_json_file(path: Path, label: str) -> dict[str, Any]:
     text = read_bounded_ascii_file(path, label, max_bytes=MAX_METADATA_BYTES)
     assert_no_forbidden_text(text, label)
     try:
-        value = json.loads(text)
-    except json.JSONDecodeError as exc:
+        value = loads_json(text)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise PublicationError(f"{label} is not valid JSON") from exc
     if not isinstance(value, dict):
         raise PublicationError(f"{label} must be a JSON object")
@@ -705,7 +706,7 @@ def collect_files(
 ) -> list[PublishFile]:
     files: list[PublishFile] = []
     total_size = 0
-    for path in sorted(site_dir.rglob("*")):
+    for path in iter_site_entries(site_dir):
         relative_path = relative_name(site_dir, path)
         if path.is_symlink():
             raise PublicationError(f"site entry must not be a symlink: {relative_path}")
@@ -742,6 +743,20 @@ def collect_files(
             )
         )
     return files
+
+
+def iter_site_entries(site_dir: Path) -> list[Path]:
+    entries: list[Path] = []
+    pending: list[Path] = [site_dir]
+    while pending:
+        current = pending.pop(0)
+        for entry in sorted(current.iterdir(), key=lambda path: relative_name(site_dir, path)):
+            entries.append(entry)
+            if entry.is_symlink():
+                continue
+            if entry.is_dir():
+                pending.append(entry)
+    return sorted(entries, key=lambda path: relative_name(site_dir, path))
 
 
 def relative_name(site_dir: Path, path: Path) -> str:


### PR DESCRIPTION
## **User description**
## Summary

- Reject duplicate JSON keys in hosted Linux repository metadata ingestion for endpoint checks, Pages preparation, S3 publication, and hosted repository generator package metadata.
- Add duplicate-key regressions for `repository.json`, `cache-policy.json`, and package metadata with sentinel checks to prove shadow values are not leaked.
- Replace S3 publication site traversal with a symlink-aware iterator so symlinked site directory entries are rejected before recursion.

## Validation

- `python -m py_compile scripts/check-hosted-linux-repositories.py scripts/generate-hosted-linux-repositories.py scripts/check-hosted-linux-repository-site.py scripts/generate-hosted-linux-repository-site.py scripts/check-hosted-linux-repository-pages.py scripts/prepare-hosted-linux-repository-pages.py scripts/check-hosted-linux-repository-endpoint-regression.py scripts/check-hosted-linux-repository-endpoint.py scripts/check-hosted-linux-repository-s3-publication.py scripts/publish-hosted-linux-repository-s3.py scripts/json_safety.py`
- `python scripts/check-hosted-linux-repositories.py`
- `python scripts/check-hosted-linux-repository-site.py`
- `python scripts/check-hosted-linux-repository-pages.py`
- `python scripts/check-hosted-linux-repository-endpoint-regression.py`
- `python scripts/check-hosted-linux-repository-s3-publication.py`
- `python -m compileall -q scripts`
- `python scripts/check-production-readiness-toolchain.py`
- `git diff --check`

## Security Review

payload exposure risk: Low. This is public release/hosted repository metadata hardening; no runtime payload handling changed.

trust/permission risk: Low. No peer trust, agent permission, or relay authentication policy changed.

storage/logging risk: Low. Duplicate-key failures are generic and regressions assert shadow values are not leaked.

relay/network risk: Low. No relay data-plane or runtime networking changed; S3 static-site traversal now rejects symlinked entries before recursion.

required fixes: None for this PR after the included duplicate-key parser conversions, regressions, and symlink-aware traversal guard.

Closes #948


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate keys in hosted repository JSON and block symlink traversal during S3 publication. Adds regressions to ensure strict parsing and no shadow-value leaks. Closes #948.

- **Bug Fixes**
  - Switched JSON decoding to `json_safety.loads_json` for `repository.json`, `cache-policy.json`, and package metadata so duplicate-key JSON now fails with clear errors.
  - Added sentinel-based regression tests to verify failure output never prints shadow values.
  - Replaced S3 site traversal with a symlink-aware iterator to reject symlinked entries before recursion.

<sup>Written for commit 7e93c65cc24fff9baed073134177f2d59a8d1825. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate keys in hosted repository metadata and block symlinked site entries**

### What Changed
- Hosted repository JSON files now fail fast when they contain duplicate keys, instead of accepting shadowed values in repository, cache policy, package metadata, and related checks.
- Error messages for invalid JSON are now consistent across the hosted repository tools.
- S3 publication now stops on symlinked site entries before walking into them, preventing unsafe files from being included.
- Added regression checks to confirm duplicate-key values are not exposed in failure output.

### Impact
`✅ Fewer malformed repository releases`
`✅ Clearer JSON parsing failures`
`✅ Safer hosted site publication`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to prevent sensitive values from leaking into error output when JSON parsing fails.
  * Introduced test cases for duplicate JSON key scenarios across multiple configuration validators.

* **Bug Fixes**
  * Improved JSON parsing robustness using safer decoding implementation.
  * Enhanced error handling to prevent accidental exposure of sensitive data in failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->