### PR TITLE
Scrub npm env before native launch

### DIFF
--- a/packaging/npm/conu-cli/lib/child-env.js
+++ b/packaging/npm/conu-cli/lib/child-env.js
@@ -1,16 +1,29 @@
 "use strict";
 
 const WRAPPER_ONLY_ENV = new Set(["CONU_BIN_NAME"]);
+const PACKAGE_MANAGER_SECRET_ENV = new Set(["NODE_AUTH_TOKEN", "NPM_TOKEN"]);
 
 function buildChildEnv(sourceEnv = process.env) {
-  const childEnv = { ...sourceEnv };
-  for (const name of WRAPPER_ONLY_ENV) {
-    delete childEnv[name];
+  const childEnv = {};
+  for (const [name, value] of Object.entries(sourceEnv)) {
+    if (!shouldScrubChildEnvName(name)) {
+      childEnv[name] = value;
+    }
   }
   return childEnv;
 }
 
+function shouldScrubChildEnvName(name) {
+  const normalized = String(name).toUpperCase();
+  if (WRAPPER_ONLY_ENV.has(normalized) || PACKAGE_MANAGER_SECRET_ENV.has(normalized)) {
+    return true;
+  }
+  return normalized.startsWith("NPM_");
+}
+
 module.exports = {
   buildChildEnv,
-  WRAPPER_ONLY_ENV
+  PACKAGE_MANAGER_SECRET_ENV,
+  WRAPPER_ONLY_ENV,
+  shouldScrubChildEnvName
 };

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -96,11 +96,33 @@ function expectChildEnvScrubsWrapperSelector() {
   const sourceEnv = {
     CONU_BIN_NAME: "conu",
     CONU_HOME: "runtime-state",
-    CONU_RELAY_TOKEN: "relay-token"
+    CONU_RELAY_TOKEN: "relay-token",
+    NODE_AUTH_TOKEN: "node-auth-token",
+    NPM_CONFIG_USERCONFIG: "npm-user-config",
+    NPM_PACKAGE_NAME: "@conu/cli",
+    NPM_TOKEN: "npm-token",
+    npm_command: "exec",
+    npm_config_cache: "npm-cache",
+    "npm_config_//registry.npmjs.org/:_authToken": "registry-auth-token",
+    npm_lifecycle_event: "start"
   };
   const childEnv = buildChildEnv(sourceEnv);
   if ("CONU_BIN_NAME" in childEnv) {
     throw new Error("launcher child env included wrapper-only CONU_BIN_NAME");
+  }
+  for (const name of [
+    "NODE_AUTH_TOKEN",
+    "NPM_CONFIG_USERCONFIG",
+    "NPM_PACKAGE_NAME",
+    "NPM_TOKEN",
+    "npm_command",
+    "npm_config_cache",
+    "npm_config_//registry.npmjs.org/:_authToken",
+    "npm_lifecycle_event"
+  ]) {
+    if (name in childEnv) {
+      throw new Error(`launcher child env included package-manager env ${name}`);
+    }
   }
   expectEqual(childEnv.CONU_HOME, "runtime-state", "child env keeps conU runtime env");
   expectEqual(childEnv.CONU_RELAY_TOKEN, "relay-token", "child env keeps conU relay env");


### PR DESCRIPTION
## What changed
- Scrub npm/package-manager environment values from the child environment before the npm wrapper starts native conU binaries.
- Remove `NODE_AUTH_TOKEN`, `NPM_TOKEN`, and all `NPM_*`/`npm_*` lifecycle/config values from the native process environment.
- Preserve normal conU runtime environment values such as `CONU_HOME` and `CONU_RELAY_TOKEN`.
- Extend the launcher privacy check to cover npm config, lifecycle, and auth token variables.

## Validation
- npm run check (packaging/npm/conu-cli)
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- git diff --check

Closes #964

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubs npm/package-manager env vars before launching native conU binaries to prevent leaking tokens and config to child processes. Preserves core conU env and extends privacy checks to cover npm config, lifecycle, and auth variables.

- **Bug Fixes**
  - Remove `NODE_AUTH_TOKEN`, `NPM_TOKEN`, and all `NPM_*`/`npm_*` vars from the child env; keep `CONU_HOME` and `CONU_RELAY_TOKEN`.
  - Add `shouldScrubChildEnvName` and update child env construction.
  - Expand install privacy test to assert npm vars are stripped.

<sup>Written for commit 492ad6a1ecef462099b4015b41b91aa1f2ff83f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable filtering to prevent sensitive authentication tokens and package manager credentials from leaking to child processes.

* **Tests**
  * Expanded privacy tests to verify proper scrubbing of package manager authentication variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->