### PR TITLE
Redact release verifier archive read failures

### DIFF
--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -294,6 +294,44 @@ def main() -> int:
         write_tar(valid_tar)
         verify_archive(verifier, valid_tar)
 
+        unreadable_zip = root / "conu-0.1.0-unreadable.zip"
+        unreadable_zip.write_bytes(b"not a zip archive\n")
+        write_checksum(unreadable_zip)
+        expect_redacted_member_failure(
+            "unreadable zip archive",
+            lambda: verifier.archive_members(unreadable_zip),
+            "not a readable zip archive",
+            ("not a zip archive",),
+        )
+
+        unreadable_tar = root / "conu-0.1.0-unreadable.tar.gz"
+        unreadable_tar.write_bytes(b"not a tar archive\n")
+        write_checksum(unreadable_tar)
+        expect_redacted_member_failure(
+            "unreadable tar archive",
+            lambda: verifier.archive_members(unreadable_tar),
+            "not a readable tar.gz archive",
+            ("not a tar archive",),
+        )
+
+        secret_tar_member = "secret-tar-member-should-not-print"
+
+        class BrokenTar:
+            def extractfile(self, _member):
+                raise tarfile.ReadError(secret_tar_member)
+
+        expect_redacted_member_failure(
+            "tar member read error",
+            lambda: verifier.read_tar_member(
+                "conu-0.1.0-broken.tar.gz",
+                BrokenTar(),
+                tarfile.TarInfo(secret_tar_member),
+                verifier.MAX_MANIFEST_BYTES,
+            ),
+            "could not read tar member",
+            (secret_tar_member,),
+        )
+
         wrong_name = root / "conu-0.1.0-wrong-name.zip"
         write_zip(wrong_name)
         write_checksum(wrong_name, archive_name="other.zip")

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -180,121 +180,128 @@ def archive_members(archive: Path) -> ArchiveMembers:
     expected_root = expected_archive_root(archive.name)
 
     if archive.suffix == ".zip":
