### PR TITLE
Redact checksum sidecar target diagnostics

### DIFF
--- a/packaging/npm/conu-cli/lib/checksum.js
+++ b/packaging/npm/conu-cli/lib/checksum.js
@@ -18,7 +18,9 @@ function parseSha256Checksum(checksumText, expectedArchiveName) {
 
   const archiveName = match[2];
   if (archiveName !== expectedArchiveName) {
-    throw new Error(`checksum file for ${expectedArchiveName} names wrong archive: ${archiveName}`);
+    throw new Error(
+      "checksum file names wrong archive; checksumTargetDisplayed=false contentsDisplayed=false"
+    );
   }
 
   return match[1].toLowerCase();

--- a/packaging/npm/conu-cli/scripts/check-checksum-verification.js
+++ b/packaging/npm/conu-cli/scripts/check-checksum-verification.js
@@ -33,7 +33,16 @@ function main() {
     expectFailure(`${digest}\n`, "invalid format", "missing archive name");
     expectFailure(`${digest}  ${ARCHIVE_NAME}\nextra\n`, "invalid format", "extra checksum content");
     expectFailure(`${digest}  ${ARCHIVE_NAME} extra\n`, "invalid format", "extra checksum fields");
-    expectFailure(`${digest}  other.zip\n`, "names wrong archive", "wrong archive name");
+    const maliciousChecksumTarget = "secret-npm-checksum-target-should-not-print.zip";
+    expectFailure(
+      `${digest}  ${maliciousChecksumTarget}\n`,
+      "names wrong archive",
+      "wrong archive name",
+      {
+        forbidden: [maliciousChecksumTarget],
+        required: ["checksumTargetDisplayed=false", "contentsDisplayed=false"]
+      }
+    );
     expectFailure(`not-a-sha256  ${ARCHIVE_NAME}\n`, "invalid format", "bad digest");
 
     const originalReadFileSync = fs.readFileSync;
@@ -58,14 +67,24 @@ function main() {
   console.log("checksum verification check passed");
 }
 
-function expectFailure(checksumText, expectedMessage, label) {
+function expectFailure(checksumText, expectedMessage, label, options = {}) {
   try {
     parseSha256Checksum(checksumText, ARCHIVE_NAME);
   } catch (error) {
-    if (error.message.includes(expectedMessage)) {
-      return;
+    if (!error.message.includes(expectedMessage)) {
+      throw new Error(`expected ${label} to fail with ${expectedMessage}, got: ${error.message}`);
     }
-    throw new Error(`expected ${label} to fail with ${expectedMessage}, got: ${error.message}`);
+    for (const value of options.required || []) {
+      if (!error.message.includes(value)) {
+        throw new Error(`expected ${label} failure to include ${value}, got: ${error.message}`);
+      }
+    }
+    for (const value of options.forbidden || []) {
+      if (error.message.includes(value)) {
+        throw new Error(`expected ${label} failure to redact ${value}, got: ${error.message}`);
+      }
+    }
+    return;
   }
   throw new Error(`expected ${label} to fail`);
 }

--- a/scripts/check-release-artifact-verifier.py
+++ b/scripts/check-release-artifact-verifier.py
@@ -160,6 +160,7 @@ def expect_failure(
     expected: str,
     *,
     forbidden: str | None = None,
+    required: tuple[str, ...] = (),
 ) -> None:
     try:
         action()
@@ -173,6 +174,11 @@ def expect_failure(
             raise AssertionError(
                 f"{description} failed with {message!r}, expected {expected!r}"
             ) from exc
+        for value in required:
+            if value not in message:
+                raise AssertionError(
+                    f"{description} omitted required value {value!r}: {message!r}"
+                ) from exc
         return
     raise AssertionError(f"{description} unexpectedly passed")
 
@@ -412,11 +418,14 @@ def main() -> int:
 
         wrong_name = root / "conu-0.1.0-wrong-name.zip"
         write_zip(wrong_name)
-        write_checksum(wrong_name, archive_name="other.zip")
+        malicious_checksum_target = "secret-release-checksum-target-should-not-print.zip"
+        write_checksum(wrong_name, archive_name=malicious_checksum_target)
         expect_failure(
             "wrong checksum archive name",
             lambda: verifier.verify_checksum(wrong_name),
             "names wrong archive",
+            forbidden=malicious_checksum_target,
+            required=("checksumTargetDisplayed=false", "contentsDisplayed=false"),
         )
 
         loose_checksum = root / "conu-0.1.0-loose-checksum.zip"

--- a/scripts/verify-release-artifacts.py
+++ b/scripts/verify-release-artifacts.py
@@ -135,7 +135,8 @@ def verify_checksum(archive: Path) -> None:
         checksum_archive_name = match.group(2)
         if checksum_archive_name != archive.name:
             raise SystemExit(
-                f"checksum file for {archive.name} names wrong archive: {checksum_archive_name}"
+                "checksum file names wrong archive; "
+                "checksumTargetDisplayed=false contentsDisplayed=false"
             )
 
         expected = match.group(1).lower()


### PR DESCRIPTION
## **User description**
## Summary
- redact attacker-controlled checksum target names from release artifact verifier wrong-target errors
- redact attacker-controlled checksum target names from npm checksum parser wrong-target errors
- add Python and Node regressions proving malicious sidecar target values are not displayed

## Validation
- python scripts\check-release-artifact-verifier.py
- node packaging\npm\conu-cli\scripts\check-checksum-verification.js
- npm run check --prefix packaging/npm/conu-cli
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- git diff --check

Fixes #1061

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts attacker-controlled checksum target names from error messages in release artifact verification and the `npm` `conu-cli` checksum parser. Adds regression tests to ensure targets and contents are never printed, and instead include "checksumTargetDisplayed=false contentsDisplayed=false".

- **Bug Fixes**
  - Replace wrong-target diagnostics to omit archive names in `packaging/npm/conu-cli/lib/checksum.js` and `scripts/verify-release-artifacts.py`.
  - Strengthen Node checks in `packaging/npm/conu-cli/scripts/check-checksum-verification.js` to require redaction flags and forbid leaking the malicious target.
  - Extend Python harness in `scripts/check-release-artifact-verifier.py` with required/forbidden assertions and a malicious target test.

<sup>Written for commit 2674a931e281391164644aa1d5df507c92e0dcc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact checksum target names from verification errors**

### What Changed
- Error messages for mismatched checksum targets no longer print the attacker-controlled archive name.
- The Node and Python checksum checks now verify that these failures include redaction markers instead of leaked target text.
- Added regression coverage for malicious checksum target values in both release artifact and npm checksum verification flows.

### Impact
`✅ Safer checksum error messages`
`✅ Fewer leaked file names in validation failures`
`✅ Clearer redaction checks in release and npm verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
