### PR TITLE
Add package-manager checksum display guards

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -419,6 +419,12 @@ def assert_not_displayed(message: str, label: str, *forbidden_values: str) -> No
             raise AssertionError(f"{label}: displayed forbidden value {value!r}: {message!r}")
 
 
+def assert_display_guards(message: str, label: str, *guards: str) -> None:
+    for guard in guards:
+        if guard not in message:
+            raise AssertionError(f"{label}: missing display guard {guard!r}: {message!r}")
+
+
 def assert_external_tool_output_redacts(generator) -> None:
     original_which = generator.shutil.which
     original_run = generator.subprocess.run
@@ -1194,6 +1200,12 @@ def main() -> int:
             rpm_package.name,
             malicious_rpm_target,
         )
+        assert_display_guards(
+            message,
+            "wrong existing RPM sidecar target",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
+        )
 
         mismatched_existing_rpm_sidecar = temp / "mismatched-existing-rpm-sidecar"
         mismatched_existing_rpm_sidecar.mkdir()
@@ -1491,6 +1503,12 @@ def main() -> int:
             "checksum names wrong archive",
             windows_archive.name,
             malicious_archive_name,
+        )
+        assert_display_guards(
+            message,
+            "checksum names wrong archive",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
         )
 
         wrong_digest = temp / "wrong-digest"

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -428,7 +428,10 @@ def read_verified_checksum(archive: Path) -> str:
         raise SystemExit("checksum file has invalid format for package-manager asset")
     named_archive = match.group(2)
     if named_archive != archive.name:
-        raise SystemExit("checksum file for package-manager asset names wrong archive")
+        raise SystemExit(
+            "checksum file for package-manager asset names wrong archive; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     expected = match.group(1).lower()
     actual = sha256_file(
         archive,
@@ -1468,7 +1471,10 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
         raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     named_path = match.group(2)
     if named_path != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
+        raise SystemExit(
+            f"SHA-256 sidecar for {label} names wrong file; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     expected = match.group(1).lower()
     actual = sha256_file(path, label, max_bytes=MAX_GENERATED_OUTPUT_BYTES)
     if expected != actual:


### PR DESCRIPTION
## **User description**
## Summary
- add explicit checksum target/content display guards to package-manager manifest wrong-target diagnostics
- strengthen package-manager manifest regressions to require the guards while keeping malicious sidecar target values redacted

## Validation
- python scripts\check-package-manager-manifests.py
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- git diff --check

Fixes #1065

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit checksum display guards to package-manager diagnostics to prevent leaking target names and contents. Error messages now include "checksumTargetDisplayed=false" and "contentsDisplayed=false", and tests enforce them. Fixes #1065.

- **Bug Fixes**
  - Append display guards to wrong-archive/sidecar errors in `scripts/generate-package-manager-manifests.py`.
  - Add `assert_display_guards` in `scripts/check-package-manager-manifests.py` and require guards for RPM and Windows archive diagnostics.
  - Keep malicious sidecar target values redacted.

<sup>Written for commit a4aba1e8bb9328c3c162d41694df85392228927d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add display guards to package-manager checksum errors**

### What Changed
- Error messages for wrong checksum targets now include explicit redaction guards, so sensitive file names and contents stay hidden in diagnostics.
- The manifest checks now require these guards for RPM and Windows archive checksum errors, and the regression tests verify they are present.
- Existing checks still block leaked target values in malicious sidecar cases.

### Impact
`✅ Fewer leaked file names in package-manager errors`
`✅ Safer checksum diagnostics`
`✅ Stronger redaction checks in manifest validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error messages in package manager manifest validation for checksum and archive naming failures.

* **Tests**
  * Enhanced regression tests for package manifest validation with additional verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->