### PR TITLE
Add Linux repository checksum display guards

### DIFF
--- a/scripts/check-linux-repository-signing.py
+++ b/scripts/check-linux-repository-signing.py
@@ -464,7 +464,7 @@ def run_source_file_preflights(signer) -> None:
         write_apt_metadata_zip(wrong_target_bundle)
         malicious_target = "secret-repository-signing-sidecar-target.zip"
         write_sha256_sidecar(wrong_target_bundle, archive_name=malicious_target)
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: signer.verify_sha256_sidecar(
                 wrong_target_bundle,
                 "APT repository metadata bundle",
@@ -473,6 +473,12 @@ def run_source_file_preflights(signer) -> None:
             "repository signing wrong sidecar target",
             wrong_target_bundle.name,
             malicious_target,
+        )
+        assert_display_guards(
+            message,
+            "repository signing wrong sidecar target",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
         )
 
         mismatched_sidecar = temp / "mismatched-sidecar"
@@ -585,6 +591,12 @@ def expect_action_failure(
                 ) from exc
         return message
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_display_guards(message: str, label: str, *guards: str) -> None:
+    for guard in guards:
+        if guard not in message:
+            raise AssertionError(f"{label}: missing display guard {guard!r}: {message!r}")
 
 
 def assert_member_failure_redacted(message: str, label: str, *forbidden_values: str) -> None:

--- a/scripts/sign-linux-repository-metadata.py
+++ b/scripts/sign-linux-repository-metadata.py
@@ -452,7 +452,10 @@ def verify_sha256_sidecar(path: Path, label: str) -> None:
     if match is None:
         raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
+        raise SystemExit(
+            f"SHA-256 sidecar for {label} names wrong file; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     if match.group(1).lower() != sha256_file(
         path,
         f"{label} {path.name}",


### PR DESCRIPTION
## **User description**
## Summary
- add explicit checksum target/content display guards to Linux repository metadata signing wrong-target SHA-256 sidecar diagnostics
- strengthen the Linux repository signing regression to require those guards while keeping malicious sidecar target values redacted

## Validation
- python scripts\check-linux-repository-signing.py (source/ZIP preflights passed; GPG-only signing portion skipped locally because gpg is unavailable)
- direct verify_sha256_sidecar wrong-target smoke passed locally
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- git diff --check

Fixes #1067

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds display guards to wrong-target SHA-256 sidecar errors in Linux repository signing to prevent leaking target names. Updates checks to enforce these guards and keep contents redacted.

- **Bug Fixes**
  - `verify_sha256_sidecar`: wrong-file errors now include "checksumTargetDisplayed=false contentsDisplayed=false".
  - Signing checks: assert guard markers and ensure malicious sidecar target strings remain redacted.

<sup>Written for commit 3928dcf33560ecc484fcca9cd9858a0dc3c42142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Show clear redaction markers when a Linux repository checksum file points to the wrong target**

### What Changed
- When a checksum sidecar names the wrong file, the error now shows that the target and contents were hidden
- The Linux repository signing check now verifies those redaction markers in the failure message
- The regression test now fails if the wrong-target checksum error leaks the target name or sidecar contents

### Impact
`✅ Fewer secret file names leaked in signing errors`
`✅ Clearer checksum-sidecar failure messages`
`✅ Safer Linux repository signing diagnostics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
