### PR TITLE
Redact release update-policy size diagnostics

### DIFF
--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -92,6 +92,7 @@ def main() -> int:
             1,
             lambda: build_policy(generator, dist),
             "is too large",
+            "conu.rb",
         )
         expect_module_failure_with_limit(
             generator,
@@ -100,6 +101,8 @@ def main() -> int:
             1,
             lambda: build_policy(generator, dist),
             "is too large",
+            f"conu-{VERSION}-windows-x64.zip",
+            f"conu-{VERSION}-windows-x64.zip.sha256",
         )
         expect_module_failure_with_limit(
             generator,
@@ -108,6 +111,8 @@ def main() -> int:
             1,
             lambda: build_policy(generator, dist),
             "is too large",
+            f"conu-{VERSION}-linux-x64.tar.gz",
+            f"conu-{VERSION}-linux-x64.tar.gz.asc",
         )
         expect_module_failure_with_limit(
             generator,
@@ -116,6 +121,40 @@ def main() -> int:
             1,
             lambda: build_policy(generator, dist),
             "source inputs exceed",
+            f"conu-{VERSION}-windows-x64.zip",
+        )
+        expect_module_failure_with_limit(
+            generator,
+            "generated policy output size bound",
+            "MAX_TEXT_ASSET_BYTES",
+            1,
+            lambda: generator.write_text_output(
+                temp / "oversized-update-policy.json",
+                "release update policy",
+                "fixture\n",
+                max_bytes=generator.MAX_TEXT_ASSET_BYTES,
+            ),
+            "is too large",
+            "oversized-update-policy.json",
+        )
+        expect_module_failure_with_limit(
+            generator,
+            "generated policy hash source size bound",
+            "MAX_TEXT_ASSET_BYTES",
+            max(0, policy.stat().st_size - 1),
+            lambda: generator.write_sha256_sidecar(policy),
+            "is too large",
+            policy.name,
+        )
+        expect_module_failure_with_limit(
+            generator,
+            "generated policy sidecar output size bound",
+            "MAX_CHECKSUM_BYTES",
+            1,
+            lambda: generator.write_sha256_sidecar(policy),
+            "is too large",
+            policy.name,
+            f"{policy.name}.sha256",
         )
         with mock.patch.object(Path, "is_symlink", return_value=True):
             expect_module_failure(
@@ -340,7 +379,12 @@ def build_policy(generator, dist: Path) -> dict[str, object]:
     )
 
 
-def expect_module_failure(description: str, action, expected: str) -> None:
+def expect_module_failure(
+    description: str,
+    action,
+    expected: str,
+    *forbidden_values: str,
+) -> None:
     try:
         action()
     except SystemExit as exc:
@@ -349,6 +393,11 @@ def expect_module_failure(description: str, action, expected: str) -> None:
             raise AssertionError(
                 f"{description} failed with {rendered!r}, expected {expected!r}"
             ) from exc
+        for value in forbidden_values:
+            if value in rendered:
+                raise AssertionError(
+                    f"{description} leaked forbidden value {value!r}: {rendered!r}"
+                ) from exc
         return
     raise AssertionError(f"{description} unexpectedly passed")
 
@@ -360,11 +409,12 @@ def expect_module_failure_with_limit(
     value: int,
     action,
     expected: str,
+    *forbidden_values: str,
 ) -> None:
     original = getattr(generator, attr)
     setattr(generator, attr, value)
     try:
-        expect_module_failure(description, action, expected)
+        expect_module_failure(description, action, expected, *forbidden_values)
     finally:
         setattr(generator, attr, original)
 

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -487,7 +487,7 @@ def release_asset(
     source_budget: SourceBudget,
 ) -> ReleaseAsset:
     path = dist / filename
