### PR TITLE
Redact npm install target IO failures

### DIFF
--- a/packaging/npm/conu-cli/lib/install-target.js
+++ b/packaging/npm/conu-cli/lib/install-target.js
@@ -21,7 +21,7 @@ function installFile(source, target, label, options = {}) {
   assertPathUnderRoot(targetPath, trustedRoot, label);
   assertRegularSource(sourcePath, label);
   assertExistingInstallAncestors(trustedRoot, installDir, label);
-  fs.mkdirSync(installDir, { recursive: true });
+  createInstallDirectory(installDir, label);
   assertInstallDirectoryTree(trustedRoot, installDir, label);
   if (options.vendorRoot) {
     assertInstallDirectoryTree(trustedRoot, path.resolve(options.vendorRoot), label);
@@ -32,18 +32,18 @@ function installFile(source, target, label, options = {}) {
   let tempCreated = false;
   let renamed = false;
   try {
-    fs.copyFileSync(sourcePath, tempTarget, fs.constants.COPYFILE_EXCL);
+    copyTemporaryInstallTarget(sourcePath, tempTarget, label);
     tempCreated = true;
     if (process.platform !== "win32") {
-      fs.chmodSync(tempTarget, 0o755);
+      setTemporaryInstallTargetPermissions(tempTarget, label);
     }
     assertRegularTempTarget(tempTarget, label);
-    fs.renameSync(tempTarget, targetPath);
+    replaceInstallTarget(tempTarget, targetPath, label);
     renamed = true;
     assertSafeInstallTarget(targetPath, label);
   } finally {
     if (tempCreated && !renamed) {
-      fs.rmSync(tempTarget, { force: true });
+      removeTemporaryInstallTarget(tempTarget);
     }
   }
 }
@@ -134,6 +134,52 @@ function assertPathUnderRoot(target, root, label) {
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
     throw new Error(`${label} install target must stay inside the package directory`);
   }
+}
+
+function createInstallDirectory(installDir, label) {
+  try {
+    fs.mkdirSync(installDir, { recursive: true });
+  } catch (_error) {
+    throw installTargetIoError(label, "create install directory");
+  }
+}
+
+function copyTemporaryInstallTarget(source, target, label) {
+  try {
+    fs.copyFileSync(source, target, fs.constants.COPYFILE_EXCL);
+  } catch (_error) {
+    throw installTargetIoError(label, "copy temporary install target");
+  }
+}
+
+function setTemporaryInstallTargetPermissions(target, label) {
+  try {
+    fs.chmodSync(target, 0o755);
+  } catch (_error) {
+    throw installTargetIoError(label, "set temporary install target permissions");
+  }
+}
+
+function replaceInstallTarget(source, target, label) {
+  try {
+    fs.renameSync(source, target);
+  } catch (_error) {
+    throw installTargetIoError(label, "replace install target");
+  }
+}
+
+function removeTemporaryInstallTarget(target) {
+  try {
+    fs.rmSync(target, { force: true });
+  } catch (_error) {
+    // Preserve the original redacted install failure.
+  }
+}
+
+function installTargetIoError(label, action) {
+  return new Error(
+    `failed to ${action} for ${label}; pathDisplayed=false contentsDisplayed=false`
+  );
 }
 
 function temporarySiblingPath(target) {

--- a/packaging/npm/conu-cli/scripts/check-install-target.js
+++ b/packaging/npm/conu-cli/scripts/check-install-target.js
@@ -81,6 +81,66 @@ function main() {
     );
   });
 
