### PR TITLE
Redact corrupt hosted repository member reads

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -263,6 +263,20 @@ def main() -> int:
             "Packages",
         )
 
+        corrupt_zip = temp / "corrupt-zip"
+        shutil.copytree(dist, corrupt_zip)
+        corrupt_zip_member_data(corrupt_zip / APT_METADATA, "Packages")
+        message = expect_action_failure(
+            lambda: generator.read_zip_members(corrupt_zip / APT_METADATA),
+            "could not read zip member",
+            "corrupt repository metadata member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "corrupt repository metadata member",
+            "Packages",
+        )
+
         unsupported_zip = temp / "unsupported-zip"
         shutil.copytree(dist, unsupported_zip)
         with zipfile.ZipFile(unsupported_zip / APT_METADATA, "w", compression=zipfile.ZIP_STORED) as archive:
@@ -681,6 +695,32 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+def corrupt_zip_member_data(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature != 0x04034B50:
+            offset += 1
+            continue
+        name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+        extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+        name_start = offset + 30
+        name_end = name_start + name_length
+        compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+        data_start = name_end + extra_length
+        data_end = data_start + compressed_size
+        if data[name_start:name_end] == target:
+            if compressed_size == 0:
+                raise AssertionError(f"{member_name} had no compressed data to corrupt")
+            data[data_end - 1] ^= 0xFF
+            path.write_bytes(data)
+            return
+        offset = data_end
+    raise AssertionError(f"zip member not found for corruption: {member_name}")
 
 
 def deterministic_gzip(data: bytes) -> bytes:

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -109,6 +109,20 @@ def main() -> int:
             "index.html",
         )
 
+        corrupt_site = temp / "corrupt-site.zip"
+        shutil.copy2(site, corrupt_site)
+        corrupt_zip_member_data(corrupt_site, "index.html")
+        message = expect_action_failure(
+            lambda: preparer.read_site_members(corrupt_site),
+            "could not read zip member",
+            "corrupt Pages site member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "corrupt Pages site member",
+            "index.html",
+        )
+
         unsupported_site = temp / "unsupported-site.zip"
         with zipfile.ZipFile(unsupported_site, "w", compression=zipfile.ZIP_STORED) as archive:
             info = zipfile.ZipInfo("index.html", ZIP_TIMESTAMP)
@@ -766,6 +780,32 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+def corrupt_zip_member_data(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature != 0x04034B50:
+            offset += 1
+            continue
+        name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+        extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+        name_start = offset + 30
+        name_end = name_start + name_length
+        compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+        data_start = name_end + extra_length
+        data_end = data_start + compressed_size
+        if data[name_start:name_end] == target:
+            if compressed_size == 0:
+                raise AssertionError(f"{member_name} had no compressed data to corrupt")
+            data[data_end - 1] ^= 0xFF
+            path.write_bytes(data)
+            return
+        offset = data_end
+    raise AssertionError(f"zip member not found for corruption: {member_name}")
 
 
 if __name__ == "__main__":

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -139,6 +139,20 @@ def main() -> int:
             "apt/Packages",
         )
 
+        corrupt_bundle = temp / "corrupt-hosted-bundle.zip"
+        shutil.copy2(hosted_bundle, corrupt_bundle)
+        corrupt_zip_member_data(corrupt_bundle, "apt/Packages")
+        message = expect_action_failure(
+            lambda: site_generator.read_hosted_bundle(corrupt_bundle),
+            "could not read zip member",
+            "corrupt hosted bundle member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "corrupt hosted bundle member",
+            "apt/Packages",
+        )
+
         unsupported_bundle = temp / "unsupported-hosted-bundle.zip"
         with zipfile.ZipFile(unsupported_bundle, "w", compression=zipfile.ZIP_STORED) as archive:
             info = zipfile.ZipInfo("README.txt", ZIP_TIMESTAMP)
@@ -764,6 +778,32 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+def corrupt_zip_member_data(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature != 0x04034B50:
+            offset += 1
+            continue
+        name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+        extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+        name_start = offset + 30
+        name_end = name_start + name_length
+        compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+        data_start = name_end + extra_length
+        data_end = data_start + compressed_size
+        if data[name_start:name_end] == target:
+            if compressed_size == 0:
+                raise AssertionError(f"{member_name} had no compressed data to corrupt")
+            data[data_end - 1] ^= 0xFF
+            path.write_bytes(data)
+            return
+        offset = data_end
+    raise AssertionError(f"zip member not found for corruption: {member_name}")
 
 
 if __name__ == "__main__":

--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -172,6 +172,20 @@ def run_zip_ingestion_preflights() -> None:
             "Release",
         )
 
