### PR TITLE
Harden release update policy JSON parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "conu-protocol",
  "flate2",
  "native-tls",
+ "serde",
  "serde_json",
  "sha2",
  "tar",

--- a/crates/conu-cli/Cargo.toml
+++ b/crates/conu-cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 conu-core.workspace = true
 conu-protocol.workspace = true
 native-tls = "=0.2.14"
+serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 flate2 = "1"

--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashSet;
 use std::env;
+use std::fmt;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpStream, ToSocketAddrs};
@@ -35,7 +36,8 @@ use conu_core::streams::{self, StreamEvent, StreamRecord};
 use conu_core::trust::{self, PeerCard, TrustStatus, TrustedPeer};
 use conu_protocol::{AgentCapabilities, OpaquePayload};
 use native_tls::{HandshakeError, TlsConnector};
-use serde_json::Value;
+use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde_json::{Map, Number, Value};
 use sha2::{Digest, Sha256};
 
 /// A rendered CLI command result.
@@ -6937,8 +6939,7 @@ fn validate_release_update_policy_files(
     verify_update_sha256_sidecar(&sha256_file, &policy_name, &sha256)?;
     verify_update_signature_sidecar(&signature_file)?;
 
-    let policy: Value = serde_json::from_slice(&policy_bytes)
-        .map_err(|error| format!("release update policy JSON is invalid: {error}"))?;
+    let policy = parse_release_update_policy_json(&policy_bytes)?;
     let policy_object = policy
         .as_object()
         .ok_or_else(|| "release update policy must be a JSON object".to_string())?;
@@ -7056,6 +7057,115 @@ fn validate_release_update_policy_files(
         },
         policy,
     })
