### PR TITLE
Redact unreadable Chocolatey submission failures

### DIFF
--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -12,6 +12,7 @@ import stat
 import sys
 import tempfile
 import zipfile
+import zlib
 from pathlib import Path
 
 
@@ -260,6 +261,14 @@ def mark_zip_member_encrypted(path: Path, member_name: str) -> None:
             continue
         offset += 1
     path.write_bytes(data)
+
+
+class BrokenChocolateyPackage:
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def open(self, _info: zipfile.ZipInfo, _mode: str):
+        raise zlib.error(self.message)
 
 
 def main() -> int:
@@ -521,6 +530,46 @@ def main() -> int:
                 VERSION,
             ),
             "signed target is missing",
+        )
+
+        unreadable_chocolatey = temp / "unreadable-chocolatey"
+        manifest_check.generate(
+            generator,
+            dist,
+            unreadable_chocolatey,
+            build_apt_repository_metadata=True,
+        )
+        write_signed_release_extras(unreadable_chocolatey)
+        unreadable_payload = "do-not-print-corrupt-chocolatey-payload"
+        (unreadable_chocolatey / "conu.0.1.0.nupkg").write_text(
+            unreadable_payload,
+            encoding="ascii",
+        )
+        expect_member_redacted_failure(
+            "unreadable Chocolatey package",
+            lambda: preparer.prepare_submission_bundle(
+                unreadable_chocolatey,
+                temp / "unreadable-chocolatey-out",
+                VERSION,
+                require_rpm_assets=True,
+                require_repository_metadata=True,
+                require_linux_signatures=True,
+            ),
+            "is not a readable Chocolatey nupkg",
+            unreadable_payload,
+        )
+
+        corrupt_member_payload = "do-not-print-corrupt-chocolatey-member"
+        expect_member_redacted_failure(
+            "corrupt Chocolatey package member read",
+            lambda: preparer.read_chocolatey_text_member(
+                BrokenChocolateyPackage(corrupt_member_payload),
+                zipfile.ZipInfo("tools/chocolateyInstall.ps1"),
+                "conu.0.1.0.nupkg",
+            ),
+            "could not read Chocolatey package member",
+            corrupt_member_payload,
+            "tools/chocolateyInstall.ps1",
         )
 
         encrypted_chocolatey = temp / "encrypted-chocolatey"

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -13,6 +13,7 @@ import shutil
 import stat
 import sys
 import zipfile
+import zlib
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, BinaryIO
@@ -442,8 +443,8 @@ def validate_chocolatey_package(path: Path, dist: Path) -> None:
                     raise archive_member_failure(path.name, "has unsafe Chocolatey package path")
                 text = read_chocolatey_text_member(package, info, path.name)
                 assert_safe_text(text, f"{path.name}:{name}", dist)
-    except (RuntimeError, zipfile.BadZipFile) as exc:
-        raise SystemExit(f"{path.name} is not a readable Chocolatey nupkg") from exc
+    except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
+        raise archive_member_failure(path.name, "is not a readable Chocolatey nupkg") from exc
     except UnicodeDecodeError as exc:
         raise SystemExit(f"{path.name} contains non-ASCII Chocolatey metadata") from exc
 
@@ -477,7 +478,7 @@ def read_chocolatey_text_member(
     try:
         with package.open(info, "r") as handle:
             data = handle.read(MAX_TEXT_BYTES + 1)
-    except (RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
+    except (RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile, zlib.error) as exc:
         raise archive_member_failure(
             package_name,
             "could not read Chocolatey package member",


### PR DESCRIPTION
## **User description**
## Summary
- route unreadable Chocolatey `.nupkg` validation failures through the redacted archive-member failure helper
- catch zlib decompression failures when reading Chocolatey package members
- add regression coverage proving corrupt package/member payload text stays hidden

## Validation
- `python -m py_compile scripts\prepare-package-manager-submissions.py scripts\check-package-manager-submissions.py`
- `python scripts\check-package-manager-submissions.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `python scripts\verify-release-versions.py`
- `python scripts\verify-npm-package-contents.py`
- `npm run check --prefix packaging/npm/conu-cli`
- `git diff --check`

Fixes #1011

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts unreadable Chocolatey `.nupkg` validation failures so corrupt payloads don’t leak, and handles `zlib` decompression errors when reading package members. Fixes #1011.

- **Bug Fixes**
  - Route unreadable `.nupkg` failures through the redacted archive-member failure helper.
  - Catch `zlib.error` in `validate_chocolatey_package` and `read_chocolatey_text_member`.
  - Add regression coverage to ensure corrupt package/member payload text stays hidden.

<sup>Written for commit 8b9abde616733f50d9ae38a85dcce6391f676687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide unreadable Chocolatey package errors from users**

### What Changed
- Chocolatey submission checks now report broken or unreadable `.nupkg` files as a redacted package error instead of a generic unreadable archive failure.
- Reading a corrupt Chocolatey package member now produces a masked failure message, so corrupted payload text is not shown.
- Added regression coverage for unreadable packages and broken package members to keep sensitive payload text hidden.

### Impact
`✅ Hidden corrupt Chocolatey payloads`
`✅ Clearer package validation errors`
`✅ Safer Chocolatey submission checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
