### PR TITLE
Redact release smoke archive member failures

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -162,6 +162,8 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "unexpected archive root",
             "unexpected manifest root",
+            forbidden="conu-9.9.9-test",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -177,6 +179,8 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "mixes rooted and rootless",
             "mixed manifest root style",
+            forbidden="conu-0.1.0-mixed/bin/conu",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -193,6 +197,8 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "duplicate archive path",
             "duplicate path during manifest read",
+            forbidden="bin/conu",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -205,6 +211,8 @@ def main() -> int:
                 lambda: smoke.read_manifest_target(archive),
                 "member is too large",
                 "oversized manifest read member",
+                forbidden="manifest.toml",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_MEMBER_BYTES = original_limit
@@ -252,6 +260,8 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "unsupported zip member",
             "unsupported member during manifest read",
+            forbidden="device",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -262,6 +272,20 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "encrypted zip member",
             "encrypted member during manifest read",
+            forbidden="bin/conu",
+            require_member_redaction=True,
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-drive.zip"
+        drive_member = "C:\\secret-manifest-path-should-not-print"
+        write_zip_entries(archive, [(drive_member, "x")])
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "unsafe archive path",
+            "manifest read Windows drive path",
+            forbidden="secret-manifest-path-should-not-print",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -281,6 +305,8 @@ def main() -> int:
             lambda: smoke.find_package_root(Path("conu-0.1.0-test.zip"), root),
             "unexpected archive root",
             "unexpected extracted root",
+            forbidden="conu-9.9.9-test",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -296,6 +322,8 @@ def main() -> int:
             lambda: smoke.extract_archive(archive, root / "extract-duplicate"),
             "duplicate archive path",
             "duplicate extracted path",
+            forbidden="bin/conu",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -308,6 +336,8 @@ def main() -> int:
                 lambda: smoke.extract_archive(archive, root / "extract-large"),
                 "member is too large",
                 "oversized extracted member",
+                forbidden="bin/conu",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_MEMBER_BYTES = original_limit
@@ -349,6 +379,20 @@ def main() -> int:
             lambda: smoke.extract_archive(archive, root / "extract-unsupported"),
             "unsupported zip member",
             "unsupported zip member type",
+            forbidden="device",
+            require_member_redaction=True,
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-drive.zip"
+        drive_member = "C:\\secret-extract-path-should-not-print"
+        write_zip_entries(archive, [(drive_member, "x")])
+        expect_action_failure(
+            lambda: smoke.extract_archive(archive, root / "extract-drive"),
+            "unsafe archive path",
+            "extracted Windows drive path",
+            forbidden="secret-extract-path-should-not-print",
+            require_member_redaction=True,
         )
 
     print("npm launcher local smoke preflight check passed")
@@ -491,6 +535,7 @@ def expect_action_failure(
     label: str,
     *,
     forbidden: str | None = None,
+    require_member_redaction: bool = False,
 ) -> None:
     try:
         action()
