### PR TITLE
Redact npm temp directory failures

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -64,6 +64,26 @@ function expectExclusiveDownloadArtifactCreation() {
     "function removeDownloadArtifact(target)",
     "redacted archive cleanup failure guard"
   );
+  expectIncludes(
+    source,
+    "const tempDir = createTempInstallDir();",
+    "redacted temp install dir creation"
+  );
+  expectIncludes(
+    source,
+    "removeTempInstallDir(tempDir, { preserveFailure: installFailed });",
+    "redacted temp install dir cleanup"
+  );
+  expectIncludes(
+    source,
+    'throw tempInstallDirError("create");',
+    "redacted temp install dir creation failure"
+  );
+  expectIncludes(
+    source,
+    'throw tempInstallDirError("remove");',
+    "redacted temp install dir cleanup failure"
+  );
 }
 
 function expectDefaultLimits() {

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -73,7 +73,8 @@ async function main() {
     validateUnverifiedDownloadBase(releaseBase);
   }
 
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "conu-npm-"));
+  const tempDir = createTempInstallDir();
+  let installFailed = false;
   try {
     const archivePath = path.join(tempDir, tempArchiveFileName(asset));
     const checksumPath = `${archivePath}.sha256`;
@@ -98,8 +99,11 @@ async function main() {
     fs.mkdirSync(extractDir, { recursive: true });
     extractArchive(archivePath, extractDir);
     installFromExtractedArchive(extractDir);
+  } catch (error) {
+    installFailed = true;
+    throw error;
   } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    removeTempInstallDir(tempDir, { preserveFailure: installFailed });
   }
 }
 
@@ -321,6 +325,30 @@ function removeDownloadArtifact(target) {
   } catch (_error) {
     // Preserve the original redacted installer failure.
   }
+}
+
+function createTempInstallDir() {
+  try {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "conu-npm-"));
+  } catch (_error) {
+    throw tempInstallDirError("create");
+  }
+}
+
+function removeTempInstallDir(tempDir, options = {}) {
+  try {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  } catch (_error) {
+    if (!options.preserveFailure) {
+      throw tempInstallDirError("remove");
+    }
+  }
+}
+
+function tempInstallDirError(action) {
+  return new Error(
+    `failed to ${action} temporary install directory; pathDisplayed=false contentsDisplayed=false`
+  );
 }
 
 function downloadArtifactWriteError(kind) {


### PR DESCRIPTION
## Summary\n- wrap npm install temporary directory creation failures in redacted errors\n- wrap temporary directory cleanup failures in redacted errors\n- preserve the original installer failure when cleanup also fails\n- extend npm download validation to guard the temp directory redaction path\n\n## Validation\n- npm run check (packaging/npm/conu-cli)\n- python scripts/verify-npm-package-contents.py\n- python scripts/verify-npm-package-contents-regression.py\n- python scripts/check-python-script-compile.py\n- python scripts/check-github-workflow-permissions.py\n- git diff --check\n\nCloses #976

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts temporary install directory creation and cleanup errors in `packaging/npm/conu-cli` to avoid leaking paths or contents. Keeps the original install error when cleanup also fails.

- **Bug Fixes**
  - Added `createTempInstallDir`, `removeTempInstallDir`, and `tempInstallDirError` to wrap mkdtemp/rm with redacted messages.
  - Updated installer to use these helpers and track `installFailed` so cleanup errors don’t mask the real failure.
  - Extended `scripts/check-download-limits.js` to assert creation/removal and redacted error paths are present.

<sup>Written for commit 9311d463fe9ae5f75daa8534798541650da4f258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

