### PR TITLE
Redact hosted repository oversized file names

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -57,6 +57,63 @@ def main() -> int:
             raise AssertionError("hosted Linux repository bundle was not deterministic")
 
         generator = load_generator()
+        oversized_input = temp / "secret-hosted-repository-input-name-should-not-print.txt"
+        oversized_input.write_bytes(b"oversized\n")
+        message = expect_action_failure(
+            lambda: generator.open_regular_file(
+                oversized_input,
+                "hosted repository input asset",
+                max_bytes=1,
+            ),
+            "hosted repository input asset is too large",
+            "oversized hosted repository input",
+        )
+        assert_not_displayed(
+            message,
+            "oversized hosted repository input",
+            oversized_input.name,
+        )
+
+        original_open_regular_file = generator.open_regular_file
+        try:
+            generator.open_regular_file = lambda _path, _label, *, max_bytes: (
+                io.BytesIO(b"xx"),
+                2,
+            )
+            message = expect_action_failure(
+                lambda: generator.read_regular_file(
+                    Path("secret-hosted-repository-read-name-should-not-print.txt"),
+                    "hosted repository read asset",
+                    max_bytes=1,
+                ),
+                "hosted repository read asset is too large",
+                "oversized hosted repository read",
+            )
+            assert_not_displayed(
+                message,
+                "oversized hosted repository read",
+                "secret-hosted-repository-read-name-should-not-print.txt",
+            )
+        finally:
+            generator.open_regular_file = original_open_regular_file
+
+        oversized_output = temp / "secret-hosted-repository-output-name-should-not-print.txt"
+        message = expect_action_failure(
+            lambda: generator.write_text_output(
+                oversized_output,
+                "hosted repository output",
+                "oversized",
+                max_bytes=1,
+            ),
+            "hosted repository output is too large",
+            "oversized hosted repository output",
+        )
+        assert_not_displayed(
+            message,
+            "oversized hosted repository output",
+            oversized_output.name,
+        )
+
         message = expect_action_failure(
             lambda: generator.parse_package_version(
                 Path("package.json"),
@@ -422,6 +479,12 @@ def assert_member_failure_redacted(message: str, label: str, *forbidden_values: 
 def assert_no_sentinel(output: str, label: str) -> None:
     if SENSITIVE_SENTINEL in output:
         raise AssertionError(f"{label} leaked duplicate-key shadow value")
+
+
+def assert_not_displayed(message: str, label: str, *forbidden_values: str) -> None:
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{label}: displayed forbidden value {value!r}: {message!r}")
 
 
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -123,6 +124,63 @@ def main() -> int:
             1,
             "uncompressed ZIP contents exceed",
             "hosted bundle total size bound",
+        )
+
+        oversized_input = temp / "secret-hosted-site-input-name-should-not-print.txt"
+        oversized_input.write_bytes(b"oversized\n")
+        message = expect_action_failure(
+            lambda: site_generator.open_regular_file(
+                oversized_input,
+                "hosted repository site input",
+                max_bytes=1,
+            ),
+            "hosted repository site input is too large",
+            "oversized hosted repository site input",
+        )
+        assert_not_displayed(
+            message,
+            "oversized hosted repository site input",
+            oversized_input.name,
+        )
+
+        original_open_regular_file = site_generator.open_regular_file
+        try:
+            site_generator.open_regular_file = lambda _path, _label, *, max_bytes: (
+                io.BytesIO(b"xx"),
+                2,
+            )
+            message = expect_action_failure(
+                lambda: site_generator.read_regular_file(
+                    Path("secret-hosted-site-read-name-should-not-print.txt"),
+                    "hosted repository site read",
+                    max_bytes=1,
+                ),
+                "hosted repository site read is too large",
+                "oversized hosted repository site read",
+            )
+            assert_not_displayed(
+                message,
+                "oversized hosted repository site read",
+                "secret-hosted-site-read-name-should-not-print.txt",
+            )
+        finally:
+            site_generator.open_regular_file = original_open_regular_file
+
+        oversized_output = temp / "secret-hosted-site-output-name-should-not-print.txt"
+        message = expect_action_failure(
+            lambda: site_generator.write_text_output(
+                oversized_output,
+                "hosted repository site output",
+                "oversized",
+                max_bytes=1,
+            ),
+            "hosted repository site output is too large",
+            "oversized hosted repository site output",
+        )
+        assert_not_displayed(
+            message,
+            "oversized hosted repository site output",
+            oversized_output.name,
         )
 
         unreadable_bundle = temp / "unreadable-hosted-bundle.zip"
@@ -541,6 +599,12 @@ def assert_member_failure_redacted(message: str, label: str, *forbidden_values: 
 def assert_no_sentinel(output: str, label: str) -> None:
     if SENSITIVE_SENTINEL in output:
         raise AssertionError(f"{label} leaked duplicate-key shadow value")
+
+
+def assert_not_displayed(message: str, label: str, *forbidden_values: str) -> None:
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{label}: displayed forbidden value {value!r}: {message!r}")
 
 
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -632,7 +632,7 @@ def open_regular_file(path: Path, label: str, *, max_bytes: int) -> tuple[Binary
         if not stat.S_ISREG(metadata.st_mode):
             raise SystemExit(f"{label} must be a regular file: {path.name}")
         if metadata.st_size > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name}")
+            raise SystemExit(f"{label} is too large")
         return os.fdopen(fd, "rb"), metadata.st_size
     except BaseException:
         os.close(fd)
@@ -684,7 +684,7 @@ def open_output_file(path: Path, label: str) -> BinaryIO:
 def write_text_output(path: Path, label: str, text: str, *, max_bytes: int) -> None:
     data = text.encode("ascii")
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name}")
+        raise SystemExit(f"{label} is too large")
     with open_output_file(path, label) as handle:
         handle.write(data)
         handle.flush()
@@ -702,7 +702,7 @@ def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
     with handle:
         data = handle.read(max_bytes + 1)
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name}")
+        raise SystemExit(f"{label} is too large")
     return data
 
 

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -754,7 +754,7 @@ def open_regular_file(path: Path, label: str, *, max_bytes: int) -> tuple[Binary
         if not stat.S_ISREG(metadata.st_mode):
             raise SystemExit(f"{label} must be a regular file: {path.name}")
         if metadata.st_size > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name}")
+            raise SystemExit(f"{label} is too large")
         return os.fdopen(fd, "rb"), metadata.st_size
     except BaseException:
         os.close(fd)
@@ -806,7 +806,7 @@ def open_output_file(path: Path, label: str) -> BinaryIO:
 def write_text_output(path: Path, label: str, text: str, *, max_bytes: int) -> None:
     data = text.encode("ascii")
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name}")
+        raise SystemExit(f"{label} is too large")
     with open_output_file(path, label) as handle:
         handle.write(data)
         handle.flush()
@@ -824,7 +824,7 @@ def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
     with handle:
         data = handle.read(max_bytes + 1)
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name}")
+        raise SystemExit(f"{label} is too large")
     return data
 
 


### PR DESCRIPTION
## **User description**
## Summary\n- remove local filenames from hosted Linux repository bundle/site oversized input, read, and output diagnostics\n- add regression coverage with secret-looking fixture names\n\n## Validation\n- python scripts\\check-hosted-linux-repositories.py\n- python scripts\\check-hosted-linux-repository-site.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- git diff --check\n\nFixes #1029


___

## **CodeAnt-AI Description**
Redact file names from oversized file errors in hosted repository checks

### What Changed
- Oversized file errors no longer print the file name, so paths are not exposed in size-limit failures
- The hosted repository and hosted site checks now cover oversized input, read, and output cases to confirm those errors stay generic
- Added assertions that these failures do not reveal secret-looking file names

### Impact
`✅ Fewer file-name leaks in build errors`
`✅ Safer oversized upload diagnostics`
`✅ Clearer privacy protection in repository checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
