### PR TITLE
Redact update apply tar member path failures

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -7677,9 +7677,9 @@ fn stage_update_tar_gz_archive(
             entry.map_err(|error| format!("release update tar member is invalid: {error}"))?;
         let raw_name = entry
             .path()
-            .map_err(|error| format!("release update tar member path is invalid: {error}"))?
+            .map_err(|_| release_update_archive_member_failure("member path is invalid"))?
             .to_str()
-            .ok_or_else(|| "release update tar member path is not UTF-8".to_string())?
+            .ok_or_else(|| release_update_archive_member_failure("member path is invalid"))?
             .to_string();
         let entry_type = entry.header().entry_type();
         if entry_type.is_symlink() || entry_type.is_hard_link() {
@@ -13963,6 +13963,24 @@ mod tests {
     }
 
     #[test]
+    fn update_apply_rejects_invalid_tar_member_path_without_path() {
+        let target = update_apply_test_target();
+        let filename = update_archive_fixture_name(&target);
+        let raw_member = b"conu-secret-local-path-\xff/bin/conu";
+        let archive_bytes =
+            update_archive_fixture_bytes_with_raw_member_name(raw_member, b"secret payload");
+        let error = stage_update_archive_binaries(&filename, &archive_bytes, &target)
+            .expect_err("invalid tar member path should fail closed");
+
+        assert_update_archive_member_error_redacted(
+            &error,
+            "member path is invalid",
+            "secret-local-path",
+        );
+        assert!(!error.contains("secret payload"), "{error}");
+    }
+
+    #[test]
     fn update_apply_rejects_duplicate_archive_member_without_path() {
         let target = update_apply_test_target();
         let filename = update_archive_fixture_name(&target);
@@ -15830,6 +15848,27 @@ mod tests {
             &update_archive_binary_bytes("conu"),
             0o755,
         );
+        builder.finish().expect("tar builder finishes");
+        let encoder = builder.into_inner().expect("tar encoder returns");
+        encoder.finish().expect("gzip finishes")
+    }
+
+    fn update_archive_fixture_bytes_with_raw_member_name(raw_name: &[u8], bytes: &[u8]) -> Vec<u8> {
+        assert!(
+            raw_name.len() <= 100,
+            "raw tar fixture member name must fit the ustar name field"
+        );
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o755);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.as_mut_bytes()[..raw_name.len()].copy_from_slice(raw_name);
+        header.set_cksum();
+        builder
+            .append(&header, bytes)
+            .expect("raw tar fixture member appends");
         builder.finish().expect("tar builder finishes");
         let encoder = builder.into_inner().expect("tar encoder returns");
         encoder.finish().expect("gzip finishes")


### PR DESCRIPTION
## **User description**
## Summary
- route invalid tar member path conversion in `conu update apply` through the guarded archive-member failure helper
- make non-UTF-8 tar member paths return `pathDisplayed=false contentsDisplayed=false`
- add a regression fixture with a raw invalid tar member name to prove member/path payload text stays hidden

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `npm run check --prefix packaging/npm/conu-cli`

## Local limitation
- `cargo test -p conu-cli update_apply_rejects_invalid_tar_member_path_without_path` could not run locally because this Windows environment is missing the MSVC linker `link.exe`; GitHub Actions Rust builders cover it.

Fixes #1013

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts invalid tar member path failures in `conu update apply` and fails closed for non‑UTF‑8 names. Prevents leaking member paths or payload text in error messages.

- **Bug Fixes**
  - Routed path parsing errors through the guarded `release_update_archive_member_failure` helper.
  - Non‑UTF‑8 tar member paths now return `pathDisplayed=false` and `contentsDisplayed=false`.
  - Added a regression test with a raw invalid member name to verify error redaction.

<sup>Written for commit 9265f389f55337692eff153a866a733d8d4aac6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide invalid tar member path failures during update apply**

### What Changed
- Update apply now treats broken tar member paths as a generic redacted failure instead of exposing the path or archive details.
- Non-UTF-8 tar member names also fail closed with hidden path and contents information.
- Added a regression test that uses a raw invalid tar member name to confirm the error stays redacted and does not leak payload text.

### Impact
`✅ Fewer leaked file paths in update errors`
`✅ Safer handling of malformed update archives`
`✅ Clearer failure behavior for invalid tar uploads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
