### PR TITLE
Redact RPM signing sidecar diagnostics

### DIFF
--- a/scripts/check-rpm-package-signing.py
+++ b/scripts/check-rpm-package-signing.py
@@ -373,6 +373,76 @@ def run_source_file_preflights() -> None:
                 "RPM signing symlink sidecar output",
             )
 
+        non_ascii_sidecar = temp / "non-ascii-sidecar"
+        non_ascii_sidecar.mkdir()
+        non_ascii_package = non_ascii_sidecar / RPM_PACKAGES[0]
+        non_ascii_package.write_bytes(b"rpm fixture\n")
+        non_ascii_package.with_name(f"{non_ascii_package.name}.sha256").write_bytes(b"\xff\n")
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(
+                non_ascii_package,
+                "generated RPM package",
+            ),
+            "SHA-256 sidecar is not ASCII",
+            "RPM signing non-ASCII sidecar",
+            non_ascii_package.name,
+        )
+
+        invalid_sidecar = temp / "invalid-sidecar"
+        invalid_sidecar.mkdir()
+        invalid_package = invalid_sidecar / RPM_PACKAGES[0]
+        invalid_package.write_bytes(b"rpm fixture\n")
+        invalid_package.with_name(f"{invalid_package.name}.sha256").write_text(
+            "not a strict checksum\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(
+                invalid_package,
+                "generated RPM package",
+            ),
+            "invalid format",
+            "RPM signing invalid sidecar",
+            invalid_package.name,
+        )
+
+        wrong_target_sidecar = temp / "wrong-target-sidecar"
+        wrong_target_sidecar.mkdir()
+        wrong_target_package = wrong_target_sidecar / RPM_PACKAGES[0]
+        wrong_target_package.write_bytes(b"rpm fixture\n")
+        malicious_target = "secret-rpm-signing-sidecar-target.rpm"
+        write_checksum(wrong_target_package, archive_name=malicious_target)
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(
+                wrong_target_package,
+                "generated RPM package",
+            ),
+            "names wrong file",
+            "RPM signing wrong sidecar target",
+            wrong_target_package.name,
+            malicious_target,
+        )
+
+        mismatched_sidecar = temp / "mismatched-sidecar"
+        mismatched_sidecar.mkdir()
+        mismatched_package = mismatched_sidecar / RPM_PACKAGES[0]
+        mismatched_package.write_bytes(b"rpm fixture\n")
+        mismatched_package.with_name(f"{mismatched_package.name}.sha256").write_text(
+            f"{'0' * 64}  {mismatched_package.name}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(
+                mismatched_package,
+                "generated RPM package",
+            ),
+            "SHA-256 mismatch",
+            "RPM signing mismatched sidecar",
+            mismatched_package.name,
+        )
+
 
 def load_signer():
     script_dir = ROOT / "scripts"

--- a/scripts/sign-rpm-packages.py
+++ b/scripts/sign-rpm-packages.py
@@ -167,20 +167,20 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
     try:
         checksum_text = read_text_file(
             sidecar,
-            f"SHA-256 sidecar for {label} {path.name}",
+            f"SHA-256 sidecar for {label}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
             encoding="ascii",
             size_label=f"SHA-256 sidecar for {label}",
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
+        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
     if match is None:
-        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     named_path = match.group(2)
     if named_path != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} {path.name} names wrong file: {named_path}")
+        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
     expected = match.group(1).lower()
     actual = sha256_file(
         path,
@@ -190,7 +190,7 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
         size_label=label,
     )
     if expected != actual:
-        raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 mismatch for {label}")
     return expected
 
 


### PR DESCRIPTION
## **User description**
## Summary
- redact RPM package signing SHA-256 sidecar diagnostics so malformed sidecars do not print local RPM basenames or attacker-controlled target text
- add source-file preflight regressions for non-ASCII, invalid, wrong-target, and mismatched RPM sidecars

## Validation
- python scripts\\check-rpm-package-signing.py (source-file preflights ran; live GPG/RPM section skipped locally because gpg/rpmbuild/rpmsign/rpmkeys are unavailable)
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1053

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacted RPM signing sidecar error messages to avoid leaking local RPM filenames or attacker-controlled target names. Added preflight checks to catch malformed sidecars early.

- **Bug Fixes**
  - Standardized and redacted diagnostics in `verify_sha256_sidecar` (non-ASCII, invalid format, wrong target, SHA-256 mismatch) without including `path.name` or sidecar target text.
  - Added source-file preflight regressions in `scripts/check-rpm-package-signing.py` for non-ASCII, invalid, wrong-target, and mismatched sidecars.

<sup>Written for commit 822a8f4056143558bc5a5710d8af6b70ab005c26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide RPM sidecar file details in signing errors**

### What Changed
- RPM signing errors no longer reveal local package names or attacker-provided target names when a sidecar is unreadable, malformed, points to the wrong file, or does not match the package checksum
- Added checks that catch broken sidecar files early, including non-ASCII content, invalid format, wrong target names, and checksum mismatches

### Impact
`✅ Less file name leakage in signing errors`
`✅ Safer handling of malformed RPM sidecars`
`✅ Clearer failure messages during package signing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
