### PR TITLE
Redact Linux public-key export size diagnostics

### DIFF
--- a/scripts/check-linux-gpg-public-key-export.py
+++ b/scripts/check-linux-gpg-public-key-export.py
@@ -188,6 +188,7 @@ def run_output_file_preflights() -> None:
             lambda: exporter.write_public_key_asset(temp / "oversized.asc", PUBLIC_KEY_FIXTURE),
             "exceeds",
             "public-key size bound",
+            "oversized.asc",
         )
 
         output_directory = temp / "output-directory.asc"
@@ -222,6 +223,40 @@ def run_output_file_preflights() -> None:
             lambda: exporter.write_sha256_sidecar(output),
             "exceeds",
             "public-key hash source size bound",
+            output.name,
+        )
+
+        oversized_sidecar_existing = temp / "oversized-sidecar-existing.asc"
+        exporter.write_public_key_asset(oversized_sidecar_existing, PUBLIC_KEY_FIXTURE)
+        oversized_existing_sidecar = oversized_sidecar_existing.with_name(
+            f"{oversized_sidecar_existing.name}.sha256"
+        )
+        oversized_existing_sidecar.write_bytes(b"existing sidecar\n")
+        expect_constant_failure(
+            exporter,
+            "MAX_CHECKSUM_BYTES",
+            max(0, oversized_existing_sidecar.stat().st_size - 1),
+            lambda: exporter.write_sha256_sidecar(oversized_sidecar_existing),
+            "is too large",
+            "public-key existing sidecar size bound",
+            oversized_existing_sidecar.name,
+            oversized_sidecar_existing.name,
+        )
+
+        oversized_sidecar_write = temp / "oversized-sidecar-write.asc"
+        exporter.write_public_key_asset(oversized_sidecar_write, PUBLIC_KEY_FIXTURE)
+        oversized_write_sidecar = oversized_sidecar_write.with_name(
+            f"{oversized_sidecar_write.name}.sha256"
+        )
+        expect_constant_failure(
+            exporter,
+            "MAX_CHECKSUM_BYTES",
+            1,
+            lambda: exporter.write_sha256_sidecar(oversized_sidecar_write),
+            "is too large",
+            "public-key sidecar write size bound",
+            oversized_write_sidecar.name,
+            oversized_sidecar_write.name,
         )
 
         symlink_output_target = temp / "real-output.asc"
@@ -331,23 +366,34 @@ def expect_constant_failure(
     action,
     expected: str,
     label: str,
+    *forbidden_values: str,
 ) -> None:
     original = getattr(module, constant_name)
     setattr(module, constant_name, value)
     try:
-        expect_action_failure(action, expected, label)
+        expect_action_failure(action, expected, label, *forbidden_values)
     finally:
         setattr(module, constant_name, original)
 
 
-def expect_action_failure(action, expected: str, label: str) -> None:
+def expect_action_failure(
+    action,
+    expected: str,
+    label: str,
+    *forbidden_values: str,
+) -> None:
     try:
         action()
     except SystemExit as exc:
         message = str(exc)
-        if expected in message:
-            return
-        raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+        if expected not in message:
+            raise AssertionError(f"{label}: expected {expected!r}, got {message!r}") from exc
+        for value in forbidden_values:
+            if value in message:
+                raise AssertionError(
+                    f"{label}: displayed forbidden value {value!r}: {message!r}"
+                ) from exc
+        return
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
 
 

--- a/scripts/export-linux-gpg-public-key.py
+++ b/scripts/export-linux-gpg-public-key.py
@@ -149,6 +149,7 @@ def prepare_public_key_output(path: Path) -> None:
             f"Linux public-key output {path.name}",
             max_bytes=MAX_PUBLIC_KEY_BYTES,
             allow_empty=True,
+            size_label="Linux public-key output",
         )
 
 
@@ -162,12 +163,14 @@ def write_public_key_asset(path: Path, public_key: bytes) -> None:
             public_key,
             f"temporary Linux public-key output {path.name}",
             max_bytes=MAX_PUBLIC_KEY_BYTES,
+            size_label="temporary Linux public-key output",
         )
         validate_regular_file(
             temp_path,
             f"temporary Linux public-key output {path.name}",
             max_bytes=MAX_PUBLIC_KEY_BYTES,
             allow_empty=False,
+            size_label="temporary Linux public-key output",
         )
         os.replace(temp_path, path)
         validate_regular_file(
@@ -175,6 +178,7 @@ def write_public_key_asset(path: Path, public_key: bytes) -> None:
             f"Linux public-key output {path.name}",
             max_bytes=MAX_PUBLIC_KEY_BYTES,
             allow_empty=False,
+            size_label="Linux public-key output",
         )
     finally:
         try:
@@ -191,8 +195,12 @@ def write_sha256_sidecar(path: Path) -> None:
             f"SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=True,
+            size_label="SHA-256 sidecar output",
         )
-    text = f"{sha256_file(path, f'Linux public-key output {path.name}')}  {path.name}\n"
+    text = (
+        f"{sha256_file(path, f'Linux public-key output {path.name}', size_label='Linux public-key output')}"
+        f"  {path.name}\n"
+    )
     temp_path = temporary_sibling_path(sidecar)
     try:
         write_output_bytes(
@@ -200,12 +208,14 @@ def write_sha256_sidecar(path: Path) -> None:
             text.encode("ascii"),
             f"temporary SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
+            size_label="temporary SHA-256 sidecar output",
         )
         validate_regular_file(
             temp_path,
             f"temporary SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
+            size_label="temporary SHA-256 sidecar output",
         )
         os.replace(temp_path, sidecar)
         validate_regular_file(
@@ -213,6 +223,7 @@ def write_sha256_sidecar(path: Path) -> None:
             f"SHA-256 sidecar output {sidecar.name}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
+            size_label="SHA-256 sidecar output",
         )
     finally:
         try:
