### PR TITLE
Harden npm launcher target validation

### DIFF
--- a/packaging/npm/conu-cli/lib/run.js
+++ b/packaging/npm/conu-cli/lib/run.js
@@ -7,11 +7,7 @@ const { BINARIES, binaryPath } = require("./platform");
 const binaryName = readBinaryName(process.env.CONU_BIN_NAME);
 const executable = resolveExecutable(binaryName);
 
-if (!fs.existsSync(executable)) {
-  console.error(`conU binary is missing for ${binaryName}; pathDisplayed=false contentsDisplayed=false`);
-  console.error("Run npm install again, or set CONU_NPM_BINARY_DIR during install.");
-  process.exit(127);
-}
+assertSafeExecutable(binaryName, executable);
 
 const child = launchExecutable(binaryName, executable);
 
@@ -48,6 +44,36 @@ function resolveExecutable(name) {
     );
     process.exit(127);
   }
+}
+
+function assertSafeExecutable(name, executable) {
+  let stat;
+  try {
+    stat = fs.lstatSync(executable);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      failInstallState(name, "conU binary is missing");
+    } else {
+      failInstallState(
+        name,
+        `conU binary could not be inspected; errorCode=${runtimeErrorCode(error)}`
+      );
+    }
+  }
+
+  if (stat.isSymbolicLink()) {
+    failInstallState(name, "conU binary is unsafe");
+  }
+
+  if (!stat.isFile()) {
+    failInstallState(name, "conU binary is not a regular file");
+  }
+}
+
+function failInstallState(name, message) {
+  console.error(`${message} for ${name}; pathDisplayed=false contentsDisplayed=false`);
+  console.error("Run npm install again, or set CONU_NPM_BINARY_DIR during install.");
+  process.exit(127);
 }
 
 function launchExecutable(name, executable) {

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -39,7 +39,8 @@ function main() {
 
   expectLauncherMissingBinaryIsRedacted();
   expectLauncherInvalidBinaryIsRedacted();
-  expectLauncherSpawnFailureIsRedacted();
+  expectLauncherNonFileBinaryIsRedacted();
+  expectLauncherSymlinkBinaryIsRedacted();
 
   console.log("install and launcher output privacy check passed");
 }
@@ -117,7 +118,7 @@ function expectLauncherInvalidBinaryIsRedacted() {
   });
 }
 
-function expectLauncherSpawnFailureIsRedacted() {
+function expectLauncherNonFileBinaryIsRedacted() {
   withFixture((root) => {
     const packageCopy = path.join(root, "package");
     copyPackage(packageRoot, packageCopy);
@@ -127,9 +128,32 @@ function expectLauncherSpawnFailureIsRedacted() {
 
     const output = runNodeFailure([path.join(packageCopy, "bin", "conu.js")], {}, packageCopy);
 
-    expectNoLocalPath(output, root, "launcher spawn error temp root");
-    expectIncludes(output, "pathDisplayed=false", "launcher spawn path display guard");
-    expectIncludes(output, "contentsDisplayed=false", "launcher spawn content display guard");
+    expectNoLocalPath(output, root, "launcher non-file temp root");
+    expectIncludes(output, "not a regular file", "launcher non-file target guard");
+    expectIncludes(output, "pathDisplayed=false", "launcher non-file path display guard");
+    expectIncludes(output, "contentsDisplayed=false", "launcher non-file content display guard");
+  });
+}
+
+function expectLauncherSymlinkBinaryIsRedacted() {
+  withFixture((root) => {
+    const packageCopy = path.join(root, "package");
+    const outside = path.join(root, "outside-binary");
+    copyPackage(packageRoot, packageCopy);
+    fs.writeFileSync(outside, "do not run\n");
+
+    const executable = path.join(packageCopy, "vendor", platformKey(), `conu${binarySuffix()}`);
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    if (!trySymlink(executable, outside, "file")) {
+      return;
+    }
+
+    const output = runNodeFailure([path.join(packageCopy, "bin", "conu.js")], {}, packageCopy);
+
+    expectNoLocalPath(output, root, "launcher symlink temp root");
+    expectIncludes(output, "binary is unsafe", "launcher symlink target guard");
+    expectIncludes(output, "pathDisplayed=false", "launcher symlink path display guard");
+    expectIncludes(output, "contentsDisplayed=false", "launcher symlink content display guard");
   });
 }
 
@@ -161,6 +185,21 @@ function writeBinaries(binaryDir) {
   const suffix = binarySuffix();
   for (const name of BINARIES) {
     fs.writeFileSync(path.join(binaryDir, `${name}${suffix}`), `${name}\n`);
+  }
+}
+
+function trySymlink(link, target, type) {
+  try {
+    fs.symlinkSync(target, link, type);
+    return true;
+  } catch (error) {
+    if (
+      error &&
+      ["EPERM", "EACCES", "ENOSYS", "EINVAL"].includes(error.code)
+    ) {
+      return false;
+    }
+    throw error;
   }
 }
 


### PR DESCRIPTION
## **User description**
Closes #958.

## What changed
- Adds launch-time `lstat` validation before the npm wrapper spawns a native conU binary.
- Rejects missing, symlink, uninspectable, and non-regular-file package-local binary targets with sanitized output.
- Extends launcher privacy checks to cover non-file and symlink vendor binary targets.

## Validation
- npm run check --prefix packaging/npm/conu-cli
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the npm launcher to validate native binary targets before spawn and emit redacted errors for unsafe cases. Addresses Linear #958 by blocking symlinks, non-files, and missing/uninspectable binaries.

- **Bug Fixes**
  - Added `lstat` checks in `run.js`; reject missing, symlink, non-regular-file, or uninspectable binaries with exit code 127.
  - Standardized sanitized errors: include `pathDisplayed=false` and `contentsDisplayed=false`.
  - Extended `check-install-output-privacy.js` to cover non-file and symlink vendor targets; added a safe symlink helper.

<sup>Written for commit bfa3895c19924fdbc20c108e74950aaf6dcb79f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reject unsafe npm launcher targets before startup**

### What Changed
- The launcher now checks that the npm binary exists and is a normal file before trying to run it.
- If the binary is missing, unreadable, a symlink, or not a regular file, it stops with a redacted error instead of launching.
- Output checks were updated to cover unsafe symlink and non-file targets.

### Impact
`✅ Safer npm launches`
`✅ Fewer failed starts from invalid binary targets`
`✅ Clearer redacted launcher errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
