### PR TITLE
Redact RPM signing size diagnostics

### DIFF
--- a/scripts/check-rpm-package-signing.py
+++ b/scripts/check-rpm-package-signing.py
@@ -251,6 +251,7 @@ def run_source_file_preflights() -> None:
             lambda: signer.rpm_package_assets(oversized_source),
             "is too large",
             "RPM signing source size bound",
+            oversized_package.name,
         )
 
         aggregate_source = temp / "aggregate-source"
@@ -278,6 +279,31 @@ def run_source_file_preflights() -> None:
             "must be a regular file",
             "RPM signing sidecar directory",
         )
+        oversized_sidecar = temp / "oversized-sidecar"
+        oversized_sidecar.mkdir()
+        oversized_sidecar_package = oversized_sidecar / RPM_PACKAGES[0]
+        oversized_sidecar_package.write_bytes(b"rpm fixture\n")
+        oversized_sidecar_path = oversized_sidecar_package.with_name(
+            f"{oversized_sidecar_package.name}.sha256"
+        )
+        oversized_sidecar_path.write_text(
+            "0" * 64 + f"  {oversized_sidecar_package.name}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_constant_failure(
+            signer,
+            "MAX_CHECKSUM_BYTES",
+            max(0, oversized_sidecar_path.stat().st_size - 1),
+            lambda: signer.verify_sha256_sidecar(
+                oversized_sidecar_package,
+                "generated RPM package",
+            ),
+            "is too large",
+            "RPM signing sidecar size bound",
+            oversized_sidecar_path.name,
+            oversized_sidecar_package.name,
+        )
 
         sidecar_output_directory = temp / "sidecar-output-directory"
         sidecar_output_directory.mkdir()
@@ -288,6 +314,24 @@ def run_source_file_preflights() -> None:
             lambda: signer.write_sha256_sidecar(output_package),
             "must be a regular file",
             "RPM signing sidecar output directory",
+        )
+        oversized_sidecar_output = temp / "oversized-sidecar-output"
+        oversized_sidecar_output.mkdir()
+        oversized_output_package = oversized_sidecar_output / RPM_PACKAGES[0]
+        oversized_output_package.write_bytes(b"rpm fixture\n")
+        oversized_output_sidecar = oversized_output_package.with_name(
+            f"{oversized_output_package.name}.sha256"
+        )
+        oversized_output_sidecar.write_bytes(b"existing sidecar\n")
+        expect_constant_failure(
+            signer,
+            "MAX_CHECKSUM_BYTES",
+            max(0, oversized_output_sidecar.stat().st_size - 1),
+            lambda: signer.write_sha256_sidecar(oversized_output_package),
+            "is too large",
+            "RPM signing sidecar output size bound",
+            oversized_output_sidecar.name,
+            oversized_output_package.name,
         )
 
         symlink_source = temp / "symlink-source"
@@ -355,23 +399,34 @@ def expect_constant_failure(
     action,
     expected: str,
     label: str,
+    *forbidden_values: str,
 ) -> None:
     original = getattr(signer, constant_name)
     setattr(signer, constant_name, value)
     try:
-        expect_action_failure(action, expected, label)
+        expect_action_failure(action, expected, label, *forbidden_values)
     finally:
         setattr(signer, constant_name, original)
 
 
-def expect_action_failure(action, expected: str, label: str) -> None:
+def expect_action_failure(
+    action,
+    expected: str,
+    label: str,
+    *forbidden_values: str,
+) -> None:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
-        if expected in message:
-            return
-        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+        if expected not in message:
+            raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+        for value in forbidden_values:
+            if value in message:
+                raise AssertionError(
+                    f"{label}: leaked forbidden value {value!r}: {message!r}"
+                ) from exc
+        return
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
 
 

--- a/scripts/sign-rpm-packages.py
+++ b/scripts/sign-rpm-packages.py
@@ -171,6 +171,7 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
             encoding="ascii",
+            size_label=f"SHA-256 sidecar for {label}",
         )
     except UnicodeDecodeError as exc:
         raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
@@ -186,6 +187,7 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
         f"{label} {path.name}",
         max_bytes=MAX_RPM_PACKAGE_BYTES,
         allow_empty=False,
+        size_label=label,
     )
     if expected != actual:
         raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
@@ -200,11 +202,13 @@ def write_sha256_sidecar(path: Path) -> None:
             f"SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=True,
+            size_label="SHA-256 sidecar output",
         )
     digest = sha256_file(
         path,
         f"RPM package asset {path.name}",
         max_bytes=MAX_RPM_PACKAGE_BYTES,
+        size_label="RPM package asset",
     )
     text = f"{digest}  {path.name}\n"
     temp_path = temporary_sibling_path(sidecar)
@@ -216,6 +220,7 @@ def write_sha256_sidecar(path: Path) -> None:
             f"temporary SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
