### PR TITLE
Add update policy checksum display guards

### DIFF
--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -218,8 +218,9 @@ def main() -> int:
         bad_checksum_name = temp / "bad-checksum-name"
         shutil.copytree(dist, bad_checksum_name)
         archive = bad_checksum_name / f"conu-{VERSION}-windows-x64.zip"
+        malicious_checksum_target = "secret-update-policy-checksum-target.zip"
         archive.with_name(f"{archive.name}.sha256").write_text(
-            f"{hashlib.sha256(archive.read_bytes()).hexdigest()}  wrong.zip\n",
+            f"{hashlib.sha256(archive.read_bytes()).hexdigest()}  {malicious_checksum_target}\n",
             encoding="ascii",
             newline="\n",
         )
@@ -227,6 +228,8 @@ def main() -> int:
             "checksum names wrong asset",
             bad_checksum_name,
             "names wrong file",
+            forbidden=(malicious_checksum_target,),
+            required=("checksumTargetDisplayed=false", "contentsDisplayed=false"),
         )
 
         expect_failure(
@@ -453,6 +456,8 @@ def expect_failure(
     release_base_url: str = BASE_URL,
     repo: str = REPO,
     tag: str = TAG,
+    forbidden: tuple[str, ...] = (),
+    required: tuple[str, ...] = (),
 ) -> None:
     failed = subprocess.run(
         [
@@ -480,6 +485,16 @@ def expect_failure(
         raise AssertionError(
             f"{description} failed with {failed.stdout!r}, expected {expected!r}"
         )
+    for value in forbidden:
+        if value in failed.stdout:
+            raise AssertionError(
+                f"{description} leaked forbidden value {value!r}: {failed.stdout!r}"
+            )
+    for value in required:
+        if value not in failed.stdout:
+            raise AssertionError(
+                f"{description} omitted required value {value!r}: {failed.stdout!r}"
+            )
 
 
 def write_dist(dist: Path) -> None:

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -541,7 +541,10 @@ def verify_sha256_sidecar(
     if match is None:
         raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
+        raise SystemExit(
+            f"SHA-256 sidecar for {label} names wrong file; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     expected = match.group(1).lower()
     if expected != actual:
         raise SystemExit(f"SHA-256 mismatch for {label}")


### PR DESCRIPTION
## **User description**
## Summary
- add explicit checksum target/content display guards to release update-policy wrong-target checksum diagnostics
- strengthen the regression with a malicious checksum target and assertions that it is not displayed

## Validation
- python scripts\check-release-update-policy.py
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- git diff --check

Fixes #1063

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaking checksum target names or contents in update-policy diagnostics when a SHA-256 sidecar names the wrong file. Adds explicit display guards and tests to enforce redaction. Fixes #1063.

- **Bug Fixes**
  - `generate-release-update-policy.py`: wrong-file error now omits target/content details and adds flags: "checksumTargetDisplayed=false contentsDisplayed=false".
  - `check-release-update-policy.py`: adds forbidden/required assertions and a malicious checksum target to ensure sensitive values are never printed.

<sup>Written for commit 3811d562b294bcd219049661fe0c658d148811ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Hide checksum target details in update policy errors

### What Changed
- When a release checksum points to the wrong file, the error now avoids showing the file name or checksum contents
- The release policy checks now verify that sensitive checksum details are not printed in this failure case
- A malicious checksum target is used in the regression test to confirm the value stays redacted

### Impact
`✅ Fewer leaked file names in release errors`
`✅ Safer checksum validation failures`
`✅ Clearer redaction checks in release diagnostics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
