### PR TITLE
Require release asset digest metadata

### DIFF
--- a/scripts/check-github-release-assets-published-regression.py
+++ b/scripts/check-github-release-assets-published-regression.py
@@ -40,6 +40,7 @@ def ready_payload(
             "name": name,
             "size": 128 + index,
             "state": "uploaded",
+            "digest": f"sha256:{index:064x}",
             "browser_download_url": f"https://example.invalid/{SENSITIVE_SENTINEL}/{name}",
         }
         for index, name in enumerate(module.expected_release_asset_names(version))
@@ -70,6 +71,8 @@ def assert_not_ready(report, pattern: str) -> None:
     if report.ready:
         raise AssertionError("expected release asset report to fail")
     rendered = json.dumps(report.as_json())
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("release asset report leaked a sensitive fixture value")
     if pattern not in rendered:
         raise AssertionError(f"expected {pattern!r} in report: {rendered}")
 
@@ -189,9 +192,28 @@ def run_audit_tests(module) -> None:
         "state must be uploaded",
     )
 
+    missing_digest_payload = ready_payload(module)
+    del missing_digest_payload["assets"][0]["digest"]
+    assert_not_ready(
+        module.audit_release_assets("owner/repo", TEST_TAG, missing_digest_payload),
+        "digest must be sha256 metadata",
+    )
+
+    bad_digest_payload = ready_payload(module)
+    bad_digest_payload["assets"][0]["digest"] = SENSITIVE_SENTINEL
+    assert_not_ready(
+        module.audit_release_assets("owner/repo", TEST_TAG, bad_digest_payload),
+        "digest must be sha256 metadata",
+    )
+
     forbidden_payload = ready_payload(module)
     forbidden_payload["assets"].append(
-        {"name": "conu-0.1.0-runtime-secret.zip", "size": 100, "state": "uploaded"}
+        {
+            "name": "conu-0.1.0-runtime-secret.zip",
+            "size": 100,
+            "state": "uploaded",
+            "digest": f"sha256:{999:064x}",
+        }
     )
     assert_not_ready(
         module.audit_release_assets("owner/repo", TEST_TAG, forbidden_payload),
@@ -207,7 +229,12 @@ def run_audit_tests(module) -> None:
 
     unexpected_payload = ready_payload(module)
     unexpected_payload["assets"].append(
-        {"name": "conu-0.1.0-extra-notes.txt", "size": 100, "state": "uploaded"}
+        {
+            "name": "conu-0.1.0-extra-notes.txt",
+            "size": 100,
+            "state": "uploaded",
+            "digest": f"sha256:{1000:064x}",
+        }
     )
     assert_not_ready(
         module.audit_release_assets("owner/repo", TEST_TAG, unexpected_payload),

--- a/scripts/check-github-release-assets-published.py
+++ b/scripts/check-github-release-assets-published.py
@@ -18,6 +18,7 @@ from json_safety import load_json_object
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 FORBIDDEN_ASSET_MARKERS = (
     ".mailbox",
     ".session",
@@ -215,6 +216,15 @@ def asset_local_issue(asset: dict[str, Any], name: str) -> str | None:
     return f"{name}: {value.strip()}"
 
 
+def asset_digest_issue(repo: str, asset: dict[str, Any], name: str) -> str | None:
+    if repo == "local/dist" and asset.get("localAsset") is True:
+        return None
+    value = asset.get("digest")
+    if not isinstance(value, str) or not SHA256_DIGEST_RE.fullmatch(value):
+        return f"{name}: digest must be sha256 metadata"
+    return None
+
+
 def forbidden_asset_marker(name: str) -> str | None:
     lower = name.lower()
     if "/" in name or "\\" in name or name in {".", ".."} or ".." in name.split("."):
@@ -261,6 +271,9 @@ def audit_release_assets(
         local_issue = asset_local_issue(asset, name)
         if local_issue:
             invalid.append(local_issue)
+        digest_issue = asset_digest_issue(repo, asset, name)
+        if digest_issue:
+            invalid.append(digest_issue)
 
         marker = forbidden_asset_marker(name)
         if marker:
@@ -381,7 +394,7 @@ def load_dist_metadata(tag: str, dist_dir: Path) -> dict[str, Any]:
     assets: list[dict[str, Any]] = []
     for path in sorted(dist.iterdir(), key=lambda item: item.name):
         name = path.name
-        asset: dict[str, Any] = {"name": name, "state": "uploaded"}
+        asset: dict[str, Any] = {"name": name, "state": "uploaded", "localAsset": True}
         try:
             stat_result = path.lstat()
         except OSError as exc:

--- a/scripts/check-unsigned-preview-release-assets-regression.py
+++ b/scripts/check-unsigned-preview-release-assets-regression.py
@@ -49,6 +49,15 @@ def assert_safe_report(report) -> dict:
     return payload
 
 
+def github_asset(name: str, index: int) -> dict[str, object]:
+    return {
+        "name": name,
+        "size": 12 + index,
+        "state": "uploaded",
+        "digest": f"sha256:{index:064x}",
+    }
+
+
 def assert_issue(report, expected: str, label: str) -> None:
     if report.ready:
         raise AssertionError(f"{label} should fail")
@@ -98,7 +107,7 @@ def run_metadata_tests(module) -> None:
         "tag_name": TAG,
         "draft": False,
         "prerelease": True,
-        "assets": [{"name": name, "size": 12, "state": "uploaded"} for name in names],
+        "assets": [github_asset(name, index) for index, name in enumerate(names)],
     }
     report = module.audit_preview_assets("local/release", TAG, payload)
     if not report.ready:
@@ -128,6 +137,18 @@ def run_metadata_tests(module) -> None:
             raise AssertionError("unexpected bad tag error") from exc
     else:
         raise AssertionError("tag mismatch should fail")
+
+    missing_digest_payload = dict(payload)
+    missing_digest_payload["assets"] = [dict(asset) for asset in payload["assets"]]
+    del missing_digest_payload["assets"][0]["digest"]
+    report = module.audit_preview_assets("local/release", TAG, missing_digest_payload)
+    assert_issue(report, "digest must be sha256 metadata", "missing preview asset digest")
+
+    bad_digest_payload = dict(payload)
+    bad_digest_payload["assets"] = [dict(asset) for asset in payload["assets"]]
+    bad_digest_payload["assets"][0]["digest"] = "do-not-print-this-token-or-payload"
+    report = module.audit_preview_assets("local/release", TAG, bad_digest_payload)
+    assert_issue(report, "digest must be sha256 metadata", "invalid preview asset digest")
 
 
 def main() -> int:

--- a/scripts/check-unsigned-preview-release-assets.py
+++ b/scripts/check-unsigned-preview-release-assets.py
@@ -24,6 +24,7 @@ PREVIEW_ARCHIVE_RE = re.compile(
     r"(?P<target>windows-x64|macos-x64|macos-arm64|linux-x64|linux-arm64)"
     r"(?P<extension>\.zip|\.tar\.gz)(?P<sidecar>\.sha256)?$"
 )
+SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 PREVIEW_TARGETS = (
     ("windows-x64", ".zip"),
     ("macos-x64", ".zip"),
@@ -178,6 +179,15 @@ def asset_local_issue(asset: dict[str, Any], name: str) -> str | None:
     return f"{name}: {value.strip()}"
 
 
+def asset_digest_issue(repo: str, asset: dict[str, Any], name: str) -> str | None:
+    if repo == "local/dist" and asset.get("localAsset") is True:
+        return None
+    value = asset.get("digest")
+    if not isinstance(value, str) or not SHA256_DIGEST_RE.fullmatch(value):
+        return f"{name}: digest must be sha256 metadata"
+    return None
+
+
 def forbidden_asset_marker(name: str) -> str | None:
     lower = name.lower()
     if "/" in name or "\\" in name or name in {".", ".."} or ".." in name.split("."):
@@ -246,6 +256,9 @@ def audit_preview_assets(
         local_issue = asset_local_issue(asset, name)
         if local_issue:
             invalid.append(local_issue)
+        digest_issue = asset_digest_issue(repo, asset, name)
+        if digest_issue:
+            invalid.append(digest_issue)
 
         marker = forbidden_asset_marker(name)
         if marker is not None:
@@ -364,7 +377,7 @@ def load_dist_metadata(tag: str, dist_dir: Path) -> dict[str, Any]:
 
     assets: list[dict[str, Any]] = []
     for path in sorted(dist.iterdir(), key=lambda item: item.name):
-        asset: dict[str, Any] = {"name": path.name, "state": "uploaded"}
+        asset: dict[str, Any] = {"name": path.name, "state": "uploaded", "localAsset": True}
         try:
             stat_result = path.lstat()
         except OSError as exc:


### PR DESCRIPTION
## **User description**
## Summary
- Require live GitHub Release assets to include `sha256:<64 hex>` digest metadata in the production release asset preflight.
- Apply the same digest metadata requirement to unsigned preview release asset verification.
- Keep local `dist` checks compatible by marking local file metadata explicitly, while preventing arbitrary release fixtures from bypassing digest checks.

Closes #954

## Validation
- `python scripts/check-unsigned-preview-release-assets-regression.py`
- `python scripts/check-github-release-assets-published-regression.py`
- `python scripts/check-unsigned-preview-release-assets.py --repo imthegoodboy/conU --tag preview-26965126130 --json`
- `python scripts/check-github-workflow-permissions.py`
- `python scripts/check-production-readiness-toolchain.py`
- `python scripts/check-python-script-compile.py`
- `git diff --check`

## Security
payload exposure risk: low; digest values are validated but not printed in readiness reports.
trust/permission risk: low; this only changes release metadata validation.
storage/logging risk: low; invalid digest reports include only asset names and generic failure categories.
relay/network risk: none; relay/runtime behavior is unchanged.
required fixes: paid signing secrets remain tracked in #274 for signed production tags.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `sha256` digest metadata on all GitHub Release assets for production and unsigned preview checks. Local `dist` files remain compatible via a `localAsset` flag.

- **New Features**
  - Enforce `digest` format `sha256:<64 hex>` for each asset; fail if missing or invalid.
  - Allow local `dist` by setting `localAsset: true`; blocks fixture-based bypass.
  - Harden tests and reports to avoid leaking sensitive sentinel values and add clear failure messages.

- **Migration**
  - Update release workflows to attach `digest` (sha256) metadata to each asset, including preview builds.

<sup>Written for commit 140d85603595664c8be877d332b3ed2ca29e2b1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Require release assets to include valid SHA-256 digest metadata**

### What Changed
- Release checks now reject assets unless they include a `sha256:<64 hex>` digest
- Unsigned preview release checks apply the same digest requirement
- Local `dist` files stay allowed during checks, while non-local fixtures can no longer skip digest validation
- Failure reports now avoid leaking sensitive fixture values while still showing clear digest errors

### Impact
`✅ Fewer bad release uploads`
`✅ Safer preview release checks`
`✅ Clearer release asset validation errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for GitHub Release asset validation with SHA256 digest verification across regression and audit test suites. Added validation to ensure release assets include properly formatted SHA256 digests while accommodating locally generated assets.

* **Chores**
  * Strengthened test fixtures and harness to catch sensitive metadata issues in release asset auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->