### PR TITLE
Redact release archive bound failures

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -389,11 +389,12 @@ def expect_zip_bound_failure(
     original = getattr(generator, constant_name)
     setattr(generator, constant_name, value)
     try:
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: generator.read_zip_members(archive),
             expected,
             label,
         )
+        assert_member_failure_redacted(message, label)
     finally:
         setattr(generator, constant_name, original)
 

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -593,11 +593,12 @@ def expect_zip_bound_failure(
     original = getattr(preparer, constant_name)
     setattr(preparer, constant_name, value)
     try:
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: preparer.read_site_members(site),
             expected,
             label,
         )
+        assert_member_failure_redacted(message, label)
     finally:
         setattr(preparer, constant_name, original)
 

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -508,11 +508,12 @@ def expect_zip_bound_failure(
     original = getattr(site_generator, constant_name)
     setattr(site_generator, constant_name, value)
     try:
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: site_generator.read_hosted_bundle(archive),
             expected,
             label,
         )
+        assert_member_failure_redacted(message, label)
     finally:
         setattr(site_generator, constant_name, original)
 

--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -411,11 +411,12 @@ def expect_zip_bound_failure(
     original = getattr(signer, constant_name)
     setattr(signer, constant_name, value)
     try:
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: signer.read_zip_members(archive),
             expected,
             label,
         )
+        assert_member_failure_redacted(message, label)
     finally:
         setattr(signer, constant_name, original)
 

--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -222,6 +222,30 @@ def main() -> int:
         write_zip(valid_zip)
         verify_archive(verifier, valid_zip)
 
