### PR TITLE
Redact npm archive member preflight failures

### DIFF
--- a/packaging/npm/conu-cli/lib/archive-preflight.js
+++ b/packaging/npm/conu-cli/lib/archive-preflight.js
@@ -49,11 +49,14 @@ function assertSafeArchiveMemberList(members, archiveLabel = "archive") {
     const name = typeof member === "string" ? member : member.name;
     const type = typeof member === "string" ? "file" : member.type || "unknown";
     if (!SUPPORTED_MEMBER_TYPES.has(type)) {
-      throw new Error(`${archiveLabel} contains unsupported ${type} member: ${name}`);
+      throw archiveMemberPathError(
+        archiveLabel,
+        `contains unsupported ${formatMemberTypeForError(type)} member`
+      );
     }
     const normalized = validateArchiveMemberName(name, archiveLabel);
     if (paths.has(normalized)) {
-      throw new Error(`${archiveLabel} contains duplicate archive path: ${normalized}`);
+      throw archiveMemberPathError(archiveLabel, "contains duplicate archive path");
     }
     paths.add(normalized);
     rejectForbiddenArchivePath(normalized, archiveLabel);
@@ -62,24 +65,24 @@ function assertSafeArchiveMemberList(members, archiveLabel = "archive") {
 
 function validateArchiveMemberName(name, archiveLabel) {
   if (typeof name !== "string" || name.length === 0) {
-    throw new Error(`${archiveLabel} contains an empty archive member path`);
+    throw archiveMemberPathError(archiveLabel, "contains an empty archive member path");
   }
   if (name.includes("\0") || name.includes("\r") || name.includes("\n")) {
-    throw new Error(`${archiveLabel} contains an unsafe archive path: ${name}`);
+    throw archiveMemberPathError(archiveLabel, "contains an unsafe archive path");
   }
 
   const normalized = name.replace(/\\/g, "/");
   const hasWindowsDrive = /^[A-Za-z]:/.test(normalized);
   if (path.posix.isAbsolute(normalized) || hasWindowsDrive || normalized.startsWith("//")) {
-    throw new Error(`${archiveLabel} contains an absolute archive path: ${name}`);
+    throw archiveMemberPathError(archiveLabel, "contains an absolute archive path");
   }
 
   const parts = normalized.split("/").filter((part) => part !== "" && part !== ".");
   if (parts.length === 0) {
-    throw new Error(`${archiveLabel} contains an empty archive member path`);
+    throw archiveMemberPathError(archiveLabel, "contains an empty archive member path");
   }
   if (parts.includes("..")) {
-    throw new Error(`${archiveLabel} contains a parent-traversal archive path: ${name}`);
+    throw archiveMemberPathError(archiveLabel, "contains a parent-traversal archive path");
   }
   return parts.join("/");
 }
@@ -89,14 +92,27 @@ function rejectForbiddenArchivePath(normalized, archiveLabel) {
   const lowerParts = new Set(parts.map((part) => part.toLowerCase()));
   for (const forbidden of FORBIDDEN_PARTS) {
     if (lowerParts.has(forbidden)) {
-      throw new Error(`${archiveLabel} contains forbidden state path: ${normalized}`);
+      throw archiveMemberPathError(archiveLabel, "contains forbidden state path");
     }
   }
 
   const fileName = parts[parts.length - 1].toLowerCase();
   if (FORBIDDEN_NAMES.has(fileName)) {
-    throw new Error(`${archiveLabel} contains forbidden state path: ${normalized}`);
+    throw archiveMemberPathError(archiveLabel, "contains forbidden state path");
   }
+}
+
+function archiveMemberPathError(archiveLabel, reason) {
+  return new Error(
+    `${archiveLabel} ${reason}; pathDisplayed=false contentsDisplayed=false`
+  );
+}
+
+function formatMemberTypeForError(type) {
+  if (["symlink", "hardlink", "encrypted", "other", "unknown"].includes(type)) {
+    return type;
+  }
+  return "unsupported";
 }
 
 function listArchiveMembers(archivePath, archiveLabel) {

--- a/packaging/npm/conu-cli/scripts/check-archive-preflight.js
+++ b/packaging/npm/conu-cli/scripts/check-archive-preflight.js
@@ -37,6 +37,7 @@ function main() {
   expectFail([{ name: "conu-0.1.0/.conu/state.toml", type: "file" }], "forbidden state path");
   expectFail([{ name: "conu-0.1.0/security/identity.key", type: "file" }], "forbidden state path");
   expectFail([{ name: "conu-0.1.0/runtime/node.toml", type: "file" }], "forbidden state path");
+  expectArchiveMemberFailurePathsAreRedacted();
   expectFail(makeMemberList(MAX_ARCHIVE_MEMBERS + 1), `more than ${MAX_ARCHIVE_MEMBERS} entries`);
   expectNativeZipInspection();
   expectArchiveInspectionPathRedacted();
@@ -58,6 +59,55 @@ function expectFail(members, expectedMessage) {
     throw new Error(`expected ${expectedMessage}, got: ${error.message}`);
   }
   throw new Error(`expected archive preflight failure: ${expectedMessage}`);
+}
+
+function expectFailWithoutArchiveMember(members, expectedMessage, forbiddenValues, label) {
+  try {
+    assertSafeArchiveMemberList(members, "fixture");
+  } catch (error) {
+    if (!error.message.includes(expectedMessage)) {
+      throw new Error(`${label}: expected ${expectedMessage}, got: ${error.message}`);
+    }
+    expectRedactedMemberFailure(error.message, forbiddenValues, label);
+    return;
+  }
+  throw new Error(`${label}: expected archive preflight failure`);
+}
+
+function expectArchiveMemberFailurePathsAreRedacted() {
+  expectFailWithoutArchiveMember(
+    [{ name: "conu-0.1.0/.conu/secret-node-state.toml", type: "file" }],
+    "forbidden state path",
+    [".conu", "secret-node-state.toml"],
+    "forbidden state member path"
+  );
+  expectFailWithoutArchiveMember(
+    [{ name: "conu-0.1.0/bin/conu\nsecret-token-fragment", type: "file" }],
+    "unsafe archive path",
+    ["secret-token-fragment"],
+    "unsafe member path"
+  );
+  expectFailWithoutArchiveMember(
+    [{ name: "C:\\Users\\parth\\AppData\\Local\\Temp\\conu.exe", type: "file" }],
+    "absolute archive path",
+    ["C:\\Users\\parth", "AppData", "conu.exe"],
+    "absolute member path"
+  );
+  expectFailWithoutArchiveMember(
+    [{ name: "conu-0.1.0/secret-bin/conu", type: "symlink" }],
+    "unsupported symlink member",
+    ["secret-bin", "conu"],
+    "unsupported member path"
+  );
+  expectFailWithoutArchiveMember(
+    [
+      { name: "conu-0.1.0/bin/secret-conu", type: "file" },
+      { name: "conu-0.1.0/bin/./secret-conu", type: "file" }
+    ],
+    "duplicate archive path",
+    ["secret-conu"],
+    "duplicate member path"
+  );
 }
 
 function makeMemberList(count) {
@@ -219,6 +269,20 @@ function expectArchiveInspectionFailurePathGuard() {
     throw new Error("expected archive inspection failure");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function expectRedactedMemberFailure(message, forbiddenValues, label) {
+  if (!message.includes("pathDisplayed=false")) {
+    throw new Error(`${label}: missing path display guard: ${message}`);
+  }
+  if (!message.includes("contentsDisplayed=false")) {
+    throw new Error(`${label}: missing contents display guard: ${message}`);
+  }
+  for (const value of forbiddenValues) {
+    if (message.includes(value)) {
+      throw new Error(`${label}: displayed archive member value ${value}: ${message}`);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #986.

## Summary
- redact npm archive member preflight rejection messages so unsafe member paths are not printed
- keep failure reasons plus pathDisplayed=false and contentsDisplayed=false guards
- add regressions for forbidden state paths, unsafe names, absolute Windows-looking paths, unsupported members, and duplicate member paths

## Validation
- npm run check (packaging/npm/conu-cli)
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- python scripts/check-python-script-compile.py
- python scripts/check-github-workflow-permissions.py
- git diff --check

## Security Review
- payload exposure risk: reduces installer stderr exposure from malicious or malformed archive member names; no payload handling added
- trust/permission risk: no trust, permission, identity, SDK, IPC, or authorization behavior changed
- storage/logging risk: npm archive preflight errors keep rejection classes but no longer print archive member paths or local-looking state paths
- relay/network risk: no relay, route, transport, redirect, or network behavior changed
- required fixes: live tagged release publishing remains blocked on issue #274 until signing secrets are configured; `NPM_TOKEN` is present but must be rotated before publishing because it was pasted in chat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacted npm archive member preflight errors to remove member paths and file names, preventing leaks in installer output. Kept clear failure reasons and added pathDisplayed=false and contentsDisplayed=false guards.

- **Bug Fixes**
  - Centralized error creation to omit member paths while preserving reasons (duplicate, forbidden, unsafe, absolute, unsupported).
  - Added regression tests for forbidden state paths, unsafe names, Windows-like absolute paths, unsupported member types, and duplicate paths; verify redaction and guard flags.

<sup>Written for commit 8e1350314c2a227994d12ad60db0aa74a6ce4106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

