### PR TITLE
Bound npm installer tool runtime

### DIFF
--- a/packaging/npm/conu-cli/lib/archive-preflight.js
+++ b/packaging/npm/conu-cli/lib/archive-preflight.js
@@ -7,6 +7,7 @@ const { buildChildEnv } = require("./child-env");
 
 const MAX_ARCHIVE_LIST_BYTES = 2 * 1024 * 1024;
 const MAX_ARCHIVE_MEMBERS = 10000;
+const MAX_ARCHIVE_TOOL_TIMEOUT_MS = 60 * 1000;
 const MAX_ZIP_EOCD_SEARCH_BYTES = 22 + 65535;
 const ZIP_EOCD_SIGNATURE = 0x06054b50;
 const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
@@ -297,7 +298,8 @@ function runTool(command, args) {
   const result = spawnSync(command, args, {
     encoding: "utf8",
     env: buildChildEnv(),
-    maxBuffer: MAX_ARCHIVE_LIST_BYTES
+    maxBuffer: MAX_ARCHIVE_LIST_BYTES,
+    timeout: MAX_ARCHIVE_TOOL_TIMEOUT_MS
   });
   return {
     status: result.status === null ? 1 : result.status,
@@ -313,6 +315,7 @@ function splitToolLines(output) {
 
 module.exports = {
   MAX_ARCHIVE_MEMBERS,
+  MAX_ARCHIVE_TOOL_TIMEOUT_MS,
   assertSafeArchiveMemberList,
   validateArchiveMembers
 };

--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -26,6 +26,17 @@ function main() {
     "installer extraction tool env scrub guard"
   );
   expectIncludes(
+    installScript,
+    "const EXTRACT_TOOL_TIMEOUT_MS =",
+    "installer extraction timeout constant"
+  );
+  expectOccurrenceCount(
+    installScript,
+    "timeout: EXTRACT_TOOL_TIMEOUT_MS",
+    2,
+    "installer extraction tool timeout guard"
+  );
+  expectIncludes(
     archivePreflight,
     'const { buildChildEnv } = require("./child-env");',
     "archive preflight child env scrub import"
@@ -35,6 +46,17 @@ function main() {
     "env: buildChildEnv()",
     1,
     "archive preflight tool env scrub guard"
+  );
+  expectIncludes(
+    archivePreflight,
+    "const MAX_ARCHIVE_TOOL_TIMEOUT_MS =",
+    "archive preflight tool timeout constant"
+  );
+  expectOccurrenceCount(
+    archivePreflight,
+    "timeout: MAX_ARCHIVE_TOOL_TIMEOUT_MS",
+    1,
+    "archive preflight tool timeout guard"
   );
 
   expectChildEnvScrubsWrapperSelector();

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -33,6 +33,8 @@ const {
   vendorDir
 } = require("../lib/platform");
 
+const EXTRACT_TOOL_TIMEOUT_MS = 120 * 1000;
+
 const checkOnly = process.argv.includes("--check-only");
 const skipDownload = process.env.CONU_NPM_SKIP_DOWNLOAD === "1";
 const allowUnverified = process.env.CONU_NPM_ALLOW_UNVERIFIED === "1";
@@ -139,7 +141,8 @@ function extractArchive(archivePath, destination) {
 
   const tar = spawnSync("tar", ["-xf", archivePath, "-C", destination], {
     env: buildChildEnv(),
-    stdio: "ignore"
+    stdio: "ignore",
+    timeout: EXTRACT_TOOL_TIMEOUT_MS
   });
   if (tar.status === 0) {
     return;
@@ -159,7 +162,8 @@ function extractArchive(archivePath, destination) {
       ],
       {
         env: buildChildEnv(),
-        stdio: "ignore"
+        stdio: "ignore",
+        timeout: EXTRACT_TOOL_TIMEOUT_MS
       }
     );
     if (ps.status === 0) {


### PR DESCRIPTION
## Summary\n- add explicit process timeouts for npm archive preflight tooling\n- add explicit process timeouts for npm archive extraction tooling\n- extend package validation to guard the timeout coverage\n\n## Validation\n- npm run check (packaging/npm/conu-cli)\n- python scripts/verify-npm-package-contents.py\n- python scripts/verify-npm-package-contents-regression.py\n- python scripts/check-python-script-compile.py\n- python scripts/check-github-workflow-permissions.py\n- git diff --check\n\nCloses #970

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hard time limits to the npm installer tools to prevent hangs: 60s for archive preflight and 120s for extraction. Also tighten validation to ensure these limits and env scrubbing are always present.

- **Bug Fixes**
  - Added `timeout` to archive preflight tool runs (60s) and exported `MAX_ARCHIVE_TOOL_TIMEOUT_MS`.
  - Added `timeout` to `tar` and PowerShell `Expand-Archive` calls (120s) via `EXTRACT_TOOL_TIMEOUT_MS`.
  - Extended `check-install-output-privacy.js` to assert timeout constants and their usage, alongside child env scrubbing.

<sup>Written for commit 5db2e9f8945b6f5aa7219df2b638bf6345ad7581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

