### PR TITLE
Redact package-manager archive read failures

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -1360,6 +1360,18 @@ def main() -> int:
             "checksum mismatch",
         )
 
+        unreadable_windows = temp / "unreadable-windows"
+        unreadable_windows.mkdir()
+        write_dist(unreadable_windows)
+        unreadable_windows_archive = unreadable_windows / TARGETS["windows-x64"]
+        unreadable_windows_archive.write_bytes(b"not a zip archive\n")
+        expect_member_redacted_failure(
+            "unreadable windows zip",
+            lambda: generator.detect_windows_extract_dir(unreadable_windows_archive, VERSION),
+            "not a readable zip",
+            "not a zip archive",
+        )
+
         corrupt_linux = temp / "corrupt-linux"
         corrupt_linux.mkdir()
         write_dist(corrupt_linux)
@@ -1372,14 +1384,33 @@ def main() -> int:
             "imthegoodboy/conU",
             f"v{VERSION}",
         )
-        expect_failure(
+        expect_member_redacted_failure(
             "corrupt linux tarball",
             lambda: generator.extract_linux_binaries(
                 corrupt_linux / corrupt_assets["linux-x64"].filename,
                 VERSION,
                 "linux-x64",
             ),
-            "linux release asset is not a readable tar.gz",
+            "not a readable tar.gz",
+            "bad",
+        )
+
+        secret_tar_member = "secret-package-manager-binary-should-not-print"
+
+        class BrokenTar:
+            def extractfile(self, _member):
+                raise tarfile.ReadError(secret_tar_member)
+
+        expect_member_redacted_failure(
+            "linux tar binary read error",
+            lambda: generator.read_tar_release_member(
+                TARGETS["linux-x64"],
+                BrokenTar(),
+                tarfile.TarInfo(secret_tar_member),
+                generator.MAX_PACKAGE_BINARY_BYTES,
+            ),
+            "could not read binary",
+            secret_tar_member,
         )
 
         encrypted_windows = temp / "encrypted-windows"

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -632,8 +632,8 @@ def detect_windows_extract_dir(archive: Path, version: str) -> str | None:
                     )
                     if is_file:
                         file_paths.add(normalized)
-    except zipfile.BadZipFile as exc:
-        raise SystemExit(f"windows release asset is not a readable zip: {archive.name}") from exc
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise release_member_failure(archive.name, "is not a readable zip") from exc
 
     if rootless_bins <= file_paths:
         if root_style == "rooted":
@@ -820,17 +820,14 @@ def extract_linux_binaries(archive: Path, version: str, target: str) -> dict[str
                     file_paths.add(normalized)
                     if normalized not in rootless_bins:
                         continue
-                    handle = package.extractfile(member)
-                    if handle is None:
-                        raise release_member_failure(archive.name, "could not read binary")
-                    extracted[normalized] = read_limited_release_member(
+                    extracted[normalized] = read_tar_release_member(
                         archive.name,
-                        member.name,
-                        handle,
+                        package,
+                        member,
                         MAX_PACKAGE_BINARY_BYTES,
                     )
     except (tarfile.TarError, EOFError, OSError, zlib.error) as exc:
-        raise SystemExit(f"linux release asset is not a readable tar.gz: {archive.name}") from exc
+        raise release_member_failure(archive.name, "is not a readable tar.gz") from exc
 
     if not rootless_bins <= file_paths:
         raise SystemExit(
@@ -852,10 +849,28 @@ def read_limited_release_member(
     handle,
     limit: int,
 ) -> bytes:
-    content = handle.read(limit + 1)
+    try:
+        content = handle.read(limit + 1)
+    except (tarfile.TarError, EOFError, OSError, zlib.error) as exc:
+        raise release_member_failure(archive_name, "could not read binary") from exc
     if len(content) > limit:
         raise release_member_failure(archive_name, "member is too large")
     return content
+
+
+def read_tar_release_member(
+    archive_name: str,
+    package: tarfile.TarFile,
+    member: tarfile.TarInfo,
+    limit: int,
+) -> bytes:
+    try:
+        handle = package.extractfile(member)
+    except (tarfile.TarError, EOFError, OSError, zlib.error) as exc:
+        raise release_member_failure(archive_name, "could not read binary") from exc
+    if handle is None:
+        raise release_member_failure(archive_name, "could not read binary")
+    return read_limited_release_member(archive_name, member.name, handle, limit)
 
 
 def render_homebrew_formula(version: str, repo: str, assets: dict[str, ReleaseAsset]) -> str:


### PR DESCRIPTION
## **User description**
## Summary
- Redact unreadable Windows ZIP and Linux tar release asset failures in package-manager manifest generation.
- Add a guarded Linux tar binary read helper so lower-level tar/read exceptions cannot expose member names.
- Extend manifest regressions for unreadable Windows ZIP, corrupt Linux tar, and tar binary read exceptions.

## Validation
- `python -m py_compile scripts\generate-package-manager-manifests.py scripts\check-package-manager-manifests.py`
- `python scripts\check-package-manager-manifests.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `python scripts\verify-release-versions.py`
- `git diff --check`

payload exposure risk: Reduces archive/member detail exposure from package-manager manifest generation failures.
trust/permission risk: No trust or permission behavior changes.
storage/logging risk: CI and local release logs now get guarded generator errors for unreadable ZIP/TAR and tar binary read failures.
relay/network risk: No relay or network behavior changes.
required fixes: Merge after CI is green; keep #274 open for live release signing and publishing secret readiness.

Closes #1007

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts archive read failure messages in package-manager manifest generation to avoid leaking member names. Adds a guarded tar member reader and regression tests for unreadable ZIP/TAR and tar read errors.

- **Bug Fixes**
  - Standardized redacted errors for Windows ZIP and Linux tar assets using `release_member_failure`.
  - Added `read_tar_release_member` to wrap tar extraction and binary reads, preventing member name exposure.
  - Extended checks to assert redaction for unreadable ZIPs, corrupt tarballs, and tar read exceptions.

<sup>Written for commit 8618e2539e3309ce2e55b876f64bda33bda4ae74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide archive read failures in package-manager manifest checks**

### What Changed
- Failed Windows ZIP and Linux tar release assets now show a short, generic error instead of exposing archive or member details.
- Reading a Linux binary from a tarball now also redacts errors that happen while opening or reading the file.
- The manifest checks now cover unreadable ZIP files, corrupt tarballs, and tar read failures to keep these errors hidden.

### Impact
`✅ Less release-log detail exposed on archive failures`
`✅ Clearer package-manager manifest errors`
`✅ Safer failure output for unreadable release assets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