+            size_label="temporary SHA-256 sidecar output",
         )
         os.replace(temp_path, sidecar)
         validate_regular_file(
@@ -223,6 +228,7 @@ def write_sha256_sidecar(path: Path) -> None:
             f"SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
+            size_label="SHA-256 sidecar output",
         )
     finally:
         try:
@@ -249,6 +255,7 @@ def validate_rpm_package(
         f"RPM package asset {path.name}",
         max_bytes=MAX_RPM_PACKAGE_BYTES,
         allow_empty=False,
+        size_label="RPM package asset",
     )
     if budget is not None:
         budget.add(size)
@@ -261,12 +268,14 @@ def validate_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> int:
     handle, size = open_regular_file(
         path,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     handle.close()
     return size
@@ -278,6 +287,7 @@ def open_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> tuple[BinaryIO, int]:
     if path.is_symlink():
         raise SystemExit(f"{label} must not be a symlink: {path.name}")
@@ -302,7 +312,8 @@ def open_regular_file(
         if not allow_empty and size == 0:
             raise SystemExit(f"{label} must not be empty: {path.name}")
         if size > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+            display_label = size_label or label
+            raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
         return os.fdopen(fd, "rb"), size
     except BaseException:
         os.close(fd)
@@ -315,6 +326,7 @@ def validate_open_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> int:
     metadata = os.fstat(handle.fileno())
     if not stat.S_ISREG(metadata.st_mode):
@@ -323,7 +335,8 @@ def validate_open_regular_file(
     if not allow_empty and size == 0:
         raise SystemExit(f"{label} must not be empty")
     if size > max_bytes:
-        raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
+        display_label = size_label or label
+        raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
     return size
 
 
@@ -334,22 +347,26 @@ def read_text_file(
     max_bytes: int,
     allow_empty: bool,
     encoding: str,
+    size_label: str | None = None,
 ) -> str:
     handle, _size = open_regular_file(
         path,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     with handle:
         data = handle.read(max_bytes + 1)
         if len(data) > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+            display_label = size_label or label
+            raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
         validate_open_regular_file(
             handle,
             label,
             max_bytes=max_bytes,
             allow_empty=allow_empty,
+            size_label=size_label,
         )
     return data.decode(encoding)
 
@@ -370,12 +387,14 @@ def sha256_file(
     *,
     max_bytes: int = MAX_RPM_PACKAGE_BYTES,
     allow_empty: bool = False,
+    size_label: str | None = None,
 ) -> str:
     handle, _size = open_regular_file(
         path,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     with handle:
         return sha256_open_file(
@@ -383,6 +402,7 @@ def sha256_file(
             label,
             max_bytes=max_bytes,
             allow_empty=allow_empty,
+            size_label=size_label,
         )
 
 
@@ -392,6 +412,7 @@ def sha256_open_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> str:
     digest = hashlib.sha256()
     handle.seek(0)
@@ -402,13 +423,15 @@ def sha256_open_file(
             break
         total += len(chunk)
         if total > max_bytes:
-            raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
+            display_label = size_label or label
+            raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
         digest.update(chunk)
     validate_open_regular_file(
         handle,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     return digest.hexdigest()
 


### PR DESCRIPTION
## **User description**
## Summary
- redact local RPM package/checksum sidecar basenames from oversized-file signing diagnostics
- add regression checks that reject package and sidecar basename leaks in size-bound failures

## Validation
- python scripts\\check-rpm-package-signing.py (RPM/GPG live signing path skipped locally because required tools are unavailable; source file preflights and redaction checks ran before the skip)
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1035

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts RPM signing size-limit errors to avoid leaking local RPM package and sidecar filenames in logs. Adds regression checks to ensure basename leaks are rejected.

- **Bug Fixes**
  - Plumb a `size_label` through file read/validate/hash helpers to print generic size errors without `path.name`.
  - Update `verify_sha256_sidecar`, `write_sha256_sidecar`, and RPM package validators to use redacted labels.
  - Add preflight tests for oversized package/sidecar and sidecar output; assert forbidden basenames never appear in failure messages.

<sup>Written for commit 120f112d3c964728b2ec5cee7933f3f96effac1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide RPM size-limit failures from leaking package and sidecar names**

### What Changed
- Oversized RPM package and checksum sidecar failures now use generic size-limit messages instead of echoing local file names
- SHA-256 sidecar checks and output writes now apply the same redaction, including temporary and existing sidecar files
- Added regression checks to confirm oversized package, sidecar, and sidecar output failures do not reveal forbidden file names

### Impact
`✅ Fewer filename leaks in signing errors`
`✅ Safer RPM signing logs`
`✅ Clearer oversized-file failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal RPM package signing verification checks to prevent sensitive values from appearing in error messages during size-limit failures.
  * Enhanced error reporting for file validation and checksum operations to provide clearer, context-specific size-limit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->