+        corrupt = temp / "corrupt.zip"
+        shutil.copy2(metadata, corrupt)
+        corrupt_zip_member_data(corrupt, "Release")
+        message = expect_action_failure(
+            lambda: signer.read_zip_members(corrupt),
+            "could not read zip member",
+            "repository signing corrupt member",
+        )
+        assert_member_failure_redacted(
+            message,
+            "repository signing corrupt member",
+            "Release",
+        )
+
         unsupported = temp / "unsupported.zip"
         with zipfile.ZipFile(unsupported, "w", compression=zipfile.ZIP_STORED) as archive:
             info = zipfile.ZipInfo("Release", (2020, 1, 1, 0, 0, 0))
@@ -524,6 +538,32 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+def corrupt_zip_member_data(path: Path, member_name: str) -> None:
+    data = bytearray(path.read_bytes())
+    target = member_name.encode("utf-8")
+    offset = 0
+    while offset + 4 <= len(data):
+        signature = int.from_bytes(data[offset : offset + 4], "little")
+        if signature != 0x04034B50:
+            offset += 1
+            continue
+        name_length = int.from_bytes(data[offset + 26 : offset + 28], "little")
+        extra_length = int.from_bytes(data[offset + 28 : offset + 30], "little")
+        name_start = offset + 30
+        name_end = name_start + name_length
+        compressed_size = int.from_bytes(data[offset + 18 : offset + 22], "little")
+        data_start = name_end + extra_length
+        data_end = data_start + compressed_size
+        if data[name_start:name_end] == target:
+            if compressed_size == 0:
+                raise AssertionError(f"{member_name} had no compressed data to corrupt")
+            data[data_end - 1] ^= 0xFF
+            path.write_bytes(data)
+            return
+        offset = data_end
+    raise AssertionError(f"zip member not found for corruption: {member_name}")
 
 
 def verify_apt_signatures(gpg: str, home: Path, bundle: Path, temp: Path) -> None:

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -13,6 +13,7 @@ import re
 import stat
 import sys
 import zipfile
+import zlib
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
@@ -416,7 +417,7 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                             f"{bundle.name} uncompressed ZIP contents exceed "
                             f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
                         )
-                    members[name] = archive.read(member)
+                    members[name] = read_zip_member(bundle.name, archive, member)
                 validate_open_regular_file(
                     archive_file,
                     "hosted repository metadata bundle",
@@ -443,6 +444,13 @@ def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name
     if member.file_size > MAX_ZIP_MEMBER_BYTES:
         raise zip_member_failure(bundle_name, "zip member is too large")
     return True
+
+
+def read_zip_member(bundle_name: str, archive: zipfile.ZipFile, member: zipfile.ZipInfo) -> bytes:
+    try:
+        return archive.read(member)
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise zip_member_failure(bundle_name, "could not read zip member") from exc
 
 
 def zip_member_failure(archive_name: str, reason: str) -> SystemExit:

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -12,6 +12,7 @@ import re
 import stat
 import sys
 import zipfile
+import zlib
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 from urllib.parse import unquote, urlparse, urlunparse
@@ -305,7 +306,7 @@ def read_hosted_bundle(bundle: Path) -> dict[str, bytes]:
                             f"{bundle.name} uncompressed ZIP contents exceed "
                             f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
                         )
-                    members[name] = archive.read(member)
+                    members[name] = read_zip_member(bundle.name, archive, member)
                 validate_open_regular_file(
                     bundle_file,
                     "hosted Linux repository bundle",
@@ -332,6 +333,13 @@ def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name
     if member.file_size > MAX_ZIP_MEMBER_BYTES:
         raise zip_member_failure(bundle_name, "zip member is too large")
     return True
+
+
+def read_zip_member(bundle_name: str, archive: zipfile.ZipFile, member: zipfile.ZipInfo) -> bytes:
+    try:
+        return archive.read(member)
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise zip_member_failure(bundle_name, "could not read zip member") from exc
 
 
 def zip_member_failure(archive_name: str, reason: str) -> SystemExit:

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -12,6 +12,7 @@ import re
 import stat
 import sys
 import zipfile
+import zlib
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 from urllib.parse import unquote, urlparse, urlunparse
@@ -324,7 +325,7 @@ def read_site_members(site_zip: Path) -> dict[str, bytes]:
                             f"{site_zip.name} uncompressed contents exceed "
                             f"{MAX_SITE_TOTAL_UNCOMPRESSED_BYTES} bytes"
                         )
