### PR TITLE
Redact npm download artifact write failures

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -49,6 +49,21 @@ function expectExclusiveDownloadArtifactCreation() {
     'fs.createWriteStream(target, { flags: "wx" })',
     "exclusive archive artifact creation"
   );
+  expectIncludes(
+    source,
+    'throw downloadArtifactWriteError("checksum");',
+    "redacted checksum artifact write failure"
+  );
+  expectIncludes(
+    source,
+    'file.on("error", () => fail(downloadArtifactWriteError("archive")));',
+    "redacted archive artifact write failure"
+  );
+  expectIncludes(
+    source,
+    "function removeDownloadArtifact(target)",
+    "redacted archive cleanup failure guard"
+  );
 }
 
 function expectDefaultLimits() {

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -84,7 +84,7 @@ async function main() {
       downloadLimits.maxChecksumBytes
     );
     if (checksum) {
-      fs.writeFileSync(checksumPath, checksum, { encoding: "utf8", flag: "wx" });
+      writeChecksumArtifact(checksumPath, checksum);
       verifySha256File(archivePath, checksum, asset);
     } else if (!allowUnverified) {
       throw new Error(
@@ -249,7 +249,7 @@ function downloadFile(url, target, maxBytes) {
       if (file) {
         file.destroy();
       }
-      fs.rmSync(target, { force: true });
+      removeDownloadArtifact(target);
       reject(error);
     };
 
@@ -267,7 +267,7 @@ function downloadFile(url, target, maxBytes) {
         return;
       }
 
-      file = fs.createWriteStream(target, { flags: "wx" });
+      file = createDownloadArtifactStream(target, fail);
       let bytes = 0;
 
       response.on("data", (chunk) => {
@@ -296,10 +296,37 @@ function downloadFile(url, target, maxBytes) {
       });
       response.on("error", fail);
       file.on("drain", () => response.resume());
-      file.on("error", fail);
     });
     activeRequest.on("error", fail);
   });
+}
+
+function writeChecksumArtifact(checksumPath, checksum) {
+  try {
+    fs.writeFileSync(checksumPath, checksum, { encoding: "utf8", flag: "wx" });
+  } catch (_error) {
+    throw downloadArtifactWriteError("checksum");
+  }
+}
+
+function createDownloadArtifactStream(target, fail) {
+  const file = fs.createWriteStream(target, { flags: "wx" });
+  file.on("error", () => fail(downloadArtifactWriteError("archive")));
+  return file;
+}
+
+function removeDownloadArtifact(target) {
+  try {
+    fs.rmSync(target, { force: true });
+  } catch (_error) {
+    // Preserve the original redacted installer failure.
+  }
+}
+
+function downloadArtifactWriteError(kind) {
+  return new Error(
+    `failed to write ${kind} download artifact; pathDisplayed=false contentsDisplayed=false`
+  );
 }
 
 function request(url, onError, handler, redirects = 0) {


### PR DESCRIPTION
## Summary\n- wrap checksum artifact write failures in redacted installer errors\n- wrap archive write-stream failures in redacted installer errors\n- avoid cleanup failures replacing the original redacted download failure\n- extend npm download validation to guard these redaction paths\n\n## Validation\n- npm run check (packaging/npm/conu-cli)\n- python scripts/verify-npm-package-contents.py\n- python scripts/verify-npm-package-contents-regression.py\n- python scripts/check-python-script-compile.py\n- python scripts/check-github-workflow-permissions.py\n- git diff --check\n\nCloses #974

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts checksum and archive artifact write failures in `conu-cli` downloads to prevent leaking paths or contents, and ensures cleanup doesn’t hide the root error (closes #974).

- **Bug Fixes**
  - Wrap checksum writes and archive write-stream errors in redacted installer errors.
  - Guard artifact removal so cleanup failures don’t replace the original error.
  - Extend `scripts/check-download-limits.js` to verify these redaction paths.

<sup>Written for commit ce165c508e676996ffc77e1bcaa0ef258d29f9db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during package installation with clearer error messages for checksum and archive write failures.
  * Enhanced cleanup of partially written artifacts when downloads fail, increasing installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->