### PR TITLE
Redact hosted repository unreadable ZIP failures

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -249,6 +249,24 @@ def main() -> int:
             "metadata zip total size bound",
         )
 
+        unreadable_zip = temp / "unreadable-zip"
+        shutil.copytree(dist, unreadable_zip)
+        unreadable_zip_payload = "secret-unreadable-repository-zip-should-not-print"
+        (unreadable_zip / APT_METADATA).write_text(
+            unreadable_zip_payload,
+            encoding="ascii",
+        )
+        message = expect_action_failure(
+            lambda: generator.read_zip_members(unreadable_zip / APT_METADATA),
+            "not a readable zip archive",
+            "unreadable repository metadata zip",
+        )
+        assert_member_failure_redacted(
+            message,
+            "unreadable repository metadata zip",
+            unreadable_zip_payload,
+        )
+
         encrypted_zip = temp / "encrypted-zip"
         shutil.copytree(dist, encrypted_zip)
         mark_zip_member_encrypted(encrypted_zip / APT_METADATA, "Packages")

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -95,6 +95,20 @@ def main() -> int:
             "Pages site total size bound",
         )
 
+        unreadable_site = temp / "unreadable-site.zip"
+        unreadable_site_payload = "secret-unreadable-pages-site-should-not-print"
+        unreadable_site.write_text(unreadable_site_payload, encoding="ascii")
+        message = expect_action_failure(
+            lambda: preparer.read_site_members(unreadable_site),
+            "not a readable zip archive",
+            "unreadable Pages site",
+        )
+        assert_member_failure_redacted(
+            message,
+            "unreadable Pages site",
+            unreadable_site_payload,
+        )
+
         encrypted_site = temp / "encrypted-site.zip"
         shutil.copy2(site, encrypted_site)
         mark_zip_member_encrypted(encrypted_site, "index.html")

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -125,6 +125,20 @@ def main() -> int:
             "hosted bundle total size bound",
         )
 
+        unreadable_bundle = temp / "unreadable-hosted-bundle.zip"
+        unreadable_bundle_payload = "secret-unreadable-hosted-bundle-should-not-print"
+        unreadable_bundle.write_text(unreadable_bundle_payload, encoding="ascii")
+        message = expect_action_failure(
+            lambda: site_generator.read_hosted_bundle(unreadable_bundle),
+            "not a readable zip archive",
+            "unreadable hosted bundle",
+        )
+        assert_member_failure_redacted(
+            message,
+            "unreadable hosted bundle",
+            unreadable_bundle_payload,
+        )
+
         encrypted_bundle = temp / "encrypted-hosted-bundle.zip"
         shutil.copy2(hosted_bundle, encrypted_bundle)
         mark_zip_member_encrypted(encrypted_bundle, "apt/Packages")

--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -158,6 +158,20 @@ def run_zip_ingestion_preflights() -> None:
             "repository signing total size bound",
         )
 
+        unreadable = temp / "unreadable.zip"
+        unreadable_payload = "secret-unreadable-signing-zip-should-not-print"
+        unreadable.write_text(unreadable_payload, encoding="ascii")
+        message = expect_action_failure(
+            lambda: signer.read_zip_members(unreadable),
+            "not a readable zip archive",
+            "repository signing unreadable zip",
+        )
+        assert_member_failure_redacted(
+            message,
+            "repository signing unreadable zip",
+            unreadable_payload,
+        )
+
         encrypted = temp / "encrypted.zip"
         shutil.copy2(metadata, encrypted)
         mark_zip_member_encrypted(encrypted, "Release")

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -423,8 +423,8 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                     "hosted repository metadata bundle",
                     max_bytes=MAX_RELEASE_ASSET_BYTES,
                 )
-    except zipfile.BadZipFile as exc:
-        raise SystemExit(f"{bundle.name} is not a readable zip archive") from exc
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise zip_member_failure(bundle.name, "is not a readable zip archive") from exc
     return members
 
 

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -312,8 +312,8 @@ def read_hosted_bundle(bundle: Path) -> dict[str, bytes]:
                     "hosted Linux repository bundle",
                     max_bytes=MAX_HOSTED_BUNDLE_BYTES,
                 )
