### PR TITLE
Redact corrupt release smoke member reads

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -277,6 +277,19 @@ def main() -> int:
         )
 
     with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-corrupt.zip"
+        secret_member = "secret-npm-manifest-member-should-not-print.txt"
+        write_zip_entries(archive, [(secret_member, "secret")])
+        corrupt_zip_member_data(archive, secret_member)
+        expect_action_failure(
+            lambda: smoke.read_archive_member(archive, secret_member),
+            "could not read zip member",
+            "corrupt npm member during manifest read",
+            forbidden=secret_member,
+            require_member_redaction=True,
+        )
+
+    with fixture_dir() as root:
         archive = root / "conu-0.1.0-manifest-drive.zip"
         drive_member = "C:\\secret-manifest-path-should-not-print"
         write_zip_entries(archive, [(drive_member, "x")])
@@ -380,6 +393,19 @@ def main() -> int:
             "unsupported zip member",
             "unsupported zip member type",
             forbidden="device",
+            require_member_redaction=True,
+        )
+
+    with fixture_dir() as root:
+        archive = root / "conu-0.1.0-corrupt-extract.zip"
+        secret_member = "secret-npm-extract-member-should-not-print.txt"
+        write_zip_entries(archive, [(secret_member, "secret")])
+        corrupt_zip_member_data(archive, secret_member)
+        expect_action_failure(
+            lambda: smoke.extract_archive(archive, root / "extract-corrupt"),
+            "could not read zip member",
+            "corrupt npm member during extraction",
+            forbidden=secret_member,
             require_member_redaction=True,
         )
 
@@ -488,6 +514,32 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+def corrupt_zip_member_data(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature != 0x04034B50:
+            offset += 1
+            continue
+        name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+        extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+        name_start = offset + 30
+        name_end = name_start + name_length
+        data_start = name_end + extra_length
+        compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+        data_end = data_start + compressed_size
+        if data[name_start:name_end] == target:
+            if compressed_size == 0:
+                raise SystemExit(f"{member_name} had no compressed data to corrupt")
+            data[data_end - 1] ^= 0xFF
+            path.write_bytes(data)
+            return
+        offset = data_end
+    raise SystemExit(f"zip member not found for corruption: {member_name}")
 
 
 def assert_safe_snippet_redacts(smoke) -> None:

--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -209,6 +209,19 @@ def main() -> int:
         )
 
     with fixture_dir() as root:
+        archive = root / "conu-0.1.0-manifest-corrupt.zip"
+        secret_member = "secret-manifest-member-should-not-print.txt"
+        write_zip_entries(archive, [(secret_member, "secret")])
+        corrupt_zip_member_data(archive, secret_member)
+        expect_action_failure(
+            lambda: smoke.read_archive_member(archive, secret_member),
+            "could not read zip member",
+            "corrupt member during manifest read",
+            forbidden=secret_member,
+            require_member_redaction=True,
+        )
+
+    with fixture_dir() as root:
         archive = root / "conu-0.1.0-manifest-drive.zip"
         drive_member = "C:\\secret-manifest-path-should-not-print"
         write_zip_entries(archive, [(drive_member, "x")])
@@ -316,6 +329,19 @@ def main() -> int:
         )
 
     with fixture_dir() as root:
+        archive = root / "conu-0.1.0-corrupt-extract.zip"
+        secret_member = "secret-extract-member-should-not-print.txt"
+        write_zip_entries(archive, [(secret_member, "secret")])
+        corrupt_zip_member_data(archive, secret_member)
+        expect_action_failure(
+            lambda: smoke.extract_archive(archive, root / "extract-corrupt"),
+            "could not read zip member",
+            "corrupt member during extraction",
+            forbidden=secret_member,
+            require_member_redaction=True,
+        )
+
+    with fixture_dir() as root:
         archive = root / "conu-0.1.0-drive.zip"
         drive_member = "C:\\secret-extract-path-should-not-print"
         write_zip_entries(archive, [(drive_member, "x")])
