### PR TITLE
Scrub npm wrapper env before launch

### DIFF
--- a/packaging/npm/conu-cli/lib/child-env.js
+++ b/packaging/npm/conu-cli/lib/child-env.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const WRAPPER_ONLY_ENV = new Set(["CONU_BIN_NAME"]);
+
+function buildChildEnv(sourceEnv = process.env) {
+  const childEnv = { ...sourceEnv };
+  for (const name of WRAPPER_ONLY_ENV) {
+    delete childEnv[name];
+  }
+  return childEnv;
+}
+
+module.exports = {
+  buildChildEnv,
+  WRAPPER_ONLY_ENV
+};

--- a/packaging/npm/conu-cli/lib/run.js
+++ b/packaging/npm/conu-cli/lib/run.js
@@ -2,6 +2,7 @@
 
 const fs = require("node:fs");
 const { spawn } = require("node:child_process");
+const { buildChildEnv } = require("./child-env");
 const { BINARIES, binaryPath } = require("./platform");
 
 const binaryName = readBinaryName(process.env.CONU_BIN_NAME);
@@ -80,7 +81,7 @@ function launchExecutable(name, executable) {
   try {
     return spawn(executable, process.argv.slice(2), {
       stdio: "inherit",
-      env: process.env
+      env: buildChildEnv()
     });
   } catch (error) {
     reportLaunchError(name, error);

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -5,6 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
+const { buildChildEnv } = require("../lib/child-env");
 const { BINARIES, binarySuffix, platformKey, vendorDir } = require("../lib/platform");
 
 const packageRoot = path.resolve(__dirname, "..");
@@ -12,6 +13,8 @@ const packageRoot = path.resolve(__dirname, "..");
 function main() {
   const installScript = fs.readFileSync(path.join(packageRoot, "scripts", "install.js"), "utf8");
   expectNotIncludes(installScript, 'stdio: "inherit"', "installer child output privacy guard");
+
+  expectChildEnvScrubsWrapperSelector();
 
   const checkOnly = runNode([path.join(packageRoot, "scripts", "install.js"), "--check-only"]);
   expectNoLocalPath(checkOnly, packageRoot, "check-only package root");
@@ -87,6 +90,23 @@ function buildEnv(envOverrides = {}) {
     }
   }
   return env;
+}
+
+function expectChildEnvScrubsWrapperSelector() {
+  const sourceEnv = {
+    CONU_BIN_NAME: "conu",
+    CONU_HOME: "runtime-state",
+    CONU_RELAY_TOKEN: "relay-token"
+  };
+  const childEnv = buildChildEnv(sourceEnv);
+  if ("CONU_BIN_NAME" in childEnv) {
+    throw new Error("launcher child env included wrapper-only CONU_BIN_NAME");
+  }
+  expectEqual(childEnv.CONU_HOME, "runtime-state", "child env keeps conU runtime env");
+  expectEqual(childEnv.CONU_RELAY_TOKEN, "relay-token", "child env keeps conU relay env");
+  if (!("CONU_BIN_NAME" in sourceEnv)) {
+    throw new Error("launcher child env builder mutated source env");
+  }
 }
 
 function expectLocalBinaryDirFailureIsRedacted() {
@@ -239,6 +259,12 @@ function expectIncludes(output, value, label) {
 function expectNotIncludes(output, value, label) {
   if (output.includes(value)) {
     throw new Error(`${label}: expected output not to include ${value}`);
+  }
+}
+
+function expectEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${expected}, got ${actual}`);
   }
 }
 

--- a/scripts/verify-npm-package-contents.py
+++ b/scripts/verify-npm-package-contents.py
@@ -82,6 +82,7 @@ PACKAGES = (
                 "bin/conu.js",
                 "bin/conud.js",
                 "lib/archive-preflight.js",
+                "lib/child-env.js",
                 "lib/checksum.js",
                 "lib/download-limits.js",
                 "lib/download-policy.js",


### PR DESCRIPTION
## What changed
- Add a small npm launcher child-env helper that removes wrapper-only `CONU_BIN_NAME` before spawning the native conU binary.
- Keep normal conU runtime environment values available to the child process.
- Extend the npm privacy check and package content verifier for the new helper.

## Validation
- npm run check (packaging/npm/conu-cli)
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-python-script-compile.py
- git diff --check

Closes #962

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubs wrapper-only env from the `conu-cli` npm wrapper before launching the native binary to avoid leaking `CONU_BIN_NAME`. Preserves runtime env vars and adds checks to enforce this.

- **Bug Fixes**
  - Added `lib/child-env.js` to build a child env that removes `CONU_BIN_NAME` while keeping runtime vars.
  - Updated launcher to use the scrubbed env when spawning the native binary.
  - Extended `check-install-output-privacy` to assert scrubbing, source env immutability, and updated package contents verification.

<sup>Written for commit c5ba09809e2504031683390db61b007c2567b934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