-        with archive_file:
-            with zipfile.ZipFile(archive_file) as package:
-                paths: set[str] = set()
-                manifest: bytes | None = None
-                total_uncompressed = 0
-                entry_count = 0
-                root_style: str | None = None
-                for member in package.infolist():
-                    if member.is_dir():
-                        if member.file_size != 0:
-                            raise archive_member_path_error(
-                                archive.name, "contains directory member with data"
+        try:
+            with archive_file:
+                with zipfile.ZipFile(archive_file) as package:
+                    paths: set[str] = set()
+                    manifest: bytes | None = None
+                    total_uncompressed = 0
+                    entry_count = 0
+                    root_style: str | None = None
+                    for member in package.infolist():
+                        if member.is_dir():
+                            if member.file_size != 0:
+                                raise archive_member_path_error(
+                                    archive.name, "contains directory member with data"
+                                )
+                            _, total_uncompressed, entry_count, root_style = record_entry(
+                                archive.name,
+                                paths,
+                                member.filename,
+                                expected_root,
+                                root_style,
+                                0,
+                                total_uncompressed,
+                                entry_count,
+                                allow_empty=True,
                             )
-                        _, total_uncompressed, entry_count, root_style = record_entry(
+                            continue
+                        if member.flag_bits & 0x1:
+                            raise archive_member_path_error(
+                                archive.name, "contains encrypted zip member"
+                            )
+                        file_type = (member.external_attr >> 16) & 0o170000
+                        if file_type == stat.S_IFLNK:
+                            raise archive_member_path_error(
+                                archive.name, "contains unsupported link member"
+                            )
+                        if file_type not in {0, stat.S_IFREG}:
+                            raise archive_member_path_error(
+                                archive.name, "contains unsupported zip member"
+                            )
+                        normalized, total_uncompressed, entry_count, root_style = record_entry(
                             archive.name,
                             paths,
                             member.filename,
                             expected_root,
                             root_style,
-                            0,
+                            member.file_size,
                             total_uncompressed,
                             entry_count,
-                            allow_empty=True,
                         )
-                        continue
-                    if member.flag_bits & 0x1:
-                        raise archive_member_path_error(
-                            archive.name, "contains encrypted zip member"
-                        )
-                    file_type = (member.external_attr >> 16) & 0o170000
-                    if file_type == stat.S_IFLNK:
-                        raise archive_member_path_error(
-                            archive.name, "contains unsupported link member"
-                        )
-                    if file_type not in {0, stat.S_IFREG}:
-                        raise archive_member_path_error(
-                            archive.name, "contains unsupported zip member"
-                        )
-                    normalized, total_uncompressed, entry_count, root_style = record_entry(
-                        archive.name,
-                        paths,
-                        member.filename,
-                        expected_root,
-                        root_style,
-                        member.file_size,
-                        total_uncompressed,
-                        entry_count,
+                        if normalized == "manifest.toml":
+                            manifest = read_zip_member(
+                                archive.name,
+                                package,
+                                member,
+                                MAX_MANIFEST_BYTES,
+                            )
+                        else:
+                            drain_zip_member(archive.name, package, member)
+                    validate_open_regular_file(
+                        archive_file,
+                        "release archive",
+                        max_bytes=MAX_ARCHIVE_BYTES,
                     )
-                    if normalized == "manifest.toml":
-                        manifest = read_zip_member(
-                            archive.name,
-                            package,
-                            member,
-                            MAX_MANIFEST_BYTES,
-                        )
-                    else:
-                        drain_zip_member(archive.name, package, member)
-                validate_open_regular_file(
-                    archive_file,
-                    "release archive",
-                    max_bytes=MAX_ARCHIVE_BYTES,
-                )
-                return ArchiveMembers(paths=paths, manifest=manifest)
+                    return ArchiveMembers(paths=paths, manifest=manifest)
+        except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+            raise archive_member_path_error(
+                archive.name, "is not a readable zip archive"
+            ) from exc
     if archive.name.endswith(".tar.gz"):
-        with archive_file:
-            with tarfile.open(fileobj=archive_file, mode="r|gz") as package:
-                paths: set[str] = set()
-                manifest: bytes | None = None
-                total_uncompressed = 0
-                entry_count = 0
-                root_style: str | None = None
-                for member in package:
-                    if member.isdir():
-                        _, total_uncompressed, entry_count, root_style = record_entry(
+        try:
+            with archive_file:
+                with tarfile.open(fileobj=archive_file, mode="r|gz") as package:
+                    paths: set[str] = set()
+                    manifest: bytes | None = None
+                    total_uncompressed = 0
+                    entry_count = 0
+                    root_style: str | None = None
+                    for member in package:
+                        if member.isdir():
+                            _, total_uncompressed, entry_count, root_style = record_entry(
+                                archive.name,
+                                paths,
+                                member.name,
+                                expected_root,
+                                root_style,
+                                0,
+                                total_uncompressed,
+                                entry_count,
+                                allow_empty=True,
+                            )
+                            continue
+                        if not member.isfile():
+                            raise archive_member_path_error(
+                                archive.name, "contains unsupported non-file member"
+                            )
+                        normalized, total_uncompressed, entry_count, root_style = record_entry(
                             archive.name,
                             paths,
                             member.name,
                             expected_root,
                             root_style,
-                            0,
+                            member.size,
                             total_uncompressed,
                             entry_count,
-                            allow_empty=True,
                         )
-                        continue
-                    if not member.isfile():
-                        raise archive_member_path_error(
-                            archive.name, "contains unsupported non-file member"
-                        )
-                    normalized, total_uncompressed, entry_count, root_style = record_entry(
-                        archive.name,
-                        paths,
-                        member.name,
-                        expected_root,
-                        root_style,
-                        member.size,
-                        total_uncompressed,
-                        entry_count,
+                        if normalized == "manifest.toml":
+                            manifest = read_tar_member(
+                                archive.name,
+                                package,
+                                member,
+                                MAX_MANIFEST_BYTES,
+                            )
+                    validate_open_regular_file(
+                        archive_file,
+                        "release archive",
+                        max_bytes=MAX_ARCHIVE_BYTES,
                     )
-                    if normalized == "manifest.toml":
-                        file_object = package.extractfile(member)
-                        if file_object is None:
-                            raise SystemExit(f"{archive.name} could not read manifest.toml")
-                        manifest = read_limited(
-                            archive.name,
-                            "manifest.toml",
-                            file_object,
-                            MAX_MANIFEST_BYTES,
-                        )
-                validate_open_regular_file(
-                    archive_file,
-                    "release archive",
-                    max_bytes=MAX_ARCHIVE_BYTES,
-                )
-                return ArchiveMembers(paths=paths, manifest=manifest)
+                    return ArchiveMembers(paths=paths, manifest=manifest)
+        except (tarfile.TarError, EOFError, OSError, zlib.error) as exc:
+            raise archive_member_path_error(
+                archive.name, "is not a readable tar.gz archive"
+            ) from exc
     raise SystemExit(f"unsupported release archive {archive.name}")
 
 
@@ -445,6 +452,21 @@ def drain_zip_member(
                 pass
     except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
         raise archive_member_path_error(archive_name, "could not read zip member") from exc
+
+
+def read_tar_member(
+    archive_name: str,
+    package: tarfile.TarFile,
+    member: tarfile.TarInfo,
+    limit: int,
+) -> bytes:
+    try:
+        file_object = package.extractfile(member)
+        if file_object is None:
+            raise archive_member_path_error(archive_name, "could not read tar member")
+        return read_limited(archive_name, "manifest.toml", file_object, limit)
+    except (tarfile.TarError, EOFError, OSError, zlib.error) as exc:
+        raise archive_member_path_error(archive_name, "could not read tar member") from exc
 
 
 def read_limited(archive_name: str, member_name: str, handle, limit: int) -> bytes:


### PR DESCRIPTION
## **User description**
## Summary
- Redact unreadable ZIP and TAR archive failures in the release artifact verifier.
- Route TAR manifest reads through a helper that converts low-level tar/read exceptions into guarded verifier errors.
- Add regressions for unreadable ZIP, unreadable TAR, and tar member read exceptions with secret-looking member names.

## Validation
- `python -m py_compile scripts\verify-release-artifacts.py scripts\check-release-artifact-verifier.py`
- `python scripts\check-release-artifact-verifier.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `python scripts\verify-release-versions.py`
- `git diff --check`

payload exposure risk: Reduces archive/member detail exposure from verifier-owned release artifact read failures.
trust/permission risk: No trust or permission behavior changes.
storage/logging risk: CI and local release logs now get guarded verifier messages for unreadable ZIP/TAR and tar member read failures.
relay/network risk: No relay or network behavior changes.
required fixes: Merge after CI is green; keep #274 open for live release signing and publishing secret readiness.

Closes #1005

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts unreadable ZIP/TAR archive failures in the release artifact verifier to prevent leaking archive or member details. Adds guarded error handling for archive parsing and tar member reads.

- **Bug Fixes**
  - ZIP: catch `RuntimeError`, `zipfile.BadZipFile`, `zlib.error` and return "not a readable zip archive".
  - TAR: catch `tarfile.TarError`, `EOFError`, `OSError`, `zlib.error` and return "not a readable tar.gz archive".
  - Tar member read failures now return "could not read tar member" without exposing names.

- **Refactors**
  - Added `read_tar_member` helper to centralize manifest reads and translate low-level exceptions.
  - Added regression tests for unreadable ZIP/TAR and secret-looking tar member read errors.

<sup>Written for commit 7e7cdaa12f88adb371cd9f6c564da8714f2ccf7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Redact unreadable release archives and member read errors

### What Changed
- Release verification now shows a generic error when a ZIP or tar.gz archive cannot be read, instead of exposing archive contents or internal error details
- If a tar manifest cannot be opened or read, the verifier now returns a generic member-read error without printing the member name
- Added checks for unreadable ZIP, unreadable tar.gz, and tar member read failures to keep these messages redacted

### Impact
`✅ Fewer secret-looking details in release logs`
`✅ Clearer archive read failures`
`✅ Safer release artifact verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
