### PR TITLE
Harden npm download DNS resolution

### DIFF
--- a/packaging/npm/conu-cli/lib/download-policy.js
+++ b/packaging/npm/conu-cli/lib/download-policy.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const dns = require("node:dns");
 const net = require("node:net");
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
@@ -47,6 +48,66 @@ function validateDownloadRedirect(fromRawUrl, toRawUrl) {
     );
   }
   return to;
+}
+
+function createDownloadLookup(rawUrl, lookup = dns.lookup) {
+  validateDownloadUrl(rawUrl);
+  return (hostname, options, callback) => {
+    let lookupOptions = options;
+    let lookupCallback = callback;
+    if (typeof lookupOptions === "function") {
+      lookupCallback = lookupOptions;
+      lookupOptions = {};
+    }
+
+    return lookup(hostname, lookupOptions, (error, address, family) => {
+      if (error) {
+        lookupCallback(error);
+        return;
+      }
+
+      try {
+        if (Array.isArray(address)) {
+          for (const entry of address) {
+            if (!entry || typeof entry.address !== "string") {
+              throw new Error("download URL hostname resolved to invalid address metadata");
+            }
+            validateResolvedDownloadAddress(rawUrl, entry.address);
+          }
+          lookupCallback(null, address);
+          return;
+        }
+
+        validateResolvedDownloadAddress(rawUrl, address);
+        lookupCallback(null, address, family);
+      } catch (policyError) {
+        lookupCallback(policyError);
+      }
+    });
+  };
+}
+
+function validateResolvedDownloadAddress(rawUrl, address) {
+  const parsed = validateDownloadUrl(rawUrl);
+  const hostClass = classifyDownloadHost(parsed.hostname);
+  const resolved = normalizeHostname(address);
+  const ipVersion = net.isIP(resolved);
+  if (ipVersion === 0) {
+    throw new Error("download URL hostname resolved to an invalid IP address");
+  }
+
+  if (hostClass === "loopback") {
+    if (!isLoopbackHost(resolved)) {
+      throw new Error("download URL loopback hostname resolved outside loopback");
+    }
+    return resolved;
+  }
+
+  const publicAddress = ipVersion === 4 ? isPublicIpv4(resolved) : isPublicIpv6(resolved);
+  if (!publicAddress) {
+    throw new Error("download URL public hostname resolved to a non-public address");
+  }
+  return resolved;
 }
 
 function formatDownloadUrlForError(rawUrl) {
@@ -276,9 +337,11 @@ function splitIpv6Half(value) {
 }
 
 module.exports = {
+  createDownloadLookup,
   formatDownloadUrlForError,
   isLoopbackHost,
   validateDownloadRedirect,
+  validateResolvedDownloadAddress,
   validateDownloadUrl,
   validateUnverifiedDownloadBase
 };

--- a/packaging/npm/conu-cli/scripts/check-download-policy.js
+++ b/packaging/npm/conu-cli/scripts/check-download-policy.js
@@ -1,8 +1,10 @@
 "use strict";
 
 const {
+  createDownloadLookup,
   formatDownloadUrlForError,
   validateDownloadRedirect,
+  validateResolvedDownloadAddress,
   validateDownloadUrl,
   validateUnverifiedDownloadBase
 } = require("../lib/download-policy");
@@ -29,6 +31,21 @@ function main() {
   expectFail("https://release.local/conu.zip", "host must be public or loopback");
   expectFail("http://localhost.evil.test/conu.zip", "download URL must use HTTPS");
   expectFail("not a url", "invalid download URL");
+  expectResolvedPass("https://example.com/conu.zip", "93.184.216.34");
+  expectResolvedPass("https://example.com/conu.zip", "2001:4860:4860::8888");
+  expectResolvedPass("http://localhost:50123/conu.zip", "127.0.0.1");
+  expectResolvedPass("https://localhost/conu.zip", "::1");
+  expectResolvedFail("https://example.com/conu.zip", "10.0.0.1", "non-public address");
+  expectResolvedFail(
+    "https://example.com/conu.zip",
+    "::ffff:192.168.1.1",
+    "non-public address"
+  );
+  expectResolvedFail("http://localhost:50123/conu.zip", "93.184.216.34", "outside loopback");
+  expectResolvedFail("https://example.com/conu.zip", "not-an-ip", "invalid IP address");
+  expectLookupPass("https://example.com/conu.zip", "93.184.216.34");
+  expectLookupFail("https://example.com/conu.zip", "172.16.0.1", "non-public address");
+  expectLookupAllFail("https://example.com/conu.zip", "192.168.1.10", "non-public address");
   expectUnverifiedPass("http://127.0.0.1:50123/releases");
   expectUnverifiedPass("https://localhost/releases");
   expectUnverifiedPass("http://[::1]:50123/releases");
@@ -84,6 +101,75 @@ function expectFail(url, expectedMessage) {
     throw new Error(`expected ${expectedMessage}, got: ${error.message}`);
   }
   throw new Error(`expected download URL policy failure: ${expectedMessage}`);
+}
+
+function expectResolvedPass(url, address) {
+  validateResolvedDownloadAddress(url, address);
+}
+
+function expectResolvedFail(url, address, expectedMessage) {
+  try {
+    validateResolvedDownloadAddress(url, address);
+  } catch (error) {
+    if (error.message.includes(expectedMessage)) {
+      return;
+    }
+    throw new Error(`expected ${expectedMessage}, got: ${error.message}`);
+  }
+  throw new Error(`expected resolved-address policy failure: ${expectedMessage}`);
+}
+
+function expectLookupPass(url, address) {
+  let called = false;
+  const lookup = createDownloadLookup(url, (_hostname, _options, callback) => {
+    callback(null, address, address.includes(":") ? 6 : 4);
+  });
+  lookup(new URL(url).hostname, {}, (error, resolved) => {
+    called = true;
+    if (error) {
+      throw error;
+    }
+    if (resolved !== address) {
+      throw new Error(`expected lookup to resolve ${address}, got ${resolved}`);
+    }
+  });
+  if (!called) {
+    throw new Error("expected download lookup callback to run");
+  }
+}
+
+function expectLookupFail(url, address, expectedMessage) {
+  let called = false;
+  const lookup = createDownloadLookup(url, (_hostname, _options, callback) => {
+    callback(null, address, address.includes(":") ? 6 : 4);
+  });
+  lookup(new URL(url).hostname, {}, (error) => {
+    called = true;
+    if (error && error.message.includes(expectedMessage)) {
+      return;
+    }
+    throw new Error(`expected lookup failure ${expectedMessage}, got: ${error && error.message}`);
+  });
+  if (!called) {
+    throw new Error("expected download lookup callback to run");
+  }
+}
+
+function expectLookupAllFail(url, address, expectedMessage) {
+  let called = false;
+  const lookup = createDownloadLookup(url, (_hostname, _options, callback) => {
+    callback(null, [{ address, family: address.includes(":") ? 6 : 4 }]);
+  });
+  lookup(new URL(url).hostname, { all: true }, (error) => {
+    called = true;
+    if (error && error.message.includes(expectedMessage)) {
+      return;
+    }
+    throw new Error(`expected lookup-all failure ${expectedMessage}, got: ${error && error.message}`);
+  });
+  if (!called) {
+    throw new Error("expected download lookup callback to run");
+  }
 }
 
 function expectUnverifiedPass(url) {

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -17,6 +17,7 @@ const {
   parseContentLength
 } = require("../lib/download-limits");
 const {
+  createDownloadLookup,
   formatDownloadUrlForError,
   validateDownloadRedirect,
   validateDownloadUrl,
@@ -293,26 +294,31 @@ function downloadFile(url, target, maxBytes) {
 function request(url, onError, handler, redirects = 0) {
   const parsedUrl = validateDownloadUrl(url);
   const client = parsedUrl.protocol === "https:" ? https : http;
-  const requestHandle = client.get(parsedUrl, (response) => {
-    if (
-      response.statusCode >= 300 &&
-      response.statusCode < 400 &&
-      response.headers.location &&
-      redirects < 5
-    ) {
-      response.resume();
-      const redirectUrl = new URL(response.headers.location, url).toString();
-      try {
-        validateDownloadRedirect(url, redirectUrl);
-      } catch (error) {
-        onError(error);
+  const requestHandle = client.get(
+    parsedUrl,
+    { lookup: createDownloadLookup(url) },
+    (response) => {
+      if (
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location &&
+        redirects < 5
+      ) {
+        response.resume();
+        const redirectUrl = new URL(response.headers.location, url).toString();
+        try {
+          validateDownloadRedirect(url, redirectUrl);
+        } catch (error) {
+          onError(error);
+          return;
+        }
+        request(redirectUrl, onError, handler, redirects + 1).on("error", onError);
         return;
       }
-      request(redirectUrl, onError, handler, redirects + 1).on("error", onError);
-      return;
+
+      handler(response);
     }
-    handler(response);
-  });
+  );
   requestHandle.setTimeout(downloadLimits.timeoutMs, () => {
     requestHandle.destroy(
       new Error(


### PR DESCRIPTION
## **User description**
Closes #956.

## What changed
- Adds request-time DNS resolution validation for npm installer downloads.
- Requires public download hosts to resolve to public IPs.
- Requires loopback test hosts to resolve only to loopback IPs.
- Applies the guard to archive and checksum downloads, including redirects.

## Validation
- npm run check --prefix packaging/npm/conu-cli
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `conu-cli` download security by validating DNS resolution for installer archives and checksums, including redirects. Public hosts must resolve to public IPs; loopback hosts must resolve only to loopback.

- **New Features**
  - Added `validateResolvedDownloadAddress` and `createDownloadLookup` to enforce DNS policy via `dns.lookup`.
  - Applied the guard in `scripts/install.js` using the `lookup` option on `http`/`https` requests.
  - Expanded policy tests to cover IPv4/IPv6, loopback-only enforcement, and `all: true` lookups.

<sup>Written for commit 12658f659e0ed9e7dd6051698bd2c23cff8fd2b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Harden npm downloads against unsafe DNS results**

### What Changed
- npm installer downloads now check the IP address returned by DNS before starting a request.
- Public download hosts are blocked if they resolve to private or otherwise non-public addresses.
- Loopback-only download hosts are blocked if they resolve to anything outside loopback.
- Redirects keep the same public/loopback boundary rules, and the policy checks now cover both single-address and multi-address DNS results.

### Impact
`✅ Safer npm downloads`
`✅ Fewer failed installs from bad DNS responses`
`✅ Stronger protection against redirect-based download abuse`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
