### PR TITLE
Redact Linux repository signing size diagnostics

### DIFF
--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -288,6 +288,7 @@ def run_source_file_preflights(signer) -> None:
             lambda: signer.repository_metadata_assets(oversized_source),
             "is too large",
             "repository signing source size bound",
+            oversized_metadata.name,
         )
 
         aggregate_source = temp / "aggregate-source"
@@ -315,6 +316,31 @@ def run_source_file_preflights(signer) -> None:
             "must be a regular file",
             "repository signing sidecar directory",
         )
+        oversized_sidecar = temp / "oversized-sidecar"
+        oversized_sidecar.mkdir()
+        oversized_sidecar_bundle = oversized_sidecar / APT_METADATA
+        write_apt_metadata_zip(oversized_sidecar_bundle)
+        oversized_sidecar_path = oversized_sidecar_bundle.with_name(
+            f"{oversized_sidecar_bundle.name}.sha256"
+        )
+        oversized_sidecar_path.write_text(
+            "0" * 64 + f"  {oversized_sidecar_bundle.name}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_constant_failure(
+            signer,
+            "MAX_CHECKSUM_BYTES",
+            max(0, oversized_sidecar_path.stat().st_size - 1),
+            lambda: signer.verify_sha256_sidecar(
+                oversized_sidecar_bundle,
+                "APT repository metadata bundle",
+            ),
+            "is too large",
+            "repository signing sidecar size bound",
+            oversized_sidecar_path.name,
+            oversized_sidecar_bundle.name,
+        )
 
         sidecar_output_directory = temp / "sidecar-output-directory"
         sidecar_output_directory.mkdir()
@@ -325,6 +351,38 @@ def run_source_file_preflights(signer) -> None:
             lambda: signer.write_sha256_sidecar(output_bundle),
             "must be a regular file",
             "repository signing sidecar output directory",
+        )
+        oversized_sidecar_output = temp / "oversized-sidecar-output"
+        oversized_sidecar_output.mkdir()
+        oversized_output_bundle = oversized_sidecar_output / APT_METADATA
+        write_apt_metadata_zip(oversized_output_bundle)
+        oversized_output_sidecar = oversized_output_bundle.with_name(
+            f"{oversized_output_bundle.name}.sha256"
+        )
+        oversized_output_sidecar.write_bytes(b"existing sidecar\n")
+        expect_constant_failure(
+            signer,
+            "MAX_CHECKSUM_BYTES",
+            max(0, oversized_output_sidecar.stat().st_size - 1),
+            lambda: signer.write_sha256_sidecar(oversized_output_bundle),
+            "is too large",
+            "repository signing sidecar output size bound",
+            oversized_output_sidecar.name,
+            oversized_output_bundle.name,
+        )
+
+        oversized_output_bundle_source = temp / "oversized-output-bundle"
+        oversized_output_bundle_source.mkdir()
+        oversized_output_zip = oversized_output_bundle_source / APT_METADATA
+        write_apt_metadata_zip(oversized_output_zip)
+        expect_constant_failure(
+            signer,
+            "MAX_REPOSITORY_METADATA_BUNDLE_BYTES",
+            max(0, oversized_output_zip.stat().st_size - 1),
+            lambda: signer.write_zip_members(oversized_output_zip, {"Release": b"x\n"}),
+            "is too large",
+            "repository signing bundle output size bound",
+            oversized_output_zip.name,
         )
 
         symlink_source = temp / "symlink-source"
@@ -428,23 +486,34 @@ def expect_constant_failure(
     action,
     expected: str,
     label: str,
+    *forbidden_values: str,
 ) -> None:
     original = getattr(signer, constant_name)
     setattr(signer, constant_name, value)
     try:
-        expect_action_failure(action, expected, label)
+        expect_action_failure(action, expected, label, *forbidden_values)
     finally:
         setattr(signer, constant_name, original)
 
 
