### PR TITLE
Redact Linux release signing size diagnostics

### DIFF
--- a/scripts/check-linux-release-signing.py
+++ b/scripts/check-linux-release-signing.py
@@ -263,6 +263,7 @@ def run_source_selection_checks() -> None:
             1,
             lambda: signer.signable_linux_assets(dist),
             "is too large",
+            asset.name,
         )
 
         expect_module_failure_with_limit(
@@ -295,6 +296,15 @@ def run_source_selection_checks() -> None:
         signature = dist / f"{asset.name}.asc"
         signature.write_bytes(b"existing signature\n")
         signer.prepare_signature_output(signature)
+        expect_module_failure_with_limit(
+            signer,
+            "detached signature output size bound",
+            "MAX_DETACHED_SIGNATURE_BYTES",
+            1,
+            lambda: signer.prepare_signature_output(signature),
+            "is too large",
+            signature.name,
+        )
 
         empty_signature = dist / f"{asset.name}.empty.asc"
         empty_signature.write_bytes(b"")
@@ -322,7 +332,12 @@ def load_signer_module():
     return module
 
 
-def expect_module_failure(description: str, action, expected: str) -> None:
+def expect_module_failure(
+    description: str,
+    action,
+    expected: str,
+    *forbidden_values: str,
+) -> None:
     try:
         action()
     except SystemExit as exc:
@@ -331,6 +346,11 @@ def expect_module_failure(description: str, action, expected: str) -> None:
             raise AssertionError(
                 f"{description} failed with {rendered!r}, expected {expected!r}"
             ) from exc
+        for value in forbidden_values:
+            if value in rendered:
+                raise AssertionError(
+                    f"{description} leaked forbidden value {value!r}: {rendered!r}"
+                ) from exc
         return
     raise AssertionError(f"{description} unexpectedly passed")
 
@@ -342,11 +362,12 @@ def expect_module_failure_with_limit(
     value: int,
     action,
     expected: str,
+    *forbidden_values: str,
 ) -> None:
     original = getattr(signer, attr)
     setattr(signer, attr, value)
     try:
-        expect_module_failure(description, action, expected)
+        expect_module_failure(description, action, expected, *forbidden_values)
     finally:
         setattr(signer, attr, original)
 

--- a/scripts/sign-linux-release-assets.py
+++ b/scripts/sign-linux-release-assets.py
@@ -258,6 +258,7 @@ def validate_signable_asset(path: Path, budget: SignableAssetBudget) -> int:
         f"signable Linux release asset {path.name}",
         max_bytes=MAX_SIGNABLE_ASSET_BYTES,
         allow_empty=False,
+        size_label="signable Linux release asset",
     )
     budget.add(size)
     return size
@@ -282,6 +283,7 @@ def prepare_signature_output(signature: Path) -> None:
         f"detached signature output {signature.name}",
         max_bytes=MAX_DETACHED_SIGNATURE_BYTES,
         allow_empty=True,
+        size_label="detached signature output",
     )
 
 
@@ -291,6 +293,7 @@ def validate_signature_output(signature: Path) -> int:
         f"detached signature output {signature.name}",
         max_bytes=MAX_DETACHED_SIGNATURE_BYTES,
         allow_empty=False,
+        size_label="detached signature output",
     )
 
 
@@ -300,6 +303,7 @@ def validate_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> int:
     if path.is_symlink():
         raise SystemExit(f"{label} must not be a symlink: {path.name}")
@@ -313,7 +317,8 @@ def validate_regular_file(
     if not allow_empty and size == 0:
         raise SystemExit(f"{label} must not be empty: {path.name}")
     if size > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+        display_label = size_label or label
+        raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
     return size
 
 


### PR DESCRIPTION
## **User description**
## Summary
- redact local asset/signature basenames from oversized Linux release signing diagnostics
- add regression checks that reject those basename leaks in size-bound failures

## Validation
- python scripts\\check-linux-release-signing.py (GPG signing path skipped because gpg is unavailable locally; source-selection and size-redaction checks ran before the skip)
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1033

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts asset and signature basenames from Linux release signing size errors to prevent leaking local file names. Adds checks to enforce generic, redacted messages. Fixes #1033.

- **Bug Fixes**
  - Use generic labels for oversize errors via a new `size_label` to avoid including `{path.name}` in messages.
  - Extend failure helpers to reject messages containing forbidden basenames and add regression tests for both asset and signature paths.

<sup>Written for commit 55129aebb418680443ea889dd55a91442a4c9fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide local file names from Linux release signing size errors**

### What Changed
- Oversized Linux release asset and signature errors now report a generic size message instead of including the file name.
- The release signing checks now verify that size-limit failures do not leak asset or signature names.
- Regression coverage now includes oversized detached signature output in addition to oversized assets.

### Impact
`✅ No file-name leaks in release signing errors`
`✅ Clearer oversize failure messages`
`✅ Safer diagnostics for local build files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
