### PR TITLE
Require exclusive npm download artifacts

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const crypto = require("node:crypto");
+const fs = require("node:fs");
 const http = require("node:http");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
@@ -19,6 +20,7 @@ const packageRoot = path.resolve(__dirname, "..");
 const installScript = path.join(__dirname, "install.js");
 
 async function main() {
+  expectExclusiveDownloadArtifactCreation();
   expectDefaultLimits();
   expectOverrideLimits();
   expectInvalidLimit("CONU_NPM_MAX_ARCHIVE_BYTES", "0");
@@ -33,6 +35,20 @@ async function main() {
   await expectInvalidArchiveUsesNeutralTempLabel();
   await expectTimeoutFailure();
   console.log("download limit check passed");
+}
+
+function expectExclusiveDownloadArtifactCreation() {
+  const source = fs.readFileSync(installScript, "utf8");
+  expectIncludes(
+    source,
+    'fs.writeFileSync(checksumPath, checksum, { encoding: "utf8", flag: "wx" })',
+    "exclusive checksum artifact creation"
+  );
+  expectIncludes(
+    source,
+    'fs.createWriteStream(target, { flags: "wx" })',
+    "exclusive archive artifact creation"
+  );
 }
 
 function expectDefaultLimits() {
@@ -248,6 +264,12 @@ function expectNoSecretDisplay(result) {
   const output = `${result.stdout || ""}${result.stderr || ""}`;
   if (output.includes("token=secret")) {
     throw new Error(`installer output displayed URL query material: ${output}`);
+  }
+}
+
+function expectIncludes(output, value, label) {
+  if (!output.includes(value)) {
+    throw new Error(`expected ${label} to include ${value}`);
   }
 }
 

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -84,7 +84,7 @@ async function main() {
       downloadLimits.maxChecksumBytes
     );
     if (checksum) {
-      fs.writeFileSync(checksumPath, checksum, "utf8");
+      fs.writeFileSync(checksumPath, checksum, { encoding: "utf8", flag: "wx" });
       verifySha256File(archivePath, checksum, asset);
     } else if (!allowUnverified) {
       throw new Error(
@@ -267,7 +267,7 @@ function downloadFile(url, target, maxBytes) {
         return;
       }
 
-      file = fs.createWriteStream(target);
+      file = fs.createWriteStream(target, { flags: "wx" });
       let bytes = 0;
 
       response.on("data", (chunk) => {


### PR DESCRIPTION
## Summary\n- require exclusive creation for downloaded npm archive files\n- require exclusive creation for downloaded checksum sidecars\n- extend npm download validation to guard those file-creation flags\n\n## Validation\n- npm run check (packaging/npm/conu-cli)\n- python scripts/verify-npm-package-contents.py\n- python scripts/verify-npm-package-contents-regression.py\n- python scripts/check-python-script-compile.py\n- python scripts/check-github-workflow-permissions.py\n- git diff --check\n\nCloses #972

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure exclusive creation of downloaded npm archive and checksum files to prevent overwrites and race conditions during `packaging/npm/conu-cli` install. Adds validation to enforce these flags in the download checks.

- **Bug Fixes**
  - Write checksum sidecar with `fs.writeFileSync(..., { flag: "wx" })` to fail if it already exists.
  - Create archive file with `fs.createWriteStream(..., { flags: "wx" })` to avoid clobbering.
  - Extend `check-download-limits.js` to assert both exclusive-creation flags alongside existing limit checks.

<sup>Written for commit 9f8bcbfefcedcf22b6aa638ebd3d885341555b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