+        original_max_member_count = verifier.MAX_MEMBER_COUNT
+        verifier.MAX_MEMBER_COUNT = 0
+        try:
+            expect_redacted_member_failure(
+                "release archive member count bound",
+                lambda: verifier.archive_members(valid_zip),
+                "contains more than",
+                (),
+            )
+        finally:
+            verifier.MAX_MEMBER_COUNT = original_max_member_count
+
+        original_max_total_uncompressed = verifier.MAX_TOTAL_UNCOMPRESSED_BYTES
+        verifier.MAX_TOTAL_UNCOMPRESSED_BYTES = 1
+        try:
+            expect_redacted_member_failure(
+                "release archive total uncompressed bound",
+                lambda: verifier.archive_members(valid_zip),
+                "uncompressed contents exceed",
+                (),
+            )
+        finally:
+            verifier.MAX_TOTAL_UNCOMPRESSED_BYTES = original_max_total_uncompressed
+
         symlink_dist = root / "symlink-dist"
         if try_symlink(root, symlink_dist, target_is_directory=True):
             expect_failure(

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -399,7 +399,10 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
             with zipfile.ZipFile(archive_file) as archive:
                 infos = archive.infolist()
                 if len(infos) > MAX_ZIP_MEMBERS:
-                    raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
+                    raise zip_member_failure(
+                        bundle.name,
+                        f"contains more than {MAX_ZIP_MEMBERS} members",
+                    )
                 for member in infos:
                     name = normalize_zip_path(bundle.name, member.filename)
                     if not validate_zip_member_for_read(bundle.name, member, name):
@@ -413,9 +416,10 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                         raise zip_member_failure(bundle.name, "contains unexpected zip member")
                     total_uncompressed += member.file_size
                     if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
-                        raise SystemExit(
-                            f"{bundle.name} uncompressed ZIP contents exceed "
-                            f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                        raise zip_member_failure(
+                            bundle.name,
+                            "uncompressed ZIP contents exceed "
+                            f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes",
                         )
                     members[name] = read_zip_member(bundle.name, archive, member)
                 validate_open_regular_file(

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -293,7 +293,10 @@ def read_hosted_bundle(bundle: Path) -> dict[str, bytes]:
             with zipfile.ZipFile(bundle_file) as archive:
                 infos = archive.infolist()
                 if len(infos) > MAX_ZIP_MEMBERS:
-                    raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
+                    raise zip_member_failure(
+                        bundle.name,
+                        f"contains more than {MAX_ZIP_MEMBERS} members",
+                    )
                 for member in infos:
                     name = normalize_zip_path(bundle.name, member.filename)
                     if not validate_zip_member_for_read(bundle.name, member, name):
@@ -302,9 +305,10 @@ def read_hosted_bundle(bundle: Path) -> dict[str, bytes]:
                         raise zip_member_failure(bundle.name, "contains duplicate zip member")
                     total_uncompressed += member.file_size
                     if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
-                        raise SystemExit(
-                            f"{bundle.name} uncompressed ZIP contents exceed "
-                            f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                        raise zip_member_failure(
+                            bundle.name,
+                            "uncompressed ZIP contents exceed "
+                            f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes",
                         )
                     members[name] = read_zip_member(bundle.name, archive, member)
                 validate_open_regular_file(

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -312,7 +312,10 @@ def read_site_members(site_zip: Path) -> dict[str, bytes]:
             with zipfile.ZipFile(site_file) as archive:
                 infos = archive.infolist()
                 if len(infos) > MAX_SITE_MEMBERS:
-                    raise SystemExit(f"{site_zip.name} has too many members for Pages deployment")
+                    raise zip_member_failure(
+                        site_zip.name,
+                        "has too many members for Pages deployment",
+                    )
                 for info in infos:
                     name = normalize_zip_path(site_zip.name, info.filename)
                     if not validate_zip_member_for_read(site_zip.name, info, name):
@@ -321,9 +324,10 @@ def read_site_members(site_zip: Path) -> dict[str, bytes]:
                         raise zip_member_failure(site_zip.name, "contains duplicate zip member")
                     total_uncompressed += info.file_size
                     if total_uncompressed > MAX_SITE_TOTAL_UNCOMPRESSED_BYTES:
-                        raise SystemExit(
-                            f"{site_zip.name} uncompressed contents exceed "
-                            f"{MAX_SITE_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                        raise zip_member_failure(
+                            site_zip.name,
+                            "uncompressed contents exceed "
+                            f"{MAX_SITE_TOTAL_UNCOMPRESSED_BYTES} bytes",
                         )
                     members[name] = read_zip_member(site_zip.name, archive, info)
                 validate_open_regular_file(

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -294,7 +294,10 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
             with zipfile.ZipFile(bundle_file) as archive:
                 infos = archive.infolist()
                 if len(infos) > MAX_ZIP_MEMBERS:
-                    raise SystemExit(f"{bundle.name} contains more than {MAX_ZIP_MEMBERS} members")
+                    raise zip_member_failure(
+                        bundle.name,
+                        f"contains more than {MAX_ZIP_MEMBERS} members",
+                    )
                 for member in infos:
                     name = normalize_zip_path(bundle.name, member.filename)
                     if not validate_zip_member_for_read(bundle.name, member, name):
@@ -303,9 +306,10 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                         raise zip_member_failure(bundle.name, "contains duplicate zip member")
                     total_uncompressed += member.file_size
                     if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES:
-                        raise SystemExit(
-                            f"{bundle.name} uncompressed ZIP contents exceed "
-                            f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes"
+                        raise zip_member_failure(
+                            bundle.name,
+                            "uncompressed ZIP contents exceed "
+                            f"{MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES} bytes",
                         )
                     members[name] = read_zip_member(bundle.name, archive, member)
             validate_open_regular_file(

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -403,7 +403,10 @@ def record_entry(
 
     entry_count += 1
     if entry_count > MAX_MEMBER_COUNT:
-        raise SystemExit(f"{archive_name} contains more than {MAX_MEMBER_COUNT} entries")
+        raise archive_member_path_error(
+            archive_name,
+            f"contains more than {MAX_MEMBER_COUNT} entries",
+        )
 
     normalized, member_root_style = normalize_member(raw_name, archive_name, expected_root)
     root_style = update_archive_root_style(
@@ -420,8 +423,9 @@ def record_entry(
 
     total_uncompressed += size
     if total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
-        raise SystemExit(
-            f"{archive_name} uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes"
+        raise archive_member_path_error(
+            archive_name,
+            f"uncompressed contents exceed {MAX_TOTAL_UNCOMPRESSED_BYTES} bytes",
         )
     return normalized, total_uncompressed, entry_count, root_style
 


### PR DESCRIPTION
## **User description**
## Summary
- route release archive aggregate member-count and uncompressed-size failures through existing guarded diagnostics
- require guard markers in hosted Linux repository, hosted site, Pages, signing, and release verifier bound regressions

## Validation
- python -m py_compile scripts\generate-hosted-linux-repositories.py scripts\generate-hosted-linux-repository-site.py scripts\sign-linux-repository-metadata.py scripts\prepare-hosted-linux-repository-pages.py scripts\check-hosted-linux-repositories.py scripts\check-hosted-linux-repository-site.py scripts\check-linux-repository-signing.py scripts\check-hosted-linux-repository-pages.py
- python scripts\check-release-artifact-verifier.py
- python scripts\check-hosted-linux-repositories.py
- python scripts\check-hosted-linux-repository-site.py
- python scripts\check-hosted-linux-repository-pages.py
- python scripts\check-linux-repository-signing.py (skipped locally because gpg is unavailable)
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- python scripts\check-hosted-linux-repository-endpoint-regression.py
- python scripts\check-hosted-linux-repository-s3-publication.py
- git diff --check

Fixes #1021

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacted error messages for release archive bound failures (member count and total uncompressed size) across release verification and hosted Linux repo tooling. This prevents leaking member/path details and standardizes failures through guarded diagnostics.

- **Bug Fixes**
  - Replaced raw `SystemExit` messages with guarded `zip_member_failure`/`archive_member_path_error` for member-count and total-uncompressed checks in repository generation, site, Pages, signing, and release verifier scripts.
  - Updated checks to capture failure messages and assert redaction (`assert_member_failure_redacted`), and added explicit verifier tests for both bounds.

<sup>Written for commit e4e82494dc3900b63d22ff32fba25cd07a9b94fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact archive size and member-count failures**

### What Changed
- Release archive checks now fail with redacted, standard error messages when an archive has too many members or too much uncompressed content
- The hosted repository, site, Pages, signing, and release verification checks now verify that these bound failures do not expose member or path details
- Release artifact verification now includes explicit coverage for both archive member-count and total uncompressed-size limits

### Impact
`✅ Fewer leaked archive details in failure messages`
`✅ Safer release validation errors`
`✅ Clearer bound-check test coverage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