@@ -407,6 +433,32 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+def corrupt_zip_member_data(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature != 0x04034B50:
+            offset += 1
+            continue
+        name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+        extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+        name_start = offset + 30
+        name_end = name_start + name_length
+        data_start = name_end + extra_length
+        compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+        data_end = data_start + compressed_size
+        if data[name_start:name_end] == target:
+            if compressed_size == 0:
+                raise SystemExit(f"{member_name} had no compressed data to corrupt")
+            data[data_end - 1] ^= 0xFF
+            path.write_bytes(data)
+            return
+        offset = data_end
+    raise SystemExit(f"zip member not found for corruption: {member_name}")
 
 
 def assert_safe_snippet_redacts(smoke) -> None:

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -15,6 +15,7 @@ import sys
 import tarfile
 import tempfile
 import zipfile
+import zlib
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 
@@ -46,6 +47,23 @@ def archive_member_failure(archive_name: str, reason: str) -> SystemExit:
 
 def has_windows_drive_prefix(path: str) -> bool:
     return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
+
+
+def read_zip_member(archive_name: str, package: zipfile.ZipFile, member: zipfile.ZipInfo) -> bytes:
+    try:
+        return package.read(member)
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise archive_member_failure(archive_name, "could not read zip member") from exc
+
+
+def read_tar_member(archive_name: str, package: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
+    try:
+        file_object = package.extractfile(member)
+        if file_object is None:
+            raise archive_member_failure(archive_name, "could not read member")
+        return file_object.read()
+    except (tarfile.TarError, EOFError, OSError, zlib.error) as exc:
+        raise archive_member_failure(archive_name, "could not read member") from exc
 
 
 def main() -> int:
@@ -198,7 +216,7 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
                                 archive.name,
                                 "contains duplicate archive path",
                             )
-                        found = package.read(member)
+                        found = read_zip_member(archive.name, package, member)
                 return found
 
     if archive.name.endswith(".tar.gz"):
@@ -227,8 +245,7 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
                                 archive.name,
                                 "contains duplicate archive path",
                             )
-                        file_object = package.extractfile(member)
-                        found = file_object.read() if file_object is not None else None
+                        found = read_tar_member(archive.name, package, member)
                 return found
 
     raise SystemExit(f"unsupported release archive {archive.name}")
@@ -455,7 +472,7 @@ def extract_archive(archive: Path, destination: Path) -> None:
                         state,
                     )
                     output_path.parent.mkdir(parents=True, exist_ok=True)
-                    output_path.write_bytes(package.read(member))
+                    output_path.write_bytes(read_zip_member(archive.name, package, member))
                     unix_mode = (member.external_attr >> 16) & 0o777
                     if unix_mode:
                         output_path.chmod(unix_mode)
@@ -497,10 +514,7 @@ def extract_archive(archive: Path, destination: Path) -> None:
                         state,
                     )
                     output_path.parent.mkdir(parents=True, exist_ok=True)
-                    file_object = package.extractfile(member)
-                    if file_object is None:
-                        raise archive_member_failure(archive.name, "could not read member")
-                    output_path.write_bytes(file_object.read())
+                    output_path.write_bytes(read_tar_member(archive.name, package, member))
                     output_path.chmod(member.mode & 0o777)
         return
 

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -15,6 +15,7 @@ import sys
 import tarfile
 import tempfile
 import zipfile
+import zlib
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 
@@ -45,6 +46,23 @@ def archive_member_failure(archive_name: str, reason: str) -> SystemExit:
 
 def has_windows_drive_prefix(path: str) -> bool:
     return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
+
+
+def read_zip_member(archive_name: str, package: zipfile.ZipFile, member: zipfile.ZipInfo) -> bytes:
+    try:
+        return package.read(member)
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise archive_member_failure(archive_name, "could not read zip member") from exc
+
+
+def read_tar_member(archive_name: str, package: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
+    try:
+        file_object = package.extractfile(member)
+        if file_object is None:
+            raise archive_member_failure(archive_name, "could not read member")
+        return file_object.read()
+    except (tarfile.TarError, EOFError, OSError, zlib.error) as exc:
+        raise archive_member_failure(archive_name, "could not read member") from exc
 
 
 def main() -> int:
@@ -154,7 +172,7 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
                                 archive.name,
                                 "contains duplicate archive path",
                             )
