### PR TITLE
Redact package-manager submission checksum diagnostics

### DIFF
--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -192,6 +192,12 @@ def expect_failure_without_leak(
     raise AssertionError(f"{description} unexpectedly passed")
 
 
+def assert_not_displayed(message: str, description: str, *forbidden_values: str) -> None:
+    for value in forbidden_values:
+        if value and value in message:
+            raise AssertionError(f"{description} leaked forbidden value {value!r}: {message!r}")
+
+
 def expect_member_redacted_failure(
     description: str,
     action,
@@ -499,7 +505,7 @@ def main() -> int:
         write_signed_release_extras(wrong_checksum)
         sidecar = wrong_checksum / "conu_0.1.0_amd64.deb.sha256"
         sidecar.write_text("0" * 64 + "  conu_0.1.0_amd64.deb\n", encoding="ascii")
-        expect_failure(
+        output = expect_failure(
             "wrong package checksum",
             lambda: preparer.prepare_submission_bundle(
                 wrong_checksum,
@@ -511,6 +517,72 @@ def main() -> int:
             ),
             "SHA-256 mismatch",
         )
+        assert_not_displayed(
+            output,
+            "wrong package checksum",
+            sidecar.name,
+            "conu_0.1.0_amd64.deb",
+        )
+
+        wrong_checksum_target = temp / "wrong-checksum-target"
+        manifest_check.generate(
+            generator,
+            dist,
+            wrong_checksum_target,
+            build_apt_repository_metadata=True,
+        )
+        write_signed_release_extras(wrong_checksum_target)
+        sidecar = wrong_checksum_target / "conu_0.1.0_amd64.deb.sha256"
+        malicious_target = "secret-package-submission-checksum-target.deb"
+        package_digest = hashlib.sha256(
+            (wrong_checksum_target / "conu_0.1.0_amd64.deb").read_bytes()
+        ).hexdigest()
+        sidecar.write_text(
+            f"{package_digest}  {malicious_target}\n",
+            encoding="ascii",
+        )
+        output = expect_failure(
+            "wrong package checksum target",
+            lambda: preparer.prepare_submission_bundle(
+                wrong_checksum_target,
+                temp / "wrong-checksum-target-out",
+                VERSION,
+                require_rpm_assets=True,
+                require_repository_metadata=True,
+                require_linux_signatures=True,
+            ),
+            "names wrong target",
+        )
+        assert_not_displayed(
+            output,
+            "wrong package checksum target",
+            sidecar.name,
+            malicious_target,
+        )
+
+        invalid_checksum = temp / "invalid-checksum"
+        manifest_check.generate(
+            generator,
+            dist,
+            invalid_checksum,
+            build_apt_repository_metadata=True,
+        )
+        write_signed_release_extras(invalid_checksum)
+        sidecar = invalid_checksum / "conu_0.1.0_amd64.deb.sha256"
+        sidecar.write_text("not a strict checksum\n", encoding="ascii")
+        output = expect_failure(
+            "invalid package checksum",
+            lambda: preparer.prepare_submission_bundle(
+                invalid_checksum,
+                temp / "invalid-checksum-out",
+                VERSION,
+                require_rpm_assets=True,
+                require_repository_metadata=True,
+                require_linux_signatures=True,
+            ),
+            "not a strict SHA-256 sidecar",
+        )
+        assert_not_displayed(output, "invalid package checksum", sidecar.name)
 
         orphan_signature = temp / "orphan-signature"
         manifest_check.generate(

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -489,32 +489,34 @@ def read_chocolatey_text_member(
 
 
 def validate_checksum_source(path: Path, dist: Path) -> None:
-    text = read_ascii_text(path, path.name)
+    sidecar_label = "package-manager submission checksum sidecar"
+    target_label = "package-manager submission checksum target"
+    text = read_ascii_text(path, sidecar_label)
     match = CHECKSUM_RE.fullmatch(text)
     if match is None:
-        raise SystemExit(f"{path.name} is not a strict SHA-256 sidecar")
+        raise SystemExit(f"{sidecar_label} is not a strict SHA-256 sidecar")
     target_name = match.group(2)
     expected_target = path.name[: -len(".sha256")]
     if target_name != expected_target:
-        raise SystemExit(f"{path.name} names wrong target: {target_name}")
+        raise SystemExit(f"{sidecar_label} names wrong target")
     target = dist / target_name
     validate_regular_file(
         target,
-        f"{path.name} target",
-        display_name=target_name,
+        target_label,
+        display_name="checksum target",
         max_bytes=MAX_BINARY_BYTES,
-        missing_message=f"{path.name} target is missing: {target_name}",
-        non_regular_message=f"{path.name} target is not a regular file: {target_name}",
+        missing_message=f"{target_label} is missing",
+        non_regular_message=f"{target_label} is not a regular file",
     )
     expected = match.group(1).lower()
     actual = sha256_file(
         target,
-        f"{path.name} target",
+        target_label,
         max_bytes=MAX_BINARY_BYTES,
-        display_name=target_name,
+        display_name="checksum target",
     )
     if expected != actual:
-        raise SystemExit(f"{path.name} SHA-256 mismatch for {target_name}")
+        raise SystemExit(f"SHA-256 mismatch for {target_label}")
 
 
 def validate_signature_source(source: Path, label: str, dist: Path) -> None:


### PR DESCRIPTION
## **User description**
## Summary
- redact package-manager submission checksum sidecar diagnostics so checksum sidecar filenames and sidecar target filenames are not reflected
- add regression coverage for invalid, wrong-target, and mismatched submission checksum sidecars

## Validation
- `python scripts\check-package-manager-submissions.py`
- `python scripts\check-python-script-compile.py`
- `python scripts\check-production-readiness-toolchain.py`
- `git diff --check`

Fixes #1059

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts checksum sidecar diagnostics in package-manager submission checks to prevent leaking sidecar and target filenames. Adds regression tests for invalid format, wrong target, and mismatched checksum cases; fixes #1059.

- **Bug Fixes**
  - Mask sidecar and target names in all checksum validation errors using generic labels.
  - Update `validate_checksum_source` to standardize messages and avoid echoing file names.
  - Add assertions in the checker to ensure forbidden values never appear in failure output.

<sup>Written for commit 506e7a90c71cf5a16eae046599db3f911c03aa03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide package checksum details in submission validation errors**

### What Changed
- Validation errors for bad package checksum sidecars now use generic wording instead of showing the sidecar filename or target filename
- Wrong-target, invalid-format, and mismatched-checksum cases all fail with redacted messages
- Regression checks now confirm these errors do not expose package or sidecar names

### Impact
`✅ Fewer filename leaks in submission errors`
`✅ Safer package submission validation`
`✅ Clearer checksum failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
