### PR TITLE
Redact hosted repository archive member failures

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -211,10 +211,16 @@ def main() -> int:
         with zipfile.ZipFile(unsafe_zip / RPM_METADATA, "w", compression=zipfile.ZIP_STORED) as archive:
             write_zip_bytes(archive, "repodata/../repomd.xml", b"<repomd />\n")
         write_checksum(unsafe_zip / RPM_METADATA)
-        expect_failure(
+        output = expect_failure(
             "unsafe zip member",
             unsafe_zip,
             "unsafe repository metadata zip path",
+        )
+        assert_member_failure_redacted(
+            output,
+            "unsafe zip member",
+            "repodata/../repomd.xml",
+            "repomd.xml",
         )
 
         generator = load_generator()
@@ -246,10 +252,15 @@ def main() -> int:
         encrypted_zip = temp / "encrypted-zip"
         shutil.copytree(dist, encrypted_zip)
         mark_zip_member_encrypted(encrypted_zip / APT_METADATA, "Packages")
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: generator.read_zip_members(encrypted_zip / APT_METADATA),
             "encrypted zip member",
             "encrypted repository metadata member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "encrypted repository metadata member",
+            "Packages",
         )
 
         unsupported_zip = temp / "unsupported-zip"
@@ -259,10 +270,15 @@ def main() -> int:
             info.compress_type = zipfile.ZIP_STORED
             info.external_attr = (stat.S_IFCHR | 0o644) << 16
             archive.writestr(info, b"device\n")
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: generator.read_zip_members(unsupported_zip / APT_METADATA),
             "unsupported zip member",
             "unsupported repository metadata member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "unsupported repository metadata member",
+            "Packages",
         )
 
     print("Hosted Linux repository regression checks passed")
@@ -302,11 +318,11 @@ def run_generator(dist: Path, output: Path) -> str:
     ).stdout
 
 
