### PR TITLE
Redact hosted Pages size diagnostics

### DIFF
--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import importlib.util
 import json
 import os
@@ -94,6 +95,37 @@ def main() -> int:
             "uncompressed contents exceed",
             "Pages site total size bound",
         )
+        expect_preparer_constant_failure(
+            preparer,
+            "MAX_SITE_ZIP_BYTES",
+            max(0, site.stat().st_size - 1),
+            lambda: preparer.validate_regular_file(
+                site,
+                "hosted Linux repository site ZIP",
+                max_bytes=preparer.MAX_SITE_ZIP_BYTES,
+            ),
+            "too large for Pages deployment",
+            "Pages site ZIP size bound",
+            site.name,
+        )
+        oversized_output = temp / "oversized-pages-output.html"
+        output_message = expect_action_failure(
+            lambda: preparer.write_bytes_output(
+                oversized_output,
+                "hosted repository Pages file",
+                b"fixture\n",
+                max_bytes=1,
+            ),
+            "too large for Pages deployment",
+            "Pages output size bound",
+        )
+        assert_not_displayed(output_message, "Pages output size bound", oversized_output.name)
+        oversized_read = temp / "oversized-pages-read.txt"
+        read_message = expect_read_regular_file_size_failure(
+            preparer,
+            oversized_read,
+        )
+        assert_not_displayed(read_message, "Pages read size bound", oversized_read.name)
 
         unreadable_site = temp / "unreadable-site.zip"
         unreadable_site_payload = "secret-unreadable-pages-site-should-not-print"
@@ -603,6 +635,45 @@ def expect_zip_bound_failure(
         setattr(preparer, constant_name, original)
 
 
+def expect_preparer_constant_failure(
+    preparer,
+    constant_name: str,
+    value: int,
+    action,
+    expected: str,
+    label: str,
+    *forbidden_values: str,
+) -> None:
+    original = getattr(preparer, constant_name)
+    setattr(preparer, constant_name, value)
+    try:
+        message = expect_action_failure(action, expected, label)
+        assert_not_displayed(message, label, *forbidden_values)
+    finally:
+        setattr(preparer, constant_name, original)
+
+
+def expect_read_regular_file_size_failure(preparer, path: Path) -> str:
+    original_open_regular_file = preparer.open_regular_file
+    try:
+
+        def oversized_open_regular_file(_path, _label, *, max_bytes):
+            return io.BytesIO(b"oversized\n"), 0
+
+        preparer.open_regular_file = oversized_open_regular_file
+        return expect_action_failure(
+            lambda: preparer.read_regular_file(
+                path,
+                "hosted repository Pages file",
+                max_bytes=1,
+            ),
+            "too large for Pages deployment",
+            "Pages read size bound",
+        )
+    finally:
+        preparer.open_regular_file = original_open_regular_file
+
+
 def expect_action_failure(action, expected: str, label: str) -> str:
     try:
         action()
@@ -621,6 +692,12 @@ def assert_member_failure_redacted(message: str, label: str, *forbidden_values: 
     for value in forbidden_values:
         if value and value in message:
             raise AssertionError(f"{label}: displayed archive member value {value!r}: {message!r}")
+
+
+def assert_not_displayed(message: str, label: str, *forbidden_values: str) -> None:
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{label}: displayed forbidden value {value!r}: {message!r}")
 
 
 def assert_no_sentinel(output: str, label: str) -> None:

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -283,7 +283,7 @@ def open_regular_file(path: Path, label: str, *, max_bytes: int) -> tuple[Binary
         if not stat.S_ISREG(metadata.st_mode):
             raise SystemExit(f"{label} must be a regular file: {path.name}")
         if metadata.st_size > max_bytes:
-            raise SystemExit(f"{label} is too large for Pages deployment: {path.name}")
+            raise SystemExit(f"{label} is too large for Pages deployment")
         return os.fdopen(fd, "rb"), metadata.st_size
     except BaseException:
         os.close(fd)
@@ -830,7 +830,7 @@ def open_output_file(path: Path, label: str) -> BinaryIO:
 
 def write_bytes_output(path: Path, label: str, data: bytes, *, max_bytes: int) -> None:
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large for Pages deployment: {path.name}")
+        raise SystemExit(f"{label} is too large for Pages deployment")
     with open_output_file(path, label) as handle:
         handle.write(data)
         handle.flush()
@@ -848,7 +848,7 @@ def read_regular_file(path: Path, label: str, *, max_bytes: int) -> bytes:
     with handle:
         data = handle.read(max_bytes + 1)
     if len(data) > max_bytes:
-        raise SystemExit(f"{label} is too large for Pages deployment: {path.name}")
+        raise SystemExit(f"{label} is too large for Pages deployment")
     return data
 
 


### PR DESCRIPTION
## **User description**
## Summary
- redact hosted Linux repository Pages size-bound diagnostics so oversized inputs/outputs do not print local basenames
- preserve expected public artifact/member names in Pages content validation
- add regression coverage for input ZIP, generated output, and read-over-limit size failures

## Validation
- python scripts/check-hosted-linux-repository-pages.py
- python scripts/check-python-script-compile.py
- python scripts/check-production-readiness-toolchain.py
- git diff --check

Fixes #1043

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts filenames from size-bound diagnostics in hosted Pages to avoid leaking local basenames, while preserving expected public artifact/member names during content validation. Adds regression coverage for ZIP input, generated output, and over-limit reads. Fixes #1043.

- **Bug Fixes**
  - Remove filenames from size errors in `open_regular_file`, `write_bytes_output`, and `read_regular_file` (messages now say “too large for Pages deployment” without the path).
  - Preserve expected public artifact/member names in Pages content validation.
  - Add regression tests and helpers: `expect_preparer_constant_failure`, `expect_read_regular_file_size_failure`, `assert_not_displayed`.

<sup>Written for commit cee1b1c89609f7d6d2cc99198ce1c882c99126ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Redact file names from Pages size error messages

### What Changed
- Size-limit errors for Pages uploads, generated output, and file reads no longer include the local file name
- Existing Pages content checks still keep public artifact and member names visible where needed
- Added regression coverage for oversized ZIP input, oversized output, and oversized file reads

### Impact
`✅ Fewer leaked local file names in Pages errors`
`✅ Safer Pages validation logs`
`✅ Clearer size-limit failures for hosted Pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