-                        found = package.read(member)
+                        found = read_zip_member(archive.name, package, member)
                 return found
 
     if archive.name.endswith(".tar.gz"):
@@ -183,8 +201,7 @@ def read_archive_member(archive: Path, normalized_name: str) -> bytes | None:
                                 archive.name,
                                 "contains duplicate archive path",
                             )
-                        file_object = package.extractfile(member)
-                        found = file_object.read() if file_object is not None else None
+                        found = read_tar_member(archive.name, package, member)
                 return found
 
     raise SystemExit(f"unsupported release archive {archive.name}")
@@ -411,7 +428,7 @@ def extract_archive(archive: Path, destination: Path) -> None:
                         state,
                     )
                     output_path.parent.mkdir(parents=True, exist_ok=True)
-                    output_path.write_bytes(package.read(member))
+                    output_path.write_bytes(read_zip_member(archive.name, package, member))
                     unix_mode = (member.external_attr >> 16) & 0o777
                     if unix_mode:
                         output_path.chmod(unix_mode)
@@ -453,10 +470,7 @@ def extract_archive(archive: Path, destination: Path) -> None:
                         state,
                     )
                     output_path.parent.mkdir(parents=True, exist_ok=True)
-                    file_object = package.extractfile(member)
-                    if file_object is None:
-                        raise archive_member_failure(archive.name, "could not read member")
-                    output_path.write_bytes(file_object.read())
+                    output_path.write_bytes(read_tar_member(archive.name, package, member))
                     output_path.chmod(member.mode & 0o777)
         return
 


### PR DESCRIPTION
## Summary
- Redact corrupt ZIP/TAR member read failures in release artifact smoke and npm launcher local smoke helpers.
- Add regressions for corrupt secret-named archive members during direct member reads and extraction.

## Validation
- `python -m py_compile scripts\smoke-release-artifacts.py scripts\check-release-artifact-smoke-preflight.py scripts\smoke-npm-launcher-local.py scripts\check-npm-launcher-local-smoke-preflight.py`
- `python scripts\check-release-artifact-smoke-preflight.py`
- `python scripts\check-npm-launcher-local-smoke-preflight.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `python scripts\verify-release-versions.py`
- `python scripts\check-release-artifact-verifier.py`
- `python scripts\verify-npm-package-contents.py`
- `python scripts\verify-npm-package-contents-regression.py`
- `python scripts\check-github-workflow-permissions.py`
- `npm run check --prefix packaging/npm/conu-cli`
- `git diff --check`

## Security Review
payload exposure risk: corrupt archive member read errors now use redacted member-failure output with `pathDisplayed=false contentsDisplayed=false`.
trust/permission risk: no trust or permission behavior changed.
storage/logging risk: release smoke and npm smoke CI logs no longer expose raw corrupt member names from Python ZIP/TAR read errors.
relay/network risk: no relay or network behavior changed.
required fixes: rotate `NPM_TOKEN` before publishing because it was pasted in chat; paid signing secrets remain required later for fully signed public releases.

Closes #1001

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts ZIP/TAR member read and extract failures in release and npm smoke scripts so CI logs don’t leak corrupt member names or contents. Adds regression tests that simulate corrupt members and assert redaction; closes #1001.

- **Bug Fixes**
  - Wraps member reads with `read_zip_member`/`read_tar_member` to catch zip/tar/zlib errors and raise redacted `archive_member_failure`.
  - Updates `scripts/smoke-release-artifacts.py` and `scripts/smoke-npm-launcher-local.py` to use these helpers for reads and extraction.
  - Adds `corrupt_zip_member_data` and preflight checks in `check-release-artifact-smoke-preflight.py` and `check-npm-launcher-local-smoke-preflight.py` to verify redaction on corrupt member reads and extraction.

<sup>Written for commit 15306d1523f172b35d2d67ba60b8275db67ebc5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