@@ -498,6 +543,12 @@ def expect_action_failure(
         message = str(exc)
         if forbidden is not None and forbidden in message:
             raise SystemExit(f"{label}: error leaked forbidden value: {message}") from exc
+        if require_member_redaction:
+            for marker in ("pathDisplayed=false", "contentsDisplayed=false"):
+                if marker not in message:
+                    raise SystemExit(
+                        f"{label}: error missing redaction marker {marker}: {message}"
+                    ) from exc
         if expected in message:
             return
         raise SystemExit(f"{label}: expected {expected}, got: {message}") from exc

--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -94,6 +94,8 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "unexpected archive root",
             "unexpected manifest root",
+            forbidden="conu-9.9.9-test",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -109,6 +111,8 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "mixes rooted and rootless",
             "mixed manifest root style",
+            forbidden="conu-0.1.0-mixed/bin/conu",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -125,6 +129,8 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "duplicate archive path",
             "duplicate path during manifest read",
+            forbidden="bin/conu",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -137,6 +143,8 @@ def main() -> int:
                 lambda: smoke.read_manifest_target(archive),
                 "member is too large",
                 "oversized manifest read member",
+                forbidden="manifest.toml",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_MEMBER_BYTES = original_limit
@@ -184,6 +192,8 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "unsupported zip member",
             "unsupported member during manifest read",
+            forbidden="device",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -194,6 +204,20 @@ def main() -> int:
             lambda: smoke.read_manifest_target(archive),
             "encrypted zip member",
             "encrypted member during manifest read",
+            forbidden="bin/conu",
+            require_member_redaction=True,
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-drive.zip"
+        drive_member = "C:\\secret-manifest-path-should-not-print"
+        write_zip_entries(archive, [(drive_member, "x")])
+        expect_action_failure(
+            lambda: smoke.read_manifest_target(archive),
+            "unsafe archive path",
+            "manifest read Windows drive path",
+            forbidden="secret-manifest-path-should-not-print",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -213,6 +237,8 @@ def main() -> int:
             lambda: smoke.find_package_root(Path("conu-0.1.0-test.zip"), root),
             "unexpected archive root",
             "unexpected extracted root",
+            forbidden="conu-9.9.9-test",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -228,6 +254,8 @@ def main() -> int:
             lambda: smoke.extract_archive(archive, root / "extract-duplicate"),
             "duplicate archive path",
             "duplicate extracted path",
+            forbidden="bin/conu",
+            require_member_redaction=True,
         )
 
     with fixture_dir() as root:
@@ -240,6 +268,8 @@ def main() -> int:
                 lambda: smoke.extract_archive(archive, root / "extract-large"),
                 "member is too large",
                 "oversized extracted member",
+                forbidden="bin/conu",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_MEMBER_BYTES = original_limit
@@ -281,6 +311,20 @@ def main() -> int:
             lambda: smoke.extract_archive(archive, root / "extract-unsupported"),
             "unsupported zip member",
             "unsupported zip member type",
+            forbidden="device",
+            require_member_redaction=True,
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-drive.zip"
+        drive_member = "C:\\secret-extract-path-should-not-print"
+        write_zip_entries(archive, [(drive_member, "x")])
+        expect_action_failure(
+            lambda: smoke.extract_archive(archive, root / "extract-drive"),
+            "unsafe archive path",
+            "extracted Windows drive path",
+            forbidden="secret-extract-path-should-not-print",
+            require_member_redaction=True,
         )
 
     print("release artifact smoke preflight check passed")
@@ -410,6 +454,7 @@ def expect_action_failure(
     label: str,
     *,
     forbidden: str | None = None,
+    require_member_redaction: bool = False,
 ) -> None:
     try:
         action()
@@ -417,6 +462,12 @@ def expect_action_failure(
         message = str(exc)
         if forbidden is not None and forbidden in message:
             raise SystemExit(f"{label}: error leaked forbidden value: {message}") from exc
+        if require_member_redaction:
+            for marker in ("pathDisplayed=false", "contentsDisplayed=false"):
+                if marker not in message:
+                    raise SystemExit(
+                        f"{label}: error missing redaction marker {marker}: {message}"
+                    ) from exc
         if expected in message:
             return
         raise SystemExit(f"{label}: expected {expected}, got: {message}") from exc

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -30,6 +30,7 @@ MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 SNIPPET_LIMIT = 2000
+MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
 
 
 class ExtractState:
@@ -37,6 +38,14 @@ class ExtractState:
         self.paths: set[str] = set()
         self.entry_count = 0
         self.total_uncompressed = 0
+
+
+def archive_member_failure(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(f"{archive_name} {reason}; {MEMBER_FAILURE_GUARDS}")
+
+
+def has_windows_drive_prefix(path: str) -> bool:
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
 
 
 def main() -> int:
@@ -185,8 +194,9 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
                         continue
                     if normalized == normalized_name:
                         if found is not None:
-                            raise SystemExit(
-                                f"{archive.name} contains duplicate archive path: {normalized_name}"
+                            raise archive_member_failure(
+                                archive.name,
+                                "contains duplicate archive path",
                             )
                         found = package.read(member)
                 return found
@@ -213,8 +223,9 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
                         continue
                     if normalized == normalized_name:
                         if found is not None:
-                            raise SystemExit(
-                                f"{archive.name} contains duplicate archive path: {normalized_name}"
+                            raise archive_member_failure(
+                                archive.name,
+                                "contains duplicate archive path",
                             )
                         file_object = package.extractfile(member)
                         found = file_object.read() if file_object is not None else None
@@ -231,17 +242,15 @@ def validate_zip_member_for_read(
     root_style: str | None,
 ) -> tuple[str, str | None, bool]:
     if member.flag_bits & 0x1:
-        raise SystemExit(f"{archive_name} contains encrypted zip member: {member.filename}")
+        raise archive_member_failure(archive_name, "contains encrypted zip member")
     file_type = (member.external_attr >> 16) & 0o170000
     is_directory = member.is_dir() or file_type == stat.S_IFDIR
     if file_type == stat.S_IFLNK:
-        raise SystemExit(f"{archive_name} contains unsupported link member: {member.filename}")
+        raise archive_member_failure(archive_name, "contains unsupported link member")
     if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
-        raise SystemExit(f"{archive_name} contains unsupported zip member: {member.filename}")
+        raise archive_member_failure(archive_name, "contains unsupported zip member")
     if is_directory and member.file_size != 0:
-        raise SystemExit(
-            f"{archive_name} contains directory member with data: {member.filename}"
-        )
+        raise archive_member_failure(archive_name, "contains directory member with data")
     normalized, root_style = validate_archive_read_entry(
         archive_name,
         member.filename,
@@ -263,7 +272,7 @@ def validate_tar_member_for_read(
 ) -> tuple[str, str | None, bool]:
     if member.isdir():
         if member.size != 0:
-            raise SystemExit(f"{archive_name} contains directory member with data: {member.name}")
+            raise archive_member_failure(archive_name, "contains directory member with data")
         normalized, root_style = validate_archive_read_entry(
             archive_name,
             member.name,
@@ -275,7 +284,7 @@ def validate_tar_member_for_read(
         )
         return normalized, root_style, False
     if not member.isfile():
-        raise SystemExit(f"{archive_name} contains unsupported non-file member: {member.name}")
+        raise archive_member_failure(archive_name, "contains unsupported non-file member")
     normalized, root_style = validate_archive_read_entry(
         archive_name,
         member.name,
@@ -298,20 +307,20 @@ def validate_archive_read_entry(
     allow_empty: bool = False,
 ) -> tuple[str, str | None]:
     if size < 0:
-        raise SystemExit(f"{archive_name} contains member with invalid size: {member_name}")
+        raise archive_member_failure(archive_name, "contains member with invalid size")
     if size > MAX_MEMBER_BYTES:
-        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+        raise archive_member_failure(archive_name, "member is too large")
 
     state.entry_count += 1
     if state.entry_count > MAX_MEMBER_COUNT:
         raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
 
-    normalized, member_style = normalize_member(member_name, expected_root)
-    root_style = update_archive_root_style(archive_name, member_name, root_style, member_style)
+    normalized, member_style = normalize_member(archive_name, member_name, expected_root)
+    root_style = update_archive_root_style(archive_name, root_style, member_style)
     if not normalized:
         if allow_empty:
             return normalized, root_style
-        raise SystemExit(f"{archive_name} contains empty archive path: {member_name}")
+        raise archive_member_failure(archive_name, "contains empty archive path")
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
@@ -319,7 +328,7 @@ def validate_archive_read_entry(
             f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
         )
     if normalized in state.paths:
-        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+        raise archive_member_failure(archive_name, "contains duplicate archive path")
     state.paths.add(normalized)
     return normalized, root_style
 
@@ -328,20 +337,26 @@ def expected_archive_root(archive: Path) -> str:
     return archive_stem(archive)
 
 
-def normalize_member(name: str, expected_root: str) -> tuple[str, str | None]:
+def normalize_member(archive_name: str, name: str, expected_root: str) -> tuple[str, str | None]:
     normalized = name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe archive path: {name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise archive_member_failure(archive_name, "contains unsafe archive path")
     root_style = None
     if parts:
         if parts[0] == expected_root:
             root_style = "rooted"
             parts = parts[1:]
         elif parts[0].startswith("conu-"):
-            raise SystemExit(
-                f"unexpected archive root: {parts[0]} (expected {expected_root})"
+            raise archive_member_failure(
+                archive_name,
+                f"contains unexpected archive root (expected {expected_root})",
             )
         else:
             root_style = "rootless"
@@ -350,16 +365,13 @@ def normalize_member(name: str, expected_root: str) -> tuple[str, str | None]:
 
 def update_archive_root_style(
     archive_name: str,
-    raw_name: str,
     current: str | None,
     member_style: str | None,
 ) -> str | None:
     if member_style is None:
         return current
     if current is not None and current != member_style:
-        raise SystemExit(
-            f"{archive_name} mixes rooted and rootless archive paths: {raw_name}"
-        )
+        raise archive_member_failure(archive_name, "mixes rooted and rootless archive paths")
     return member_style
 
 
@@ -410,9 +422,9 @@ def extract_archive(archive: Path, destination: Path) -> None:
                 for member in package.infolist():
                     if member.filename.endswith("/"):
                         if member.file_size != 0:
-                            raise SystemExit(
-                                f"{archive.name} contains directory member with data: "
-                                f"{member.filename}"
+                            raise archive_member_failure(
+                                archive.name,
+                                "contains directory member with data",
                             )
                         validate_extract_entry(
                             archive.name,
@@ -423,17 +435,17 @@ def extract_archive(archive: Path, destination: Path) -> None:
                         )
                         continue
                     if member.flag_bits & 0x1:
-                        raise SystemExit(
-                            f"{archive.name} contains encrypted zip member: {member.filename}"
-                        )
+                        raise archive_member_failure(archive.name, "contains encrypted zip member")
                     file_type = (member.external_attr >> 16) & 0o170000
                     if file_type == stat.S_IFLNK:
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported link member: {member.filename}"
+                        raise archive_member_failure(
+                            archive.name,
+                            "contains unsupported link member",
                         )
                     if file_type not in {0, stat.S_IFREG}:
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported zip member: {member.filename}"
+                        raise archive_member_failure(
+                            archive.name,
+                            "contains unsupported zip member",
                         )
                     output_path = checked_extract_path(
                         archive.name,
@@ -460,8 +472,9 @@ def extract_archive(archive: Path, destination: Path) -> None:
                 for member in package:
                     if member.isdir():
                         if member.size != 0:
-                            raise SystemExit(
-                                f"{archive.name} contains directory member with data: {member.name}"
+                            raise archive_member_failure(
+                                archive.name,
+                                "contains directory member with data",
                             )
                         validate_extract_entry(
                             archive.name,
@@ -472,8 +485,9 @@ def extract_archive(archive: Path, destination: Path) -> None:
                         )
                         continue
                     if not member.isfile():
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported non-file member: {member.name}"
+                        raise archive_member_failure(
+                            archive.name,
+                            "contains unsupported non-file member",
                         )
                     output_path = checked_extract_path(
                         archive.name,
@@ -485,7 +499,7 @@ def extract_archive(archive: Path, destination: Path) -> None:
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     file_object = package.extractfile(member)
                     if file_object is None:
-                        raise SystemExit(f"{archive.name} could not read member {member.name}")
+                        raise archive_member_failure(archive.name, "could not read member")
                     output_path.write_bytes(file_object.read())
                     output_path.chmod(member.mode & 0o777)
         return
@@ -534,7 +548,7 @@ def checked_extract_path(
     try:
         output_path.relative_to(destination_resolved)
     except ValueError as exc:
-        raise SystemExit(f"unsafe archive path: {member_name}") from exc
+        raise archive_member_failure(archive_name, "contains unsafe archive path") from exc
     return output_path
 
 
@@ -547,19 +561,19 @@ def validate_extract_entry(
     allow_empty: bool = False,
 ) -> str:
     if size < 0:
-        raise SystemExit(f"{archive_name} contains member with invalid size: {member_name}")
+        raise archive_member_failure(archive_name, "contains member with invalid size")
     if size > MAX_MEMBER_BYTES:
-        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+        raise archive_member_failure(archive_name, "member is too large")
 
     state.entry_count += 1
     if state.entry_count > MAX_MEMBER_COUNT:
         raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
 
-    normalized = normalize_extract_path(member_name)
+    normalized = normalize_extract_path(archive_name, member_name)
     if not normalized:
         if allow_empty:
             return normalized
-        raise SystemExit(f"{archive_name} contains empty archive path: {member_name}")
+        raise archive_member_failure(archive_name, "contains empty archive path")
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
@@ -567,17 +581,22 @@ def validate_extract_entry(
             f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
         )
     if normalized in state.paths:
-        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+        raise archive_member_failure(archive_name, "contains duplicate archive path")
     state.paths.add(normalized)
     return normalized
 
 
-def normalize_extract_path(member_name: str) -> str:
+def normalize_extract_path(archive_name: str, member_name: str) -> str:
     normalized = member_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe archive path: {member_name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise archive_member_failure(archive_name, "contains unsafe archive path")
     return "/".join(parts)
 
 
@@ -590,7 +609,7 @@ def find_package_root(archive: Path, extract_dir: Path) -> Path:
     has_rooted = rooted_manifest.is_file()
 
     if has_rootless and has_rooted:
-        raise SystemExit(f"{archive.name} mixes rooted and rootless archive paths")
+        raise archive_member_failure(archive.name, "mixes rooted and rootless archive paths")
     if has_rooted:
         return rooted_dir
     if has_rootless:
@@ -602,9 +621,9 @@ def find_package_root(archive: Path, extract_dir: Path) -> Path:
         if path.is_dir() and path.name.startswith("conu-")
     )
     if unexpected_roots:
-        raise SystemExit(
-            f"{archive.name} contains unexpected archive root: "
-            f"{unexpected_roots[0]} (expected {expected_root})"
+        raise archive_member_failure(
+            archive.name,
+            f"contains unexpected archive root (expected {expected_root})",
         )
     raise SystemExit(
         f"{archive.name} missing manifest.toml at expected release root {expected_root}"

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -29,6 +29,7 @@ MAX_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 SNIPPET_LIMIT = 2000
+MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
 
 
 class ExtractState:
@@ -36,6 +37,14 @@ class ExtractState:
         self.paths: set[str] = set()
         self.entry_count = 0
         self.total_uncompressed = 0
+
+
+def archive_member_failure(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(f"{archive_name} {reason}; {MEMBER_FAILURE_GUARDS}")
+
+
+def has_windows_drive_prefix(path: str) -> bool:
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
 
 
 def main() -> int:
@@ -141,8 +150,9 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
                         continue
                     if normalized == normalized_name:
                         if found is not None:
-                            raise SystemExit(
-                                f"{archive.name} contains duplicate archive path: {normalized_name}"
+                            raise archive_member_failure(
+                                archive.name,
+                                "contains duplicate archive path",
                             )
                         found = package.read(member)
                 return found
@@ -169,8 +179,9 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
                         continue
                     if normalized == normalized_name:
                         if found is not None:
-                            raise SystemExit(
-                                f"{archive.name} contains duplicate archive path: {normalized_name}"
+                            raise archive_member_failure(
+                                archive.name,
+                                "contains duplicate archive path",
                             )
                         file_object = package.extractfile(member)
                         found = file_object.read() if file_object is not None else None
@@ -187,17 +198,15 @@ def validate_zip_member_for_read(
     root_style: str | None,
 ) -> tuple[str, str | None, bool]:
     if member.flag_bits & 0x1:
-        raise SystemExit(f"{archive_name} contains encrypted zip member: {member.filename}")
+        raise archive_member_failure(archive_name, "contains encrypted zip member")
     file_type = (member.external_attr >> 16) & 0o170000
     is_directory = member.is_dir() or file_type == stat.S_IFDIR
     if file_type == stat.S_IFLNK:
-        raise SystemExit(f"{archive_name} contains unsupported link member: {member.filename}")
+        raise archive_member_failure(archive_name, "contains unsupported link member")
     if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
-        raise SystemExit(f"{archive_name} contains unsupported zip member: {member.filename}")
+        raise archive_member_failure(archive_name, "contains unsupported zip member")
     if is_directory and member.file_size != 0:
-        raise SystemExit(
-            f"{archive_name} contains directory member with data: {member.filename}"
-        )
+        raise archive_member_failure(archive_name, "contains directory member with data")
     normalized, root_style = validate_archive_read_entry(
         archive_name,
         member.filename,
@@ -219,7 +228,7 @@ def validate_tar_member_for_read(
 ) -> tuple[str, str | None, bool]:
     if member.isdir():
         if member.size != 0:
-            raise SystemExit(f"{archive_name} contains directory member with data: {member.name}")
+            raise archive_member_failure(archive_name, "contains directory member with data")
         normalized, root_style = validate_archive_read_entry(
             archive_name,
             member.name,
@@ -231,7 +240,7 @@ def validate_tar_member_for_read(
         )
         return normalized, root_style, False
     if not member.isfile():
-        raise SystemExit(f"{archive_name} contains unsupported non-file member: {member.name}")
+        raise archive_member_failure(archive_name, "contains unsupported non-file member")
     normalized, root_style = validate_archive_read_entry(
         archive_name,
         member.name,
@@ -254,20 +263,20 @@ def validate_archive_read_entry(
     allow_empty: bool = False,
 ) -> tuple[str, str | None]:
     if size < 0:
-        raise SystemExit(f"{archive_name} contains member with invalid size: {member_name}")
+        raise archive_member_failure(archive_name, "contains member with invalid size")
     if size > MAX_MEMBER_BYTES:
-        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+        raise archive_member_failure(archive_name, "member is too large")
 
     state.entry_count += 1
     if state.entry_count > MAX_MEMBER_COUNT:
         raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
 
-    normalized, member_style = normalize_member(member_name, expected_root)
-    root_style = update_archive_root_style(archive_name, member_name, root_style, member_style)
+    normalized, member_style = normalize_member(archive_name, member_name, expected_root)
+    root_style = update_archive_root_style(archive_name, root_style, member_style)
     if not normalized:
         if allow_empty:
             return normalized, root_style
-        raise SystemExit(f"{archive_name} contains empty archive path: {member_name}")
+        raise archive_member_failure(archive_name, "contains empty archive path")
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
@@ -275,7 +284,7 @@ def validate_archive_read_entry(
             f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
         )
     if normalized in state.paths:
-        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+        raise archive_member_failure(archive_name, "contains duplicate archive path")
     state.paths.add(normalized)
     return normalized, root_style
 
@@ -284,20 +293,26 @@ def expected_archive_root(archive: Path) -> str:
     return archive_stem(archive)
 
 
-def normalize_member(name: str, expected_root: str) -> tuple[str, str | None]:
+def normalize_member(archive_name: str, name: str, expected_root: str) -> tuple[str, str | None]:
     normalized = name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe archive path: {name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise archive_member_failure(archive_name, "contains unsafe archive path")
     root_style = None
     if parts:
         if parts[0] == expected_root:
             root_style = "rooted"
             parts = parts[1:]
         elif parts[0].startswith("conu-"):
-            raise SystemExit(
-                f"unexpected archive root: {parts[0]} (expected {expected_root})"
+            raise archive_member_failure(
+                archive_name,
+                f"contains unexpected archive root (expected {expected_root})",
             )
         else:
             root_style = "rootless"
@@ -306,16 +321,13 @@ def normalize_member(name: str, expected_root: str) -> tuple[str, str | None]:
 
 def update_archive_root_style(
     archive_name: str,
-    raw_name: str,
     current: str | None,
     member_style: str | None,
 ) -> str | None:
     if member_style is None:
         return current
     if current is not None and current != member_style:
-        raise SystemExit(
-            f"{archive_name} mixes rooted and rootless archive paths: {raw_name}"
-        )
+        raise archive_member_failure(archive_name, "mixes rooted and rootless archive paths")
     return member_style
 
 
@@ -366,9 +378,9 @@ def extract_archive(archive: Path, destination: Path) -> None:
                 for member in package.infolist():
                     if member.filename.endswith("/"):
                         if member.file_size != 0:
-                            raise SystemExit(
-                                f"{archive.name} contains directory member with data: "
-                                f"{member.filename}"
+                            raise archive_member_failure(
+                                archive.name,
+                                "contains directory member with data",
                             )
                         validate_extract_entry(
                             archive.name,
@@ -379,17 +391,17 @@ def extract_archive(archive: Path, destination: Path) -> None:
                         )
                         continue
                     if member.flag_bits & 0x1:
-                        raise SystemExit(
-                            f"{archive.name} contains encrypted zip member: {member.filename}"
-                        )
+                        raise archive_member_failure(archive.name, "contains encrypted zip member")
                     file_type = (member.external_attr >> 16) & 0o170000
                     if file_type == stat.S_IFLNK:
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported link member: {member.filename}"
+                        raise archive_member_failure(
+                            archive.name,
+                            "contains unsupported link member",
                         )
                     if file_type not in {0, stat.S_IFREG}:
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported zip member: {member.filename}"
+                        raise archive_member_failure(
+                            archive.name,
+                            "contains unsupported zip member",
                         )
                     output_path = checked_extract_path(
                         archive.name,
@@ -416,8 +428,9 @@ def extract_archive(archive: Path, destination: Path) -> None:
                 for member in package:
                     if member.isdir():
                         if member.size != 0:
-                            raise SystemExit(
-                                f"{archive.name} contains directory member with data: {member.name}"
+                            raise archive_member_failure(
+                                archive.name,
+                                "contains directory member with data",
                             )
                         validate_extract_entry(
                             archive.name,
@@ -428,8 +441,9 @@ def extract_archive(archive: Path, destination: Path) -> None:
                         )
                         continue
                     if not member.isfile():
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported non-file member: {member.name}"
+                        raise archive_member_failure(
+                            archive.name,
+                            "contains unsupported non-file member",
                         )
                     output_path = checked_extract_path(
                         archive.name,
@@ -441,7 +455,7 @@ def extract_archive(archive: Path, destination: Path) -> None:
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     file_object = package.extractfile(member)
                     if file_object is None:
-                        raise SystemExit(f"{archive.name} could not read member {member.name}")
+                        raise archive_member_failure(archive.name, "could not read member")
                     output_path.write_bytes(file_object.read())
                     output_path.chmod(member.mode & 0o777)
         return
@@ -499,7 +513,7 @@ def checked_extract_path(
     try:
         output_path.relative_to(destination_resolved)
     except ValueError as exc:
-        raise SystemExit(f"unsafe archive path: {member_name}") from exc
+        raise archive_member_failure(archive_name, "contains unsafe archive path") from exc
     return output_path
 
 
@@ -512,19 +526,19 @@ def validate_extract_entry(
     allow_empty: bool = False,
 ) -> str:
     if size < 0:
-        raise SystemExit(f"{archive_name} contains member with invalid size: {member_name}")
+        raise archive_member_failure(archive_name, "contains member with invalid size")
     if size > MAX_MEMBER_BYTES:
-        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+        raise archive_member_failure(archive_name, "member is too large")
 
     state.entry_count += 1
     if state.entry_count > MAX_MEMBER_COUNT:
         raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
 
-    normalized = normalize_extract_path(member_name)
+    normalized = normalize_extract_path(archive_name, member_name)
     if not normalized:
         if allow_empty:
             return normalized
-        raise SystemExit(f"{archive_name} contains empty archive path: {member_name}")
+        raise archive_member_failure(archive_name, "contains empty archive path")
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
@@ -532,17 +546,22 @@ def validate_extract_entry(
             f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
         )
     if normalized in state.paths:
-        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+        raise archive_member_failure(archive_name, "contains duplicate archive path")
     state.paths.add(normalized)
     return normalized
 
 
-def normalize_extract_path(member_name: str) -> str:
+def normalize_extract_path(archive_name: str, member_name: str) -> str:
     normalized = member_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe archive path: {member_name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise archive_member_failure(archive_name, "contains unsafe archive path")
     return "/".join(parts)
 
 
@@ -607,7 +626,7 @@ def find_package_root(archive: Path, smoke_dir: Path) -> Path:
     has_rooted = rooted_manifest.is_file()
 
     if has_rootless and has_rooted:
-        raise SystemExit(f"{archive.name} mixes rooted and rootless archive paths")
+        raise archive_member_failure(archive.name, "mixes rooted and rootless archive paths")
     if has_rooted:
         return rooted_dir
     if has_rootless:
@@ -619,9 +638,9 @@ def find_package_root(archive: Path, smoke_dir: Path) -> Path:
         if path.is_dir() and path.name.startswith("conu-")
     )
     if unexpected_roots:
-        raise SystemExit(
-            f"{archive.name} contains unexpected archive root: "
-            f"{unexpected_roots[0]} (expected {expected_root})"
+        raise archive_member_failure(
+            archive.name,
+            f"contains unexpected archive root (expected {expected_root})",
         )
     raise SystemExit(
         f"{archive.name} missing manifest.toml at expected release root {expected_root}"

--- a/user.md
+++ b/user.md
@@ -18,7 +18,7 @@ You already ran:
 gh secret set NPM_TOKEN --repo imthegoodboy/conU
 ```
 
-The npm token rotation marker is also already set, so there is nothing else you need to paste or configure for npm right now.
+For simple testing, there is nothing else you need to paste or configure for npm right now. Before any real npm publish, rotate the token because a token value was pasted in chat.
 
 ## What You Can Skip For Now
 


### PR DESCRIPTION
## Summary
- redact malformed release-smoke archive member failure messages while preserving failure categories
- add Windows-drive archive path rejection in release and npm local smoke preflights
- strengthen regressions to require pathDisplayed=false and contentsDisplayed=false and to reject raw member names
- correct user.md simple-launch npm guidance so testing can continue while real publishing still requires token rotation

## Security review
payload exposure risk: reduced; malformed archive member paths are no longer echoed in smoke failure output.
trust/permission risk: unchanged; no trust or permission boundary changed.
storage/logging risk: reduced for smoke-script failure output; no new storage surface added.
relay/network risk: unchanged; no relay or network behavior changed.
required fixes: rotate NPM_TOKEN before real npm publishing because a token value was pasted in chat; configure real signing secrets before fully signed public tagged releases.

## Validation
- python scripts\check-release-artifact-smoke-preflight.py
- python scripts\check-npm-launcher-local-smoke-preflight.py
- python scripts\check-python-script-compile.py
- python scripts\verify-npm-package-contents.py
- python scripts\verify-npm-package-contents-regression.py
- python scripts\check-release-artifact-verifier.py
- python scripts\check-github-workflow-permissions.py
- npm run check (packaging/npm/conu-cli)
- .\scripts\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Closes #990
Closes #991

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts archive member names and contents in smoke failures and blocks unsafe Windows drive paths to prevent sensitive data leakage and harden release/npm smoke checks. Meets the requirements in #990 and #991.

- **Bug Fixes**
  - Standardized failure messages with `pathDisplayed=false` and `contentsDisplayed=false` redaction markers in release and npm smoke scripts.
  - Preflight tests now assert redaction and reject forbidden values; added cases for `C:\` drive and other unsafe paths.
  - Reject absolute, `//`, `C:\`-prefixed, and parent-traversal paths during manifest read and extract.
  - Clarified `user.md`: simple testing needs no changes; rotate the npm token before any real publish.

<sup>Written for commit 9759cfba6cd8ee5583363c222c985b8e315d43a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now redact sensitive archive path and content details to enhance security
  * Improved Windows drive path detection and validation in archive processing

* **Tests**
  * Expanded regression coverage for path safety assertions and redaction verification across archive operations

* **Documentation**
  * Added explicit guidance to rotate npm token before publishing to production

<!-- end of auto-generated comment: release notes by coderabbit.ai -->