### PR TITLE
Redact npm extraction directory failures

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -84,6 +84,21 @@ function expectExclusiveDownloadArtifactCreation() {
     'throw tempInstallDirError("remove");',
     "redacted temp install dir cleanup failure"
   );
+  expectIncludes(
+    source,
+    "createExtractDir(extractDir);",
+    "redacted temp extraction dir creation"
+  );
+  expectIncludes(
+    source,
+    "function createExtractDir(extractDir)",
+    "redacted temp extraction dir helper"
+  );
+  expectIncludes(
+    source,
+    "failed to create temporary extraction directory; pathDisplayed=false contentsDisplayed=false",
+    "redacted temp extraction dir failure"
+  );
 }
 
 function expectDefaultLimits() {

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -96,7 +96,7 @@ async function main() {
     }
 
     const extractDir = path.join(tempDir, "extract");
-    fs.mkdirSync(extractDir, { recursive: true });
+    createExtractDir(extractDir);
     extractArchive(archivePath, extractDir);
     installFromExtractedArchive(extractDir);
   } catch (error) {
@@ -345,9 +345,23 @@ function removeTempInstallDir(tempDir, options = {}) {
   }
 }
 
+function createExtractDir(extractDir) {
+  try {
+    fs.mkdirSync(extractDir, { recursive: true });
+  } catch (_error) {
+    throw tempExtractDirError();
+  }
+}
+
 function tempInstallDirError(action) {
   return new Error(
     `failed to ${action} temporary install directory; pathDisplayed=false contentsDisplayed=false`
+  );
+}
+
+function tempExtractDirError() {
+  return new Error(
+    "failed to create temporary extraction directory; pathDisplayed=false contentsDisplayed=false"
   );
 }
 


### PR DESCRIPTION
## Summary\n- Wrap npm installer extraction-directory creation in a redacted helper.\n- Add a source regression guard so extraction directory failures keep pathDisplayed=false and contentsDisplayed=false.\n\n## Validation\n- npm run check (packaging/npm/conu-cli)\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-github-workflow-permissions.py\n- git diff --check\n\nCloses #978

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts temporary extraction directory creation failures in the `packaging/npm/conu-cli` installer to prevent leaking paths or contents. Adds regression checks to ensure this redaction stays enforced.

- **Bug Fixes**
  - Wrap extraction directory creation in `createExtractDir()` that throws a redacted error (`pathDisplayed=false contentsDisplayed=false`).
  - Update `install.js` to use the helper and extend `check-download-limits.js` to assert the helper call, definition, and redacted error text.

<sup>Written for commit 425c5f9c49ce486baf44adfc42ada54eded845a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

