### PR TITLE
Redact hosted bundle sidecar diagnostics

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -128,6 +128,65 @@ def main() -> int:
         )
         assert_no_sentinel(message, "duplicate package metadata JSON output")
 
+        non_ascii_checksum = temp / "non-ascii-checksum"
+        shutil.copytree(dist, non_ascii_checksum)
+        (non_ascii_checksum / f"{DEBIAN_PACKAGES[0]}.sha256").write_bytes(b"\xff\n")
+        output = expect_failure(
+            "non-ASCII package checksum",
+            non_ascii_checksum,
+            "SHA-256 sidecar is not ASCII",
+        )
+        assert_not_displayed(output, "non-ASCII package checksum", DEBIAN_PACKAGES[0])
+
+        invalid_checksum = temp / "invalid-checksum"
+        shutil.copytree(dist, invalid_checksum)
+        (invalid_checksum / f"{DEBIAN_PACKAGES[0]}.sha256").write_text(
+            "not a strict checksum\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "invalid package checksum",
+            invalid_checksum,
+            "invalid format",
+        )
+        assert_not_displayed(output, "invalid package checksum", DEBIAN_PACKAGES[0])
+
+        wrong_checksum_target = temp / "wrong-checksum-target"
+        shutil.copytree(dist, wrong_checksum_target)
+        malicious_target = "secret-hosted-bundle-sidecar-target.deb"
+        package_asset = dist / DEBIAN_PACKAGES[0]
+        (wrong_checksum_target / f"{DEBIAN_PACKAGES[0]}.sha256").write_text(
+            f"{hashlib.sha256(package_asset.read_bytes()).hexdigest()}  {malicious_target}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "wrong package checksum target",
+            wrong_checksum_target,
+            "names wrong file",
+        )
+        assert_not_displayed(
+            output,
+            "wrong package checksum target",
+            DEBIAN_PACKAGES[0],
+            malicious_target,
+        )
+
+        mismatched_checksum = temp / "mismatched-checksum"
+        shutil.copytree(dist, mismatched_checksum)
+        (mismatched_checksum / f"{DEBIAN_PACKAGES[0]}.sha256").write_text(
+            f"{'0' * 64}  {DEBIAN_PACKAGES[0]}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "mismatched package checksum",
+            mismatched_checksum,
+            "SHA-256 mismatch",
+        )
+        assert_not_displayed(output, "mismatched package checksum", DEBIAN_PACKAGES[0])
+
         missing_signature = temp / "missing-signature"
         shutil.copytree(dist, missing_signature)
         (missing_signature / f"{DEBIAN_PACKAGES[0]}.asc").unlink()
@@ -135,6 +194,38 @@ def main() -> int:
             "missing package signature",
             missing_signature,
             "missing detached signature",
+        )
+
+        non_ascii_signature = temp / "non-ascii-signature"
+        shutil.copytree(dist, non_ascii_signature)
+        (non_ascii_signature / f"{DEBIAN_PACKAGES[0]}.asc").write_bytes(b"\xff\n")
+        output = expect_failure(
+            "non-ASCII package signature",
+            non_ascii_signature,
+            "detached signature is not ASCII-armored",
+        )
+        assert_not_displayed(
+            output,
+            "non-ASCII package signature",
+            f"{DEBIAN_PACKAGES[0]}.asc",
+        )
+
+        non_armored_signature = temp / "non-armored-signature"
+        shutil.copytree(dist, non_armored_signature)
+        (non_armored_signature / f"{DEBIAN_PACKAGES[0]}.asc").write_text(
+            "not a signature\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        output = expect_failure(
+            "non-armored package signature",
+            non_armored_signature,
+            "detached signature is not ASCII-armored",
+        )
+        assert_not_displayed(
+            output,
+            "non-armored package signature",
+            f"{DEBIAN_PACKAGES[0]}.asc",
         )
 
         private_key_signature = temp / "private-key-signature"
@@ -147,10 +238,15 @@ def main() -> int:
             encoding="ascii",
             newline="\n",
         )
-        expect_failure(
+        output = expect_failure(
             "private key signature sidecar",
             private_key_signature,
             "private key material",
+        )
+        assert_not_displayed(
+            output,
+            "private key signature sidecar",
+            f"{DEBIAN_PACKAGES[0]}.asc",
         )
 
         symlink_dist = temp / "symlink-dist"
@@ -246,6 +342,32 @@ def main() -> int:
             "missing signed APT member",
         )
 
