### PR TITLE
Add RPM signing checksum display guards

### DIFF
--- a/scripts/check-rpm-package-signing.py
+++ b/scripts/check-rpm-package-signing.py
@@ -413,7 +413,7 @@ def run_source_file_preflights() -> None:
         wrong_target_package.write_bytes(b"rpm fixture\n")
         malicious_target = "secret-rpm-signing-sidecar-target.rpm"
         write_checksum(wrong_target_package, archive_name=malicious_target)
-        expect_action_failure(
+        message = expect_action_failure(
             lambda: signer.verify_sha256_sidecar(
                 wrong_target_package,
                 "generated RPM package",
@@ -422,6 +422,12 @@ def run_source_file_preflights() -> None:
             "RPM signing wrong sidecar target",
             wrong_target_package.name,
             malicious_target,
+        )
+        assert_display_guards(
+            message,
+            "RPM signing wrong sidecar target",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
         )
 
         mismatched_sidecar = temp / "mismatched-sidecar"
@@ -484,7 +490,7 @@ def expect_action_failure(
     expected: str,
     label: str,
     *forbidden_values: str,
-) -> None:
+) -> str:
     try:
         action()
     except SystemExit as exc:
@@ -496,8 +502,14 @@ def expect_action_failure(
                 raise AssertionError(
                     f"{label}: leaked forbidden value {value!r}: {message!r}"
                 ) from exc
-        return
+        return message
     raise AssertionError(f"{label}: expected failure containing {expected!r}")
+
+
+def assert_display_guards(message: str, label: str, *guards: str) -> None:
+    for guard in guards:
+        if guard not in message:
+            raise AssertionError(f"{label}: missing display guard {guard!r}: {message!r}")
 
 
 def try_symlink(link: Path, target: Path) -> bool:

--- a/scripts/sign-rpm-packages.py
+++ b/scripts/sign-rpm-packages.py
@@ -180,7 +180,10 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
         raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     named_path = match.group(2)
     if named_path != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
+        raise SystemExit(
+            f"SHA-256 sidecar for {label} names wrong file; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     expected = match.group(1).lower()
     actual = sha256_file(
         path,


### PR DESCRIPTION
## **User description**
## Summary
- add explicit checksum target/content display guards to RPM package signing wrong-target SHA-256 sidecar diagnostics
- strengthen the RPM signing regression to require those guards while keeping malicious sidecar target values redacted

## Validation
- python scripts\check-rpm-package-signing.py (source preflights passed; native signing portion skipped locally because gpg/rpmbuild/rpm tooling is unavailable)
- direct verify_sha256_sidecar wrong-target smoke passed locally
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- git diff --check

Fixes #1069

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds display guards to RPM SHA-256 sidecar “wrong file” errors to prevent leaking target names or contents. Strengthens tests to require these guards and keeps malicious sidecar targets redacted. Fixes #1069.

- **Bug Fixes**
  - Append "checksumTargetDisplayed=false contentsDisplayed=false" when the sidecar names the wrong file.
  - Add guard assertions in tests and keep forbidden values redacted.
  - Let expect_action_failure return the error message for assertions.

<sup>Written for commit 5cb2552b57ad23d6a21c1db83c9bb7f3a05e340e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide sensitive sidecar details when an RPM checksum points to the wrong file**

### What Changed
- RPM signing now reports a wrong-file checksum sidecar without showing the target name or sidecar contents
- The signing regression checks now require those redaction guards to appear in the error message
- Test helpers now keep the full failure message so the redaction checks can verify what users see

### Impact
`✅ Fewer leaked file names in signing errors`
`✅ Safer RPM signing diagnostics`
`✅ Clearer redaction checks for checksum failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
