### PR TITLE
Redact hosted Pages embedded download diagnostics

### DIFF
--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -392,6 +392,96 @@ def main() -> int:
             "unexpected Pages member",
         )
 
+        invalid_download_checksum = temp / "invalid-download-checksum"
+        shutil.copytree(dist, invalid_download_checksum)
+        rewrite_site_zip(
+            invalid_download_checksum / SITE_BUNDLE,
+            {f"downloads/{HOSTED_BUNDLE}.sha256": b"not a strict checksum\n"},
+        )
+        sign_site(invalid_download_checksum / SITE_BUNDLE)
+        output = expect_failure(
+            "invalid embedded download checksum",
+            invalid_download_checksum / SITE_BUNDLE,
+            temp / "invalid-download-checksum-pages",
+            "downloaded hosted repository bundle checksum has invalid format",
+        )
+        assert_not_displayed(
+            output,
+            "invalid embedded download checksum",
+            f"downloads/{HOSTED_BUNDLE}.sha256",
+        )
+
+        wrong_download_checksum_target = temp / "wrong-download-checksum-target"
+        shutil.copytree(dist, wrong_download_checksum_target)
+        malicious_download_target = "secret-pages-download-sidecar-target.zip"
+        hosted_bundle_digest = hashlib.sha256(
+            read_site_member(dist / SITE_BUNDLE, f"downloads/{HOSTED_BUNDLE}")
+        ).hexdigest()
+        rewrite_site_zip(
+            wrong_download_checksum_target / SITE_BUNDLE,
+            {
+                f"downloads/{HOSTED_BUNDLE}.sha256": (
+                    f"{hosted_bundle_digest}  {malicious_download_target}\n".encode("ascii")
+                )
+            },
+        )
+        sign_site(wrong_download_checksum_target / SITE_BUNDLE)
+        output = expect_failure(
+            "wrong embedded download checksum target",
+            wrong_download_checksum_target / SITE_BUNDLE,
+            temp / "wrong-download-checksum-target-pages",
+            "downloaded hosted repository bundle checksum names wrong file",
+        )
+        assert_not_displayed(
+            output,
+            "wrong embedded download checksum target",
+            f"downloads/{HOSTED_BUNDLE}.sha256",
+            malicious_download_target,
+        )
+
+        mismatched_download_checksum = temp / "mismatched-download-checksum"
+        shutil.copytree(dist, mismatched_download_checksum)
+        rewrite_site_zip(
+            mismatched_download_checksum / SITE_BUNDLE,
+            {
+                f"downloads/{HOSTED_BUNDLE}.sha256": (
+                    f"{'0' * 64}  {HOSTED_BUNDLE}\n".encode("ascii")
+                )
+            },
+        )
+        sign_site(mismatched_download_checksum / SITE_BUNDLE)
+        output = expect_failure(
+            "mismatched embedded download checksum",
+            mismatched_download_checksum / SITE_BUNDLE,
+            temp / "mismatched-download-checksum-pages",
+            "downloaded hosted repository bundle checksum mismatch",
+        )
+        assert_not_displayed(
+            output,
+            "mismatched embedded download checksum",
+            f"downloads/{HOSTED_BUNDLE}.sha256",
+            HOSTED_BUNDLE,
+        )
+
+        non_armored_download_signature = temp / "non-armored-download-signature"
+        shutil.copytree(dist, non_armored_download_signature)
+        rewrite_site_zip(
+            non_armored_download_signature / SITE_BUNDLE,
+            {f"downloads/{HOSTED_BUNDLE}.asc": b"not a signature\n"},
+        )
+        sign_site(non_armored_download_signature / SITE_BUNDLE)
+        output = expect_failure(
+            "non-armored embedded download signature",
+            non_armored_download_signature / SITE_BUNDLE,
+            temp / "non-armored-download-signature-pages",
+            "downloaded hosted repository bundle signature is not armored",
+        )
+        assert_not_displayed(
+            output,
+            "non-armored embedded download signature",
+            f"downloads/{HOSTED_BUNDLE}.asc",
+        )
+
         missing_cache_policy = temp / "missing-cache-policy"
         shutil.copytree(dist, missing_cache_policy)
         rewrite_site_zip(
@@ -892,6 +982,11 @@ def read_site_json(path: Path) -> dict:
 def read_site_json_member(path: Path, name: str) -> dict:
     with zipfile.ZipFile(path) as archive:
         return json.loads(archive.read(name).decode("ascii"))
+
+
+def read_site_member(path: Path, name: str) -> bytes:
+    with zipfile.ZipFile(path) as archive:
+        return archive.read(name)
 
 
 def rewrite_repository_base_url(repository: dict, base_url: str) -> None:

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -750,17 +750,20 @@ def validate_downloaded_bundle(version: str, members: dict[str, bytes]) -> None:
     bundle_path = f"downloads/{hosted_bundle}"
     checksum_path = f"{bundle_path}.sha256"
     signature_path = f"{bundle_path}.asc"
-    checksum = members[checksum_path].decode("ascii")
+    try:
+        checksum = members[checksum_path].decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise SystemExit("downloaded hosted repository bundle checksum is not ASCII") from exc
     match = CHECKSUM_RE.fullmatch(checksum)
     if match is None:
-        raise SystemExit(f"{checksum_path} has invalid SHA-256 sidecar format")
+        raise SystemExit("downloaded hosted repository bundle checksum has invalid format")
     if match.group(2) != hosted_bundle:
-        raise SystemExit(f"{checksum_path} names wrong file: {match.group(2)}")
+        raise SystemExit("downloaded hosted repository bundle checksum names wrong file")
     actual = hashlib.sha256(members[bundle_path]).hexdigest()
     if match.group(1).lower() != actual:
-        raise SystemExit(f"{checksum_path} does not match embedded hosted repository bundle")
+        raise SystemExit("downloaded hosted repository bundle checksum mismatch")
     if b"BEGIN PGP SIGNATURE" not in members[signature_path]:
-        raise SystemExit(f"{signature_path} is not armored signature material")
+        raise SystemExit("downloaded hosted repository bundle signature is not armored")
 
 
 def extract_members(output_dir: Path, members: dict[str, bytes]) -> None:


### PR DESCRIPTION
## **User description**
## Summary
- redact hosted Linux repository Pages diagnostics for malformed embedded hosted-bundle download checksums and signatures
- add regression coverage for invalid, wrong-target, mismatched embedded download checksums, plus bad embedded download signatures

## Validation
- `python scripts\check-hosted-linux-repository-pages.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `git diff --check`

Fixes #1057

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts error output for embedded download checksum/signature validation in hosted Linux repository Pages to avoid leaking sidecar names or content. Adds tests for malformed checksums, wrong targets, mismatches, non-ASCII checksums, and non‑armored signatures, fixing #1057.

- **Bug Fixes**
  - Use generic errors for checksum/signature validation; no sidecar paths, filenames, or digests in output.
  - Treat non-ASCII checksums as an error during validation.
  - Add regression tests for invalid format, wrong target, checksum mismatch, and non-armored signature.

<sup>Written for commit 4f716938cda087fb84568898d094cc8ade948e56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide hosted Pages download validation details from error output**

### What Changed
- Hosted Pages validation now returns short, generic errors when an embedded download checksum or signature is invalid
- Error messages no longer reveal embedded sidecar names, target filenames, or digest values
- Checksums with non-ASCII content are now rejected with a clear validation error
- Added regression coverage for invalid format, wrong target, checksum mismatch, and non-armored signature cases

### Impact
`✅ Less sensitive download details in error logs`
`✅ Safer hosted repository validation failures`
`✅ Clearer checksum and signature error messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
