### PR TITLE
Add hosted checksum display guards

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -172,6 +172,12 @@ def main() -> int:
             DEBIAN_PACKAGES[0],
             malicious_target,
         )
+        assert_display_guards(
+            output,
+            "wrong package checksum target",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
+        )
 
         mismatched_checksum = temp / "mismatched-checksum"
         shutil.copytree(dist, mismatched_checksum)
@@ -608,6 +614,12 @@ def assert_not_displayed(message: str, label: str, *forbidden_values: str) -> No
     for value in forbidden_values:
         if value and value in message:
             raise AssertionError(f"{label}: displayed forbidden value {value!r}: {message!r}")
+
+
+def assert_display_guards(message: str, label: str, *guards: str) -> None:
+    for guard in guards:
+        if guard not in message:
+            raise AssertionError(f"{label}: missing display guard {guard!r}: {message!r}")
 
 
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -242,6 +242,12 @@ def main() -> int:
             SITE_BUNDLE,
             malicious_target,
         )
+        assert_display_guards(
+            output,
+            "wrong site checksum target",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
+        )
 
         mismatched_checksum = temp / "mismatched-checksum"
         shutil.copytree(dist, mismatched_checksum)
@@ -437,6 +443,12 @@ def main() -> int:
             "wrong embedded download checksum target",
             f"downloads/{HOSTED_BUNDLE}.sha256",
             malicious_download_target,
+        )
+        assert_display_guards(
+            output,
+            "wrong embedded download checksum target",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
         )
 
         mismatched_download_checksum = temp / "mismatched-download-checksum"
@@ -877,6 +889,12 @@ def assert_not_displayed(message: str, label: str, *forbidden_values: str) -> No
     for value in forbidden_values:
         if value and value in message:
             raise AssertionError(f"{label}: displayed forbidden value {value!r}: {message!r}")
+
+
+def assert_display_guards(message: str, label: str, *guards: str) -> None:
+    for guard in guards:
+        if guard not in message:
+            raise AssertionError(f"{label}: missing display guard {guard!r}: {message!r}")
 
 
 def assert_no_sentinel(output: str, label: str) -> None:

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -306,6 +306,12 @@ def main() -> int:
             HOSTED_BUNDLE,
             malicious_target,
         )
+        assert_display_guards(
+            output,
+            "wrong hosted bundle checksum target",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
+        )
 
         mismatched_checksum = temp / "mismatched-checksum"
         shutil.copytree(dist, mismatched_checksum)
@@ -706,6 +712,12 @@ def assert_not_displayed(message: str, label: str, *forbidden_values: str) -> No
     for value in forbidden_values:
         if value and value in message:
             raise AssertionError(f"{label}: displayed forbidden value {value!r}: {message!r}")
+
+
+def assert_display_guards(message: str, label: str, *guards: str) -> None:
+    for guard in guards:
+        if guard not in message:
+            raise AssertionError(f"{label}: missing display guard {guard!r}: {message!r}")
 
 
 def try_symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> bool:

--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -198,6 +198,12 @@ def assert_not_displayed(message: str, description: str, *forbidden_values: str)
             raise AssertionError(f"{description} leaked forbidden value {value!r}: {message!r}")
 
 
+def assert_display_guards(message: str, description: str, *guards: str) -> None:
+    for guard in guards:
+        if guard not in message:
+            raise AssertionError(f"{description} missing display guard {guard!r}: {message!r}")
+
+
 def expect_member_redacted_failure(
     description: str,
     action,
@@ -558,6 +564,12 @@ def main() -> int:
             "wrong package checksum target",
             sidecar.name,
             malicious_target,
+        )
+        assert_display_guards(
+            output,
+            "wrong package checksum target",
+            "checksumTargetDisplayed=false",
+            "contentsDisplayed=false",
         )
 
         invalid_checksum = temp / "invalid-checksum"

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -564,7 +564,10 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
     if match is None:
         raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
