### PR TITLE
Redact package-manager archive aggregate bounds

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -1103,7 +1103,7 @@ def main() -> int:
                 "SHA-256 sidecar for generated RPM package must not be a symlink",
             )
 
-        expect_failure_with_limit(
+        expect_member_redacted_failure_with_limit(
             generator,
             "MAX_RELEASE_MEMBER_COUNT",
             1,
@@ -1497,7 +1497,7 @@ def main() -> int:
             "bin/conu",
         )
 
-        expect_failure_with_limit(
+        expect_member_redacted_failure_with_limit(
             generator,
             "MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES",
             1,

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -619,8 +619,9 @@ def detect_windows_extract_dir(archive: Path, version: str) -> str | None:
             with zipfile.ZipFile(archive_file) as package:
                 infos = package.infolist()
                 if len(infos) > MAX_RELEASE_MEMBER_COUNT:
-                    raise SystemExit(
-                        f"{archive.name} contains more than {MAX_RELEASE_MEMBER_COUNT} entries"
+                    raise release_member_failure(
+                        archive.name,
+                        f"contains more than {MAX_RELEASE_MEMBER_COUNT} entries",
                     )
                 for member in infos:
                     normalized, root_style, is_file = validate_zip_release_member_for_scan(
@@ -701,7 +702,10 @@ def record_release_archive_member(
 
     state.entry_count += 1
     if state.entry_count > MAX_RELEASE_MEMBER_COUNT:
-        raise SystemExit(f"{archive_name} contains more than {MAX_RELEASE_MEMBER_COUNT} entries")
+        raise release_member_failure(
+            archive_name,
+            f"contains more than {MAX_RELEASE_MEMBER_COUNT} entries",
+        )
 
     normalized, member_style = normalize_release_member_path(
         archive_name,
@@ -720,9 +724,9 @@ def record_release_archive_member(
 
     state.total_uncompressed += size
     if state.total_uncompressed > MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES:
-        raise SystemExit(
-            f"{archive_name} uncompressed contents exceed "
-            f"{MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        raise release_member_failure(
+            archive_name,
+            f"uncompressed contents exceed {MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES} bytes",
         )
     return normalized, root_style
 


### PR DESCRIPTION
## **User description**
## Summary
- route package-manager release archive member-count bounds through the guarded member failure formatter
- route release archive total-uncompressed bounds through the same guarded formatter
- require pathDisplayed=false and contentsDisplayed=false in the focused package-manager regression cases

## Validation
- python -m py_compile scripts\\generate-package-manager-manifests.py scripts\\check-package-manager-manifests.py
- python scripts\\check-package-manager-manifests.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-package-manager-submissions.py
- python scripts\\check-release-artifact-verifier.py
- python scripts\\check-release-artifact-smoke-preflight.py
- python scripts\\check-npm-launcher-local-smoke-preflight.py
- python scripts\\verify-npm-package-contents.py
- npm run check --prefix packaging/npm/conu-cli
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\verify-release-versions.py
- git diff --check

Fixes #1019

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts archive bound failures in the package-manager tooling so member count and total uncompressed size errors don’t leak file paths or contents. Aligns generator and checker to use the guarded formatter for consistent, safe error messages.

- **Bug Fixes**
  - Use expect_member_redacted_failure_with_limit for `MAX_RELEASE_MEMBER_COUNT` and `MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES` checks.
  - Replace SystemExit with release_member_failure(...) when bounds are exceeded.
  - Update regression checks to require pathDisplayed=false and contentsDisplayed=false.

<sup>Written for commit 2e47dce25b70f5c860fafa7cbdb267ca0b6cf44e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact package-manager archive size and entry-limit errors**

### What Changed
- Archive checks now report oversized package-manager archives through the same redacted error path as other release-member failures, instead of exposing raw failure output.
- The package-manager regression checks now expect redacted failures when an archive has too many entries or exceeds the total uncompressed size limit.
- The existing member-size limit check remains covered by the same redacted failure behavior.

### Impact
`✅ No file paths in archive limit errors`
`✅ Safer package-manager validation messages`
`✅ Clearer regression coverage for archive bounds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages to properly redact sensitive information when archive validation fails, preventing data exposure in failure outputs.

* **Tests**
  * Updated validation tests to verify proper redaction behavior in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->