### PR TITLE
Redact hosted site sidecar diagnostics

### DIFF
--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -260,6 +260,68 @@ def main() -> int:
         )
         assert_no_sentinel(message, "duplicate package metadata JSON output")
 
+        non_ascii_checksum = temp / "non-ascii-checksum"
+        shutil.copytree(dist, non_ascii_checksum)
+        (non_ascii_checksum / f"{HOSTED_BUNDLE}.sha256").write_bytes(b"\xff\n")
+        output = expect_failure(
+            "non-ASCII hosted bundle checksum",
+            non_ascii_checksum,
+            BASE_URL,
+            "SHA-256 sidecar is not ASCII",
+        )
+        assert_not_displayed(output, "non-ASCII hosted bundle checksum", HOSTED_BUNDLE)
+
+        invalid_checksum = temp / "invalid-checksum"
+        shutil.copytree(dist, invalid_checksum)
+        (invalid_checksum / f"{HOSTED_BUNDLE}.sha256").write_text(
+            "not a strict checksum\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "invalid hosted bundle checksum",
+            invalid_checksum,
+            BASE_URL,
+            "invalid format",
+        )
+        assert_not_displayed(output, "invalid hosted bundle checksum", HOSTED_BUNDLE)
+
+        wrong_checksum_target = temp / "wrong-checksum-target"
+        shutil.copytree(dist, wrong_checksum_target)
+        malicious_target = "secret-hosted-site-sidecar-target.zip"
+        (wrong_checksum_target / f"{HOSTED_BUNDLE}.sha256").write_text(
+            f"{hashlib.sha256(hosted_bundle.read_bytes()).hexdigest()}  {malicious_target}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "wrong hosted bundle checksum target",
+            wrong_checksum_target,
+            BASE_URL,
+            "names wrong file",
+        )
+        assert_not_displayed(
+            output,
+            "wrong hosted bundle checksum target",
+            HOSTED_BUNDLE,
+            malicious_target,
+        )
+
+        mismatched_checksum = temp / "mismatched-checksum"
+        shutil.copytree(dist, mismatched_checksum)
+        (mismatched_checksum / f"{HOSTED_BUNDLE}.sha256").write_text(
+            f"{'0' * 64}  {HOSTED_BUNDLE}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "mismatched hosted bundle checksum",
+            mismatched_checksum,
+            BASE_URL,
+            "SHA-256 mismatch",
+        )
+        assert_not_displayed(output, "mismatched hosted bundle checksum", HOSTED_BUNDLE)
+
         missing_signature = temp / "missing-signature"
         shutil.copytree(dist, missing_signature)
         (missing_signature / f"{HOSTED_BUNDLE}.asc").unlink()
@@ -268,6 +330,40 @@ def main() -> int:
             missing_signature,
             BASE_URL,
             "missing detached signature",
+        )
+
+        non_ascii_signature = temp / "non-ascii-signature"
+        shutil.copytree(dist, non_ascii_signature)
+        (non_ascii_signature / f"{HOSTED_BUNDLE}.asc").write_bytes(b"\xff\n")
+        output = expect_failure(
+            "non-ASCII hosted bundle signature",
+            non_ascii_signature,
+            BASE_URL,
+            "detached signature is not ASCII-armored",
+        )
+        assert_not_displayed(
+            output,
+            "non-ASCII hosted bundle signature",
+            f"{HOSTED_BUNDLE}.asc",
+        )
+
+        non_armored_signature = temp / "non-armored-signature"
+        shutil.copytree(dist, non_armored_signature)
+        (non_armored_signature / f"{HOSTED_BUNDLE}.asc").write_text(
+            "not a signature\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "non-armored hosted bundle signature",
+            non_armored_signature,
+            BASE_URL,
+            "detached signature is not ASCII-armored",
+        )
+        assert_not_displayed(
+            output,
+            "non-armored hosted bundle signature",
+            f"{HOSTED_BUNDLE}.asc",
         )
 
         private_key_signature = temp / "private-key-signature"
@@ -282,11 +378,16 @@ def main() -> int:
             encoding="ascii",
             newline="\n",
         )
-        expect_failure(
+        output = expect_failure(
             "private key hosted bundle signature",
             private_key_signature,
             BASE_URL,
             "private key material",
+        )
+        assert_not_displayed(
+            output,
+            "private key hosted bundle signature",
+            f"{HOSTED_BUNDLE}.asc",
         )
 
         symlink_dist = temp / "symlink-dist"

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -272,11 +272,11 @@ def require_detached_signature(path: Path) -> Path:
             max_bytes=MAX_SIGNATURE_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}") from exc
+        raise SystemExit("detached signature is not ASCII-armored") from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
-        raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}")
+        raise SystemExit("detached signature is not ASCII-armored")
     if "PRIVATE KEY BLOCK" in signature_text:
-        raise SystemExit(f"detached signature contains private key material: {signature.name}")
+        raise SystemExit("detached signature contains private key material")
     return signature
 
 
@@ -651,18 +651,16 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
             max_bytes=MAX_CHECKSUM_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
+        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
     if match is None:
-        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(
-            f"SHA-256 sidecar for {label} {path.name} names wrong file: {match.group(2)}"
-        )
+        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
     expected = match.group(1).lower()
     actual = sha256_file(path, label, max_bytes=MAX_HOSTED_BUNDLE_BYTES)
     if expected != actual:
-        raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 mismatch for {label}")
     return expected
 
 


### PR DESCRIPTION
## **User description**
## Summary
- redact hosted repository site checksum/signature diagnostics so malformed sidecars do not print local bundle or signature names
- add regressions for non-ASCII, invalid, wrong-target, mismatched checksum, non-armored signature, non-ASCII signature, and private-key signature paths

## Validation
- python scripts\\check-hosted-linux-repository-site.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1047

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts hosted site checksum and signature diagnostics to avoid leaking bundle or signature file names. Adds regression tests to ensure malformed sidecars don’t print sensitive names.

- **Bug Fixes**
  - Removed file names from exceptions in `require_detached_signature` and `verify_sha256_sidecar` (now generic messages).
  - Added negative tests for non-ASCII/invalid/wrong-target/mismatched checksums and non-ASCII/non-armored/private-key signatures, asserting outputs never include the bundle or `.asc` names.

<sup>Written for commit 3e7de2875e38f9ee2d44d219db3cf39d8834966c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact hosted site sidecar diagnostics**

### What Changed
- Error messages for bad checksum and signature sidecar files no longer include the bundle or signature file names.
- Checks now fail with generic messages for non-ASCII, malformed, wrong-target, mismatched checksum, non-armored, and private-key signature sidecars.
- Added regression coverage to ensure these failure paths do not reveal sensitive file names in output.

### Impact
`✅ Less sensitive file name leakage in release checks`
`✅ Safer error output for malformed sidecars`
`✅ Clearer hosted site validation failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