-def expect_failure(description: str, dist: Path, expected: str) -> None:
-    expect_failure_at_output(description, dist, dist / "out", expected)
+def expect_failure(description: str, dist: Path, expected: str) -> str:
+    return expect_failure_at_output(description, dist, dist / "out", expected)
 
 
-def expect_failure_at_output(description: str, dist: Path, output: Path, expected: str) -> None:
+def expect_failure_at_output(description: str, dist: Path, output: Path, expected: str) -> str:
     failed = subprocess.run(
         [
             sys.executable,
@@ -327,6 +343,7 @@ def expect_failure_at_output(description: str, dist: Path, output: Path, expecte
         raise AssertionError(
             f"{description} failed with {failed.stdout!r}, expected {expected!r}"
         )
+    return failed.stdout
 
 
 def expect_zip_bound_failure(
@@ -358,6 +375,15 @@ def expect_action_failure(action, expected: str, label: str) -> str:
             return message
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_member_failure_redacted(message: str, label: str, *forbidden_values: str) -> None:
+    for marker in ("pathDisplayed=false", "contentsDisplayed=false"):
+        if marker not in message:
+            raise AssertionError(f"{label}: missing {marker}: {message!r}")
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{label}: displayed archive member value {value!r}: {message!r}")
 
 
 def assert_no_sentinel(output: str, label: str) -> None:

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -98,10 +98,15 @@ def main() -> int:
         encrypted_site = temp / "encrypted-site.zip"
         shutil.copy2(site, encrypted_site)
         mark_zip_member_encrypted(encrypted_site, "index.html")
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: preparer.read_site_members(encrypted_site),
             "encrypted zip member",
             "encrypted Pages site member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "encrypted Pages site member",
+            "index.html",
         )
 
         unsupported_site = temp / "unsupported-site.zip"
@@ -110,10 +115,15 @@ def main() -> int:
             info.compress_type = zipfile.ZIP_STORED
             info.external_attr = (stat.S_IFCHR | 0o644) << 16
             archive.writestr(info, b"device\n")
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: preparer.read_site_members(unsupported_site),
             "unsupported member type",
             "unsupported Pages site member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "unsupported Pages site member",
+            "index.html",
         )
 
         missing_checksum = temp / "missing-checksum"
@@ -198,11 +208,17 @@ def main() -> int:
         shutil.copytree(dist, unsafe)
         rewrite_site_zip(unsafe / SITE_BUNDLE, {"../index.html": b"escape\n"})
         sign_site(unsafe / SITE_BUNDLE)
-        expect_failure(
+        output = expect_failure(
             "unsafe site member path",
             unsafe / SITE_BUNDLE,
             temp / "unsafe-pages",
             "unsafe hosted repository site path",
+        )
+        assert_member_failure_redacted(
+            output,
+            "unsafe site member path",
+            "../index.html",
+            "index.html",
         )
 
         forbidden = temp / "forbidden"
@@ -558,15 +574,24 @@ def expect_zip_bound_failure(
         setattr(preparer, constant_name, original)
 
 
-def expect_action_failure(action, expected: str, label: str) -> None:
+def expect_action_failure(action, expected: str, label: str) -> str:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
         if expected in message:
-            return
+            return message
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_member_failure_redacted(message: str, label: str, *forbidden_values: str) -> None:
+    for marker in ("pathDisplayed=false", "contentsDisplayed=false"):
+        if marker not in message:
+            raise AssertionError(f"{label}: missing {marker}: {message!r}")
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{label}: displayed archive member value {value!r}: {message!r}")
 
 
 def assert_no_sentinel(output: str, label: str) -> None:

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -128,10 +128,15 @@ def main() -> int:
         encrypted_bundle = temp / "encrypted-hosted-bundle.zip"
         shutil.copy2(hosted_bundle, encrypted_bundle)
         mark_zip_member_encrypted(encrypted_bundle, "apt/Packages")
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: site_generator.read_hosted_bundle(encrypted_bundle),
             "encrypted zip member",
             "encrypted hosted bundle member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "encrypted hosted bundle member",
+            "apt/Packages",
         )
 
         unsupported_bundle = temp / "unsupported-hosted-bundle.zip"
@@ -140,10 +145,15 @@ def main() -> int:
             info.compress_type = zipfile.ZIP_STORED
             info.external_attr = (stat.S_IFCHR | 0o644) << 16
             archive.writestr(info, b"device\n")
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: site_generator.read_hosted_bundle(unsupported_bundle),
             "unsupported zip member",
             "unsupported hosted bundle member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "unsupported hosted bundle member",
+            "README.txt",
         )
 
         run_generator(dist, repeat, BASE_URL)
@@ -286,11 +296,17 @@ def main() -> int:
             write_zip_bytes(archive, "../apt/Packages", b"Package: conu\n")
         write_checksum(unsafe_bundle / HOSTED_BUNDLE)
         write_signature(unsafe_bundle / HOSTED_BUNDLE)
-        expect_failure(
+        output = expect_failure(
             "unsafe hosted bundle member",
             unsafe_bundle,
             BASE_URL,
             "unsafe hosted repository zip path",
+        )
+        assert_member_failure_redacted(
+            output,
+            "unsafe hosted bundle member",
+            "../apt/Packages",
+            "apt/Packages",
         )
 
         expect_failure(
@@ -417,8 +433,8 @@ def run_generator(dist: Path, output: Path, base_url: str) -> str:
     ).stdout
 
 
-def expect_failure(description: str, dist: Path, base_url: str, expected: str) -> None:
-    expect_failure_at_output(description, dist, dist / "out", base_url, expected)
+def expect_failure(description: str, dist: Path, base_url: str, expected: str) -> str:
+    return expect_failure_at_output(description, dist, dist / "out", base_url, expected)
 
 
 def expect_failure_at_output(
@@ -427,7 +443,7 @@ def expect_failure_at_output(
     output: Path,
     base_url: str,
     expected: str,
-) -> None:
+) -> str:
     failed = subprocess.run(
         [
             sys.executable,
@@ -450,6 +466,7 @@ def expect_failure_at_output(
         raise AssertionError(
             f"{description} failed with {failed.stdout!r}, expected {expected!r}"
         )
+    return failed.stdout
 
 
 def expect_zip_bound_failure(
@@ -481,6 +498,15 @@ def expect_action_failure(action, expected: str, label: str) -> str:
             return message
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_member_failure_redacted(message: str, label: str, *forbidden_values: str) -> None:
+    for marker in ("pathDisplayed=false", "contentsDisplayed=false"):
+        if marker not in message:
+            raise AssertionError(f"{label}: missing {marker}: {message!r}")
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{label}: displayed archive member value {value!r}: {message!r}")
 
 
 def assert_no_sentinel(output: str, label: str) -> None:

--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -161,10 +161,15 @@ def run_zip_ingestion_preflights() -> None:
         encrypted = temp / "encrypted.zip"
         shutil.copy2(metadata, encrypted)
         mark_zip_member_encrypted(encrypted, "Release")
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: signer.read_zip_members(encrypted),
             "encrypted zip member",
             "repository signing encrypted member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "repository signing encrypted member",
+            "Release",
         )
 
         unsupported = temp / "unsupported.zip"
@@ -173,10 +178,30 @@ def run_zip_ingestion_preflights() -> None:
             info.compress_type = zipfile.ZIP_STORED
             info.external_attr = (stat.S_IFCHR | 0o644) << 16
             archive.writestr(info, b"device\n")
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: signer.read_zip_members(unsupported),
             "unsupported zip member",
             "repository signing unsupported member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "repository signing unsupported member",
+            "Release",
+        )
+
+        unsafe = temp / "unsafe.zip"
+        with zipfile.ZipFile(unsafe, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("../Release", b"escape\n")
+        message = expect_action_failure(
+            lambda: signer.read_zip_members(unsafe),
+            "unsafe repository metadata zip path",
+            "repository signing unsafe member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "repository signing unsafe member",
+            "../Release",
+            "Release",
         )
 
 
@@ -383,15 +408,24 @@ def expect_constant_failure(
         setattr(signer, constant_name, original)
 
 
-def expect_action_failure(action, expected: str, label: str) -> None:
+def expect_action_failure(action, expected: str, label: str) -> str:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
         if expected in message:
-            return
+            return message
         raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_member_failure_redacted(message: str, label: str, *forbidden_values: str) -> None:
+    for marker in ("pathDisplayed=false", "contentsDisplayed=false"):
+        if marker not in message:
+            raise AssertionError(f"{label}: missing {marker}: {message!r}")
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{label}: displayed archive member value {value!r}: {message!r}")
 
 
 def try_symlink(link: Path, target: Path) -> bool:

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -33,6 +33,7 @@ MAX_HOSTED_BUNDLE_BYTES = 6 * 1024 * 1024 * 1024
 MAX_ZIP_MEMBER_BYTES = 512_000_000
 MAX_ZIP_MEMBERS = 10_000
 MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 DEBIAN_ARCHES = {
     "linux-x64": "amd64",
@@ -399,16 +400,16 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                 if len(infos) > MAX_ZIP_MEMBERS:
                     raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
                 for member in infos:
-                    name = normalize_zip_path(member.filename)
+                    name = normalize_zip_path(bundle.name, member.filename)
                     if not validate_zip_member_for_read(bundle.name, member, name):
                         continue
                     if name in members:
-                        raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
+                        raise zip_member_failure(bundle.name, "contains duplicate zip member")
                     if name != "README.txt" and not (
                         name in {"Packages", "Packages.gz", "Release", "InRelease", "Release.gpg"}
                         or name.startswith("repodata/")
                     ):
-                        raise SystemExit(f"{bundle.name} contains unexpected zip member: {name}")
+                        raise zip_member_failure(bundle.name, "contains unexpected zip member")
                     total_uncompressed += member.file_size
                     if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
                         raise SystemExit(
@@ -428,30 +429,43 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
 
 def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name: str) -> bool:
     if member.flag_bits & 0x1:
-        raise SystemExit(f"{bundle_name} contains encrypted zip member: {name}")
+        raise zip_member_failure(bundle_name, "contains encrypted zip member")
     file_type = (member.external_attr >> 16) & 0o170000
     is_directory = member.is_dir() or file_type == stat.S_IFDIR
     if file_type == stat.S_IFLNK:
-        raise SystemExit(f"{bundle_name} contains unsupported link member: {name}")
+        raise zip_member_failure(bundle_name, "contains unsupported link member")
     if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
-        raise SystemExit(f"{bundle_name} contains unsupported zip member: {name}")
+        raise zip_member_failure(bundle_name, "contains unsupported zip member")
     if is_directory:
         if member.file_size != 0:
-            raise SystemExit(f"{bundle_name} contains directory member with data: {name}")
+            raise zip_member_failure(bundle_name, "contains directory member with data")
         return False
     if member.file_size > MAX_ZIP_MEMBER_BYTES:
-        raise SystemExit(f"{bundle_name} zip member is too large: {name}")
+        raise zip_member_failure(bundle_name, "zip member is too large")
     return True
 
 
-def normalize_zip_path(raw_name: str) -> str:
+def zip_member_failure(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(f"{archive_name} {reason}; {MEMBER_FAILURE_GUARDS}")
+
+
+def has_windows_drive_prefix(path: str) -> bool:
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
+
+
+def normalize_zip_path(archive_name: str, raw_name: str) -> str:
     normalized = raw_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe repository metadata zip path: {raw_name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise zip_member_failure(archive_name, "contains unsafe repository metadata zip path")
     if not parts:
-        raise SystemExit(f"unsafe empty repository metadata zip path: {raw_name}")
+        raise zip_member_failure(archive_name, "contains empty repository metadata zip path")
     return "/".join(parts)
 
 

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -29,6 +29,7 @@ MAX_HOSTED_BUNDLE_BYTES = 4 * 1024 * 1024 * 1024
 MAX_ZIP_MEMBER_BYTES = 512_000_000
 MAX_ZIP_MEMBERS = 10_000
 MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
@@ -293,11 +294,11 @@ def read_hosted_bundle(bundle: Path) -> dict[str, bytes]:
                 if len(infos) > MAX_ZIP_MEMBERS:
                     raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
                 for member in infos:
-                    name = normalize_zip_path(member.filename)
+                    name = normalize_zip_path(bundle.name, member.filename)
                     if not validate_zip_member_for_read(bundle.name, member, name):
                         continue
                     if name in members:
-                        raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
+                        raise zip_member_failure(bundle.name, "contains duplicate zip member")
                     total_uncompressed += member.file_size
                     if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
                         raise SystemExit(
@@ -317,30 +318,43 @@ def read_hosted_bundle(bundle: Path) -> dict[str, bytes]:
 
 def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name: str) -> bool:
     if member.flag_bits & 0x1:
-        raise SystemExit(f"{bundle_name} contains encrypted zip member: {name}")
+        raise zip_member_failure(bundle_name, "contains encrypted zip member")
     file_type = (member.external_attr >> 16) & 0o170000
     is_directory = member.is_dir() or file_type == stat.S_IFDIR
     if file_type == stat.S_IFLNK:
-        raise SystemExit(f"{bundle_name} contains unsupported link member: {name}")
+        raise zip_member_failure(bundle_name, "contains unsupported link member")
     if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
-        raise SystemExit(f"{bundle_name} contains unsupported zip member: {name}")
+        raise zip_member_failure(bundle_name, "contains unsupported zip member")
     if is_directory:
         if member.file_size != 0:
-            raise SystemExit(f"{bundle_name} contains directory member with data: {name}")
+            raise zip_member_failure(bundle_name, "contains directory member with data")
         return False
     if member.file_size > MAX_ZIP_MEMBER_BYTES:
-        raise SystemExit(f"{bundle_name} zip member is too large: {name}")
+        raise zip_member_failure(bundle_name, "zip member is too large")
     return True
 
 
-def normalize_zip_path(raw_name: str) -> str:
+def zip_member_failure(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(f"{archive_name} {reason}; {MEMBER_FAILURE_GUARDS}")
+
+
+def has_windows_drive_prefix(path: str) -> bool:
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
+
+
+def normalize_zip_path(archive_name: str, raw_name: str) -> str:
     normalized = raw_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe hosted repository zip path: {raw_name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise zip_member_failure(archive_name, "contains unsafe hosted repository zip path")
     if not parts:
-        raise SystemExit(f"unsafe empty hosted repository zip path: {raw_name}")
+        raise zip_member_failure(archive_name, "contains empty hosted repository zip path")
     return "/".join(parts)
 
 

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -31,6 +31,7 @@ MAX_SITE_ZIP_BYTES = 2 * 1024 * 1024 * 1024
 MAX_SITE_MEMBER_BYTES = 512_000_000
 MAX_SITE_MEMBERS = 10000
 MAX_SITE_TOTAL_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024
+MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
 CACHE_CONTROL_RULES = (
@@ -312,11 +313,11 @@ def read_site_members(site_zip: Path) -> dict[str, bytes]:
                 if len(infos) > MAX_SITE_MEMBERS:
                     raise SystemExit(f"{site_zip.name} has too many members for Pages deployment")
                 for info in infos:
-                    name = normalize_zip_path(info.filename)
+                    name = normalize_zip_path(site_zip.name, info.filename)
                     if not validate_zip_member_for_read(site_zip.name, info, name):
                         continue
                     if name in members:
-                        raise SystemExit(f"{site_zip.name} contains duplicate zip member: {name}")
+                        raise zip_member_failure(site_zip.name, "contains duplicate zip member")
                     total_uncompressed += info.file_size
                     if total_uncompressed > MAX_SITE_TOTAL_UNCOMPRESSED_BYTES:
                         raise SystemExit(
@@ -334,36 +335,49 @@ def read_site_members(site_zip: Path) -> dict[str, bytes]:
     return members
 
 
-def normalize_zip_path(raw_name: str) -> str:
+def zip_member_failure(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(f"{archive_name} {reason}; {MEMBER_FAILURE_GUARDS}")
+
+
+def has_windows_drive_prefix(path: str) -> bool:
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
+
+
+def normalize_zip_path(archive_name: str, raw_name: str) -> str:
     normalized = raw_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe hosted repository site path: {raw_name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise zip_member_failure(archive_name, "contains unsafe hosted repository site path")
     if not parts:
-        raise SystemExit(f"unsafe empty hosted repository site path: {raw_name}")
+        raise zip_member_failure(archive_name, "contains empty hosted repository site path")
     lowered = {part.lower() for part in parts}
     forbidden = sorted(lowered & FORBIDDEN_SEGMENTS)
     if forbidden:
-        raise SystemExit(f"hosted repository site contains forbidden local-state path: {'/'.join(parts)}")
+        raise zip_member_failure(archive_name, "contains forbidden local-state path")
     return "/".join(parts)
 
 
 def validate_zip_member_for_read(site_name: str, info: zipfile.ZipInfo, name: str) -> bool:
     if info.flag_bits & 0x1:
-        raise SystemExit(f"{site_name} contains encrypted zip member: {name}")
+        raise zip_member_failure(site_name, "contains encrypted zip member")
     file_type = (info.external_attr >> 16) & 0o170000
     is_directory = info.is_dir() or file_type == stat.S_IFDIR
     if file_type == stat.S_IFLNK:
-        raise SystemExit(f"hosted repository site contains unsupported link member: {name}")
+        raise zip_member_failure(site_name, "contains unsupported link member")
     if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
-        raise SystemExit(f"hosted repository site contains unsupported member type: {name}")
+        raise zip_member_failure(site_name, "contains unsupported member type")
     if is_directory:
         if info.file_size != 0:
-            raise SystemExit(f"{site_name} contains directory member with data: {name}")
+            raise zip_member_failure(site_name, "contains directory member with data")
         return False
     if info.file_size > MAX_SITE_MEMBER_BYTES:
-        raise SystemExit(f"{site_name} member is too large for Pages deployment: {name}")
+        raise zip_member_failure(site_name, "member is too large for Pages deployment")
     return True
 
 

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -35,6 +35,7 @@ MAX_TOTAL_REPOSITORY_METADATA_BUNDLE_BYTES = 1_000_000_000
 MAX_ZIP_MEMBER_BYTES = 512_000_000
 MAX_ZIP_MEMBERS = 10_000
 MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
+MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
 MAX_GENERATED_SIGNATURE_BYTES = 1024 * 1024
 HASH_CHUNK_BYTES = 1024 * 1024
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
@@ -294,11 +295,11 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                 if len(infos) > MAX_ZIP_MEMBERS:
                     raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
                 for member in infos:
-                    name = normalize_zip_path(member.filename)
+                    name = normalize_zip_path(bundle.name, member.filename)
                     if not validate_zip_member_for_read(bundle.name, member, name):
                         continue
                     if name in members:
-                        raise SystemExit(f"{bundle.name} contains duplicate zip member: {name}")
+                        raise zip_member_failure(bundle.name, "contains duplicate zip member")
                     total_uncompressed += member.file_size
                     if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
                         raise SystemExit(
@@ -319,30 +320,43 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
 
 def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name: str) -> bool:
     if member.flag_bits & 0x1:
-        raise SystemExit(f"{bundle_name} contains encrypted zip member: {name}")
+        raise zip_member_failure(bundle_name, "contains encrypted zip member")
     file_type = (member.external_attr >> 16) & 0o170000
     is_directory = member.is_dir() or file_type == stat.S_IFDIR
     if file_type == stat.S_IFLNK:
-        raise SystemExit(f"{bundle_name} contains unsupported link member: {name}")
+        raise zip_member_failure(bundle_name, "contains unsupported link member")
     if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
-        raise SystemExit(f"{bundle_name} contains unsupported zip member: {name}")
+        raise zip_member_failure(bundle_name, "contains unsupported zip member")
     if is_directory:
         if member.file_size != 0:
-            raise SystemExit(f"{bundle_name} contains directory member with data: {name}")
+            raise zip_member_failure(bundle_name, "contains directory member with data")
         return False
     if member.file_size > MAX_ZIP_MEMBER_BYTES:
-        raise SystemExit(f"{bundle_name} zip member is too large: {name}")
+        raise zip_member_failure(bundle_name, "zip member is too large")
     return True
 
 
-def normalize_zip_path(raw_name: str) -> str:
+def zip_member_failure(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(f"{archive_name} {reason}; {MEMBER_FAILURE_GUARDS}")
+
+
+def has_windows_drive_prefix(path: str) -> bool:
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
+
+
+def normalize_zip_path(archive_name: str, raw_name: str) -> str:
     normalized = raw_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts:
-        raise SystemExit(f"unsafe repository metadata zip path: {raw_name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+    ):
+        raise zip_member_failure(archive_name, "contains unsafe repository metadata zip path")
     if not parts:
-        raise SystemExit(f"unsafe empty repository metadata zip path: {raw_name}")
+        raise zip_member_failure(archive_name, "contains empty repository metadata zip path")
     return "/".join(parts)
 
 


### PR DESCRIPTION
Closes #997.

## Changes
- Redact hosted Linux repository ZIP member names from unsafe, empty, duplicate, encrypted, unsupported, forbidden local-state, and oversized member failures.
- Add `pathDisplayed=false contentsDisplayed=false` guards to member-specific hosted repository ZIP diagnostics.
- Reject Windows drive-style and `//` archive member paths in hosted repository ZIP readers.
- Add regressions across hosted repository bundle/site, repository metadata signing ingestion, and Pages deployment ingestion.

## Validation
- `python -m py_compile scripts\generate-hosted-linux-repository-site.py scripts\generate-hosted-linux-repositories.py scripts\sign-linux-repository-metadata.py scripts\prepare-hosted-linux-repository-pages.py scripts\check-hosted-linux-repository-site.py scripts\check-hosted-linux-repositories.py scripts\check-linux-repository-signing.py scripts\check-hosted-linux-repository-pages.py`
- `python scripts\check-hosted-linux-repository-site.py`
- `python scripts\check-hosted-linux-repositories.py`
- `python scripts\check-linux-repository-signing.py` (ZIP ingestion preflights passed; GPG integration skipped locally because `gpg` is unavailable)
- `python scripts\check-hosted-linux-repository-pages.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-github-workflow-permissions.py`
- `python scripts\verify-npm-package-contents.py`
- `python scripts\verify-npm-package-contents-regression.py`
- `npm run check` from `packaging\npm\conu-cli`
- raw member-output `rg` scans for hosted ZIP errors
- `git diff --check`

## Security Categories
- payload exposure risk: reduces attacker-controlled archive member exposure in hosted repository release diagnostics.
- trust/permission risk: no permission expansion.
- storage/logging risk: prevents raw hosted ZIP member names from being written to CI/release failure logs.
- relay/network risk: not touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts archive member details from hosted Linux repository and Pages deployment error messages to prevent leaking untrusted paths. Also adds stricter ZIP member path validation.

- **Bug Fixes**
  - Add "pathDisplayed=false contentsDisplayed=false" guards and shared redacted failure handling for empty, unsafe, duplicate, encrypted, unsupported, forbidden, and oversized member errors across hosted bundle, site, signing, and Pages flows.
  - Reject Windows drive-style and double-slash paths during normalization; extend regression tests to capture failure output and assert redaction across bundle/site generation, repository metadata signing ingestion, and Pages deployment.

<sup>Written for commit b1a0680ba22caedc594f6e9ba5805f45e3bc8c64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced archive member validation to reject unsafe and invalid paths, including absolute paths, Windows drive prefixes, and path traversal attempts.
  * Error messages now properly redact sensitive archive member details and paths to protect information during validation.
  * Standardized validation failure handling and error reporting across scripts for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->