### PR TITLE
Redact aggregate release smoke archive bounds

### DIFF
--- a/scripts/check-npm-launcher-local-smoke-preflight.py
+++ b/scripts/check-npm-launcher-local-smoke-preflight.py
@@ -227,6 +227,7 @@ def main() -> int:
                 lambda: smoke.read_manifest_target(archive),
                 "contains more than",
                 "manifest read member count bound",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_MEMBER_COUNT = original_limit
@@ -241,6 +242,7 @@ def main() -> int:
                 lambda: smoke.read_manifest_target(archive),
                 "uncompressed contents exceed",
                 "manifest read total size bound",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = original_limit
@@ -365,6 +367,7 @@ def main() -> int:
                 lambda: smoke.extract_archive(archive, root / "extract-many"),
                 "contains more than",
                 "extracted entry count bound",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_MEMBER_COUNT = original_limit
@@ -379,6 +382,7 @@ def main() -> int:
                 lambda: smoke.extract_archive(archive, root / "extract-total"),
                 "uncompressed contents exceed",
                 "extracted total size bound",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = original_limit

--- a/scripts/check-release-artifact-smoke-preflight.py
+++ b/scripts/check-release-artifact-smoke-preflight.py
@@ -159,6 +159,7 @@ def main() -> int:
                 lambda: smoke.read_manifest_target(archive),
                 "contains more than",
                 "manifest read member count bound",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_MEMBER_COUNT = original_limit
@@ -173,6 +174,7 @@ def main() -> int:
                 lambda: smoke.read_manifest_target(archive),
                 "uncompressed contents exceed",
                 "manifest read total size bound",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = original_limit
@@ -297,6 +299,7 @@ def main() -> int:
                 lambda: smoke.extract_archive(archive, root / "extract-many"),
                 "contains more than",
                 "extracted entry count bound",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_MEMBER_COUNT = original_limit
@@ -311,6 +314,7 @@ def main() -> int:
                 lambda: smoke.extract_archive(archive, root / "extract-total"),
                 "uncompressed contents exceed",
                 "extracted total size bound",
+                require_member_redaction=True,
             )
         finally:
             smoke.MAX_TOTAL_UNCOMPRESSED_BYTES = original_limit

--- a/scripts/smoke-npm-launcher-local.py
+++ b/scripts/smoke-npm-launcher-local.py
@@ -330,7 +330,10 @@ def validate_archive_read_entry(
 
     state.entry_count += 1
     if state.entry_count > MAX_MEMBER_COUNT:
-        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+        raise archive_member_failure(
+            archive_name,
+            f"contains more than {MAX_MEMBER_COUNT} entries",
+        )
 
     normalized, member_style = normalize_member(archive_name, member_name, expected_root)
     root_style = update_archive_root_style(archive_name, root_style, member_style)
@@ -341,8 +344,9 @@ def validate_archive_read_entry(
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
-        raise SystemExit(
-            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        raise archive_member_failure(
+            archive_name,
+            f"uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes",
         )
     if normalized in state.paths:
         raise archive_member_failure(archive_name, "contains duplicate archive path")
@@ -581,7 +585,10 @@ def validate_extract_entry(
 
     state.entry_count += 1
     if state.entry_count > MAX_MEMBER_COUNT:
-        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+        raise archive_member_failure(
+            archive_name,
+            f"contains more than {MAX_MEMBER_COUNT} entries",
+        )
 
     normalized = normalize_extract_path(archive_name, member_name)
     if not normalized:
@@ -591,8 +598,9 @@ def validate_extract_entry(
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
-        raise SystemExit(
-            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        raise archive_member_failure(
+            archive_name,
+            f"uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes",
         )
     if normalized in state.paths:
         raise archive_member_failure(archive_name, "contains duplicate archive path")

--- a/scripts/smoke-release-artifacts.py
+++ b/scripts/smoke-release-artifacts.py
@@ -286,7 +286,10 @@ def validate_archive_read_entry(
 
     state.entry_count += 1
     if state.entry_count > MAX_MEMBER_COUNT:
-        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+        raise archive_member_failure(
+            archive_name,
+            f"contains more than {MAX_MEMBER_COUNT} entries",
+        )
 
     normalized, member_style = normalize_member(archive_name, member_name, expected_root)
     root_style = update_archive_root_style(archive_name, root_style, member_style)
@@ -297,8 +300,9 @@ def validate_archive_read_entry(
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
-        raise SystemExit(
-            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        raise archive_member_failure(
+            archive_name,
+            f"uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes",
         )
     if normalized in state.paths:
         raise archive_member_failure(archive_name, "contains duplicate archive path")
@@ -546,7 +550,10 @@ def validate_extract_entry(
 
     state.entry_count += 1
     if state.entry_count > MAX_MEMBER_COUNT:
-        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+        raise archive_member_failure(
+            archive_name,
+            f"contains more than {MAX_MEMBER_COUNT} entries",
+        )
 
     normalized = normalize_extract_path(archive_name, member_name)
     if not normalized:
@@ -556,8 +563,9 @@ def validate_extract_entry(
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
-        raise SystemExit(
-            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        raise archive_member_failure(
+            archive_name,
+            f"uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes",
         )
     if normalized in state.paths:
         raise archive_member_failure(archive_name, "contains duplicate archive path")


### PR DESCRIPTION
## **User description**
## Summary
- route release artifact smoke entry-count and total-uncompressed failures through the guarded archive-member failure formatter
- apply the same guard to npm launcher local smoke archive read/extract aggregate bounds
- tighten both focused preflight checks so aggregate-bound failures require pathDisplayed=false and contentsDisplayed=false

## Validation
- python -m py_compile scripts\\smoke-release-artifacts.py scripts\\smoke-npm-launcher-local.py scripts\\check-release-artifact-smoke-preflight.py scripts\\check-npm-launcher-local-smoke-preflight.py
- python scripts\\check-release-artifact-smoke-preflight.py
- python scripts\\check-npm-launcher-local-smoke-preflight.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-release-artifact-verifier.py
- python scripts\\check-package-manager-manifests.py
- python scripts\\check-package-manager-submissions.py
- python scripts\\verify-npm-package-contents.py
- npm run check --prefix packaging/npm/conu-cli
- git diff --check
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\verify-release-versions.py

Fixes #1017

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts archive details when entry-count or total-uncompressed limits are exceeded in release and npm-launcher smoke tests. Routes these failures through the guarded formatter and enforces redaction in preflight checks. Fixes #1017.

- **Bug Fixes**
  - Route aggregate bound failures (read/extract) to guarded `archive_member_failure` in `scripts/smoke-release-artifacts.py` and `scripts/smoke-npm-launcher-local.py`.
  - Require redaction for entry-count and total-size bounds in preflight checks (`require_member_redaction=True`) in `scripts/check-release-artifact-smoke-preflight.py` and `scripts/check-npm-launcher-local-smoke-preflight.py`.
  - Ensure these failures show pathDisplayed=false and contentsDisplayed=false to avoid leaking member names or contents.

<sup>Written for commit 1e25255f7d580717be00d49db4c6d0650587e2b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact archive bound failures in smoke checks**

### What Changed
- Archive entry-count and total-uncompressed-size failures now use the same redacted error format as other archive checks.
- Release artifact and npm launcher smoke tests no longer surface raw archive names in these aggregate-bound failures.
- Preflight checks now require redaction for these failure cases, so they must hide path and contents details.

### Impact
`✅ Fewer leaked archive details in failure messages`
`✅ Clearer redacted smoke-test errors`
`✅ Safer archive limit checks in release validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