-                    members[name] = archive.read(info)
+                    members[name] = read_zip_member(site_zip.name, archive, info)
                 validate_open_regular_file(
                     site_file,
                     "hosted Linux repository site ZIP",
@@ -379,6 +380,13 @@ def validate_zip_member_for_read(site_name: str, info: zipfile.ZipInfo, name: st
     if info.file_size > MAX_SITE_MEMBER_BYTES:
         raise zip_member_failure(site_name, "member is too large for Pages deployment")
     return True
+
+
+def read_zip_member(site_name: str, archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> bytes:
+    try:
+        return archive.read(info)
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise zip_member_failure(site_name, "could not read zip member") from exc
 
 
 def validate_site_members(site_name: str, version: str, members: dict[str, bytes]) -> None:

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import zipfile
+import zlib
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
@@ -306,7 +307,7 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                             f"{bundle.name} uncompressed ZIP contents exceed "
                             f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
                         )
-                    members[name] = archive.read(member)
+                    members[name] = read_zip_member(bundle.name, archive, member)
             validate_open_regular_file(
                 bundle_file,
                 f"repository metadata bundle {bundle.name}",
@@ -334,6 +335,13 @@ def validate_zip_member_for_read(bundle_name: str, member: zipfile.ZipInfo, name
     if member.file_size > MAX_ZIP_MEMBER_BYTES:
         raise zip_member_failure(bundle_name, "zip member is too large")
     return True
+
+
+def read_zip_member(bundle_name: str, archive: zipfile.ZipFile, member: zipfile.ZipInfo) -> bytes:
+    try:
+        return archive.read(member)
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise zip_member_failure(bundle_name, "could not read zip member") from exc
 
 
 def zip_member_failure(archive_name: str, reason: str) -> SystemExit:


### PR DESCRIPTION
## **User description**
## Summary
- Wrap hosted repository ZIP member reads with redacted failure helpers.
- Cover corrupt member reads in hosted repository generation, hosted site generation, Pages preparation, and Linux repository signing preflights.
- Preserve existing ZIP member validation for unsafe paths, encryption, member count, size bounds, and unsupported member types.

## Validation
- `python -m py_compile scripts\generate-hosted-linux-repositories.py scripts\generate-hosted-linux-repository-site.py scripts\prepare-hosted-linux-repository-pages.py scripts\sign-linux-repository-metadata.py scripts\check-hosted-linux-repositories.py scripts\check-hosted-linux-repository-site.py scripts\check-hosted-linux-repository-pages.py scripts\check-linux-repository-signing.py`
- `python scripts\check-hosted-linux-repositories.py`
- `python scripts\check-hosted-linux-repository-site.py`
- `python scripts\check-hosted-linux-repository-pages.py`
- `python scripts\check-linux-repository-signing.py` (ZIP ingestion preflights ran; signing regression skipped because local `gpg` is unavailable)
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `python scripts\check-github-workflow-permissions.py`
- `python scripts\verify-release-versions.py`
- `python scripts\verify-npm-package-contents.py`
- `npm run check --prefix packaging/npm/conu-cli`
- `cargo fmt --all --check`
- `git diff --check`

Local `cargo test --workspace` could not run because this Windows environment is missing the MSVC linker `link.exe`; GitHub Actions must verify the Rust build gate.

payload exposure risk: Reduces archive-member path exposure from corrupt hosted repository ZIP reads.
trust/permission risk: No trust or permission behavior changes.
storage/logging risk: Hardens CI and local release logs by surfacing generic read failures instead of raw member names.
relay/network risk: No relay or network behavior changes.
required fixes: Merge after CI is green; keep #274 open for live release signing and publishing secret readiness.

Closes #1003

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts error messages for corrupt ZIP member reads across hosted repo generation, site generation, Pages preparation, and signing preflights to prevent member path exposure in logs. Preserves all existing ZIP validation. Closes #1003.

- **Bug Fixes**
  - Wrap ZIP reads in a helper that catches RuntimeError/zipfile.BadZipFile/zlib.error and raises a redacted “could not read zip member” error.
  - Add checks that corrupt specific members and assert redacted failures for hosted bundles, site ZIPs, Pages, and signing preflights.
  - Keep existing validations for unsafe paths, encryption, member counts, size limits, and unsupported types.

<sup>Written for commit 88b91303276d9d5b6e60dd6d78e702afb7b90a2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide corrupt ZIP member details when reading hosted repository bundles and Pages artifacts**

### What Changed
- Reading a damaged ZIP member now fails with a generic message instead of exposing the member’s raw contents or low-level read error.
- Hosted repository generation, hosted site generation, Pages preparation, and repository metadata signing all use the same redacted failure behavior for corrupt archive members.
- Test coverage now includes corrupt member reads in each of those flows, alongside the existing checks for encrypted and unsupported members.

### Impact
`✅ Less archive-member detail in failure logs`
`✅ Clearer error handling for damaged release artifacts`
`✅ Safer hosted repository and Pages validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regression test coverage with new ZIP corruption test cases to validate proper error handling when ZIP members are corrupted or invalid.

* **Bug Fixes**
  * Enhanced ZIP member reading with improved error handling and consistent reporting for decompression failures and read errors across all bundle processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->