+  withFixture((root) => {
+    const source = writeSource(root, "conu");
+    const target = path.join(root, "vendor", "linux-x64", "conu");
+    withPatchedFs({ mkdirSync: () => failWithPath(root) }, () => {
+      expectRedactedFailure(
+        () => install(root, source, target),
+        "failed to create install directory for test binary",
+        root,
+        "redacted install directory creation failure"
+      );
+    });
+  });
+
+  withFixture((root) => {
+    const source = writeSource(root, "conu");
+    const target = path.join(root, "vendor", "linux-x64", "conu");
+    withPatchedFs({ copyFileSync: () => failWithPath(root) }, () => {
+      expectRedactedFailure(
+        () => install(root, source, target),
+        "failed to copy temporary install target for test binary",
+        root,
+        "redacted temporary copy failure"
+      );
+    });
+  });
+
+  if (process.platform !== "win32") {
+    withFixture((root) => {
+      const source = writeSource(root, "conu");
+      const target = path.join(root, "vendor", "linux-x64", "conu");
+      withPatchedFs({ chmodSync: () => failWithPath(root) }, () => {
+        expectRedactedFailure(
+          () => install(root, source, target),
+          "failed to set temporary install target permissions for test binary",
+          root,
+          "redacted temporary permission failure"
+        );
+      });
+    });
+  }
+
+  withFixture((root) => {
+    const source = writeSource(root, "conu");
+    const target = path.join(root, "vendor", "linux-x64", "conu");
+    withPatchedFs(
+      {
+        renameSync: () => failWithPath(root),
+        rmSync: () => failWithPath(root)
+      },
+      () => {
+        expectRedactedFailure(
+          () => install(root, source, target),
+          "failed to replace install target for test binary",
+          root,
+          "redacted replace failure with cleanup failure"
+        );
+      }
+    );
+  });
+
   console.log("install target check passed");
 }
 
@@ -118,6 +178,25 @@ function trySymlink(link, target, type) {
   }
 }
 
+function withPatchedFs(patches, callback) {
+  const originals = {};
+  for (const name of Object.keys(patches)) {
+    originals[name] = fs[name];
+    fs[name] = patches[name];
+  }
+  try {
+    callback();
+  } finally {
+    for (const name of Object.keys(originals)) {
+      fs[name] = originals[name];
+    }
+  }
+}
+
+function failWithPath(root) {
+  throw new Error(`simulated filesystem failure at ${root}`);
+}
+
 function expectFailure(action, expectedMessage, label) {
   try {
     action();
@@ -128,6 +207,28 @@ function expectFailure(action, expectedMessage, label) {
     throw new Error(`${label}: expected ${expectedMessage}, got: ${error.message}`);
   }
   throw new Error(`${label}: expected install target failure`);
+}
+
+function expectRedactedFailure(action, expectedMessage, forbiddenPath, label) {
+  try {
+    action();
+  } catch (error) {
+    const message = error.message;
+    if (!message.includes(expectedMessage)) {
+      throw new Error(`${label}: expected ${expectedMessage}, got: ${message}`);
+    }
+    if (!message.includes("pathDisplayed=false")) {
+      throw new Error(`${label}: missing path display guard: ${message}`);
+    }
+    if (!message.includes("contentsDisplayed=false")) {
+      throw new Error(`${label}: missing contents display guard: ${message}`);
+    }
+    if (message.includes(forbiddenPath)) {
+      throw new Error(`${label}: displayed filesystem path: ${message}`);
+    }
+    return;
+  }
+  throw new Error(`${label}: expected redacted install target failure`);
 }
 
 function expectEqual(actual, expected, label) {


### PR DESCRIPTION
## Summary\n- Wrap npm install target mkdir/copy/chmod/rename failures in neutral redacted errors.\n- Suppress temporary target cleanup errors after an original redacted install failure.\n- Add install-target regression coverage for forced filesystem failures.\n\n## Validation\n- npm run check (packaging/npm/conu-cli)\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-github-workflow-permissions.py\n- git diff --check\n\nCloses #980

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts filesystem errors during `conu-cli` install target operations to avoid leaking paths or contents. Suppresses cleanup noise and adds regression checks for forced I/O failures.

- **Bug Fixes**
  - Wrap `fs.mkdirSync`, `fs.copyFileSync`, `fs.chmodSync` (non-Windows), and `fs.renameSync` in neutral, redacted errors with `pathDisplayed=false contentsDisplayed=false`.
  - Suppress `fs.rmSync` cleanup errors when an install fails to keep the original redacted error.
  - Add regression tests that simulate mkdir/copy/chmod/rename failures and assert redaction (no path leakage).

<sup>Written for commit d44a8ec10b97f48649764c59d3303cd15e7697d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