-    except zipfile.BadZipFile as exc:
-        raise SystemExit(f"{bundle.name} is not a readable zip archive") from exc
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise zip_member_failure(bundle.name, "is not a readable zip archive") from exc
     return members
 
 

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -331,8 +331,8 @@ def read_site_members(site_zip: Path) -> dict[str, bytes]:
                     "hosted Linux repository site ZIP",
                     max_bytes=MAX_SITE_ZIP_BYTES,
                 )
-    except zipfile.BadZipFile as exc:
-        raise SystemExit(f"{site_zip.name} is not a readable zip archive") from exc
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise zip_member_failure(site_zip.name, "is not a readable zip archive") from exc
     return members
 
 

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -314,8 +314,8 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                 max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
                 allow_empty=False,
             )
-    except zipfile.BadZipFile as exc:
-        raise SystemExit(f"{bundle.name} is not a readable zip archive") from exc
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise zip_member_failure(bundle.name, "is not a readable zip archive") from exc
     return members
 
 


### PR DESCRIPTION
## **User description**
## Summary
- Convert unreadable ZIP archive open failures to guarded release-tooling errors in hosted Linux repository scripts.
- Cover repository bundle generation, hosted site generation, Pages preparation, and Linux repository signing metadata reads.
- Add regressions with secret-looking unreadable ZIP fixture contents to ensure failure output remains redacted.

## Validation
- `python -m py_compile scripts\generate-hosted-linux-repositories.py scripts\generate-hosted-linux-repository-site.py scripts\prepare-hosted-linux-repository-pages.py scripts\sign-linux-repository-metadata.py scripts\check-hosted-linux-repositories.py scripts\check-hosted-linux-repository-site.py scripts\check-hosted-linux-repository-pages.py scripts\check-linux-repository-signing.py`
- `python scripts\check-hosted-linux-repositories.py`
- `python scripts\check-hosted-linux-repository-site.py`
- `python scripts\check-hosted-linux-repository-pages.py`
- `python scripts\check-linux-repository-signing.py` (ZIP ingestion preflights ran; signing regression skipped because local `gpg` is unavailable)
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `python scripts\verify-release-versions.py`
- `python scripts\verify-npm-package-contents.py`
- `npm run check --prefix packaging/npm/conu-cli`
- `git diff --check`

payload exposure risk: Reduces archive-content/path exposure from unreadable hosted repository ZIP failures.
trust/permission risk: No trust or permission behavior changes.
storage/logging risk: CI and local release logs now get guarded unreadable-ZIP messages for hosted repository tooling.
relay/network risk: No relay or network behavior changes.
required fixes: Merge after CI is green; keep #274 open for live release signing and publishing secret readiness.

Closes #1009

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts unreadable ZIP errors in hosted Linux repository tooling to prevent leaking file paths or contents. Standardizes failure handling and adds regression checks to keep logs clean. Closes #1009.

- **Bug Fixes**
  - Convert unreadable ZIP failures to guarded `zip_member_failure` errors across generation, site, pages, and signing scripts; logs now show a generic “not a readable zip archive” message.
  - Broaden exception handling to include `RuntimeError` and `zlib.error` alongside `zipfile.BadZipFile`.
  - Add regression checks that feed secret-looking payloads to unreadable ZIPs and assert redaction in the check scripts.

<sup>Written for commit 8fde3bb382b69d0573668278fbe8684119344e44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact unreadable ZIP failures across hosted repository tooling**

### What Changed
- Unreadable ZIP files now fail with a guarded message instead of exposing raw archive details.
- The same redacted failure behavior now applies to hosted repository bundles, hosted site bundles, Pages site ZIPs, and repository signing ZIPs.
- Coverage was added to confirm unreadable ZIP errors stay redacted in each of these paths.

### Impact
`✅ Fewer archive path leaks in release logs`
`✅ Safer failure messages for hosted repository ZIPs`
`✅ Consistent redacted errors during repository packaging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive regression test cases across multiple utilities for handling unreadable ZIP archives, verifying error messaging is properly reported and sensitive payload contents are redacted.

* **Bug Fixes**
  * Expanded error detection for corrupted ZIP files to recognize additional failure modes, improving robustness when processing repository metadata and bundle archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->