### PR TITLE
Redact package submission archive member failures

### DIFF
--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -158,7 +158,7 @@ def assert_bundle(preparer, dist: Path, output: Path) -> Path:
     return bundle
 
 
-def expect_failure(description: str, action, expected: str) -> None:
+def expect_failure(description: str, action, expected: str) -> str:
     try:
         action()
     except SystemExit as exc:
@@ -167,7 +167,7 @@ def expect_failure(description: str, action, expected: str) -> None:
             raise AssertionError(
                 f"{description} failed with {message!r}, expected {expected!r}"
             ) from exc
-        return
+        return message
     raise AssertionError(f"{description} unexpectedly passed")
 
 
@@ -189,6 +189,21 @@ def expect_failure_without_leak(
             raise AssertionError(f"{description} leaked forbidden value: {message!r}") from exc
         return
     raise AssertionError(f"{description} unexpectedly passed")
+
+
+def expect_member_redacted_failure(
+    description: str,
+    action,
+    expected: str,
+    *forbidden_values: str,
+) -> None:
+    message = expect_failure(description, action, expected)
+    for marker in ("pathDisplayed=false", "contentsDisplayed=false"):
+        if marker not in message:
+            raise AssertionError(f"{description} did not include {marker}: {message!r}")
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{description} leaked archive member value {value!r}: {message!r}")
 
 
 def expect_failure_with_limit(
@@ -517,7 +532,7 @@ def main() -> int:
         )
         write_signed_release_extras(encrypted_chocolatey)
         mark_zip_member_encrypted(encrypted_chocolatey / "conu.0.1.0.nupkg", "conu.nuspec")
-        expect_failure(
+        expect_member_redacted_failure(
             "encrypted Chocolatey package member",
             lambda: preparer.prepare_submission_bundle(
                 encrypted_chocolatey,
@@ -528,6 +543,7 @@ def main() -> int:
                 require_linux_signatures=True,
             ),
             "contains encrypted Chocolatey package member",
+            "conu.nuspec",
         )
 
         unsupported_chocolatey = temp / "unsupported-chocolatey"
@@ -546,7 +562,7 @@ def main() -> int:
             info = zipfile.ZipInfo("device")
             info.external_attr = stat.S_IFCHR << 16
             archive.writestr(info, b"device\n")
-        expect_failure(
+        expect_member_redacted_failure(
             "unsupported Chocolatey package member",
             lambda: preparer.prepare_submission_bundle(
                 unsupported_chocolatey,
@@ -557,6 +573,55 @@ def main() -> int:
                 require_linux_signatures=True,
             ),
             "contains unsupported Chocolatey package member",
+            "device",
+        )
+
+        unexpected_chocolatey = temp / "unexpected-chocolatey"
+        manifest_check.generate(
+            generator,
+            dist,
+            unexpected_chocolatey,
+            build_apt_repository_metadata=True,
+        )
+        write_signed_release_extras(unexpected_chocolatey)
+        unexpected_member = "tools/secret-package-manager-member.txt"
+        with zipfile.ZipFile(
+            unexpected_chocolatey / "conu.0.1.0.nupkg",
+            "a",
+            compression=zipfile.ZIP_STORED,
+        ) as archive:
+            archive.writestr(unexpected_member, b"secret\n")
+        expect_member_redacted_failure(
+            "unexpected Chocolatey package member",
+            lambda: preparer.prepare_submission_bundle(
+                unexpected_chocolatey,
+                temp / "unexpected-chocolatey-out",
+                VERSION,
+                require_rpm_assets=True,
+                require_repository_metadata=True,
+                require_linux_signatures=True,
+            ),
+            "has unexpected Chocolatey package entries",
+            unexpected_member,
+            "secret-package-manager-member",
+        )
+
+        expect_member_redacted_failure(
+            "duplicate package-manager submission archive path",
+            lambda: preparer.validate_no_duplicate_archive_names(
+                ("bundle/safe.txt", "bundle/./safe.txt")
+            ),
+            "duplicate package-manager submission archive path",
+            "bundle/safe.txt",
+        )
+
+        unsafe_submission_member = "C:\\secret-package-manager-submission-path"
+        expect_member_redacted_failure(
+            "unsafe package-manager submission archive path",
+            lambda: preparer.normalize_archive_path(unsafe_submission_member),
+            "unsafe package-manager submission archive path",
+            unsafe_submission_member,
+            "secret-package-manager-submission-path",
         )
 
         forbidden = temp / "forbidden"

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -30,6 +30,7 @@ MAX_SUBMISSION_BUNDLE_BYTES = MAX_TOTAL_SOURCE_BYTES + MAX_TEXT_BYTES + (1024 * 
 MAX_CHECKSUM_BYTES = 4096
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
+MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
 ZIP_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 DEBIAN_ARCHES = ("amd64", "arm64")
 RPM_ARCHES = ("x86_64", "aarch64")
@@ -430,12 +431,15 @@ def validate_chocolatey_package(path: Path, dist: Path) -> None:
             for info in infos:
                 validate_chocolatey_member(path.name, info)
             if names != expected:
-                raise SystemExit(f"{path.name} has unexpected Chocolatey package entries: {names!r}")
+                raise archive_member_failure(
+                    path.name,
+                    "has unexpected Chocolatey package entries",
+                )
             for info in infos:
                 name = info.filename
                 normalized = normalize_archive_path(name)
                 if normalized != name:
-                    raise SystemExit(f"{path.name} has unsafe Chocolatey package path: {name}")
+                    raise archive_member_failure(path.name, "has unsafe Chocolatey package path")
                 text = read_chocolatey_text_member(package, info, path.name)
                 assert_safe_text(text, f"{path.name}:{name}", dist)
     except (RuntimeError, zipfile.BadZipFile) as exc:
@@ -447,19 +451,22 @@ def validate_chocolatey_package(path: Path, dist: Path) -> None:
 def validate_chocolatey_member(package_name: str, info: zipfile.ZipInfo) -> None:
     name = info.filename
     if info.flag_bits & 0x1:
-        raise SystemExit(f"{package_name} contains encrypted Chocolatey package member: {name}")
+        raise archive_member_failure(package_name, "contains encrypted Chocolatey package member")
     file_type = (info.external_attr >> 16) & 0o170000
     is_directory = info.is_dir() or file_type == stat.S_IFDIR
     if file_type == stat.S_IFLNK:
-        raise SystemExit(f"{package_name} contains unsupported Chocolatey link member: {name}")
+        raise archive_member_failure(package_name, "contains unsupported Chocolatey link member")
     if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
-        raise SystemExit(f"{package_name} contains unsupported Chocolatey package member: {name}")
+        raise archive_member_failure(package_name, "contains unsupported Chocolatey package member")
     if is_directory:
         if info.file_size != 0:
-            raise SystemExit(f"{package_name} contains Chocolatey directory member with data: {name}")
-        raise SystemExit(f"{package_name} has unexpected Chocolatey package directory: {name}")
+            raise archive_member_failure(
+                package_name,
+                "contains Chocolatey directory member with data",
+            )
+        raise archive_member_failure(package_name, "has unexpected Chocolatey package directory")
     if info.file_size > MAX_TEXT_BYTES:
-        raise SystemExit(f"{package_name}:{name} is too large")
+        raise archive_member_failure(package_name, "Chocolatey package member is too large")
 
 
 def read_chocolatey_text_member(
@@ -471,9 +478,12 @@ def read_chocolatey_text_member(
         with package.open(info, "r") as handle:
             data = handle.read(MAX_TEXT_BYTES + 1)
     except (RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
-        raise SystemExit(f"{package_name} could not read Chocolatey package member: {info.filename}") from exc
+        raise archive_member_failure(
+            package_name,
+            "could not read Chocolatey package member",
+        ) from exc
     if len(data) > MAX_TEXT_BYTES:
-        raise SystemExit(f"{package_name}:{info.filename} is too large")
+        raise archive_member_failure(package_name, "Chocolatey package member is too large")
     return data.decode("ascii")
 
 
@@ -548,7 +558,10 @@ def validate_no_duplicate_archive_names(names: Any) -> None:
     for name in names:
         normalized = normalize_archive_path(name)
         if normalized in seen:
-            raise SystemExit(f"duplicate package-manager submission archive path: {normalized}")
+            raise archive_member_failure(
+                "package-manager submission bundle",
+                "contains duplicate package-manager submission archive path",
+            )
         seen.add(normalized)
 
 
@@ -556,9 +569,26 @@ def normalize_archive_path(raw_name: str) -> str:
     normalized = raw_name.replace("\\", "/")
     path = PurePosixPath(normalized)
     parts = [part for part in path.parts if part not in {"", ".", "/"}]
-    if path.is_absolute() or ".." in parts or not parts:
-        raise SystemExit(f"unsafe package-manager submission archive path: {raw_name}")
+    if (
+        path.is_absolute()
+        or normalized.startswith("//")
+        or has_windows_drive_prefix(normalized)
+        or ".." in parts
+        or not parts
+    ):
+        raise archive_member_failure(
+            "package-manager submission bundle",
+            "contains unsafe package-manager submission archive path",
+        )
     return "/".join(parts)
+
+
+def archive_member_failure(archive_name: str, reason: str) -> SystemExit:
+    return SystemExit(f"{archive_name} {reason}; {MEMBER_FAILURE_GUARDS}")
+
+
+def has_windows_drive_prefix(path: str) -> bool:
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
 
 
 def validate_input_directory(path: Path, label: str) -> None:


### PR DESCRIPTION
Closes #999.

## Changes
- Redact Chocolatey/package-manager submission archive member names from encrypted, unsupported, unexpected, duplicate, unsafe, and oversized member failure output.
- Add `pathDisplayed=false contentsDisplayed=false` guards for member-specific submission failures.
- Reject Windows drive-style and `//` package-manager submission archive paths.
- Add regressions that fail if raw member names are displayed.

## Validation
- `python -m py_compile scripts\prepare-package-manager-submissions.py scripts\check-package-manager-submissions.py`
- `python scripts\check-package-manager-submissions.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-package-manager-manifests.py`
- `python scripts\verify-npm-package-contents.py`
- `python scripts\verify-npm-package-contents-regression.py`
- `python scripts\check-github-workflow-permissions.py`
- `npm run check` from `packaging\npm\conu-cli`
- raw member-output `rg` scan for package-manager submission errors
- `git diff --check`

## Security Categories
- payload exposure risk: reduces attacker-controlled archive member exposure in package-manager submission diagnostics.
- trust/permission risk: no permission expansion.
- storage/logging risk: prevents raw submission/Chocolatey member names from being written to CI/release failure logs.
- relay/network risk: not touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts archive member names from `Chocolatey` and package-manager submission failure messages to prevent leaking attacker-controlled values in logs. Tightens path validation to block unsafe or duplicate archive entries.

- **Bug Fixes**
  - Redacted member names for encrypted, unsupported, unexpected, oversized, unsafe, and duplicate failures.
  - Added `pathDisplayed=false contentsDisplayed=false` markers to member-specific failures.
  - Rejected unsafe paths during normalization (absolute, `//`, Windows drive prefixes, `..`, empty) and duplicate names.
  - Added regression checks to ensure no raw member names appear in diagnostics.

<sup>Written for commit 5e7e9a051b057cd4777f62f41ad3b7396825e3a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

