### PR TITLE
Redact verifier oversized file names

### DIFF
--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -303,16 +303,39 @@ def main() -> int:
             "checksum file for conu-0.1.0-directory-checksum.zip must be a regular file",
         )
 
+        oversized_archive = root / "secret-release-verifier-archive-name-should-not-print.zip"
+        write_zip(oversized_archive)
         original_max_archive_bytes = verifier.MAX_ARCHIVE_BYTES
         verifier.MAX_ARCHIVE_BYTES = 1
         try:
             expect_failure(
                 "oversized archive before checksum hashing",
-                lambda: verifier.verify_checksum(valid_zip),
-                "is larger than",
+                lambda: verifier.verify_checksum(oversized_archive),
+                "release archive is larger than",
+                forbidden=oversized_archive.name,
+            )
+            expect_failure(
+                "oversized archive before member scan",
+                lambda: verifier.archive_members(oversized_archive),
+                "release archive is larger than",
+                forbidden=oversized_archive.name,
             )
         finally:
             verifier.MAX_ARCHIVE_BYTES = original_max_archive_bytes
+
+        oversized_checksum = root / "secret-release-verifier-checksum-name-should-not-print.zip"
+        write_zip(oversized_checksum)
+        original_max_checksum_bytes = verifier.MAX_CHECKSUM_BYTES
+        verifier.MAX_CHECKSUM_BYTES = 1
+        try:
+            expect_failure(
+                "oversized checksum sidecar",
+                lambda: verifier.verify_checksum(oversized_checksum),
+                "checksum file is too large",
+                forbidden=oversized_checksum.name,
+            )
+        finally:
+            verifier.MAX_CHECKSUM_BYTES = original_max_checksum_bytes
 
         valid_tar = root / "conu-0.1.0-test.tar.gz"
         write_tar(valid_tar)

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -104,7 +104,7 @@ def verify_checksum(archive: Path) -> None:
         archive,
         "release archive",
         max_bytes=MAX_ARCHIVE_BYTES,
-        too_large_message=f"{archive.name} is larger than {MAX_ARCHIVE_BYTES} bytes",
+        too_large_message=f"release archive is larger than {MAX_ARCHIVE_BYTES} bytes",
     )
 
     checksum_path = archive.with_name(f"{archive.name}.sha256")
@@ -113,7 +113,7 @@ def verify_checksum(archive: Path) -> None:
         f"checksum file for {archive.name}",
         max_bytes=MAX_CHECKSUM_BYTES,
         missing_message=f"missing checksum file for {archive.name}",
-        too_large_message=f"checksum file is too large for {archive.name}",
+        too_large_message="checksum file is too large",
     )
 
     with archive_file:
@@ -175,7 +175,7 @@ def archive_members(archive: Path) -> ArchiveMembers:
         archive,
         "release archive",
         max_bytes=MAX_ARCHIVE_BYTES,
-        too_large_message=f"{archive.name} is larger than {MAX_ARCHIVE_BYTES} bytes",
+        too_large_message=f"release archive is larger than {MAX_ARCHIVE_BYTES} bytes",
     )
     expected_root = expected_archive_root(archive.name)
 
@@ -359,7 +359,7 @@ def open_regular_file(
         if not stat.S_ISREG(metadata.st_mode):
             raise SystemExit(f"{label} must be a regular file: {path.name}")
         if metadata.st_size > max_bytes:
-            raise SystemExit(too_large_message or f"{label} is too large: {path.name}")
+            raise SystemExit(too_large_message or f"{label} is too large")
         return os.fdopen(fd, "rb"), metadata.st_size
     except BaseException:
         os.close(fd)


### PR DESCRIPTION
## **User description**
## Summary\n- remove archive/checksum basenames from oversized release verifier file-bound errors\n- add regression coverage for oversized archive checksum, member scan, and checksum sidecar paths\n\n## Validation\n- python scripts\\check-release-artifact-verifier.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-release-artifact-smoke-preflight.py\n- git diff --check\n\nFixes #1027

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redact archive and checksum filenames from “too large” verifier errors to avoid leaking sensitive names. Adds regression tests to lock this behavior for archives and checksum sidecars.

- **Bug Fixes**
  - Use generic messages: “release archive is larger than …” and “checksum file is too large” (no filenames).
  - Ensure `open_regular_file` omits filenames when reporting oversize errors.
  - Add regression tests for oversized archive (checksum hashing and member scan) and oversized checksum sidecar, asserting filenames are not shown.

<sup>Written for commit a6d2a28e74549aa39d8d3a8a766861cf978089fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide oversized release file names in verifier errors**

### What Changed
- Oversized archive and checksum files now fail with generic messages instead of printing the file name
- The same redaction applies when the verifier checks an archive’s checksum or scans its contents
- Added regression coverage to confirm oversized archive and checksum errors do not expose the release file name

### Impact
`✅ Less file-name exposure in release checks`
`✅ Safer oversized-file error messages`
`✅ Fewer sensitive details in verifier output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