@@ -227,12 +238,14 @@ def validate_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> int:
     handle, size = open_regular_file(
         path,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     handle.close()
     return size
@@ -244,6 +257,7 @@ def open_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> tuple[BinaryIO, int]:
     if path.is_symlink():
         raise SystemExit(f"{label} must not be a symlink: {path.name}")
@@ -268,7 +282,8 @@ def open_regular_file(
         if not allow_empty and size == 0:
             raise SystemExit(f"{label} must not be empty: {path.name}")
         if size > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+            display_label = size_label or label
+            raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
         return os.fdopen(fd, "rb"), size
     except BaseException:
         os.close(fd)
@@ -281,6 +296,7 @@ def validate_open_regular_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> int:
     metadata = os.fstat(handle.fileno())
     if not stat.S_ISREG(metadata.st_mode):
@@ -289,13 +305,22 @@ def validate_open_regular_file(
     if not allow_empty and size == 0:
         raise SystemExit(f"{label} must not be empty")
     if size > max_bytes:
-        raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
+        display_label = size_label or label
+        raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
     return size
 
 
-def write_output_bytes(path: Path, data: bytes, label: str, *, max_bytes: int) -> None:
+def write_output_bytes(
+    path: Path,
+    data: bytes,
+    label: str,
+    *,
+    max_bytes: int,
+    size_label: str | None = None,
+) -> None:
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+        display_label = size_label or label
+        raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
     if path.is_symlink():
         raise SystemExit(f"{label} must not be a symlink: {path.name}")
     flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC | OPEN_BINARY | OPEN_NOFOLLOW
@@ -319,6 +344,7 @@ def write_output_bytes(path: Path, data: bytes, label: str, *, max_bytes: int) -
                 label,
                 max_bytes=max_bytes,
                 allow_empty=False,
+                size_label=size_label,
             )
         path.chmod(0o644)
     except BaseException:
@@ -343,6 +369,7 @@ def sha256_file(
     *,
     max_bytes: int | None = None,
     allow_empty: bool = False,
+    size_label: str | None = None,
 ) -> str:
     effective_max_bytes = MAX_PUBLIC_KEY_BYTES if max_bytes is None else max_bytes
     handle, _size = open_regular_file(
@@ -350,6 +377,7 @@ def sha256_file(
         label,
         max_bytes=effective_max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     with handle:
         return sha256_open_file(
@@ -357,6 +385,7 @@ def sha256_file(
             label,
             max_bytes=effective_max_bytes,
             allow_empty=allow_empty,
+            size_label=size_label,
         )
 
 
@@ -366,6 +395,7 @@ def sha256_open_file(
     *,
     max_bytes: int,
     allow_empty: bool,
+    size_label: str | None = None,
 ) -> str:
     digest = hashlib.sha256()
     handle.seek(0)
@@ -376,13 +406,15 @@ def sha256_open_file(
             break
         total += len(chunk)
         if total > max_bytes:
-            raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
+            display_label = size_label or label
+            raise SystemExit(f"{display_label} is too large: exceeds {max_bytes} bytes")
         digest.update(chunk)
     validate_open_regular_file(
         handle,
         label,
         max_bytes=max_bytes,
         allow_empty=allow_empty,
+        size_label=size_label,
     )
     return digest.hexdigest()
 


### PR DESCRIPTION
## **User description**
## Summary
- redact local public-key output/checksum sidecar basenames from oversized-file export diagnostics
- add regression checks that reject public-key and sidecar basename leaks in size-bound failures

## Validation
- python scripts\\check-linux-gpg-public-key-export.py (GPG integration skipped locally because gpg is unavailable; output preflights and redaction checks ran before the skip)
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1039

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts local public‑key and sidecar basenames from oversize error messages in the Linux export scripts to prevent leaking local paths. Adds regression checks that fail if any basename appears in size-bound diagnostics. Fixes #1039.

- **Bug Fixes**
  - Removed path basenames from oversize errors across public‑key and `.sha256` sidecar flows by introducing an optional `size_label`.
  - Passed redaction‑safe labels through `write_public_key_asset`, `write_sha256_sidecar`, and helpers (`open_regular_file`, `validate_*`, `write_output_bytes`, `sha256_*`).
  - Added tests that assert oversize errors include the expected message and reject any leaked output or sidecar filename.

<sup>Written for commit 39d5bf1e6fa2b1bbd5ba73462dc3e910e00b2480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Hide local file names from Linux public-key export size errors

### What Changed
- Size-limit failures for public-key output and SHA-256 sidecar files now show a generic message instead of the local file name
- Sidecar checks also cover both an already-existing sidecar and a new sidecar write, without exposing either basename in the error
- Added regression checks that fail if oversized-file diagnostics leak output or sidecar names

### Impact
`✅ Fewer local file name leaks in export errors`
`✅ Clearer oversized export failures`
`✅ Safer public-key and checksum diagnostics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
