### PR TITLE
Redact package-manager checksum diagnostics

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -1149,6 +1149,68 @@ def main() -> int:
                 "SHA-256 sidecar for generated RPM package must not be a symlink",
             )
 
+        non_ascii_existing_rpm_sidecar = temp / "non-ascii-existing-rpm-sidecar"
+        non_ascii_existing_rpm_sidecar.mkdir()
+        rpm_package = non_ascii_existing_rpm_sidecar / RPM_X64_FILENAME
+        rpm_package.write_bytes(b"rpm package\n")
+        rpm_package.with_name(f"{rpm_package.name}.sha256").write_bytes(b"\xff\n")
+        message = expect_failure(
+            "non-ASCII existing RPM sidecar",
+            lambda: generator.existing_rpm_package_paths(VERSION, non_ascii_existing_rpm_sidecar),
+            "SHA-256 sidecar is not ASCII",
+        )
+        assert_not_displayed(message, "non-ASCII existing RPM sidecar", rpm_package.name)
+
+        invalid_existing_rpm_sidecar = temp / "invalid-existing-rpm-sidecar"
+        invalid_existing_rpm_sidecar.mkdir()
+        rpm_package = invalid_existing_rpm_sidecar / RPM_X64_FILENAME
+        rpm_package.write_bytes(b"rpm package\n")
+        rpm_package.with_name(f"{rpm_package.name}.sha256").write_text(
+            "not a strict checksum\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        message = expect_failure(
+            "invalid existing RPM sidecar",
+            lambda: generator.existing_rpm_package_paths(VERSION, invalid_existing_rpm_sidecar),
+            "invalid format",
+        )
+        assert_not_displayed(message, "invalid existing RPM sidecar", rpm_package.name)
+
+        wrong_existing_rpm_sidecar = temp / "wrong-existing-rpm-sidecar"
+        wrong_existing_rpm_sidecar.mkdir()
+        rpm_package = wrong_existing_rpm_sidecar / RPM_X64_FILENAME
+        rpm_package.write_bytes(b"rpm package\n")
+        malicious_rpm_target = "secret-package-manager-rpm-sidecar-target.rpm"
+        write_checksum(rpm_package, archive_name=malicious_rpm_target)
+        message = expect_failure(
+            "wrong existing RPM sidecar target",
+            lambda: generator.existing_rpm_package_paths(VERSION, wrong_existing_rpm_sidecar),
+            "names wrong file",
+        )
+        assert_not_displayed(
+            message,
+            "wrong existing RPM sidecar target",
+            rpm_package.name,
+            malicious_rpm_target,
+        )
+
+        mismatched_existing_rpm_sidecar = temp / "mismatched-existing-rpm-sidecar"
+        mismatched_existing_rpm_sidecar.mkdir()
+        rpm_package = mismatched_existing_rpm_sidecar / RPM_X64_FILENAME
+        rpm_package.write_bytes(b"rpm package\n")
+        rpm_package.with_name(f"{rpm_package.name}.sha256").write_text(
+            f"{'0' * 64}  {rpm_package.name}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        message = expect_failure(
+            "mismatched existing RPM sidecar",
+            lambda: generator.existing_rpm_package_paths(VERSION, mismatched_existing_rpm_sidecar),
+            "SHA-256 mismatch",
+        )
+        assert_not_displayed(message, "mismatched existing RPM sidecar", rpm_package.name)
+
         expect_member_redacted_failure_with_limit(
             generator,
             "MAX_RELEASE_MEMBER_COUNT",
@@ -1371,12 +1433,50 @@ def main() -> int:
             "missing checksum file",
         )
 
+        non_ascii_checksum = temp / "non-ascii-checksum"
+        non_ascii_checksum.mkdir()
+        write_dist(non_ascii_checksum)
+        non_ascii_archive = non_ascii_checksum / TARGETS["windows-x64"]
+        non_ascii_archive.with_name(f"{non_ascii_archive.name}.sha256").write_bytes(b"\xff\n")
+        message = expect_failure(
+            "non-ASCII checksum",
+            lambda: generator.load_release_assets(
+                non_ascii_checksum,
+                VERSION,
+                "imthegoodboy/conU",
+                f"v{VERSION}",
+            ),
+            "checksum file is not ASCII",
+        )
+        assert_not_displayed(message, "non-ASCII checksum", non_ascii_archive.name)
+
+        invalid_checksum = temp / "invalid-checksum"
+        invalid_checksum.mkdir()
+        write_dist(invalid_checksum)
+        invalid_archive = invalid_checksum / TARGETS["windows-x64"]
+        invalid_archive.with_name(f"{invalid_archive.name}.sha256").write_text(
+            "not a strict checksum\n",
+            encoding="ascii",
+        )
+        message = expect_failure(
+            "invalid checksum",
+            lambda: generator.load_release_assets(
+                invalid_checksum,
+                VERSION,
+                "imthegoodboy/conU",
+                f"v{VERSION}",
+            ),
+            "invalid format",
+        )
+        assert_not_displayed(message, "invalid checksum", invalid_archive.name)
+
         wrong_name = temp / "wrong-name"
         wrong_name.mkdir()
         write_dist(wrong_name)
         windows_archive = wrong_name / TARGETS["windows-x64"]
