### PR TITLE
Redact hosted Pages sidecar diagnostics

### DIFF
--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -196,6 +196,68 @@ def main() -> int:
             "missing SHA-256 sidecar",
         )
 
+        non_ascii_checksum = temp / "non-ascii-checksum"
+        shutil.copytree(dist, non_ascii_checksum)
+        (non_ascii_checksum / f"{SITE_BUNDLE}.sha256").write_bytes(b"\xff\n")
+        output = expect_failure(
+            "non-ASCII site checksum",
+            non_ascii_checksum / SITE_BUNDLE,
+            temp / "non-ascii-checksum-pages",
+            "SHA-256 sidecar is not ASCII",
+        )
+        assert_not_displayed(output, "non-ASCII site checksum", SITE_BUNDLE)
+
+        invalid_checksum = temp / "invalid-checksum"
+        shutil.copytree(dist, invalid_checksum)
+        (invalid_checksum / f"{SITE_BUNDLE}.sha256").write_text(
+            "not a strict checksum\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "invalid site checksum",
+            invalid_checksum / SITE_BUNDLE,
+            temp / "invalid-checksum-pages",
+            "invalid format",
+        )
+        assert_not_displayed(output, "invalid site checksum", SITE_BUNDLE)
+
+        wrong_checksum_target = temp / "wrong-checksum-target"
+        shutil.copytree(dist, wrong_checksum_target)
+        malicious_target = "secret-pages-sidecar-target.zip"
+        (wrong_checksum_target / f"{SITE_BUNDLE}.sha256").write_text(
+            f"{hashlib.sha256(site.read_bytes()).hexdigest()}  {malicious_target}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "wrong site checksum target",
+            wrong_checksum_target / SITE_BUNDLE,
+            temp / "wrong-checksum-target-pages",
+            "names wrong file",
+        )
+        assert_not_displayed(
+            output,
+            "wrong site checksum target",
+            SITE_BUNDLE,
+            malicious_target,
+        )
+
+        mismatched_checksum = temp / "mismatched-checksum"
+        shutil.copytree(dist, mismatched_checksum)
+        (mismatched_checksum / f"{SITE_BUNDLE}.sha256").write_text(
+            f"{'0' * 64}  {SITE_BUNDLE}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "mismatched site checksum",
+            mismatched_checksum / SITE_BUNDLE,
+            temp / "mismatched-checksum-pages",
+            "SHA-256 mismatch",
+        )
+        assert_not_displayed(output, "mismatched site checksum", SITE_BUNDLE)
+
         missing_signature = temp / "missing-signature"
         shutil.copytree(dist, missing_signature)
         (missing_signature / f"{SITE_BUNDLE}.asc").unlink()
@@ -205,6 +267,32 @@ def main() -> int:
             temp / "missing-signature-pages",
             "missing detached signature",
         )
+
+        non_ascii_signature = temp / "non-ascii-signature"
+        shutil.copytree(dist, non_ascii_signature)
+        (non_ascii_signature / f"{SITE_BUNDLE}.asc").write_bytes(b"\xff\n")
+        output = expect_failure(
+            "non-ASCII site signature",
+            non_ascii_signature / SITE_BUNDLE,
+            temp / "non-ascii-signature-pages",
+            "detached signature is not ASCII-armored",
+        )
+        assert_not_displayed(output, "non-ASCII site signature", f"{SITE_BUNDLE}.asc")
+
+        non_armored_signature = temp / "non-armored-signature"
+        shutil.copytree(dist, non_armored_signature)
+        (non_armored_signature / f"{SITE_BUNDLE}.asc").write_text(
+            "not a signature\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "non-armored site signature",
+            non_armored_signature / SITE_BUNDLE,
+            temp / "non-armored-signature-pages",
+            "detached signature is not ASCII-armored",
+        )
+        assert_not_displayed(output, "non-armored site signature", f"{SITE_BUNDLE}.asc")
 
         private_key_signature = temp / "private-key-signature"
         shutil.copytree(dist, private_key_signature)
@@ -218,12 +306,13 @@ def main() -> int:
             encoding="ascii",
             newline="\n",
         )
-        expect_failure(
+        output = expect_failure(
             "private key site signature",
             private_key_signature / SITE_BUNDLE,
             temp / "private-key-signature-pages",
             "private key material",
         )
+        assert_not_displayed(output, "private key site signature", f"{SITE_BUNDLE}.asc")
 
         symlink_site = temp / "symlink-site"
         shutil.copytree(dist, symlink_site)

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -212,16 +212,16 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
             max_bytes=MAX_CHECKSUM_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
+        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
     if match is None:
-        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file: {match.group(2)}")
+        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
     expected = match.group(1).lower()
     actual = sha256_file(path, label, max_bytes=MAX_SITE_ZIP_BYTES)
     if expected != actual:
-        raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 mismatch for {label}")
     return expected
 
 
@@ -239,11 +239,11 @@ def require_detached_signature(path: Path) -> None:
             max_bytes=MAX_SIGNATURE_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}") from exc
+        raise SystemExit("detached signature is not ASCII-armored") from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
-        raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}")
+        raise SystemExit("detached signature is not ASCII-armored")
     if "PRIVATE KEY BLOCK" in signature_text:
-        raise SystemExit(f"detached signature contains private key material: {signature.name}")
+        raise SystemExit("detached signature contains private key material")
 
 
 def prepare_output_dir(output_dir: Path) -> None:


### PR DESCRIPTION
## **User description**
## Summary
- redact hosted Pages checksum/signature diagnostics so malformed sidecars do not print local artifact names or attacker-controlled checksum targets
- preserve public artifact names in valid Pages content and checksum validation
- add regression coverage for non-ASCII, invalid, wrong-target, mismatch, non-armored, and private-key signature failures

## Validation
- python scripts/check-hosted-linux-repository-pages.py
- python scripts/check-python-script-compile.py
- python scripts/check-production-readiness-toolchain.py
- git diff --check

Fixes #1045

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts sensitive details in hosted Pages checksum/signature diagnostics to prevent leaking local artifact names or attacker-controlled targets. Adds regression tests to ensure redaction for malformed sidecars while preserving public names for valid content. Fixes #1045.

- **Bug Fixes**
  - Remove file/target names from SHA-256 and detached signature error messages (non-ASCII, invalid format, wrong target, mismatch, non-armored, private key).
  - Preserve public artifact names in successful validations only.
  - Add negative tests with assertions to ensure failures do not print `SITE_BUNDLE` or malicious targets.

<sup>Written for commit 1ecfd5f1672724b0d59fd92905581da7b868df00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide site artifact details in hosted Pages validation errors**

### What Changed
- Validation errors for broken checksum and signature sidecars no longer expose local file names or attacker-controlled target names
- Checks now fail with shorter messages for non-ASCII, invalid, mismatched, wrong-target, non-armored, and private-key sidecar cases
- Added coverage to confirm valid pages still show public artifact names, while failure cases keep sensitive names out of the output

### Impact
`✅ Fewer leaked file names in Pages errors`
`✅ Safer hosted Pages validation logs`
`✅ Clearer failure messages for broken sidecars`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages during checksum and signature validation no longer display sensitive file details.

* **Tests**
  * Expanded test coverage for checksum validation edge cases including non-ASCII content, invalid formats, filename mismatches, and value mismatches.
  * Added test scenarios for detached signature validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->