### PR TITLE
Redact npm binary stat failures

### DIFF
--- a/packaging/npm/conu-cli/lib/install-target.js
+++ b/packaging/npm/conu-cli/lib/install-target.js
@@ -59,7 +59,7 @@ function assertRegularSource(source, label) {
 }
 
 function assertSafeInstallTarget(target, label) {
-  const stat = lstatMaybe(target);
+  const stat = lstatMaybe(target, `${label} install target`);
   if (!stat) {
     return;
   }
@@ -83,7 +83,7 @@ function assertRegularTempTarget(target, label) {
 
 function assertExistingInstallAncestors(root, targetDir, label) {
   for (const current of pathComponents(root, targetDir, { includeMissing: false })) {
-    const stat = lstatMaybe(current);
+    const stat = lstatMaybe(current, `${label} install directory`);
     if (!stat) {
       return;
     }
@@ -121,7 +121,7 @@ function pathComponents(root, targetDir, { includeMissing }) {
   let current = rootPath;
   for (const part of relative.split(path.sep)) {
     current = path.join(current, part);
-    if (!includeMissing && !lstatMaybe(current)) {
+    if (!includeMissing && !lstatMaybe(current, "install target directory")) {
       break;
     }
     components.push(current);
@@ -190,7 +190,7 @@ function temporarySiblingPath(target) {
       dir,
       `.${base}.${process.pid}.${Date.now()}.${index}.tmp`
     );
-    if (!lstatMaybe(candidate)) {
+    if (!lstatMaybe(candidate, `${base} temporary install target`)) {
       return candidate;
     }
   }
@@ -198,22 +198,28 @@ function temporarySiblingPath(target) {
 }
 
 function lstatRequired(target, label) {
-  const stat = lstatMaybe(target);
+  const stat = lstatMaybe(target, label);
   if (!stat) {
     throw new Error(`missing ${label}: ${path.basename(target)}`);
   }
   return stat;
 }
 
-function lstatMaybe(target) {
+function lstatMaybe(target, label) {
   try {
     return fs.lstatSync(target);
   } catch (error) {
     if (error && error.code === "ENOENT") {
       return null;
     }
-    throw error;
+    throw installTargetInspectionError(label);
   }
+}
+
+function installTargetInspectionError(label) {
+  return new Error(
+    `failed to inspect ${label}; pathDisplayed=false contentsDisplayed=false`
+  );
 }
 
 module.exports = {

--- a/packaging/npm/conu-cli/lib/local-binary-dir.js
+++ b/packaging/npm/conu-cli/lib/local-binary-dir.js
@@ -9,7 +9,7 @@ function resolveLocalBinaries(sourceDir, { binaryNames, binarySuffix }) {
   }
 
   const resolvedDir = path.resolve(sourceDir);
-  const dirStat = lstatMaybe(resolvedDir);
+  const dirStat = lstatMaybe(resolvedDir, "CONU_NPM_BINARY_DIR");
   if (!dirStat) {
     throw new Error("CONU_NPM_BINARY_DIR must point to an existing directory");
   }
@@ -24,7 +24,7 @@ function resolveLocalBinaries(sourceDir, { binaryNames, binarySuffix }) {
   for (const name of binaryNames) {
     const fileName = `${name}${binarySuffix}`;
     const source = path.join(resolvedDir, fileName);
-    const stat = lstatMaybe(source);
+    const stat = lstatMaybe(source, `CONU_NPM_BINARY_DIR required binary ${fileName}`);
     if (!stat) {
       throw new Error(`CONU_NPM_BINARY_DIR missing required binary: ${fileName}`);
     }
@@ -36,15 +36,21 @@ function resolveLocalBinaries(sourceDir, { binaryNames, binarySuffix }) {
   return binaries;
 }
 
-function lstatMaybe(target) {
+function lstatMaybe(target, label) {
   try {
     return fs.lstatSync(target);
   } catch (error) {
     if (error && error.code === "ENOENT") {
       return null;
     }
-    throw error;
+    throw localBinaryDirInspectionError(label);
   }
+}
+
+function localBinaryDirInspectionError(label) {
+  return new Error(
+    `failed to inspect ${label}; pathDisplayed=false contentsDisplayed=false`
+  );
 }
 
 module.exports = {

--- a/packaging/npm/conu-cli/scripts/check-install-target.js
+++ b/packaging/npm/conu-cli/scripts/check-install-target.js
@@ -97,6 +97,19 @@ function main() {
   withFixture((root) => {
     const source = writeSource(root, "conu");
     const target = path.join(root, "vendor", "linux-x64", "conu");
+    withPatchedFs({ lstatSync: () => failWithPath(root) }, () => {
+      expectRedactedFailure(
+        () => install(root, source, target),
+        "failed to inspect test binary source",
+        root,
+        "redacted source inspection failure"
+      );
+    });
+  });
+
+  withFixture((root) => {
+    const source = writeSource(root, "conu");
+    const target = path.join(root, "vendor", "linux-x64", "conu");
     withPatchedFs({ copyFileSync: () => failWithPath(root) }, () => {
       expectRedactedFailure(
         () => install(root, source, target),

--- a/packaging/npm/conu-cli/scripts/check-local-binary-dir.js
+++ b/packaging/npm/conu-cli/scripts/check-local-binary-dir.js
@@ -43,6 +43,41 @@ function main() {
   });
 
   withFixture((root) => {
+    writeBinaries(root);
+    withPatchedFs({ lstatSync: () => failWithPath(root) }, () => {
+      expectRedactedFailure(
+        root,
+        "failed to inspect CONU_NPM_BINARY_DIR",
+        root,
+        "redacted source directory inspection failure"
+      );
+    });
+  });
+
+  withFixture((root) => {
+    writeBinaries(root);
+    const originalLstatSync = fs.lstatSync;
+    withPatchedFs(
+      {
+        lstatSync: (target) => {
+          if (path.basename(target) === "conud") {
+            failWithPath(root);
+          }
+          return originalLstatSync.call(fs, target);
+        }
+      },
+      () => {
+        expectRedactedFailure(
+          root,
+          "failed to inspect CONU_NPM_BINARY_DIR required binary conud",
+          root,
+          "redacted required binary inspection failure"
+        );
+      }
+    );
+  });
+
+  withFixture((root) => {
     writeBinaries(root, { skip: "conu-relay" });
     fs.mkdirSync(path.join(root, "conu-relay"));
     expectFailure(root, "not a regular file: conu-relay", "directory named as binary");
@@ -90,6 +125,25 @@ function trySymlink(link, target, type) {
   }
 }
 
+function withPatchedFs(patches, callback) {
+  const originals = {};
+  for (const name of Object.keys(patches)) {
+    originals[name] = fs[name];
+    fs[name] = patches[name];
+  }
+  try {
+    callback();
+  } finally {
+    for (const name of Object.keys(originals)) {
+      fs[name] = originals[name];
+    }
+  }
+}
+
+function failWithPath(root) {
+  throw new Error(`simulated filesystem failure at ${root}`);
+}
+
 function resolve(sourceDir) {
   return resolveLocalBinaries(sourceDir, {
     binaryNames: BINARIES,
@@ -107,6 +161,28 @@ function expectFailure(sourceDir, expectedMessage, label) {
     throw new Error(`${label}: expected ${expectedMessage}, got: ${error.message}`);
   }
   throw new Error(`${label}: expected local binary dir failure`);
+}
+
+function expectRedactedFailure(sourceDir, expectedMessage, forbiddenPath, label) {
+  try {
+    resolve(sourceDir);
+  } catch (error) {
+    const message = error.message;
+    if (!message.includes(expectedMessage)) {
+      throw new Error(`${label}: expected ${expectedMessage}, got: ${message}`);
+    }
+    if (!message.includes("pathDisplayed=false")) {
+      throw new Error(`${label}: missing path display guard: ${message}`);
+    }
+    if (!message.includes("contentsDisplayed=false")) {
+      throw new Error(`${label}: missing contents display guard: ${message}`);
+    }
+    if (message.includes(forbiddenPath)) {
+      throw new Error(`${label}: displayed filesystem path: ${message}`);
+    }
+    return;
+  }
+  throw new Error(`${label}: expected redacted local binary dir failure`);
 }
 
 function expectEqual(actual, expected, label) {


### PR DESCRIPTION
## Summary\n- Redact non-ENOENT npm install target lstat failures.\n- Redact non-ENOENT CONU_NPM_BINARY_DIR and required binary lstat failures.\n- Add regression coverage for forced stat failures that include fixture paths.\n\n## Validation\n- npm run check (packaging/npm/conu-cli)\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-github-workflow-permissions.py\n- git diff --check\n\nCloses #982

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts filesystem paths from `packaging/npm/conu-cli` lstat failures for install targets and `CONU_NPM_BINARY_DIR`, preventing path/content leakage. Adds regression tests to verify redaction while keeping ENOENT handling unchanged.

- **Bug Fixes**
  - `lib/install-target.js`: label-aware lstat checks; non-ENOENT errors now throw redacted messages via `installTargetInspectionError`.
  - `lib/local-binary-dir.js`: redacted errors for `CONU_NPM_BINARY_DIR` and required binaries via `localBinaryDirInspectionError`.
  - ENOENT continues to return null; only non-ENOENT cases are redacted.
  - Tests updated (`check-install-target.js`, `check-local-binary-dir.js`) to simulate fs failures and assert redaction flags and absence of fixture paths.

<sup>Written for commit 7cbcf7b08844bc8ecee4cdee8f78452647d56959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filesystem inspection errors now display consistent, user-friendly messages that redact sensitive path information.
  * Improved error reporting context during binary validation and installation.

* **Tests**
  * Added tests validating proper error redaction behavior and message clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->