+        raise SystemExit(
+            f"SHA-256 sidecar for {label} names wrong file; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     expected = match.group(1).lower()
     actual = sha256_file(path, label, max_bytes=MAX_RELEASE_ASSET_BYTES)
     if expected != actual:

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -656,7 +656,10 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
     if match is None:
         raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
+        raise SystemExit(
+            f"SHA-256 sidecar for {label} names wrong file; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     expected = match.group(1).lower()
     actual = sha256_file(path, label, max_bytes=MAX_HOSTED_BUNDLE_BYTES)
     if expected != actual:

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -217,7 +217,10 @@ def verify_sha256_sidecar(path: Path, label: str) -> str:
     if match is None:
         raise SystemExit(f"SHA-256 sidecar has invalid format for {label}")
     if match.group(2) != path.name:
-        raise SystemExit(f"SHA-256 sidecar for {label} names wrong file")
+        raise SystemExit(
+            f"SHA-256 sidecar for {label} names wrong file; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     expected = match.group(1).lower()
     actual = sha256_file(path, label, max_bytes=MAX_SITE_ZIP_BYTES)
     if expected != actual:
@@ -758,7 +761,10 @@ def validate_downloaded_bundle(version: str, members: dict[str, bytes]) -> None:
     if match is None:
         raise SystemExit("downloaded hosted repository bundle checksum has invalid format")
     if match.group(2) != hosted_bundle:
-        raise SystemExit("downloaded hosted repository bundle checksum names wrong file")
+        raise SystemExit(
+            "downloaded hosted repository bundle checksum names wrong file; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     actual = hashlib.sha256(members[bundle_path]).hexdigest()
     if match.group(1).lower() != actual:
         raise SystemExit("downloaded hosted repository bundle checksum mismatch")

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -498,7 +498,10 @@ def validate_checksum_source(path: Path, dist: Path) -> None:
     target_name = match.group(2)
     expected_target = path.name[: -len(".sha256")]
     if target_name != expected_target:
-        raise SystemExit(f"{sidecar_label} names wrong target")
+        raise SystemExit(
+            f"{sidecar_label} names wrong target; "
+            "checksumTargetDisplayed=false contentsDisplayed=false"
+        )
     target = dist / target_name
     validate_regular_file(
         target,


### PR DESCRIPTION
## **User description**
## Summary
- Add explicit checksumTargetDisplayed=false and contentsDisplayed=false guards to remaining wrong-target checksum diagnostics in hosted repository and package submission helpers.
- Require those guards in focused regressions for hosted bundle generation, hosted site generation, Pages prep, embedded hosted-bundle download validation, and package-manager submission checks.

## Validation
- python scripts\\check-hosted-linux-repositories.py
- python scripts\\check-hosted-linux-repository-site.py
- python scripts\\check-hosted-linux-repository-pages.py
- python scripts\\check-package-manager-submissions.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1071

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit display guards to all wrong-target checksum errors to prevent leaking filenames or contents, and updates check scripts to assert these guards across hosted repos, sites, pages, and package submissions. Fixes #1071.

- **Bug Fixes**
  - Emit checksumTargetDisplayed=false and contentsDisplayed=false in wrong-target checksum diagnostics in generate/prepare scripts for hosted bundles, sites, pages, and package submissions.
  - Add assert_display_guards to check scripts and require these guards for hosted bundle generation, hosted site generation, Pages prep, embedded hosted-bundle download validation, and package-manager submission checks.

<sup>Written for commit 91a37d48fb8d05b9ba7094b13142cb9d45d88ea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide sensitive file details in checksum mismatch errors**

### What Changed
- Checksum errors for hosted repositories, hosted sites, Pages downloads, and package submissions now include explicit guard text that confirms the target file name and contents are not shown.
- The related validation checks now require those guards in failure cases, so these redaction rules are enforced across the affected workflows.

### Impact
`✅ Fewer file-name leaks in checksum errors`
`✅ Safer hosted repository and Pages validation failures`
`✅ Clearer redaction checks for submission and download checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
