### PR TITLE
Redact release archive member verifier failures

### DIFF
--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -177,6 +177,34 @@ def expect_failure(
     raise AssertionError(f"{description} unexpectedly passed")
 
 
+def expect_redacted_member_failure(
+    description: str,
+    action,
+    expected: str,
+    forbidden_values: tuple[str, ...],
+) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+        if expected not in message:
+            raise AssertionError(
+                f"{description} failed with {message!r}, expected {expected!r}"
+            ) from exc
+        for guard in ("pathDisplayed=false", "contentsDisplayed=false"):
+            if guard not in message:
+                raise AssertionError(
+                    f"{description} omitted display guard {guard}: {message!r}"
+                ) from exc
+        for value in forbidden_values:
+            if value in message:
+                raise AssertionError(
+                    f"{description} leaked forbidden value {value!r}: {message!r}"
+                ) from exc
+        return
+    raise AssertionError(f"{description} unexpectedly passed")
+
+
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:
     try:
         os.symlink(target, link, target_is_directory=target_is_directory)
@@ -290,44 +318,60 @@ def main() -> int:
 
         duplicate = root / "conu-0.1.0-duplicate.zip"
         write_zip(duplicate, {f"{archive_prefix(duplicate)}/./manifest.toml": b"duplicate"})
-        expect_failure(
+        expect_redacted_member_failure(
             "duplicate normalized path",
             lambda: verifier.archive_members(duplicate),
             "duplicate archive path",
+            ("manifest.toml",),
         )
 
         encrypted = root / "conu-0.1.0-encrypted.zip"
         write_zip(encrypted)
         mark_zip_member_encrypted(encrypted, f"{archive_prefix(encrypted)}/bin/conu")
-        expect_failure(
+        expect_redacted_member_failure(
             "encrypted zip member",
             lambda: verifier.archive_members(encrypted),
             "encrypted zip member",
+            ("bin/conu",),
         )
 
         corrupt_member = root / "conu-0.1.0-corrupt-member.zip"
         write_zip(corrupt_member)
         corrupt_zip_member_data(corrupt_member, f"{archive_prefix(corrupt_member)}/bin/conu")
-        expect_failure(
+        expect_redacted_member_failure(
             "corrupt zip member",
             lambda: verifier.archive_members(corrupt_member),
             "could not read zip member",
+            ("bin/conu",),
+        )
+
+        secret_corrupt_member = root / "conu-0.1.0-secret-corrupt-member.zip"
+        secret_corrupt_path = f"{archive_prefix(secret_corrupt_member)}/docs/secret-local-path.txt"
+        write_zip(secret_corrupt_member, {secret_corrupt_path: b"secret path fixture"})
+        corrupt_zip_member_data(secret_corrupt_member, secret_corrupt_path)
+        expect_redacted_member_failure(
+            "corrupt secret-named zip member",
+            lambda: verifier.archive_members(secret_corrupt_member),
+            "could not read zip member",
+            ("secret-local-path.txt",),
         )
 
         forbidden = root / "conu-0.1.0-forbidden.zip"
         write_zip(forbidden, {f"{archive_prefix(forbidden)}/.conu/node.toml": b"state"})
-        expect_failure(
+        expect_redacted_member_failure(
             "forbidden state path",
             lambda: verify_archive(verifier, forbidden),
             "forbidden release archive path",
+            (".conu", "node.toml"),
         )
 
         forbidden_dir = root / "conu-0.1.0-forbidden-dir.zip"
         write_zip(forbidden_dir, {f"{archive_prefix(forbidden_dir)}/security/": b""})
-        expect_failure(
+        expect_redacted_member_failure(
             "forbidden state directory",
             lambda: verify_archive(verifier, forbidden_dir),
             "forbidden release archive path",
+            ("security",),
         )
 
         forbidden_env = root / "conu-0.1.0-forbidden-env.zip"
@@ -369,26 +413,41 @@ def main() -> int:
 
         wrong_root = root / "conu-0.1.0-wrong-root.zip"
         write_zip(wrong_root, prefix="conu-9.9.9-test")
-        expect_failure(
+        expect_redacted_member_failure(
             "unexpected archive root",
             lambda: verifier.archive_members(wrong_root),
             "unexpected archive root",
+            ("conu-9.9.9-test",),
         )
 
         mixed_root = root / "conu-0.1.0-mixed-root.zip"
         write_zip(mixed_root, {"bin/conu": b"rootless duplicate"})
-        expect_failure(
+        expect_redacted_member_failure(
             "mixed rooted and rootless archive paths",
             lambda: verifier.archive_members(mixed_root),
             "mixes rooted and rootless",
+            ("bin/conu",),
         )
 
         data_dir = root / "conu-0.1.0-data-dir.zip"
         write_zip(data_dir, {f"{archive_prefix(data_dir)}/docs/": b"payload"})
-        expect_failure(
+        expect_redacted_member_failure(
             "data-bearing directory",
             lambda: verifier.archive_members(data_dir),
             "directory member with data",
+            ("docs/",),
+        )
+
+        windows_path = root / "conu-0.1.0-windows-path.zip"
+        write_zip(
+            windows_path,
+            {"C:\\Users\\parth\\AppData\\Local\\Temp\\conu-secret.exe": b"secret"},
+        )
+        expect_redacted_member_failure(
+            "windows absolute archive path",
+            lambda: verifier.archive_members(windows_path),
+            "unsafe archive path",
+            ("C:\\Users\\parth", "AppData", "conu-secret.exe"),
         )
 
     print("release artifact verifier regression checks passed")

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -71,6 +71,12 @@ class ArchiveMembers:
     manifest: bytes | None
 
 
+def archive_member_path_error(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(
+        f"{archive_name} {reason}; pathDisplayed=false contentsDisplayed=false"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("dist", type=Path, help="directory containing release archives")
@@ -184,8 +190,8 @@ def archive_members(archive: Path) -> ArchiveMembers:
                 for member in package.infolist():
                     if member.is_dir():
                         if member.file_size != 0:
-                            raise SystemExit(
-                                f"{archive.name} contains directory member with data: {member.filename}"
+                            raise archive_member_path_error(
+                                archive.name, "contains directory member with data"
                             )
                         _, total_uncompressed, entry_count, root_style = record_entry(
                             archive.name,
@@ -200,17 +206,17 @@ def archive_members(archive: Path) -> ArchiveMembers:
                         )
                         continue
                     if member.flag_bits & 0x1:
-                        raise SystemExit(
-                            f"{archive.name} contains encrypted zip member: {member.filename}"
+                        raise archive_member_path_error(
+                            archive.name, "contains encrypted zip member"
                         )
                     file_type = (member.external_attr >> 16) & 0o170000
                     if file_type == stat.S_IFLNK:
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported link member: {member.filename}"
+                        raise archive_member_path_error(
+                            archive.name, "contains unsupported link member"
                         )
                     if file_type not in {0, stat.S_IFREG}:
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported zip member: {member.filename}"
+                        raise archive_member_path_error(
+                            archive.name, "contains unsupported zip member"
                         )
                     normalized, total_uncompressed, entry_count, root_style = record_entry(
                         archive.name,
@@ -260,8 +266,8 @@ def archive_members(archive: Path) -> ArchiveMembers:
                         )
                         continue
                     if not member.isfile():
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported non-file member: {member.name}"
+                        raise archive_member_path_error(
+                            archive.name, "contains unsupported non-file member"
                         )
                     normalized, total_uncompressed, entry_count, root_style = record_entry(
                         archive.name,
@@ -384,24 +390,24 @@ def record_entry(
     allow_empty: bool = False,
 ) -> tuple[str, int, int, str | None]:
     if size < 0:
-        raise SystemExit(f"{archive_name} contains member with invalid size: {raw_name}")
+        raise archive_member_path_error(archive_name, "contains member with invalid size")
     if size > MAX_MEMBER_BYTES:
-        raise SystemExit(f"{archive_name} member is too large: {raw_name}")
+        raise archive_member_path_error(archive_name, "member is too large")
 
     entry_count += 1
     if entry_count > MAX_MEMBER_COUNT:
         raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
 
-    normalized, member_root_style = normalize_member(raw_name, expected_root)
+    normalized, member_root_style = normalize_member(raw_name, archive_name, expected_root)
     root_style = update_archive_root_style(
         archive_name, raw_name, root_style, member_root_style
     )
     if not normalized:
         if allow_empty:
             return normalized, total_uncompressed, entry_count, root_style
-        raise SystemExit(f"{archive_name} contains empty archive path: {raw_name}")
+        raise archive_member_path_error(archive_name, "contains empty archive path")
     if normalized in paths:
-        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+        raise archive_member_path_error(archive_name, "contains duplicate archive path")
 
     paths.add(normalized)
 
@@ -425,9 +431,7 @@ def read_zip_member(
         with package.open(member, "r") as handle:
             return read_limited(archive_name, "manifest.toml", handle, limit)
     except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
-        raise SystemExit(
-            f"{archive_name} could not read zip member: {member.filename}"
-        ) from exc
+        raise archive_member_path_error(archive_name, "could not read zip member") from exc
 
 
 def drain_zip_member(
@@ -440,9 +444,7 @@ def drain_zip_member(
             while handle.read(HASH_CHUNK_BYTES):
                 pass
     except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
-        raise SystemExit(
-            f"{archive_name} could not read zip member: {member.filename}"
-        ) from exc
+        raise archive_member_path_error(archive_name, "could not read zip member") from exc
 
 
 def read_limited(archive_name: str, member_name: str, handle, limit: int) -> bytes:
@@ -460,21 +462,20 @@ def expected_archive_root(archive_name: str) -> str:
     raise SystemExit(f"unsupported release archive {archive_name}")
 
 
-def normalize_member(name: str, expected_root: str) -> tuple[str, str | None]:
+def normalize_member(name: str, archive_name: str, expected_root: str) -> tuple[str, str | None]:
     normalized = name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe archive path: {name}")
+    has_windows_drive = re.match(r"^[A-Za-z]:", normalized) is not None
+    if path.is_absolute() or has_windows_drive or normalized.startswith("//") or ".." in parts:
+        raise archive_member_path_error(archive_name, "contains unsafe archive path")
     root_style = None
     if parts:
         if parts[0] == expected_root:
             root_style = "rooted"
             parts = parts[1:]
         elif parts[0].startswith("conu-"):
-            raise SystemExit(
-                f"unexpected archive root: {parts[0]} (expected {expected_root})"
-            )
+            raise archive_member_path_error(archive_name, "contains unexpected archive root")
         else:
             root_style = "rootless"
     return "/".join(parts), root_style
@@ -489,8 +490,8 @@ def update_archive_root_style(
     if member_style is None:
         return current
     if current is not None and current != member_style:
-        raise SystemExit(
-            f"{archive_name} mixes rooted and rootless archive paths: {raw_name}"
+        raise archive_member_path_error(
+            archive_name, "mixes rooted and rootless archive paths"
         )
     return member_style
 
@@ -518,7 +519,9 @@ def verify_members(archive: Path, members: ArchiveMembers) -> None:
 
     for path in sorted(paths):
         if is_forbidden_release_path(path):
-            raise SystemExit(f"{archive.name} contains forbidden release archive path: {path}")
+            raise archive_member_path_error(
+                archive.name, "contains forbidden release archive path"
+            )
 
 
 def required_binary_paths(paths: set[str]) -> set[str]:


### PR DESCRIPTION
Closes #988.

## Summary
- redact release artifact verifier errors that previously included raw archive member names
- add explicit pathDisplayed=false and contentsDisplayed=false guards to member-specific verifier failures
- reject Windows drive-style archive member paths as unsafe instead of treating them as rootless release entries
- add regressions for duplicate, encrypted, corrupt, forbidden-state, wrong-root, mixed-root, data-bearing directory, and Windows path members

## Validation
- python scripts/check-release-artifact-verifier.py
- python scripts/check-python-script-compile.py
- python scripts/verify-npm-package-contents.py
- python scripts/verify-npm-package-contents-regression.py
- npm run check (packaging/npm/conu-cli)
- python scripts/check-github-workflow-permissions.py
- git diff --check
- ./scripts/verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions

## Security Review
- payload exposure risk: reduces CI/verifier output exposure from malicious or malformed release archive member names; no payload inspection added
- trust/permission risk: no trust, permission, identity, SDK, IPC, or authorization behavior changed
- storage/logging risk: release verifier failures keep rejection classes but no longer print archive member paths or local-state-looking member values
- relay/network risk: no relay, route, transport, download URL policy, redirect policy, or network behavior changed
- required fixes: live tagged release publishing remains blocked on issue #274 until signing secrets are configured; `NPM_TOKEN` is present but must be rotated before publishing because it was pasted in chat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts release verifier errors to avoid leaking archive member names and adds display guards in all paths. Also rejects Windows drive-style and UNC-like member paths as unsafe and adds regressions for key failure cases.

- **Bug Fixes**
  - Centralized error formatting (`archive_member_path_error`) to include `pathDisplayed=false` and `contentsDisplayed=false`.
  - Stopped printing member names for duplicate/forbidden/encrypted/corrupt/unsupported path errors while preserving rejection classes.
  - Treated Windows absolute or drive-letter paths as unsafe instead of rootless; added regressions for duplicates, encrypted/corrupt members, forbidden state files/dirs, unexpected root, mixed roots, data-bearing dirs, and Windows paths.

<sup>Written for commit ee9468ee2d393444df3d0f882ae994e2cc4dfa36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