-def expect_action_failure(action, expected: str, label: str) -> str:
+def expect_action_failure(
+    action,
+    expected: str,
+    label: str,
+    *forbidden_values: str,
+) -> str:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
-        if expected in message:
-            return message
-        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+        if expected not in message:
+            raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+        for value in forbidden_values:
+            if value in message:
+                raise AssertionError(
+                    f"{label}: displayed forbidden value {value!r}: {message!r}"
+                ) from exc
+        return message
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
 
 

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -288,6 +288,7 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
         f"repository metadata bundle {bundle.name}",
         max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
         allow_empty=False,
+        size_label="repository metadata bundle",
     )
     try:
         with bundle_file:
@@ -317,6 +318,7 @@ def read_zip_members(bundle: Path) -> dict[str, bytes]:
                 f"repository metadata bundle {bundle.name}",
                 max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
                 allow_empty=False,
+                size_label="repository metadata bundle",
             )
     except (RuntimeError, zipfile.BadZipFile, zlib.error) as exc:
         raise zip_member_failure(bundle.name, "is not a readable zip archive") from exc
@@ -378,6 +380,7 @@ def write_zip_members(bundle: Path, members: dict[str, bytes]) -> None:
         f"repository metadata bundle output {bundle.name}",
         max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
         allow_empty=False,
+        size_label="repository metadata bundle output",
     )
     order = [name for name in members if not signature_member(name)]
     for signature in ("InRelease", "Release.gpg", "repodata/repomd.xml.asc"):
@@ -395,6 +398,7 @@ def write_zip_members(bundle: Path, members: dict[str, bytes]) -> None:
             f"rewritten repository metadata bundle {bundle.name}",
             max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
             allow_empty=False,
+            size_label="rewritten repository metadata bundle",
         )
         os.replace(temp_path, bundle)
         validate_regular_file(
@@ -402,6 +406,7 @@ def write_zip_members(bundle: Path, members: dict[str, bytes]) -> None:
             f"repository metadata bundle output {bundle.name}",
             max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
             allow_empty=False,
+            size_label="repository metadata bundle output",
         )
     finally:
         try:
@@ -439,6 +444,7 @@ def verify_sha256_sidecar(path: Path, label: str) -> None:
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
             encoding="ascii",
+            size_label=f"SHA-256 sidecar for {label}",
         )
     except UnicodeDecodeError as exc:
         raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
@@ -453,6 +459,7 @@ def verify_sha256_sidecar(path: Path, label: str) -> None:
         path,
         f"{label} {path.name}",
         max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+        size_label=label,
     ):
         raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
 
@@ -465,11 +472,13 @@ def write_sha256_sidecar(path: Path) -> None:
             f"SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=True,
+            size_label="SHA-256 sidecar output",
         )
     digest = sha256_file(
         path,
         f"repository metadata bundle {path.name}",
         max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
+        size_label="repository metadata bundle",
     )
     text = f"{digest}  {path.name}\n"
     temp_path = temporary_sibling_path(sidecar)
@@ -481,6 +490,7 @@ def write_sha256_sidecar(path: Path) -> None:
             f"temporary SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
+            size_label="temporary SHA-256 sidecar output",
         )
         os.replace(temp_path, sidecar)
         validate_regular_file(
@@ -488,6 +498,7 @@ def write_sha256_sidecar(path: Path) -> None:
             f"SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
+            size_label="SHA-256 sidecar output",
         )
     finally:
         try:
@@ -505,6 +516,7 @@ def validate_repository_metadata_bundle(
         f"repository metadata bundle {path.name}",
         max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
         allow_empty=False,
+        size_label="repository metadata bundle",
     )
     if budget is not None:
         budget.add(size)
@@ -517,6 +529,7 @@ def read_generated_signature(path: Path, label: str) -> bytes:
         label,
         max_bytes=MAX_GENERATED_SIGNATURE_BYTES,
         allow_empty=False,
+        size_label="generated repository metadata signature",
     )
 
 