+        non_ascii_public_key = temp / "non-ascii-public-key"
+        shutil.copytree(dist, non_ascii_public_key)
+        (non_ascii_public_key / PUBLIC_KEY).write_bytes(b"\xff\n")
+        write_checksum(non_ascii_public_key / PUBLIC_KEY)
+        output = expect_failure(
+            "non-ASCII public key asset",
+            non_ascii_public_key,
+            "Linux public key asset is not ASCII-armored",
+        )
+        assert_not_displayed(output, "non-ASCII public key asset", PUBLIC_KEY)
+
+        non_armored_public_key = temp / "non-armored-public-key"
+        shutil.copytree(dist, non_armored_public_key)
+        (non_armored_public_key / PUBLIC_KEY).write_text(
+            "not a public key\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        write_checksum(non_armored_public_key / PUBLIC_KEY)
+        output = expect_failure(
+            "non-armored public key asset",
+            non_armored_public_key,
+            "not an armored public key",
+        )
+        assert_not_displayed(output, "non-armored public key asset", PUBLIC_KEY)
+
         private_key_asset = temp / "private-key-asset"
         shutil.copytree(dist, private_key_asset)
         (private_key_asset / PUBLIC_KEY).write_text(
@@ -257,11 +379,12 @@ def main() -> int:
             newline="\n",
         )
         write_checksum(private_key_asset / PUBLIC_KEY)
-        expect_failure(
+        output = expect_failure(
             "private key asset",
             private_key_asset,
             "private key material",
         )
+        assert_not_displayed(output, "private key asset", PUBLIC_KEY)
 
         unsafe_zip = temp / "unsafe-zip"
         shutil.copytree(dist, unsafe_zip)

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -204,11 +204,11 @@ def require_detached_signature(path: Path) -> Path:
             max_bytes=MAX_SIGNATURE_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}") from exc
+        raise SystemExit("detached signature is not ASCII-armored") from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
-        raise SystemExit(f"detached signature is not ASCII-armored: {signature.name}")
+        raise SystemExit("detached signature is not ASCII-armored")
     if "PRIVATE KEY BLOCK" in signature_text:
-        raise SystemExit(f"detached signature contains private key material: {signature.name}")
+        raise SystemExit("detached signature contains private key material")
     return signature
 
 
@@ -217,11 +217,11 @@ def verify_public_key(path: Path) -> None:
     try:
         text = read_ascii_file(path, "Linux public key asset", max_bytes=MAX_PUBLIC_KEY_BYTES)
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"Linux public key asset is not ASCII-armored: {path.name}") from exc
+        raise SystemExit("Linux public key asset is not ASCII-armored") from exc
     if "BEGIN PGP PUBLIC KEY BLOCK" not in text:
-        raise SystemExit(f"Linux public key asset is not an armored public key: {path.name}")
+        raise SystemExit("Linux public key asset is not an armored public key")
     if "PRIVATE KEY BLOCK" in text:
-        raise SystemExit(f"refusing to bundle private key material from {path.name}")
+        raise SystemExit("refusing to bundle private key material")
 
 
 def build_hosted_repository_members(assets: HostedLinuxAssets) -> dict[str, bytes]:
@@ -559,18 +559,16 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
             max_bytes=MAX_CHECKSUM_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
+        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
     if match is None:
-        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(
-            f"SHA-256 sidecar for {label} {path.name} names wrong file: {match.group(2)}"
-        )
+        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
     expected = match.group(1).lower()
     actual = sha256_file(path, label, max_bytes=MAX_RELEASE_ASSET_BYTES)
     if expected != actual:
-        raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 mismatch for {label}")
     return expected
 
 


### PR DESCRIPTION
## **User description**
## Summary
- redact hosted repository bundle checksum/signature/public-key diagnostics so malformed inputs do not print local asset or signature names
- add regressions for non-ASCII, invalid, wrong-target, mismatched checksum, non-armored signature, non-ASCII signature, private-key signature, and malformed public-key paths

## Validation
- python scripts\\check-hosted-linux-repositories.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1049

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts sidecar diagnostics in the hosted Linux repository tooling to avoid leaking asset/signature filenames on malformed input. Adds regression coverage for checksum, signature, and public key failures to prevent info disclosure.

- **Bug Fixes**
  - Removed file/asset names and malicious target values from checksum, detached signature, and public key error messages (`verify_sha256_sidecar`, `require_detached_signature`, `verify_public_key`).
  - Added regressions for non-ASCII, invalid format, wrong checksum target, checksum mismatch, non-armored/non-ASCII/private-key signatures, and non-ASCII/non-armored public keys.

<sup>Written for commit bb570b7304741cbc74095f4aba3eebcbc557dfc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide asset and signature names from hosted bundle validation errors**

### What Changed
- Error messages for broken checksum, signature, and public key files no longer include the file name or malicious target text
- Invalid checksum sidecars now fail with clearer messages for non-ASCII content, bad format, wrong target, and checksum mismatch
- Invalid signatures and public keys now fail without exposing sidecar or key filenames, including private key content cases
- Added regression coverage for non-ASCII, malformed, mismatched, and private-key inputs across hosted Linux repository checks

### Impact
`✅ Fewer leaked filenames in release validation errors`
`✅ Safer handling of malformed hosted repository assets`
`✅ Clearer failure messages for checksum and signature checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