-    label = f"release update policy asset {filename}"
+    label = f"release update policy {kind} asset"
     max_bytes = MAX_TEXT_ASSET_BYTES if is_text_asset(filename) else MAX_SOURCE_ASSET_BYTES
     asset_file, _size = open_source_file(
         path,
@@ -530,23 +530,21 @@ def verify_sha256_sidecar(
     try:
         checksum_text = read_text_file(
             sidecar,
-            f"SHA-256 sidecar for {label} {path.name}",
+            f"SHA-256 sidecar for release update policy {label}",
             max_bytes=MAX_CHECKSUM_BYTES,
             source_budget=source_budget,
             encoding="ascii",
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
+        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
     if match is None:
-        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(
-            f"SHA-256 sidecar for {label} {path.name} names wrong file: {match.group(2)}"
-        )
+        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
     expected = match.group(1).lower()
     if expected != actual:
-        raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 mismatch for {label}")
     return expected
 
 
@@ -555,17 +553,17 @@ def require_detached_signature(path: Path, source_budget: SourceBudget) -> None:
     try:
         signature_text = read_text_file(
             signature,
-            f"detached signature for release update policy asset {path.name}",
+            "detached signature for release update policy asset",
             max_bytes=MAX_SIGNATURE_BYTES,
             source_budget=source_budget,
             encoding="ascii",
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}") from exc
+        raise SystemExit("detached signature is not ASCII-armored") from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
-        raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}")
+        raise SystemExit("detached signature is not ASCII-armored")
     if "PRIVATE KEY BLOCK" in signature_text:
-        raise SystemExit(f"detached signature contains private key material: {signature.name}")
+        raise SystemExit("detached signature contains private key material")
 
 
 def asset_url(release_base_url: str, filename: str) -> str:
@@ -662,7 +660,7 @@ def open_regular_file(path: Path, label: str, *, max_bytes: int) -> tuple[Binary
             raise SystemExit(f"{label} must be a regular file: {path.name}")
         size = metadata.st_size
         if size > max_bytes:
-            raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+            raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
         return os.fdopen(fd, "rb"), size
     except BaseException:
         os.close(fd)
@@ -686,7 +684,7 @@ def read_regular_file(
         data = handle.read(max_bytes + 1)
         validate_open_regular_file(handle, label, max_bytes=max_bytes)
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+        raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
     return data
 
 
@@ -759,7 +757,7 @@ def open_output_file(path: Path, label: str) -> BinaryIO:
 def write_text_output(path: Path, label: str, text: str, *, max_bytes: int) -> None:
     data = text.encode("ascii")
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {path.name} exceeds {max_bytes} bytes")
+        raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
     with open_output_file(path, label) as handle:
         handle.write(data)
         handle.flush()
@@ -780,12 +778,12 @@ def validate_open_regular_file(handle: BinaryIO, label: str, *, max_bytes: int) 
 def write_sha256_sidecar(path: Path) -> None:
     digest = sha256_file(
         path,
-        f"release update policy output {path.name}",
+        "release update policy output",
         max_bytes=MAX_TEXT_ASSET_BYTES,
     )
     write_text_output(
         path.with_name(f"{path.name}.sha256"),
-        f"SHA-256 sidecar for {path.name}",
+        "release update policy SHA-256 sidecar",
         f"{digest}  {path.name}\n",
         max_bytes=MAX_CHECKSUM_BYTES,
     )
@@ -809,7 +807,7 @@ def is_text_asset(filename: str) -> bool:
 
 def assert_open_file_text_safe(
     handle: BinaryIO,
-    filename: str,
+    _filename: str,
     label: str,
     *,
     max_bytes: int,
@@ -817,14 +815,14 @@ def assert_open_file_text_safe(
     handle.seek(0)
     data = handle.read(max_bytes + 1)
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large: {filename} exceeds {max_bytes} bytes")
+        raise SystemExit(f"{label} is too large: exceeds {max_bytes} bytes")
     try:
         text = data.decode("utf-8")
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"{filename} is not UTF-8 text") from exc
+        raise SystemExit(f"{label} is not UTF-8 text") from exc
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
-            raise SystemExit(f"{filename} contains forbidden text: {forbidden}")
+            raise SystemExit(f"{label} contains forbidden text: {forbidden}")
     validate_open_regular_file(handle, label, max_bytes=max_bytes)
     handle.seek(0)
 


### PR DESCRIPTION
## **User description**
## Summary
- redact release update-policy asset, checksum, signature, and generated-output size diagnostics so they do not print local fixture basenames
- keep public release filenames in generated policy metadata and checksum sidecars
- add regression coverage for size-bound redaction across source, sidecar, signature, aggregate, and output paths

## Validation
- python scripts/check-release-update-policy.py
- python scripts/check-python-script-compile.py
- python scripts/check-production-readiness-toolchain.py
- git diff --check

Fixes #1041

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts filenames and paths from release update‑policy size diagnostics to avoid leaking local fixture names, while keeping public release filenames in policy metadata and checksum sidecars. Fixes #1041.

- **Bug Fixes**
  - Redact basenames from size/validation errors for assets, checksums, signatures, aggregate, and generated outputs.
  - Use generic labels in generator errors (no local filenames in messages).
  - Add regression checks in `scripts/check-release-update-policy.py` to assert forbidden values never appear in errors.

<sup>Written for commit 196642b9840ff8d94ee4da1865ce21a488c29d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Redact filenames from release update policy size and validation errors

### What Changed
- Error messages for oversized assets, checksum files, signatures, and generated policy files no longer include local filenames
- SHA-256 and signature checks now report generic failures without naming the file that triggered them
- Regression checks now verify that redacted errors do not leak fixture or output filenames

### Impact
`✅ Fewer leaked local filenames in release checks`
`✅ Safer validation errors for policy generation`
`✅ Clearer redaction coverage for oversized file failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
