### PR TITLE
Redact oversized release artifact member failures

### DIFF
--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -332,6 +332,37 @@ def main() -> int:
             (secret_tar_member,),
         )
 
+        oversized_manifest = root / "conu-0.1.0-oversized-manifest.zip"
+        write_zip(oversized_manifest)
+        original_max_manifest_bytes = verifier.MAX_MANIFEST_BYTES
+        verifier.MAX_MANIFEST_BYTES = 1
+        try:
+            expect_redacted_member_failure(
+                "oversized manifest zip member",
+                lambda: verifier.archive_members(oversized_manifest),
+                "member is larger than 1 bytes",
+                ("manifest.toml",),
+            )
+        finally:
+            verifier.MAX_MANIFEST_BYTES = original_max_manifest_bytes
+
+        class OversizedMemberReader:
+            def read(self, _limit):
+                return b"secret payload should not print"
+
+        oversized_member_name = "secret-local-path/manifest.toml"
+        expect_redacted_member_failure(
+            "oversized streaming member read",
+            lambda: verifier.read_limited(
+                "conu-0.1.0-oversized.tar.gz",
+                oversized_member_name,
+                OversizedMemberReader(),
+                1,
+            ),
+            "member is larger than 1 bytes",
+            (oversized_member_name, "secret-local-path", "secret payload should not print"),
+        )
+
         wrong_name = root / "conu-0.1.0-wrong-name.zip"
         write_zip(wrong_name)
         write_checksum(wrong_name, archive_name="other.zip")

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -433,7 +433,7 @@ def read_zip_member(
     limit: int,
 ) -> bytes:
     if member.file_size > limit:
-        raise SystemExit(f"{archive_name} manifest.toml is larger than {limit} bytes")
+        raise archive_member_path_error(archive_name, f"member is larger than {limit} bytes")
     try:
         with package.open(member, "r") as handle:
             return read_limited(archive_name, "manifest.toml", handle, limit)
@@ -472,7 +472,7 @@ def read_tar_member(
 def read_limited(archive_name: str, member_name: str, handle, limit: int) -> bytes:
     content = handle.read(limit + 1)
     if len(content) > limit:
-        raise SystemExit(f"{archive_name} {member_name} is larger than {limit} bytes")
+        raise archive_member_path_error(archive_name, f"member is larger than {limit} bytes")
     return content
 
 


### PR DESCRIPTION
## **User description**
## Summary
- route oversized release artifact member reads through the guarded archive-member failure helper
- keep `pathDisplayed=false contentsDisplayed=false` on oversized manifest/member failures
- add regressions for ZIP manifest metadata and streaming member reads so member names and payload-looking bytes stay hidden

## Validation
- `python -m py_compile scripts\verify-release-artifacts.py scripts\check-release-artifact-verifier.py`
- `python scripts\check-release-artifact-verifier.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `python scripts\verify-release-versions.py`
- `python scripts\verify-npm-package-contents.py`
- `npm run check --prefix packaging/npm/conu-cli`
- `git diff --check`

Fixes #1015

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts oversized release artifact member errors to prevent leaking member paths and payload-looking bytes. Routes ZIP and streaming reads through the guarded error helper and adds regression tests. Fixes #1015.

- **Bug Fixes**
  - Use `archive_member_path_error` for oversized ZIP manifest and streaming member reads in `scripts/verify-release-artifacts.py`.
  - Keep `pathDisplayed=false` and `contentsDisplayed=false` on oversized manifest/member failures.
  - Add regression tests in `scripts/check-release-artifact-verifier.py` for ZIP manifest metadata and streaming reads to ensure redaction.

<sup>Written for commit 90a6192953bf2480736091cbe9221473f3978a6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide oversized release artifact member details in failure messages**

### What Changed
- Oversized ZIP and streaming member reads now fail with a generic message instead of printing the member path or payload-like bytes.
- Oversized manifest reads in ZIP archives use the same redacted error handling as other archive member failures.
- Added regression coverage for oversized manifest and streaming member reads to confirm sensitive names and contents stay hidden.

### Impact
`✅ Fewer leaked file paths in release checks`
`✅ Safer oversized artifact error messages`
`✅ Clearer redaction for release-verifier failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
