### PR TITLE
Scrub npm installer tool env

### DIFF
--- a/packaging/npm/conu-cli/lib/archive-preflight.js
+++ b/packaging/npm/conu-cli/lib/archive-preflight.js
@@ -3,6 +3,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
+const { buildChildEnv } = require("./child-env");
 
 const MAX_ARCHIVE_LIST_BYTES = 2 * 1024 * 1024;
 const MAX_ARCHIVE_MEMBERS = 10000;
@@ -295,6 +296,7 @@ function displayArchiveLabel(archivePath) {
 function runTool(command, args) {
   const result = spawnSync(command, args, {
     encoding: "utf8",
+    env: buildChildEnv(),
     maxBuffer: MAX_ARCHIVE_LIST_BYTES
   });
   return {

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -12,7 +12,30 @@ const packageRoot = path.resolve(__dirname, "..");
 
 function main() {
   const installScript = fs.readFileSync(path.join(packageRoot, "scripts", "install.js"), "utf8");
+  const archivePreflight = fs.readFileSync(path.join(packageRoot, "lib", "archive-preflight.js"), "utf8");
   expectNotIncludes(installScript, 'stdio: "inherit"', "installer child output privacy guard");
+  expectIncludes(
+    installScript,
+    'const { buildChildEnv } = require("../lib/child-env");',
+    "installer child env scrub import"
+  );
+  expectOccurrenceCount(
+    installScript,
+    "env: buildChildEnv()",
+    2,
+    "installer extraction tool env scrub guard"
+  );
+  expectIncludes(
+    archivePreflight,
+    'const { buildChildEnv } = require("./child-env");',
+    "archive preflight child env scrub import"
+  );
+  expectOccurrenceCount(
+    archivePreflight,
+    "env: buildChildEnv()",
+    1,
+    "archive preflight tool env scrub guard"
+  );
 
   expectChildEnvScrubsWrapperSelector();
 
@@ -281,6 +304,13 @@ function expectIncludes(output, value, label) {
 function expectNotIncludes(output, value, label) {
   if (output.includes(value)) {
     throw new Error(`${label}: expected output not to include ${value}`);
+  }
+}
+
+function expectOccurrenceCount(output, value, expectedCount, label) {
+  const actualCount = output.split(value).length - 1;
+  if (actualCount !== expectedCount) {
+    throw new Error(`${label}: expected ${expectedCount} occurrence(s), got ${actualCount}`);
   }
 }
 

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const { validateArchiveMembers } = require("../lib/archive-preflight");
+const { buildChildEnv } = require("../lib/child-env");
 const { verifySha256File } = require("../lib/checksum");
 const { resolveExtractedBinaries } = require("../lib/extract-selection");
 const { resolveLocalBinaries } = require("../lib/local-binary-dir");
@@ -136,7 +137,10 @@ function installFromExtractedArchive(root) {
 function extractArchive(archivePath, destination) {
   validateArchiveMembers(archivePath);
 
-  const tar = spawnSync("tar", ["-xf", archivePath, "-C", destination], { stdio: "ignore" });
+  const tar = spawnSync("tar", ["-xf", archivePath, "-C", destination], {
+    env: buildChildEnv(),
+    stdio: "ignore"
+  });
   if (tar.status === 0) {
     return;
   }
@@ -153,7 +157,10 @@ function extractArchive(archivePath, destination) {
         archivePath,
         destination
       ],
-      { stdio: "ignore" }
+      {
+        env: buildChildEnv(),
+        stdio: "ignore"
+      }
     );
     if (ps.status === 0) {
       return;


### PR DESCRIPTION
## What changed
- Scrub npm/package-manager environment before the npm installer invokes external extraction tools.
- Apply the same scrubbed environment to archive preflight tool subprocesses.
- Keep normal OS environment such as `PATH` intact so tools can still be found.
- Add a regression guard in the npm install/privacy check so extraction and preflight tool env scrubbing remains present.

## Validation
- npm run check (packaging/npm/conu-cli)
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- git diff --check

Closes #966

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubs the npm/package-manager environment for installer extraction and archive preflight tools to prevent leaking npm metadata. Preserves normal OS env (e.g., PATH) and adds regression checks to ensure scrubbing stays in place.

- **Bug Fixes**
  - Use `buildChildEnv()` for `tar` and PowerShell extraction in `scripts/install.js`.
  - Apply the same scrubbed env to archive preflight subprocesses in `lib/archive-preflight.js`.
  - Add regression guards in `scripts/check-install-output-privacy.js` to verify the import and exact call counts of `buildChildEnv()`.

<sup>Written for commit 219dd0f7d18bd863923e697317b9715e4a271739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

