### PR TITLE
Redact package-manager oversized file names

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -261,7 +261,7 @@ def generate(
         generator.write_sha256_sidecar(metadata_path, rpm_repository_metadata.sha256)
 
 
-def expect_failure(description: str, action, expected: str) -> None:
+def expect_failure(description: str, action, expected: str) -> str:
     try:
         action()
     except SystemExit as exc:
@@ -270,7 +270,7 @@ def expect_failure(description: str, action, expected: str) -> None:
             raise AssertionError(
                 f"{description} failed with {message!r}, expected {expected!r}"
             ) from exc
-        return
+        return message
     raise AssertionError(f"{description} unexpectedly passed")
 
 
@@ -411,6 +411,12 @@ def assert_no_forbidden_text(text: str, label: str, temp: Path) -> None:
     for literal in forbidden:
         if literal and literal in normalized:
             raise AssertionError(f"{label} contained forbidden literal {literal!r}")
+
+
+def assert_not_displayed(message: str, label: str, *forbidden_values: str) -> None:
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{label}: displayed forbidden value {value!r}: {message!r}")
 
 
 def assert_external_tool_output_redacts(generator) -> None:
@@ -961,6 +967,46 @@ def main() -> int:
         rootless_dist.mkdir()
         hashes = write_dist(rootless_dist, rooted_windows=False)
         generate(generator, rootless_dist, rootless_out)
+
+        oversized_input = temp / "secret-package-manager-input-name-should-not-print.zip"
+        oversized_input.write_bytes(b"oversized\n")
+        message = expect_failure(
+            "oversized package-manager input",
+            lambda: generator.open_regular_file(
+                oversized_input,
+                "package-manager input asset",
+                max_bytes=1,
+            ),
+            "package-manager input asset is too large",
+        )
+        assert_not_displayed(
+            message,
+            "oversized package-manager input",
+            oversized_input.name,
+        )
+
+        original_open_regular_file = generator.open_regular_file
+        try:
+            generator.open_regular_file = lambda _path, _label, *, max_bytes: (
+                io.BytesIO(b"xx"),
+                2,
+            )
+            message = expect_failure(
+                "oversized package-manager read",
+                lambda: generator.read_regular_file(
+                    Path("secret-package-manager-read-name-should-not-print.zip"),
+                    "package-manager read asset",
+                    max_bytes=1,
+                ),
+                "package-manager read asset is too large",
+            )
+            assert_not_displayed(
+                message,
+                "oversized package-manager read",
+                "secret-package-manager-read-name-should-not-print.zip",
+            )
+        finally:
+            generator.open_regular_file = original_open_regular_file
 
         for literal in ("PRIVATE KEY BLOCK", "BEGIN OPENSSH PRIVATE KEY"):
             expect_failure(

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -484,7 +484,7 @@ def open_regular_file(path: Path, label: str, *, max_bytes: int) -> tuple[Binary
         if not stat.S_ISREG(metadata.st_mode):
             raise SystemExit(f"{label} must be a regular file: {path.name}")
         if metadata.st_size > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name}")
+            raise SystemExit(f"{label} is too large")
         return os.fdopen(fd, "rb"), metadata.st_size
     except BaseException:
         os.close(fd)
@@ -559,7 +559,7 @@ def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
     with handle:
         data = handle.read(max_bytes + 1)
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name}")
+        raise SystemExit(f"{label} is too large")
     return data
 
 


### PR DESCRIPTION
## **User description**
## Summary\n- remove local filenames from package-manager oversized input/read diagnostics\n- add regression coverage with secret-looking fixture names\n\n## Validation\n- python scripts\\check-package-manager-manifests.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- git diff --check\n\nFixes #1031

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts file names from package-manager “too large” errors to prevent leaking local paths. Adds regression checks to ensure the messages stay redacted.

- **Bug Fixes**
  - Remove `path.name` from oversized errors in `open_regular_file` and `read_regular_file` (now only the label is shown).
  - Extend tests: `expect_failure` returns the message, new `assert_not_displayed`, and checks for both input and read cases with secret-looking names.

<sup>Written for commit 65c6b45a2907cd86cb588a7e6739844e878da33c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Hide local file names in oversized package-manager errors

### What Changed
- When a package-manager input file is too large, the error now says only that the file is too large and no longer includes the local file name.
- The same redaction now applies when a package-manager file read exceeds the size limit.
- Added checks to make sure oversized-file errors do not reveal secret-looking or path-like file names.

### Impact
`✅ Fewer leaked local file names in build errors`
`✅ Safer package-manager validation messages`
`✅ Lower risk of exposing sensitive filenames in logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
