### PR TITLE
Redact npm extracted tree inspection failures

### DIFF
--- a/packaging/npm/conu-cli/lib/extract-selection.js
+++ b/packaging/npm/conu-cli/lib/extract-selection.js
@@ -36,7 +36,7 @@ function resolveExtractedBinaries(
   for (const name of binaryNames) {
     const fileName = `${name}${binarySuffix}`;
     const expectedPath = path.join(root, "bin", fileName);
-    if (!isFile(expectedPath)) {
+    if (!isFile(expectedPath, archiveName)) {
       throw new Error(`archive ${archiveName} missing expected binary: bin/${fileName}`);
     }
 
@@ -59,8 +59,8 @@ function resolveReleaseRoot(extractDir, archiveName, expectedRootName) {
   const rootlessManifest = path.join(extractDir, "manifest.toml");
   const rootedDir = path.join(extractDir, expectedRootName);
   const rootedManifest = path.join(rootedDir, "manifest.toml");
-  const hasRootless = isFile(rootlessManifest);
-  const hasRooted = isFile(rootedManifest);
+  const hasRootless = isFile(rootlessManifest, archiveName);
+  const hasRooted = isFile(rootedManifest, archiveName);
 
   if (hasRootless && hasRooted) {
     throw new Error(`archive ${archiveName} contains multiple release roots`);
@@ -88,9 +88,9 @@ function collectBinaryMatches(root, fileNames, archiveName, limits) {
 }
 
 function visit(root, archiveName, limits, onEntry, depth = 0, state = { entries: 0 }) {
-  const dir = fs.opendirSync(root);
+  const dir = openExtractedTreeDirectory(root, archiveName);
   try {
-    let entry = dir.readSync();
+    let entry = readExtractedTreeDirectory(dir, archiveName);
     while (entry !== null) {
       state.entries += 1;
       if (state.entries > limits.maxEntries) {
@@ -111,7 +111,7 @@ function visit(root, archiveName, limits, onEntry, depth = 0, state = { entries:
       if (entry.isDirectory()) {
         visit(entryPath, archiveName, limits, onEntry, entryDepth, state);
       }
-      entry = dir.readSync();
+      entry = readExtractedTreeDirectory(dir, archiveName);
     }
   } finally {
     dir.closeSync();
@@ -125,15 +125,37 @@ function parsePositiveInteger(value, label, archiveName) {
   return value;
 }
 
-function isFile(filePath) {
+function isFile(filePath, archiveName) {
   try {
     return fs.statSync(filePath).isFile();
   } catch (error) {
     if (error && error.code === "ENOENT") {
       return false;
     }
-    throw error;
+    throw extractedTreeInspectionError(archiveName);
   }
+}
+
+function openExtractedTreeDirectory(root, archiveName) {
+  try {
+    return fs.opendirSync(root);
+  } catch (_error) {
+    throw extractedTreeInspectionError(archiveName);
+  }
+}
+
+function readExtractedTreeDirectory(dir, archiveName) {
+  try {
+    return dir.readSync();
+  } catch (_error) {
+    throw extractedTreeInspectionError(archiveName);
+  }
+}
+
+function extractedTreeInspectionError(archiveName) {
+  return new Error(
+    `failed to inspect extracted tree for archive ${archiveName}; pathDisplayed=false contentsDisplayed=false`
+  );
 }
 
 function samePath(left, right) {

--- a/packaging/npm/conu-cli/scripts/check-extract-selection.js
+++ b/packaging/npm/conu-cli/scripts/check-extract-selection.js
@@ -65,6 +65,30 @@ function main() {
 
   withFixture((root) => {
     writeReleaseLayout(root);
+    withPatchedFs({ statSync: () => failWithPath(root) }, () => {
+      expectRedactedFailure(
+        root,
+        "failed to inspect extracted tree",
+        root,
+        "redacted extracted stat failure"
+      );
+    });
+  });
+
+  withFixture((root) => {
+    writeReleaseLayout(root);
+    withPatchedFs({ opendirSync: () => failWithPath(root) }, () => {
+      expectRedactedFailure(
+        root,
+        "failed to inspect extracted tree",
+        root,
+        "redacted extracted directory open failure"
+      );
+    });
+  });
+
+  withFixture((root) => {
+    writeReleaseLayout(root);
     expectFailure(
       root,
       "exceeds maximum entry count",
@@ -126,6 +150,25 @@ function writeFile(filePath, content) {
   fs.writeFileSync(filePath, content);
 }
 
+function withPatchedFs(patches, callback) {
+  const originals = {};
+  for (const name of Object.keys(patches)) {
+    originals[name] = fs[name];
+    fs[name] = patches[name];
+  }
+  try {
+    callback();
+  } finally {
+    for (const name of Object.keys(originals)) {
+      fs[name] = originals[name];
+    }
+  }
+}
+
+function failWithPath(root) {
+  throw new Error(`simulated filesystem failure at ${root}`);
+}
+
 function expectResolved(root, expectedRoot, label) {
   const resolved = resolveExtractedBinaries(root, resolveOptions());
   for (const name of BINARIES) {
@@ -143,6 +186,28 @@ function expectFailure(root, expectedMessage, label, overrides = {}) {
     throw new Error(`${label}: expected ${expectedMessage}, got: ${error.message}`);
   }
   throw new Error(`${label}: expected extract selection failure`);
+}
+
+function expectRedactedFailure(root, expectedMessage, forbiddenPath, label, overrides = {}) {
+  try {
+    resolveExtractedBinaries(root, resolveOptions(overrides));
+  } catch (error) {
+    const message = error.message;
+    if (!message.includes(expectedMessage)) {
+      throw new Error(`${label}: expected ${expectedMessage}, got: ${message}`);
+    }
+    if (!message.includes("pathDisplayed=false")) {
+      throw new Error(`${label}: missing path display guard: ${message}`);
+    }
+    if (!message.includes("contentsDisplayed=false")) {
+      throw new Error(`${label}: missing contents display guard: ${message}`);
+    }
+    if (message.includes(forbiddenPath)) {
+      throw new Error(`${label}: displayed filesystem path: ${message}`);
+    }
+    return;
+  }
+  throw new Error(`${label}: expected redacted extract selection failure`);
 }
 
 function resolveOptions(overrides = {}) {


### PR DESCRIPTION
## Summary\n- Redact extracted-tree stat/open/read inspection failures during npm archive binary selection.\n- Keep missing-file behavior unchanged while redacting non-ENOENT filesystem failures.\n- Add regression coverage for forced path-bearing stat and directory-open failures.\n\n## Validation\n- npm run check (packaging/npm/conu-cli)\n- python scripts\\verify-npm-package-contents.py\n- python scripts\\verify-npm-package-contents-regression.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-github-workflow-permissions.py\n- git diff --check\n\nCloses #984

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts filesystem details in extracted-tree inspection errors during `conu-cli` npm archive binary selection. ENOENT “missing file” behavior is unchanged; other filesystem failures are now redacted and covered by tests.

- **Bug Fixes**
  - Wrap `stat`, directory open, and directory read failures with a generic “failed to inspect extracted tree” error including `pathDisplayed=false` and `contentsDisplayed=false`.
  - Keep missing-binary checks intact by passing `archiveName` into `isFile` and only redacting non-ENOENT errors.
  - Add regression tests for redacted `stat` and directory-open failures.

<sup>Written for commit b9e037f28fd49950e488c9460e77c9412d51edb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