-        write_checksum(windows_archive, archive_name="other.zip")
-        expect_failure(
+        malicious_archive_name = "secret-package-manager-checksum-target.zip"
+        write_checksum(windows_archive, archive_name=malicious_archive_name)
+        message = expect_failure(
             "checksum names wrong archive",
             lambda: generator.load_release_assets(
                 wrong_name,
@@ -1385,6 +1485,12 @@ def main() -> int:
                 f"v{VERSION}",
             ),
             "names wrong archive",
+        )
+        assert_not_displayed(
+            message,
+            "checksum names wrong archive",
+            windows_archive.name,
+            malicious_archive_name,
         )
 
         wrong_digest = temp / "wrong-digest"
@@ -1395,7 +1501,7 @@ def main() -> int:
             f"{'0' * 64}  {linux_archive.name}\n",
             encoding="ascii",
         )
-        expect_failure(
+        message = expect_failure(
             "checksum mismatch",
             lambda: generator.load_release_assets(
                 wrong_digest,
@@ -1405,6 +1511,7 @@ def main() -> int:
             ),
             "checksum mismatch",
         )
+        assert_not_displayed(message, "checksum mismatch", linux_archive.name)
 
         unreadable_windows = temp / "unreadable-windows"
         unreadable_windows.mkdir()

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -422,15 +422,13 @@ def read_verified_checksum(archive: Path) -> str:
             max_bytes=MAX_CHECKSUM_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"checksum file is not ASCII for package-manager asset: {archive.name}") from exc
+        raise SystemExit("checksum file is not ASCII for package-manager asset") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
     if match is None:
-        raise SystemExit(f"checksum file has invalid format for package-manager asset: {archive.name}")
+        raise SystemExit("checksum file has invalid format for package-manager asset")
     named_archive = match.group(2)
     if named_archive != archive.name:
-        raise SystemExit(
-            f"checksum file for package-manager asset {archive.name} names wrong archive: {named_archive}"
-        )
+        raise SystemExit("checksum file for package-manager asset names wrong archive")
     expected = match.group(1).lower()
     actual = sha256_file(
         archive,
@@ -438,7 +436,7 @@ def read_verified_checksum(archive: Path) -> str:
         max_bytes=MAX_RELEASE_ARCHIVE_BYTES,
     )
     if expected != actual:
-        raise SystemExit(f"checksum mismatch for package-manager asset: {archive.name}")
+        raise SystemExit("checksum mismatch for package-manager asset")
     return expected
 
 
@@ -1464,19 +1462,17 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
             max_bytes=MAX_CHECKSUM_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
+        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
     if match is None:
-        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     named_path = match.group(2)
     if named_path != path.name:
-        raise SystemExit(
-            f"SHA-256 sidecar for {label} {path.name} names wrong file: {named_path}"
-        )
+        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
     expected = match.group(1).lower()
     actual = sha256_file(path, label, max_bytes=MAX_GENERATED_OUTPUT_BYTES)
     if expected != actual:
-        raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 mismatch for {label}")
     return expected
 
 


### PR DESCRIPTION
## **User description**
## Summary
- redact package-manager release checksum diagnostics so malformed sidecars do not print local archive names or attacker-controlled targets
- redact generated RPM package sidecar diagnostics for the same malformed checksum paths
- add regressions covering non-ASCII, invalid, wrong-target, and mismatched sidecars

## Validation
- python scripts\\check-package-manager-manifests.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1051

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts filenames from package-manager checksum and RPM sidecar errors to avoid leaking local or attacker-controlled names. Adds regression tests for non-ASCII, invalid, wrong-target, and mismatched cases. Fixes #1051.

- **Bug Fixes**
  - Remove archive/target names from checksum validation errors in release asset and RPM sidecar paths.
  - Add tests that cover non-ASCII, invalid format, wrong target, and digest mismatch, asserting sensitive names are not shown.

<sup>Written for commit 0ff6a53b4438d82e7bea176a5e6805e9e3da5515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact checksum errors so they no longer reveal file names**

### What Changed
- Checksum validation errors for package-manager releases and generated RPM sidecars no longer include local archive names or target names
- Added coverage for non-ASCII, invalid-format, wrong-target, and mismatched checksum files to confirm sensitive names stay hidden

### Impact
`✅ Less file-name leakage in release validation errors`
`✅ Safer checksum failure messages`
`✅ Fewer sensitive details exposed in malformed sidecar cases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
