### PR TITLE
Redact npm local binary override failures

### DIFF
--- a/packaging/npm/conu-cli/lib/local-binary-dir.js
+++ b/packaging/npm/conu-cli/lib/local-binary-dir.js
@@ -10,8 +10,14 @@ function resolveLocalBinaries(sourceDir, { binaryNames, binarySuffix }) {
 
   const resolvedDir = path.resolve(sourceDir);
   const dirStat = lstatMaybe(resolvedDir);
-  if (!dirStat || !dirStat.isDirectory()) {
-    throw new Error(`CONU_NPM_BINARY_DIR must point to an existing directory: ${sourceDir}`);
+  if (!dirStat) {
+    throw new Error("CONU_NPM_BINARY_DIR must point to an existing directory");
+  }
+  if (dirStat.isSymbolicLink()) {
+    throw new Error("CONU_NPM_BINARY_DIR must not be a symlink");
+  }
+  if (!dirStat.isDirectory()) {
+    throw new Error("CONU_NPM_BINARY_DIR must point to an existing directory");
   }
 
   const binaries = {};

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -37,6 +37,7 @@ function main() {
     expectIncludes(output, "sourcePathDisplayed=false", "local install source path guard");
   });
 
+  expectLocalBinaryDirFailureIsRedacted();
   expectLauncherMissingBinaryIsRedacted();
   expectLauncherInvalidBinaryIsRedacted();
   expectLauncherNonFileBinaryIsRedacted();
@@ -86,6 +87,25 @@ function buildEnv(envOverrides = {}) {
     }
   }
   return env;
+}
+
+function expectLocalBinaryDirFailureIsRedacted() {
+  withFixture((root) => {
+    const packageCopy = path.join(root, "package");
+    const missingBinaryDir = path.join(root, "secret-local-binary-dir");
+    copyPackage(packageRoot, packageCopy);
+
+    const output = runNodeFailure([path.join(packageCopy, "scripts", "install.js")], {
+      CONU_NPM_BINARY_DIR: missingBinaryDir,
+      CONU_NPM_SKIP_DOWNLOAD: "",
+      CONU_NPM_DIST_BASE: "",
+      CONU_NPM_ALLOW_UNVERIFIED: ""
+    }, packageCopy);
+
+    expectNoLocalPath(output, root, "local binary dir failure temp root");
+    expectNotIncludes(output, missingBinaryDir, "local binary dir failure override path guard");
+    expectIncludes(output, "CONU_NPM_BINARY_DIR must point to an existing directory", "local binary dir failure reason");
+  });
 }
 
 function expectLauncherMissingBinaryIsRedacted() {

--- a/packaging/npm/conu-cli/scripts/check-local-binary-dir.js
+++ b/packaging/npm/conu-cli/scripts/check-local-binary-dir.js
@@ -28,6 +28,16 @@ function main() {
   });
 
   withFixture((root) => {
+    const realDir = path.join(root, "real-binaries");
+    const linkDir = path.join(root, "linked-binaries");
+    fs.mkdirSync(realDir);
+    if (!trySymlink(linkDir, realDir, "dir")) {
+      return;
+    }
+    expectFailure(linkDir, "must not be a symlink", "symlink source directory");
+  });
+
+  withFixture((root) => {
     writeBinaries(root, { skip: "conud" });
     expectFailure(root, "missing required binary: conud", "missing binary");
   });
@@ -62,6 +72,21 @@ function writeBinaries(root, options = {}) {
       continue;
     }
     fs.writeFileSync(path.join(root, name), name);
+  }
+}
+
+function trySymlink(link, target, type) {
+  try {
+    fs.symlinkSync(target, link, type);
+    return true;
+  } catch (error) {
+    if (
+      error &&
+      ["EPERM", "EACCES", "ENOSYS", "EINVAL"].includes(error.code)
+    ) {
+      return false;
+    }
+    throw error;
   }
 }
 


### PR DESCRIPTION
Closes #960.

## What changed
- Keeps `CONU_NPM_BINARY_DIR` validation failures path-redacted in npm install output.
- Rejects symlink local override directories explicitly before resolving binaries.
- Adds regression coverage for failed local override install output and symlink override directories.

## Validation
- npm run check --prefix packaging/npm/conu-cli
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts paths from `CONU_NPM_BINARY_DIR` failures in `conu-cli` install logs and blocks symlinked override directories. Adds regression tests to keep error messages private and behavior consistent.

- **Bug Fixes**
  - Redact absolute/local paths in install errors from `CONU_NPM_BINARY_DIR` validation.
  - Fail fast when the override directory is a symlink; only real directories are allowed.

- **Migration**
  - If you use a symlink for `CONU_NPM_BINARY_DIR`, switch to a real directory.

<sup>Written for commit 0c3ab9111c9e47aab69903d0c993e29029a11e15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

