### PR TITLE
Scrub npm installer control env

### DIFF
--- a/packaging/npm/conu-cli/lib/child-env.js
+++ b/packaging/npm/conu-cli/lib/child-env.js
@@ -2,6 +2,7 @@
 
 const WRAPPER_ONLY_ENV = new Set(["CONU_BIN_NAME"]);
 const PACKAGE_MANAGER_SECRET_ENV = new Set(["NODE_AUTH_TOKEN", "NPM_TOKEN"]);
+const INSTALLER_ONLY_ENV_PREFIXES = ["CONU_NPM_"];
 
 function buildChildEnv(sourceEnv = process.env) {
   const childEnv = {};
@@ -18,11 +19,17 @@ function shouldScrubChildEnvName(name) {
   if (WRAPPER_ONLY_ENV.has(normalized) || PACKAGE_MANAGER_SECRET_ENV.has(normalized)) {
     return true;
   }
+  for (const prefix of INSTALLER_ONLY_ENV_PREFIXES) {
+    if (normalized.startsWith(prefix)) {
+      return true;
+    }
+  }
   return normalized.startsWith("NPM_");
 }
 
 module.exports = {
   buildChildEnv,
+  INSTALLER_ONLY_ENV_PREFIXES,
   PACKAGE_MANAGER_SECRET_ENV,
   WRAPPER_ONLY_ENV,
   shouldScrubChildEnvName

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -119,6 +119,12 @@ function expectChildEnvScrubsWrapperSelector() {
   const sourceEnv = {
     CONU_BIN_NAME: "conu",
     CONU_HOME: "runtime-state",
+    CONU_NPM_ALLOW_UNVERIFIED: "1",
+    CONU_NPM_BINARY_DIR: "local-binary-dir",
+    CONU_NPM_DIST_BASE: "https://example.invalid/conu",
+    CONU_NPM_DOWNLOAD_TIMEOUT_MS: "5000",
+    CONU_NPM_MAX_ARCHIVE_BYTES: "1024",
+    CONU_NPM_MAX_CHECKSUM_BYTES: "512",
     CONU_RELAY_TOKEN: "relay-token",
     NODE_AUTH_TOKEN: "node-auth-token",
     NPM_CONFIG_USERCONFIG: "npm-user-config",
@@ -134,6 +140,12 @@ function expectChildEnvScrubsWrapperSelector() {
     throw new Error("launcher child env included wrapper-only CONU_BIN_NAME");
   }
   for (const name of [
+    "CONU_NPM_ALLOW_UNVERIFIED",
+    "CONU_NPM_BINARY_DIR",
+    "CONU_NPM_DIST_BASE",
+    "CONU_NPM_DOWNLOAD_TIMEOUT_MS",
+    "CONU_NPM_MAX_ARCHIVE_BYTES",
+    "CONU_NPM_MAX_CHECKSUM_BYTES",
     "NODE_AUTH_TOKEN",
     "NPM_CONFIG_USERCONFIG",
     "NPM_PACKAGE_NAME",
@@ -151,6 +163,9 @@ function expectChildEnvScrubsWrapperSelector() {
   expectEqual(childEnv.CONU_RELAY_TOKEN, "relay-token", "child env keeps conU relay env");
   if (!("CONU_BIN_NAME" in sourceEnv)) {
     throw new Error("launcher child env builder mutated source env");
+  }
+  if (!("CONU_NPM_BINARY_DIR" in sourceEnv)) {
+    throw new Error("launcher child env builder mutated installer env source");
   }
 }
 


### PR DESCRIPTION
## What changed
- Treat `CONU_NPM_*` as npm wrapper/installer-only control state in the shared npm child environment builder.
- Prevent installer override paths, dist-base URLs, unverified-download flags, and download-limit controls from being inherited by native conU launches or external installer tools.
- Preserve normal conU runtime environment such as `CONU_HOME` and `CONU_RELAY_TOKEN`.
- Extend the install/output privacy check to cover the `CONU_NPM_*` scrub behavior and source-env immutability.

## Validation
- npm run check (packaging/npm/conu-cli)
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- git diff --check

Closes #968

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubs `CONU_NPM_*` installer control env from npm child processes so installer-only settings don’t leak into native conU runs or external tools, while keeping runtime env (e.g., `CONU_HOME`, `CONU_RELAY_TOKEN`) intact. Closes #968.

- **Bug Fixes**
  - Added `INSTALLER_ONLY_ENV_PREFIXES` to scrub `CONU_NPM_*` (alongside `NPM_*`) in the child env builder.
  - Blocked installer overrides (paths, dist base, unverified flags, download limits) from propagating to runtime.
  - Extended the install/output privacy check to cover the new scrub and ensure source-env immutability.

<sup>Written for commit ffbe9f46a18c6db0b5fe3bc3eb0907590ccd2c57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

