### PR TITLE
Redact package-manager archive member failures

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -274,6 +274,28 @@ def expect_failure(description: str, action, expected: str) -> None:
     raise AssertionError(f"{description} unexpectedly passed")
 
 
+def expect_member_redacted_failure(
+    description: str,
+    action,
+    expected: str,
+    *forbidden_values: str,
+) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        message = str(exc)
+    else:
+        raise AssertionError(f"{description} unexpectedly passed")
+    if expected not in message:
+        raise AssertionError(f"{description} failed with {message!r}, expected {expected!r}")
+    for marker in ("pathDisplayed=false", "contentsDisplayed=false"):
+        if marker not in message:
+            raise AssertionError(f"{description} did not include {marker}: {message!r}")
+    for value in forbidden_values:
+        if value in message:
+            raise AssertionError(f"{description} leaked archive member value {value!r}")
+
+
 def expect_redacted_failure(description: str, action, expected: str) -> None:
     try:
         action()
@@ -348,6 +370,23 @@ def expect_failure_with_limit(
     setattr(generator, limit_name, value)
     try:
         expect_failure(description, action, expected)
+    finally:
+        setattr(generator, limit_name, original)
+
+
+def expect_member_redacted_failure_with_limit(
+    generator,
+    limit_name: str,
+    value: int,
+    description: str,
+    action,
+    expected: str,
+    *forbidden_values: str,
+) -> None:
+    original = getattr(generator, limit_name)
+    setattr(generator, limit_name, value)
+    try:
+        expect_member_redacted_failure(description, action, expected, *forbidden_values)
     finally:
         setattr(generator, limit_name, original)
 
@@ -1348,10 +1387,11 @@ def main() -> int:
         write_dist(encrypted_windows)
         encrypted_archive = encrypted_windows / TARGETS["windows-x64"]
         mark_zip_member_encrypted(encrypted_archive, "bin/conu.exe")
-        expect_failure(
+        expect_member_redacted_failure(
             "encrypted windows zip member",
             lambda: generator.detect_windows_extract_dir(encrypted_archive, VERSION),
             "contains encrypted zip member",
+            "bin/conu.exe",
         )
 
         unsupported_windows = temp / "unsupported-windows"
@@ -1362,10 +1402,41 @@ def main() -> int:
             info = zipfile.ZipInfo("device")
             info.external_attr = stat.S_IFCHR << 16
             package.writestr(info, b"device\n")
-        expect_failure(
+        expect_member_redacted_failure(
             "unsupported windows zip member",
             lambda: generator.detect_windows_extract_dir(unsupported_archive, VERSION),
             "contains unsupported zip member",
+            "device",
+        )
+
+        duplicate_windows = temp / "duplicate-windows"
+        duplicate_windows.mkdir()
+        write_dist(duplicate_windows)
+        duplicate_archive = duplicate_windows / TARGETS["windows-x64"]
+        with zipfile.ZipFile(duplicate_archive, "a", compression=zipfile.ZIP_STORED) as package:
+            package.writestr("bin/./conu.exe", b"duplicate\n")
+        expect_member_redacted_failure(
+            "duplicate windows zip member",
+            lambda: generator.detect_windows_extract_dir(duplicate_archive, VERSION),
+            "contains duplicate archive path",
+            "bin/./conu.exe",
+            "bin/conu.exe",
+        )
+
+        drive_windows = temp / "drive-windows"
+        drive_windows.mkdir()
+        write_dist(drive_windows)
+        drive_archive = drive_windows / TARGETS["windows-x64"]
+        drive_member = "C:\\secret-package-manager-path"
+        with zipfile.ZipFile(drive_archive, "a", compression=zipfile.ZIP_STORED) as package:
+            package.writestr(drive_member, b"drive\n")
+        expect_member_redacted_failure(
+            "Windows drive zip member",
+            lambda: generator.detect_windows_extract_dir(drive_archive, VERSION),
+            "unsafe archive path",
+            drive_member,
+            "C:/secret-package-manager-path",
+            "secret-package-manager-path",
         )
 
         mixed_windows = temp / "mixed-windows"
@@ -1374,13 +1445,14 @@ def main() -> int:
         mixed_archive = mixed_windows / TARGETS["windows-x64"]
         with zipfile.ZipFile(mixed_archive, "a", compression=zipfile.ZIP_STORED) as package:
             package.writestr(f"conu-{VERSION}-windows-x64/README.md", "# conU\n")
-        expect_failure(
+        expect_member_redacted_failure(
             "mixed rooted windows archive",
             lambda: generator.detect_windows_extract_dir(mixed_archive, VERSION),
             "mixes rooted and rootless archive paths",
+            f"conu-{VERSION}-windows-x64/README.md",
         )
 
-        expect_failure_with_limit(
+        expect_member_redacted_failure_with_limit(
             generator,
             "MAX_RELEASE_MEMBER_BYTES",
             1,
@@ -1391,6 +1463,7 @@ def main() -> int:
                 "linux-x64",
             ),
             "member is too large",
+            "bin/conu",
         )
 
         expect_failure_with_limit(
@@ -1422,7 +1495,7 @@ def main() -> int:
             link.linkname = "bin/conu"
             link.mtime = 1577836800
             package.addfile(link)
-        expect_failure(
+        expect_member_redacted_failure(
             "unsupported linux tar member",
             lambda: generator.extract_linux_binaries(
                 unsupported_linux_archive,
@@ -1430,6 +1503,7 @@ def main() -> int:
                 "linux-x64",
             ),
             "contains unsupported non-file member",
+            "bin/linked-conu",
         )
 
         mixed_linux = temp / "mixed-linux"
@@ -1449,7 +1523,7 @@ def main() -> int:
             rooted_info.mode = 0o644
             rooted_info.mtime = 1577836800
             package.addfile(rooted_info, io.BytesIO(rooted_data))
-        expect_failure(
+        expect_member_redacted_failure(
             "mixed rooted linux archive",
             lambda: generator.extract_linux_binaries(
                 mixed_linux_archive,
@@ -1457,6 +1531,7 @@ def main() -> int:
                 "linux-x64",
             ),
             "mixes rooted and rootless archive paths",
+            f"conu-{VERSION}-linux-x64/README.md",
         )
 
     print("package-manager manifest generation regressions passed")

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -56,6 +56,7 @@ MAX_RELEASE_ARCHIVE_BYTES = 1_000_000_000
 MAX_RELEASE_MEMBER_BYTES = 512_000_000
 MAX_RELEASE_MEMBER_COUNT = 10_000
 MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
 MAX_PACKAGE_BINARY_BYTES = MAX_RELEASE_MEMBER_BYTES
 MAX_GENERATED_OUTPUT_BYTES = MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES
 
@@ -65,6 +66,14 @@ class ArchiveScanState:
     paths: set[str]
     entry_count: int = 0
     total_uncompressed: int = 0
+
+
+def release_member_failure(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(f"{archive_name} {reason}; {MEMBER_FAILURE_GUARDS}")
+
+
+def has_windows_drive_prefix(path: str) -> bool:
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
 
 
 @dataclass(frozen=True)
@@ -644,16 +653,16 @@ def validate_zip_release_member_for_scan(
 ) -> tuple[str, str | None, bool]:
     raw_name = member.filename
     if member.flag_bits & 0x1:
-        raise SystemExit(f"{archive_name} contains encrypted zip member: {raw_name}")
+        raise release_member_failure(archive_name, "contains encrypted zip member")
     file_type = (member.external_attr >> 16) & 0o170000
     is_directory = member.is_dir() or file_type == stat.S_IFDIR
     if file_type == stat.S_IFLNK:
-        raise SystemExit(f"{archive_name} contains unsupported link member: {raw_name}")
+        raise release_member_failure(archive_name, "contains unsupported link member")
     if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
-        raise SystemExit(f"{archive_name} contains unsupported zip member: {raw_name}")
+        raise release_member_failure(archive_name, "contains unsupported zip member")
     if is_directory:
         if member.file_size != 0:
-            raise SystemExit(f"{archive_name} contains directory member with data: {raw_name}")
+            raise release_member_failure(archive_name, "contains directory member with data")
         normalized, root_style = record_release_archive_member(
             archive_name,
             raw_name,
@@ -686,23 +695,27 @@ def record_release_archive_member(
     allow_empty: bool = False,
 ) -> tuple[str, str | None]:
     if size < 0:
-        raise SystemExit(f"{archive_name} contains member with invalid size: {raw_name}")
+        raise release_member_failure(archive_name, "contains member with invalid size")
     if size > MAX_RELEASE_MEMBER_BYTES:
-        raise SystemExit(f"{archive_name} member is too large: {raw_name}")
+        raise release_member_failure(archive_name, "member is too large")
 
     state.entry_count += 1
     if state.entry_count > MAX_RELEASE_MEMBER_COUNT:
         raise SystemExit(f"{archive_name} contains more than {MAX_RELEASE_MEMBER_COUNT} entries")
 
-    normalized, member_style = normalize_release_member_path(raw_name, expected_root)
-    root_style = update_release_root_style(archive_name, raw_name, root_style, member_style)
+    normalized, member_style = normalize_release_member_path(
+        archive_name,
+        raw_name,
+        expected_root,
+    )
+    root_style = update_release_root_style(archive_name, root_style, member_style)
     if not normalized:
         if allow_empty:
             return normalized, root_style
-        raise SystemExit(f"{archive_name} contains empty archive path: {raw_name}")
+        raise release_member_failure(archive_name, "contains empty archive path")
 
     if normalized in state.paths:
-        raise SystemExit(f"{archive_name} contains duplicate archive path: {normalized}")
+        raise release_member_failure(archive_name, "contains duplicate archive path")
     state.paths.add(normalized)
 
     state.total_uncompressed += size
@@ -714,21 +727,30 @@ def record_release_archive_member(
     return normalized, root_style
 
 
-def normalize_release_member_path(raw_name: str, expected_root: str) -> tuple[str, str | None]:
+def normalize_release_member_path(
+    archive_name: str,
+    raw_name: str,
+    expected_root: str,
+) -> tuple[str, str | None]:
     normalized = raw_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe archive path in package-manager asset: {raw_name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise release_member_failure(archive_name, "contains unsafe archive path")
     root_style = None
     if parts:
         if parts[0] == expected_root:
             root_style = "rooted"
             parts = parts[1:]
         elif parts[0].startswith("conu-"):
-            raise SystemExit(
-                f"unexpected archive root in package-manager asset: {parts[0]} "
-                f"(expected {expected_root})"
+            raise release_member_failure(
+                archive_name,
+                f"contains unexpected archive root (expected {expected_root})",
             )
         else:
             root_style = "rootless"
@@ -737,14 +759,13 @@ def normalize_release_member_path(raw_name: str, expected_root: str) -> tuple[st
 
 def update_release_root_style(
     archive_name: str,
-    raw_name: str,
     current: str | None,
     member_style: str | None,
 ) -> str | None:
     if member_style is None:
         return current
     if current is not None and current != member_style:
-        raise SystemExit(f"{archive_name} mixes rooted and rootless archive paths: {raw_name}")
+        raise release_member_failure(archive_name, "mixes rooted and rootless archive paths")
     return member_style
 
 
@@ -767,8 +788,9 @@ def extract_linux_binaries(archive: Path, version: str, target: str) -> dict[str
                 for member in package:
                     if member.isdir():
                         if member.size != 0:
-                            raise SystemExit(
-                                f"{archive.name} contains directory member with data: {member.name}"
+                            raise release_member_failure(
+                                archive.name,
+                                "contains directory member with data",
                             )
                         _, root_style = record_release_archive_member(
                             archive.name,
@@ -781,8 +803,9 @@ def extract_linux_binaries(archive: Path, version: str, target: str) -> dict[str
                         )
                         continue
                     if not member.isfile():
-                        raise SystemExit(
-                            f"{archive.name} contains unsupported non-file member: {member.name}"
+                        raise release_member_failure(
+                            archive.name,
+                            "contains unsupported non-file member",
                         )
                     normalized, root_style = record_release_archive_member(
                         archive.name,
@@ -799,7 +822,7 @@ def extract_linux_binaries(archive: Path, version: str, target: str) -> dict[str
                         continue
                     handle = package.extractfile(member)
                     if handle is None:
-                        raise SystemExit(f"{archive.name} could not read binary: {member.name}")
+                        raise release_member_failure(archive.name, "could not read binary")
                     extracted[normalized] = read_limited_release_member(
                         archive.name,
                         member.name,
@@ -831,7 +854,7 @@ def read_limited_release_member(
 ) -> bytes:
     content = handle.read(limit + 1)
     if len(content) > limit:
-        raise SystemExit(f"{archive_name} member is too large: {member_name}")
+        raise release_member_failure(archive_name, "member is too large")
     return content
 
 


### PR DESCRIPTION
Closes #995.

## Changes
- Redact package-manager release archive member names for unsafe, unsupported, duplicate, encrypted, mixed-root, and oversized member failures.
- Add regression coverage that requires `pathDisplayed=false contentsDisplayed=false` and rejects raw/normalized member values in failure output.
- Reject Windows drive-style member paths before package-manager manifest generation uses archive contents.

## Validation
- `python -m py_compile scripts\generate-package-manager-manifests.py scripts\check-package-manager-manifests.py`
- `python scripts\check-package-manager-manifests.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\verify-npm-package-contents.py`
- `python scripts\verify-npm-package-contents-regression.py`
- `python scripts\check-release-artifact-verifier.py`
- `python scripts\check-github-workflow-permissions.py`
- `python scripts\check-release-artifact-smoke-preflight.py`
- `python scripts\check-npm-launcher-local-smoke-preflight.py`
- `npm run check` from `packaging\npm\conu-cli`
- `git diff --check`

## Security Categories
- payload exposure risk: reduces archive-member path exposure in release/package-manager failure output.
- trust/permission risk: no permission expansion.
- storage/logging risk: prevents raw member names from being logged in these diagnostics.
- relay/network risk: not touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts archive member names from package-manager failure output and hardens path validation to prevent leaking sensitive paths in logs. Adds regression tests to enforce redaction and blocks Windows drive-style paths before manifest generation.

- **Bug Fixes**
  - Redact member names for encrypted, unsupported, duplicate, mixed-root, unsafe, and oversized failures; append `pathDisplayed=false contentsDisplayed=false`.
  - Reject Windows drive-letter and `//` absolute paths during normalization; detect duplicates after normalization.
  - Standardize errors for directories-with-data, unsupported non-file entries, and oversized members via a single redacted failure path.
  - Add regression tests to ensure errors never include raw or normalized member values.

<sup>Written for commit 5d2d6286355bf2f648f84c16d67946bc71343f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