+}
+
+struct DuplicateKeyCheckedJson;
+
+impl<'de> DeserializeSeed<'de> for DuplicateKeyCheckedJson {
+    type Value = Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(DuplicateKeyCheckedVisitor)
+    }
+}
+
+struct DuplicateKeyCheckedVisitor;
+
+impl<'de> Visitor<'de> for DuplicateKeyCheckedVisitor {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("JSON without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(Value::Number(Number::from(value)))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Value::Number(Number::from(value)))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Number::from_f64(value)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("invalid JSON number"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(Value::String(value.to_string()))
+    }
+
+    fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E> {
+        Ok(Value::String(value.to_string()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(Value::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        DuplicateKeyCheckedJson.deserialize(deserializer)
+    }
+
+    fn visit_seq<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = access.next_element_seed(DuplicateKeyCheckedJson)? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut seen = HashSet::new();
+        let mut object = Map::new();
+        while let Some(key) = access.next_key::<String>()? {
+            if !seen.insert(key.clone()) {
+                return Err(de::Error::custom(format!("duplicate JSON key: {key}")));
+            }
+            let value = access.next_value_seed(DuplicateKeyCheckedJson)?;
+            object.insert(key, value);
+        }
+        Ok(Value::Object(object))
+    }
+}
+
+fn parse_release_update_policy_json(policy_bytes: &[u8]) -> Result<Value, String> {
+    let mut deserializer = serde_json::Deserializer::from_slice(policy_bytes);
+    let policy = DuplicateKeyCheckedJson
+        .deserialize(&mut deserializer)
+        .map_err(|error| format!("release update policy JSON is invalid: {error}"))?;
+    deserializer
+        .end()
+        .map_err(|error| format!("release update policy JSON is invalid: {error}"))?;
+    Ok(policy)
 }
 
 fn validate_policy_asset(
@@ -11841,6 +11951,41 @@ mod tests {
         assert!(!text_output.stdout.contains("BEGIN PGP SIGNATURE"));
         assert!(!output.stdout.contains("private message contents"));
         assert!(!text_output.stdout.contains("private message contents"));
+    }
+
+    #[test]
+    fn update_check_rejects_duplicate_policy_json_keys_without_leaking_shadow_value() {
+        let home = temp_home("update-check-duplicate-policy-json");
+        let policy = write_update_policy_fixture(&home, false);
+        let policy_path = policy.to_str().expect("policy path");
+        let shadow_value = "do-not-print-this-shadow-value";
+        let mut policy_text = fs::read_to_string(&policy).expect("policy reads");
+        let trimmed_len = policy_text.trim_end().len();
+        policy_text.truncate(trimmed_len);
+        policy_text.pop();
+        policy_text.push_str(&format!(",\n  \"version\": \"{shadow_value}\"\n}}\n"));
+        fs::write(&policy, policy_text.as_bytes()).expect("policy rewrite succeeds");
+        let digest = sha256_hex(policy_text.as_bytes());
+        fs::write(
+            sidecar_path(&policy, ".sha256"),
+            format!("{digest}  conu-0.1.0-update-policy.json\n"),
+        )
+        .expect("policy sidecar rewrite succeeds");
+
+        let output = run(["update", "check", "--policy-file", policy_path]);
+
+        assert_eq!(output.code, 1);
+        assert!(
+            output
+                .stderr
+                .contains("release update policy JSON is invalid")
+        );
+        assert!(output.stderr.contains("duplicate JSON key: version"));
+        assert!(output.stderr.contains("contentsDisplayed=false"));
+        assert!(!output.stderr.contains(shadow_value));
+        assert!(!output.stderr.contains(policy_path));
+        assert!(!output.stderr.contains("BEGIN PGP SIGNATURE"));
+        assert!(!output.stderr.contains("private message contents"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary

- Adds duplicate-key checked JSON parsing for release update-policy metadata before existing validation.
- Rejects duplicate object keys recursively instead of accepting `serde_json::Value` last-key-wins behavior.
- Adds a regression proving duplicate-key failures do not leak the shadow value, local policy path, detached signature contents, or private payload text.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `python scripts/check-release-update-policy.py`
- `python scripts/check-production-readiness-toolchain.py`
- `cargo +stable-x86_64-pc-windows-gnu check -p conu-cli --all-targets`
- `cargo +stable-x86_64-pc-windows-gnu clippy -p conu-cli --all-targets -- -D warnings`
- Attempted: `cargo +stable-x86_64-pc-windows-gnu test -p conu-cli update_check_rejects_duplicate_policy_json_keys_without_leaking_shadow_value -- --nocapture`
  - Local result: blocked by missing `dlltool.exe` while compiling `getrandom`/`windows-sys`; PR CI should cover executable Rust tests.

## Security review

payload exposure risk: Low. The parser consumes public release-policy metadata, and the regression verifies the duplicate shadow value, policy path, detached signature contents, and private payload marker do not appear in stderr.
trust/permission risk: None. No trust-store, identity, peer-policy, or permission behavior changed.
storage/logging risk: Low. No new storage or logging path; errors remain metadata-only and include only the duplicate key name.
relay/network risk: None. No relay, route, transport, or remote fetch behavior changed.
required fixes: Reject duplicate release update-policy JSON keys before validation and keep failure output sanitized.

Closes #950

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate keys in release update-policy JSON and sanitizes failures to avoid leaking values. Adds a strict JSON deserializer in `conu-cli` that aborts on duplicates before validation.

- **Bug Fixes**
  - Switch to strict parsing that rejects duplicate keys at any depth and disallows trailing data.
  - Return clear errors with the offending key name.
  - Add a regression test to ensure errors do not expose shadow values, local policy paths, detached signatures, or private payload text.

- **Dependencies**
  - Add `serde` to `conu-cli` to implement the custom `DeserializeSeed`/`Visitor` parser.

<sup>Written for commit 86825df4bba75fcd29536d95ad0a64351c9bb6f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject duplicate keys in release update policy JSON**

### What Changed
- Release update policy checks now fail when the policy JSON contains duplicate object keys, instead of accepting the last value silently.
- The error stays sanitized: it names the duplicate key but does not print the hidden replacement value, local file path, signature text, or private payload text.
- Added a regression test that confirms duplicate-key policies are rejected and sensitive content is not exposed in the error output.

### Impact
`✅ Safer policy validation`
`✅ Fewer hidden-value parsing surprises`
`✅ Clearer duplicate-key errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
