### PR TITLE
Redact update installer archive bound failures

### DIFF
--- a/crates/conu-cli/src/lib.rs
+++ b/crates/conu-cli/src/lib.rs
@@ -7773,8 +7773,9 @@ impl UpdateArchiveScan {
     ) -> Result<String, String> {
         self.entries_scanned += 1;
         if self.entries_scanned > MAX_UPDATE_ARCHIVE_ENTRIES {
-            return Err(format!(
-                "release update archive {archive_name} contains more than {MAX_UPDATE_ARCHIVE_ENTRIES} entries"
+            return Err(release_update_archive_named_member_failure(
+                archive_name,
+                &format!("contains more than {MAX_UPDATE_ARCHIVE_ENTRIES} entries"),
             ));
         }
         if size > MAX_UPDATE_ARCHIVE_MEMBER_BYTES {
@@ -7797,9 +7798,9 @@ impl UpdateArchiveScan {
                 .checked_add(size)
                 .ok_or_else(|| "release update archive unpacked size overflowed".to_string())?;
             if self.unpacked_bytes > MAX_UPDATE_ARCHIVE_UNPACKED_BYTES {
-                return Err(format!(
-                    "release update archive uncompressed contents exceed {MAX_UPDATE_ARCHIVE_UNPACKED_BYTES} bytes"
-                ));
+                return Err(release_update_archive_member_failure(&format!(
+                    "uncompressed contents exceed {MAX_UPDATE_ARCHIVE_UNPACKED_BYTES} bytes"
+                )));
             }
             self.reject_unexpected_binary_path(&normalized)?;
         }
@@ -14090,6 +14091,58 @@ mod tests {
         assert!(!output.stderr.contains(&mixed_member));
         assert!(!output.stderr.contains("fixture binary bytes"));
         assert!(!install_dir.exists());
+    }
+
+    #[test]
+    fn update_apply_archive_bound_failures_are_redacted() {
+        let target = update_apply_test_target();
+        let filename = update_archive_fixture_name(&target);
+        let root = format!("conu-0.1.0-{target}");
+
+        let mut count_scan =
+            UpdateArchiveScan::new(&target, &filename).expect("count scan creates");
+        let mut count_error = None;
+        for index in 0..=MAX_UPDATE_ARCHIVE_ENTRIES {
+            let raw_name = format!("{root}/docs/secret-count-bound-{index}.txt");
+            match count_scan.record_member(&filename, &raw_name, 0, false) {
+                Ok(_) => {}
+                Err(error) => {
+                    count_error = Some(error);
+                    break;
+                }
+            }
+        }
+        let count_error = count_error.expect("member count bound fails");
+        assert_update_archive_member_error_redacted(
+            &count_error,
+            "contains more than",
+            "secret-count-bound",
+        );
+
+        let mut total_scan =
+            UpdateArchiveScan::new(&target, &filename).expect("total scan creates");
+        let mut total_error = None;
+        for index in 0..5 {
+            let raw_name = format!("{root}/docs/secret-total-bound-{index}.bin");
+            match total_scan.record_member(
+                &filename,
+                &raw_name,
+                MAX_UPDATE_ARCHIVE_MEMBER_BYTES,
+                false,
+            ) {
+                Ok(_) => {}
+                Err(error) => {
+                    total_error = Some(error);
+                    break;
+                }
+            }
+        }
+        let total_error = total_error.expect("uncompressed total bound fails");
+        assert_update_archive_member_error_redacted(
+            &total_error,
+            "uncompressed contents exceed",
+            "secret-total-bound",
+        );
     }
 
     #[test]

--- a/packaging/npm/conu-cli/lib/archive-preflight.js
+++ b/packaging/npm/conu-cli/lib/archive-preflight.js
@@ -41,7 +41,10 @@ function assertSafeArchiveMemberList(members, archiveLabel = "archive") {
     throw new Error(`${archiveLabel} did not contain any extractable members`);
   }
   if (members.length > MAX_ARCHIVE_MEMBERS) {
-    throw new Error(`${archiveLabel} contains more than ${MAX_ARCHIVE_MEMBERS} entries`);
+    throw archiveMemberPathError(
+      archiveLabel,
+      `contains more than ${MAX_ARCHIVE_MEMBERS} entries`
+    );
   }
 
   const paths = new Set();
@@ -103,9 +106,11 @@ function rejectForbiddenArchivePath(normalized, archiveLabel) {
 }
 
 function archiveMemberPathError(archiveLabel, reason) {
-  return new Error(
+  const error = new Error(
     `${archiveLabel} ${reason}; pathDisplayed=false contentsDisplayed=false`
   );
+  error.archiveMemberPathError = true;
+  return error;
 }
 
 function formatMemberTypeForError(type) {
@@ -176,7 +181,7 @@ function listZipMembersWithNode(archivePath, archiveLabel) {
     const { centralDirectory, entryCount } = readZipCentralDirectory(fd, size, archiveLabel);
     return parseZipCentralDirectory(centralDirectory, entryCount, archiveLabel);
   } catch (error) {
-    if (error && error.zipInspectionError) {
+    if (error && (error.zipInspectionError || error.archiveMemberPathError)) {
       throw error;
     }
     throw zipInspectionError(archiveLabel);
@@ -227,7 +232,10 @@ function readZipCentralDirectory(fd, size, archiveLabel) {
       throw zipInspectionError(archiveLabel);
     }
     if (entryCount > MAX_ARCHIVE_MEMBERS) {
-      throw new Error(`${archiveLabel} contains more than ${MAX_ARCHIVE_MEMBERS} entries`);
+      throw archiveMemberPathError(
+        archiveLabel,
+        `contains more than ${MAX_ARCHIVE_MEMBERS} entries`
+      );
     }
     if (centralSize > MAX_ARCHIVE_LIST_BYTES) {
       throw zipInspectionError(archiveLabel);

--- a/packaging/npm/conu-cli/scripts/check-archive-preflight.js
+++ b/packaging/npm/conu-cli/scripts/check-archive-preflight.js
@@ -38,7 +38,12 @@ function main() {
   expectFail([{ name: "conu-0.1.0/security/identity.key", type: "file" }], "forbidden state path");
   expectFail([{ name: "conu-0.1.0/runtime/node.toml", type: "file" }], "forbidden state path");
   expectArchiveMemberFailurePathsAreRedacted();
-  expectFail(makeMemberList(MAX_ARCHIVE_MEMBERS + 1), `more than ${MAX_ARCHIVE_MEMBERS} entries`);
+  expectFailWithoutArchiveMember(
+    makeMemberList(MAX_ARCHIVE_MEMBERS + 1, "secret-count-bound"),
+    `more than ${MAX_ARCHIVE_MEMBERS} entries`,
+    ["secret-count-bound"],
+    "archive member count bound"
+  );
   expectNativeZipInspection();
   expectArchiveInspectionPathRedacted();
   expectArchiveInspectionFailurePathGuard();
@@ -110,9 +115,9 @@ function expectArchiveMemberFailurePathsAreRedacted() {
   );
 }
 
-function makeMemberList(count) {
+function makeMemberList(count, prefix = "file") {
   return Array.from({ length: count }, (_value, index) => ({
-    name: `conu-0.1.0/docs/file-${index}.txt`,
+    name: `conu-0.1.0/docs/${prefix}-${index}.txt`,
     type: "file"
   }));
 }
@@ -138,6 +143,21 @@ function expectNativeZipInspection() {
       { name: "conu-0.1.0-windows-x64/bin/conu.exe", mode: 0o120777 }
     ]);
     expectValidateArchiveFail(symlinkArchive, "unsupported symlink member");
+
+    const tooManyArchive = path.join(root, "conu-0.1.0-windows-x64-too-many.zip");
+    writeZipFixture(
+      tooManyArchive,
+      Array.from({ length: MAX_ARCHIVE_MEMBERS + 1 }, (_value, index) => ({
+        name: `z/s${index}`,
+        mode: 0o100644
+      }))
+    );
+    expectValidateArchiveFailRedacted(
+      tooManyArchive,
+      `more than ${MAX_ARCHIVE_MEMBERS} entries`,
+      ["z/s"],
+      "native ZIP member count bound"
+    );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -153,6 +173,19 @@ function expectValidateArchiveFail(archive, expectedMessage) {
     throw new Error(`expected ${expectedMessage}, got: ${error.message}`);
   }
   throw new Error(`expected archive inspection failure: ${expectedMessage}`);
+}
+
+function expectValidateArchiveFailRedacted(archive, expectedMessage, forbiddenValues, label) {
+  try {
+    validateArchiveMembers(archive);
+  } catch (error) {
+    if (!error.message.includes(expectedMessage)) {
+      throw new Error(`${label}: expected ${expectedMessage}, got: ${error.message}`);
+    }
+    expectRedactedMemberFailure(error.message, forbiddenValues, label);
+    return;
+  }
+  throw new Error(`${label}: expected archive inspection failure`);
 }
 
 function writeZipFixture(archive, entries) {


### PR DESCRIPTION
## **User description**
## Summary
- route Rust release update archive member-count and total-uncompressed failures through guarded archive diagnostics
- route npm archive preflight list-count and native ZIP EOCD-count failures through guarded member diagnostics
- add regressions requiring `pathDisplayed=false contentsDisplayed=false` for these aggregate bound failures

## Validation
- node --check packaging\npm\conu-cli\lib\archive-preflight.js
- node --check packaging\npm\conu-cli\scripts\check-archive-preflight.js
- node packaging\npm\conu-cli\scripts\check-archive-preflight.js
- npm run check --prefix packaging\npm\conu-cli
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check -p conu-cli --tests
- cargo +stable-x86_64-pc-windows-gnu check --workspace --all-targets
- cargo +stable-x86_64-pc-windows-gnu clippy -p conu-cli --tests -- -D warnings
- cargo +stable-x86_64-pc-windows-gnu clippy --workspace --all-targets -- -D warnings
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- python scripts\check-release-update-download-gate.py
- python scripts\check-github-workflow-permissions-regression.py
- python scripts\check-npm-launcher-local-smoke-preflight.py
- python scripts\verify-release-versions.py
- python scripts\check-release-version-regression.py
- python scripts\verify-npm-package-contents.py
- python scripts\verify-npm-package-contents-regression.py
- python scripts\check-release-update-policy.py
- git diff --check

Note: local targeted Rust test execution was attempted, but this Windows environment is missing `dlltool.exe`; CI should cover Rust test execution.

Fixes #1023

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts update installer archive limit failures so errors never include member names. Applies to Rust update scanning and Node preflight/native ZIP inspection in `conu-cli`. Fixes #1023.

- Bug Fixes
  - Rust: Route member-count and total-uncompressed-size failures through guarded diagnostics with pathDisplayed=false contentsDisplayed=false; added tests to verify redaction.
  - Node: `archive-preflight.js` now throws a guarded `archiveMemberPathError` for over-limit member lists and ZIP entry counts; propagates guarded errors without exposing paths; added regression tests, including a native ZIP “too many entries” case.

<sup>Written for commit 9ec74a1a7ec3fadb71bde690b26a8170772d1de6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact archive limit failures so installer and package checks do not reveal file names**

### What Changed
- When an update archive has too many entries or too much unpacked content, the error now hides member names and shows only a redacted archive-limit message.
- npm archive preflight checks now return the same redacted message for oversized member lists, including native ZIP files.
- Added regression checks to ensure these bound failures do not expose sensitive path details.

### Impact
`✅ Fewer archive errors exposing file names`
`✅ Safer update installer failure messages`
`✅ Redacted ZIP and package preflight limits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