@@ -526,12 +539,14 @@ def validate_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> int:
     handle, size = open_regular_file(
         path,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     handle.close()
     return size
@@ -543,6 +558,7 @@ def open_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> tuple[BinaryIO, int]:
     if path.is_symlink():
         raise SystemExit(f"{label} must not be a symlink: {path.name}")
@@ -567,7 +583,8 @@ def open_regular_file(
         if not allow_empty and size == 0:
             raise SystemExit(f"{label} must not be empty: {path.name}")
         if size > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+            display_label = size_label or label
+            raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
         return os.fdopen(fd, "rb"), size
     except BaseException:
         os.close(fd)
@@ -580,6 +597,7 @@ def validate_open_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> int:
     metadata = os.fstat(handle.fileno())
     if not stat.S_ISREG(metadata.st_mode):
@@ -588,26 +606,37 @@ def validate_open_regular_file(
     if not allow_empty and size == 0:
         raise SystemExit(f"{label} must not be empty")
     if size > max_bytes:
-        raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
+        display_label = size_label or label
+        raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
     return size
 
 
-def read_binary_file(path: Path, label: str, *, max_bytes: int, allow_empty: bool) -> bytes:
+def read_binary_file(
+    path: Path,
+    label: str,
+    *,
+    max_bytes: int,
+    allow_empty: bool,
+    size_label: str | None = None,
+) -> bytes:
     handle, _size = open_regular_file(
         path,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     with handle:
         data = handle.read(max_bytes + 1)
         if len(data) > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+            display_label = size_label or label
+            raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
         validate_open_regular_file(
             handle,
             label,
             max_bytes=max_bytes,
             allow_empty=allow_empty,
+            size_label=size_label,
         )
     return data
 
@@ -619,12 +648,14 @@ def read_text_file(
     max_bytes: int,
     allow_empty: bool,
     encoding: str,
+    size_label: str | None = None,
 ) -> str:
     return read_binary_file(
         path,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     ).decode(encoding)
 
 
@@ -644,12 +675,14 @@ def sha256_file(
     *,
     max_bytes: int = MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
     allow_empty: bool = False,
+    size_label: str | None = None,
 ) -> str:
     handle, _size = open_regular_file(
         path,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     with handle:
         return sha256_open_file(
@@ -657,6 +690,7 @@ def sha256_file(
             label,
             max_bytes=max_bytes,
             allow_empty=allow_empty,
+            size_label=size_label,
         )
 
 
@@ -666,6 +700,7 @@ def sha256_open_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> str:
     digest = hashlib.sha256()
     handle.seek(0)
@@ -676,13 +711,15 @@ def sha256_open_file(
             break
         total += len(chunk)
         if total > max_bytes:
-            raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
+            display_label = size_label or label
+            raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
         digest.update(chunk)
     validate_open_regular_file(
         handle,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     return digest.hexdigest()
 


### PR DESCRIPTION
## **User description**
## Summary
- redact local repository metadata bundle/checksum sidecar basenames from oversized-file signing diagnostics
- add regression checks that reject bundle and sidecar basename leaks in size-bound failures

## Validation
- python scripts\\check-linux-repository-signing.py (GPG signing path skipped locally because gpg is unavailable; source file preflights and redaction checks ran before the skip)
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1037

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts file names from size-limit error messages in Linux repository signing to prevent leaking bundle and sidecar basenames. Adds regression checks and unified size-label handling to keep diagnostics generic and consistent. Fixes #1037.

- **Bug Fixes**
  - Replace file names in “too large” diagnostics with generic labels via a new optional `size_label` across read/validate/hash and zip/sidecar paths.
  - Add preflight tests that exceed `MAX_*` limits and assert that bundle and sidecar basenames never appear; test helpers now reject forbidden values.

<sup>Written for commit 84f2189dc520096f6295ce2cc4dabd496b7be8ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact file names from Linux repository signing size-limit errors**

### What Changed
- Size-limit failures for repository metadata bundles, checksum sidecars, and generated signatures now show generic labels instead of file names.
- The same redaction is applied when checking existing bundles, writing new bundles, and validating SHA-256 sidecars.
- Regression checks now cover oversized bundle, sidecar, and output cases to ensure file names do not appear in these error messages.

### Impact
`✅ Fewer file-name leaks in signing errors`
`✅ Clearer oversized-file diagnostics`
`✅ Safer repository signing logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
