### PR TITLE
Redact Linux repository signing sidecar diagnostics

### DIFF
--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -424,6 +424,76 @@ def run_source_file_preflights(signer) -> None:
                 "repository signing symlink sidecar output",
             )
 
+        non_ascii_sidecar = temp / "non-ascii-sidecar"
+        non_ascii_sidecar.mkdir()
+        non_ascii_bundle = non_ascii_sidecar / APT_METADATA
+        write_apt_metadata_zip(non_ascii_bundle)
+        non_ascii_bundle.with_name(f"{non_ascii_bundle.name}.sha256").write_bytes(b"\xff\n")
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(
+                non_ascii_bundle,
+                "APT repository metadata bundle",
+            ),
+            "SHA-256 sidecar is not ASCII",
+            "repository signing non-ASCII sidecar",
+            non_ascii_bundle.name,
+        )
+
+        invalid_sidecar = temp / "invalid-sidecar"
+        invalid_sidecar.mkdir()
+        invalid_bundle = invalid_sidecar / APT_METADATA
+        write_apt_metadata_zip(invalid_bundle)
+        invalid_bundle.with_name(f"{invalid_bundle.name}.sha256").write_text(
+            "not a strict checksum\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(
+                invalid_bundle,
+                "APT repository metadata bundle",
+            ),
+            "invalid format",
+            "repository signing invalid sidecar",
+            invalid_bundle.name,
+        )
+
+        wrong_target_sidecar = temp / "wrong-target-sidecar"
+        wrong_target_sidecar.mkdir()
+        wrong_target_bundle = wrong_target_sidecar / APT_METADATA
+        write_apt_metadata_zip(wrong_target_bundle)
+        malicious_target = "secret-repository-signing-sidecar-target.zip"
+        write_sha256_sidecar(wrong_target_bundle, archive_name=malicious_target)
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(
+                wrong_target_bundle,
+                "APT repository metadata bundle",
+            ),
+            "names wrong file",
+            "repository signing wrong sidecar target",
+            wrong_target_bundle.name,
+            malicious_target,
+        )
+
+        mismatched_sidecar = temp / "mismatched-sidecar"
+        mismatched_sidecar.mkdir()
+        mismatched_bundle = mismatched_sidecar / APT_METADATA
+        write_apt_metadata_zip(mismatched_bundle)
+        mismatched_bundle.with_name(f"{mismatched_bundle.name}.sha256").write_text(
+            f"{'0' * 64}  {mismatched_bundle.name}\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        expect_action_failure(
+            lambda: signer.verify_sha256_sidecar(
+                mismatched_bundle,
+                "APT repository metadata bundle",
+            ),
+            "SHA-256 mismatch",
+            "repository signing mismatched sidecar",
+            mismatched_bundle.name,
+        )
+
         symlink_output_bundle = temp / "symlink-output-bundle"
         symlink_output_bundle.mkdir()
         real_output_bundle = symlink_output_bundle / "real.zip"
@@ -695,9 +765,14 @@ def assert_zip_member_normalized(archive: zipfile.ZipFile, name: str) -> None:
         raise AssertionError(f"{name} had mode {oct(mode)}")
 
 
-def write_sha256_sidecar(path: Path, *, sidecar: Path | None = None) -> None:
+def write_sha256_sidecar(
+    path: Path,
+    *,
+    archive_name: str | None = None,
+    sidecar: Path | None = None,
+) -> None:
     (sidecar or path.with_name(f"{path.name}.sha256")).write_text(
-        f"{sha256_file(path)}  {path.name}\n",
+        f"{sha256_file(path)}  {archive_name or path.name}\n",
         encoding="ascii",
         newline="\n",
     )

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -440,28 +440,26 @@ def verify_sha256_sidecar(path: Path, label: str) -> None:
     try:
         checksum_text = read_text_file(
             sidecar,
-            f"SHA-256 sidecar for {label} {path.name}",
+            f"SHA-256 sidecar for {label}",
             max_bytes=MAX_CHECKSUM_BYTES,
             allow_empty=False,
             encoding="ascii",
             size_label=f"SHA-256 sidecar for {label}",
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}: {path.name}") from exc
+        raise SystemExit(f"SHA-256 sidecar is not ASCII for {label}") from exc
     match = CHECKSUM_RE.fullmatch(checksum_text)
     if match is None:
-        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(
-            f"SHA-256 sidecar for {label} {path.name} names wrong file: {match.group(2)}"
-        )
+        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
     if match.group(1).lower() != sha256_file(
         path,
         f"{label} {path.name}",
         max_bytes=MAX_REPOSITORY_METADATA_BUNDLE_BYTES,
         size_label=label,
     ):
-        raise SystemExit(f"SHA-256 mismatch for {label}: {path.name}")
+        raise SystemExit(f"SHA-256 mismatch for {label}")
 
 
 def write_sha256_sidecar(path: Path) -> None:


### PR DESCRIPTION
## **User description**
## Summary
- redact malformed Linux repository metadata SHA-256 sidecar diagnostics so bundle basenames and attacker-controlled checksum target text are not reflected
- add source-level regression coverage for non-ASCII, invalid-format, wrong-target, and checksum-mismatch sidecars

## Validation
- `python scripts\check-linux-repository-signing.py` (source preflights ran; live signing section skipped because local `gpg` is unavailable)
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `git diff --check`

Fixes #1055

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redact sidecar verification errors so they don’t echo bundle names or attacker-controlled text. Add tests for non-ASCII, invalid format, wrong target, and checksum mismatch cases, addressing #1055.

- **Bug Fixes**
  - Updated `verify_sha256_sidecar` to remove `path.name` and target details from diagnostics for: not ASCII, invalid format, wrong file, and SHA-256 mismatch.
  - Added regression coverage in `check-linux-repository-signing.py` for these scenarios.
  - Extended `write_sha256_sidecar` to accept `archive_name` to simulate wrong-target inputs.

<sup>Written for commit 8e418b3f8772ba5bbe008774d55ca6b38ec4d38f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide repository sidecar details in checksum errors**

### What Changed
- Checksum sidecar failures no longer repeat bundle names or attacker-controlled target text in error messages
- Non-ASCII, invalid-format, wrong-file, and checksum-mismatch sidecars now fail with shorter, generic messages
- Added regression coverage for these sidecar failure cases, including a wrong-target example

### Impact
`✅ Less leaking of repository file names in errors`
`✅ Safer checksum validation messages`
`✅ Fewer exposed attacker-controlled details during signing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced repository signing verification with stricter validation checks for SHA-256 sidecars, including detection of invalid formats, encoding issues, mismatched filenames, and checksum mismatches.
  * Improved error messages for signing verification failures to provide clearer diagnostics when validation issues are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->