### PR TITLE
Add hosted signature display guards

### DIFF
--- a/scripts/check-hosted-linux-repositories.py
+++ b/scripts/check-hosted-linux-repositories.py
@@ -215,6 +215,12 @@ def main() -> int:
             "non-ASCII package signature",
             f"{DEBIAN_PACKAGES[0]}.asc",
         )
+        assert_display_guards(
+            output,
+            "non-ASCII package signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
 
         non_armored_signature = temp / "non-armored-signature"
         shutil.copytree(dist, non_armored_signature)
@@ -232,6 +238,12 @@ def main() -> int:
             output,
             "non-armored package signature",
             f"{DEBIAN_PACKAGES[0]}.asc",
+        )
+        assert_display_guards(
+            output,
+            "non-armored package signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         private_key_signature = temp / "private-key-signature"
@@ -253,6 +265,12 @@ def main() -> int:
             output,
             "private key signature sidecar",
             f"{DEBIAN_PACKAGES[0]}.asc",
+        )
+        assert_display_guards(
+            output,
+            "private key signature sidecar",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         symlink_dist = temp / "symlink-dist"
@@ -358,6 +376,12 @@ def main() -> int:
             "Linux public key asset is not ASCII-armored",
         )
         assert_not_displayed(output, "non-ASCII public key asset", PUBLIC_KEY)
+        assert_display_guards(
+            output,
+            "non-ASCII public key asset",
+            "keyContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
 
         non_armored_public_key = temp / "non-armored-public-key"
         shutil.copytree(dist, non_armored_public_key)
@@ -373,6 +397,12 @@ def main() -> int:
             "not an armored public key",
         )
         assert_not_displayed(output, "non-armored public key asset", PUBLIC_KEY)
+        assert_display_guards(
+            output,
+            "non-armored public key asset",
+            "keyContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
 
         private_key_asset = temp / "private-key-asset"
         shutil.copytree(dist, private_key_asset)
@@ -391,6 +421,12 @@ def main() -> int:
             "private key material",
         )
         assert_not_displayed(output, "private key asset", PUBLIC_KEY)
+        assert_display_guards(
+            output,
+            "private key asset",
+            "keyContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
 
         unsafe_zip = temp / "unsafe-zip"
         shutil.copytree(dist, unsafe_zip)

--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -284,6 +284,12 @@ def main() -> int:
             "detached signature is not ASCII-armored",
         )
         assert_not_displayed(output, "non-ASCII site signature", f"{SITE_BUNDLE}.asc")
+        assert_display_guards(
+            output,
+            "non-ASCII site signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
 
         non_armored_signature = temp / "non-armored-signature"
         shutil.copytree(dist, non_armored_signature)
@@ -299,6 +305,12 @@ def main() -> int:
             "detached signature is not ASCII-armored",
         )
         assert_not_displayed(output, "non-armored site signature", f"{SITE_BUNDLE}.asc")
+        assert_display_guards(
+            output,
+            "non-armored site signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
 
         private_key_signature = temp / "private-key-signature"
         shutil.copytree(dist, private_key_signature)
@@ -319,6 +331,12 @@ def main() -> int:
             "private key material",
         )
         assert_not_displayed(output, "private key site signature", f"{SITE_BUNDLE}.asc")
+        assert_display_guards(
+            output,
+            "private key site signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
 
         symlink_site = temp / "symlink-site"
         shutil.copytree(dist, symlink_site)
@@ -492,6 +510,12 @@ def main() -> int:
             output,
             "non-armored embedded download signature",
             f"downloads/{HOSTED_BUNDLE}.asc",
+        )
+        assert_display_guards(
+            output,
+            "non-armored embedded download signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         missing_cache_policy = temp / "missing-cache-policy"

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -352,6 +352,12 @@ def main() -> int:
             "non-ASCII hosted bundle signature",
             f"{HOSTED_BUNDLE}.asc",
         )
+        assert_display_guards(
+            output,
+            "non-ASCII hosted bundle signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
 
         non_armored_signature = temp / "non-armored-signature"
         shutil.copytree(dist, non_armored_signature)
@@ -370,6 +376,12 @@ def main() -> int:
             output,
             "non-armored hosted bundle signature",
             f"{HOSTED_BUNDLE}.asc",
+        )
+        assert_display_guards(
+            output,
+            "non-armored hosted bundle signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         private_key_signature = temp / "private-key-signature"
@@ -394,6 +406,12 @@ def main() -> int:
             output,
             "private key hosted bundle signature",
             f"{HOSTED_BUNDLE}.asc",
+        )
+        assert_display_guards(
+            output,
+            "private key hosted bundle signature",
+            "signatureContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         symlink_dist = temp / "symlink-dist"

--- a/scripts/check-package-manager-submissions.py
+++ b/scripts/check-package-manager-submissions.py
@@ -772,7 +772,7 @@ def main() -> int:
             "# NPM_TOKEN\n",
             encoding="ascii",
         )
-        expect_failure(
+        output = expect_failure(
             "forbidden manifest text",
             lambda: preparer.prepare_submission_bundle(
                 forbidden,
@@ -783,6 +783,13 @@ def main() -> int:
                 require_linux_signatures=True,
             ),
             "forbidden literal",
+        )
+        assert_not_displayed(output, "forbidden manifest text", "NPM_TOKEN")
+        assert_display_guards(
+            output,
+            "forbidden manifest text",
+            "contentsDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         private_key_signature = temp / "private-key-signature"
@@ -803,7 +810,7 @@ def main() -> int:
             encoding="ascii",
             newline="\n",
         )
-        expect_failure(
+        output = expect_failure(
             "private key material in signature sidecar",
             lambda: preparer.prepare_submission_bundle(
                 private_key_signature,
@@ -814,6 +821,17 @@ def main() -> int:
                 require_linux_signatures=True,
             ),
             "forbidden literal",
+        )
+        assert_not_displayed(
+            output,
+            "private key material in signature sidecar",
+            "BEGIN PGP PRIVATE KEY BLOCK",
+        )
+        assert_display_guards(
+            output,
+            "private key material in signature sidecar",
+            "contentsDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         private_key_public_asset = temp / "private-key-public-asset"
@@ -836,7 +854,7 @@ def main() -> int:
             newline="\n",
         )
         write_sha256(public_key)
-        expect_failure(
+        output = expect_failure(
             "private key material in public-key asset",
             lambda: preparer.prepare_submission_bundle(
                 private_key_public_asset,
@@ -847,6 +865,17 @@ def main() -> int:
                 require_linux_signatures=True,
             ),
             "private key material",
+        )
+        assert_not_displayed(
+            output,
+            "private key material in public-key asset",
+            "BEGIN PGP PRIVATE KEY BLOCK",
+        )
+        assert_display_guards(
+            output,
+            "private key material in public-key asset",
+            "keyContentsDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         no_optional = temp / "no-optional"

--- a/scripts/generate-hosted-linux-repositories.py
+++ b/scripts/generate-hosted-linux-repositories.py
@@ -35,6 +35,8 @@ MAX_ZIP_MEMBER_BYTES = 512_000_000
 MAX_ZIP_MEMBERS = 10_000
 MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
+SIGNATURE_FAILURE_GUARDS = "signatureContentsDisplayed=false keyMaterialDisplayed=false"
+KEY_FAILURE_GUARDS = "keyContentsDisplayed=false keyMaterialDisplayed=false"
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 DEBIAN_ARCHES = {
     "linux-x64": "amd64",
@@ -204,11 +206,15 @@ def require_detached_signature(path: Path) -> Path:
             max_bytes=MAX_SIGNATURE_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit("detached signature is not ASCII-armored") from exc
+        raise SystemExit(
+            f"detached signature is not ASCII-armored; {SIGNATURE_FAILURE_GUARDS}"
+        ) from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
-        raise SystemExit("detached signature is not ASCII-armored")
+        raise SystemExit(f"detached signature is not ASCII-armored; {SIGNATURE_FAILURE_GUARDS}")
     if "PRIVATE KEY BLOCK" in signature_text:
-        raise SystemExit("detached signature contains private key material")
+        raise SystemExit(
+            f"detached signature contains private key material; {SIGNATURE_FAILURE_GUARDS}"
+        )
     return signature
 
 
@@ -217,11 +223,13 @@ def verify_public_key(path: Path) -> None:
     try:
         text = read_ascii_file(path, "Linux public key asset", max_bytes=MAX_PUBLIC_KEY_BYTES)
     except UnicodeDecodeError as exc:
-        raise SystemExit("Linux public key asset is not ASCII-armored") from exc
+        raise SystemExit(
+            f"Linux public key asset is not ASCII-armored; {KEY_FAILURE_GUARDS}"
+        ) from exc
     if "BEGIN PGP PUBLIC KEY BLOCK" not in text:
-        raise SystemExit("Linux public key asset is not an armored public key")
+        raise SystemExit(f"Linux public key asset is not an armored public key; {KEY_FAILURE_GUARDS}")
     if "PRIVATE KEY BLOCK" in text:
-        raise SystemExit("refusing to bundle private key material")
+        raise SystemExit(f"refusing to bundle private key material; {KEY_FAILURE_GUARDS}")
 
 
 def build_hosted_repository_members(assets: HostedLinuxAssets) -> dict[str, bytes]:
@@ -329,9 +337,13 @@ def validate_apt_metadata(
             if f" {digest} {len(content)} {name}" not in release_text:
                 raise SystemExit(f"{bundle.name} Release metadata does not hash {name}")
     if b"BEGIN PGP SIGNED MESSAGE" not in members["InRelease"]:
-        raise SystemExit(f"{bundle.name} is missing an armored InRelease signature")
+        raise SystemExit(
+            f"{bundle.name} is missing an armored InRelease signature; {SIGNATURE_FAILURE_GUARDS}"
+        )
     if b"BEGIN PGP SIGNATURE" not in members["Release.gpg"]:
-        raise SystemExit(f"{bundle.name} is missing an armored Release.gpg signature")
+        raise SystemExit(
+            f"{bundle.name} is missing an armored Release.gpg signature; {SIGNATURE_FAILURE_GUARDS}"
+        )
 
 
 def validate_rpm_metadata(
@@ -343,7 +355,10 @@ def validate_rpm_metadata(
         if name not in members:
             raise SystemExit(f"{bundle.name} is missing signed RPM member: {name}")
     if b"BEGIN PGP SIGNATURE" not in members["repodata/repomd.xml.asc"]:
-        raise SystemExit(f"{bundle.name} is missing an armored repomd.xml.asc signature")
+        raise SystemExit(
+            f"{bundle.name} is missing an armored repomd.xml.asc signature; "
+            f"{SIGNATURE_FAILURE_GUARDS}"
+        )
     primary_member = find_primary_metadata_member(bundle, members)
     try:
         primary_text = gzip.decompress(members[primary_member]).decode("utf-8")

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -31,6 +31,8 @@ MAX_ZIP_MEMBER_BYTES = 512_000_000
 MAX_ZIP_MEMBERS = 10_000
 MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
+SIGNATURE_FAILURE_GUARDS = "signatureContentsDisplayed=false keyMaterialDisplayed=false"
+KEY_FAILURE_GUARDS = "keyContentsDisplayed=false keyMaterialDisplayed=false"
 ZIP_SOURCE_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
@@ -272,11 +274,15 @@ def require_detached_signature(path: Path) -> Path:
             max_bytes=MAX_SIGNATURE_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit("detached signature is not ASCII-armored") from exc
+        raise SystemExit(
+            f"detached signature is not ASCII-armored; {SIGNATURE_FAILURE_GUARDS}"
+        ) from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
-        raise SystemExit("detached signature is not ASCII-armored")
+        raise SystemExit(f"detached signature is not ASCII-armored; {SIGNATURE_FAILURE_GUARDS}")
     if "PRIVATE KEY BLOCK" in signature_text:
-        raise SystemExit("detached signature contains private key material")
+        raise SystemExit(
+            f"detached signature contains private key material; {SIGNATURE_FAILURE_GUARDS}"
+        )
     return signature
 
 
@@ -404,17 +410,31 @@ def validate_hosted_bundle_members(bundle_name: str, members: dict[str, bytes]) 
             assert_no_forbidden_text(data, f"{bundle_name}:{name}")
     public_key = members[PUBLIC_KEY_NAME]
     if b"BEGIN PGP PUBLIC KEY BLOCK" not in public_key:
-        raise SystemExit(f"{bundle_name} root public key is not armored public key material")
+        raise SystemExit(
+            f"{bundle_name} root public key is not armored public key material; {KEY_FAILURE_GUARDS}"
+        )
     if b"BEGIN PGP PUBLIC KEY BLOCK" not in members[f"apt/{PUBLIC_KEY_NAME}"]:
-        raise SystemExit(f"{bundle_name} APT public key is not armored public key material")
+        raise SystemExit(
+            f"{bundle_name} APT public key is not armored public key material; {KEY_FAILURE_GUARDS}"
+        )
     if b"BEGIN PGP PUBLIC KEY BLOCK" not in members[f"rpm/{PUBLIC_KEY_NAME}"]:
-        raise SystemExit(f"{bundle_name} RPM public key is not armored public key material")
+        raise SystemExit(
+            f"{bundle_name} RPM public key is not armored public key material; {KEY_FAILURE_GUARDS}"
+        )
     if b"BEGIN PGP SIGNED MESSAGE" not in members["apt/InRelease"]:
-        raise SystemExit(f"{bundle_name} APT InRelease is not armored signed metadata")
+        raise SystemExit(
+            f"{bundle_name} APT InRelease is not armored signed metadata; {SIGNATURE_FAILURE_GUARDS}"
+        )
     if b"BEGIN PGP SIGNATURE" not in members["apt/Release.gpg"]:
-        raise SystemExit(f"{bundle_name} APT Release.gpg is not armored signature material")
+        raise SystemExit(
+            f"{bundle_name} APT Release.gpg is not armored signature material; "
+            f"{SIGNATURE_FAILURE_GUARDS}"
+        )
     if b"BEGIN PGP SIGNATURE" not in members["rpm/repodata/repomd.xml.asc"]:
-        raise SystemExit(f"{bundle_name} RPM repomd.xml.asc is not armored signature material")
+        raise SystemExit(
+            f"{bundle_name} RPM repomd.xml.asc is not armored signature material; "
+            f"{SIGNATURE_FAILURE_GUARDS}"
+        )
 
 
 def build_site_members(

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -33,6 +33,8 @@ MAX_SITE_MEMBER_BYTES = 512_000_000
 MAX_SITE_MEMBERS = 10000
 MAX_SITE_TOTAL_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024
 MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
+SIGNATURE_FAILURE_GUARDS = "signatureContentsDisplayed=false keyMaterialDisplayed=false"
+KEY_FAILURE_GUARDS = "keyContentsDisplayed=false keyMaterialDisplayed=false"
 PUBLIC_KEY_NAME = "conu-linux-gpg-key.asc"
 CACHE_POLICY_SCHEMA = "conu.hostedLinuxRepository.cachePolicy.v1"
 CACHE_CONTROL_RULES = (
@@ -242,11 +244,15 @@ def require_detached_signature(path: Path) -> None:
             max_bytes=MAX_SIGNATURE_BYTES,
         )
     except UnicodeDecodeError as exc:
-        raise SystemExit("detached signature is not ASCII-armored") from exc
+        raise SystemExit(
+            f"detached signature is not ASCII-armored; {SIGNATURE_FAILURE_GUARDS}"
+        ) from exc
     if "BEGIN PGP SIGNATURE" not in signature_text:
-        raise SystemExit("detached signature is not ASCII-armored")
+        raise SystemExit(f"detached signature is not ASCII-armored; {SIGNATURE_FAILURE_GUARDS}")
     if "PRIVATE KEY BLOCK" in signature_text:
-        raise SystemExit("detached signature contains private key material")
+        raise SystemExit(
+            f"detached signature contains private key material; {SIGNATURE_FAILURE_GUARDS}"
+        )
 
 
 def prepare_output_dir(output_dir: Path) -> None:
@@ -740,12 +746,20 @@ def parse_headers_file(text: str) -> dict[str, dict[str, str]]:
 def validate_key_and_signature_material(site_name: str, members: dict[str, bytes]) -> None:
     for name in (PUBLIC_KEY_NAME, f"apt/{PUBLIC_KEY_NAME}", f"rpm/{PUBLIC_KEY_NAME}"):
         if b"BEGIN PGP PUBLIC KEY BLOCK" not in members[name]:
-            raise SystemExit(f"{site_name}:{name} is not armored public key material")
+            raise SystemExit(
+                f"{site_name}:{name} is not armored public key material; {KEY_FAILURE_GUARDS}"
+            )
     for name in ("apt/Release.gpg", "rpm/repodata/repomd.xml.asc"):
         if b"BEGIN PGP SIGNATURE" not in members[name]:
-            raise SystemExit(f"{site_name}:{name} is not armored signature material")
+            raise SystemExit(
+                f"{site_name}:{name} is not armored signature material; "
+                f"{SIGNATURE_FAILURE_GUARDS}"
+            )
     if b"BEGIN PGP SIGNED MESSAGE" not in members["apt/InRelease"]:
-        raise SystemExit(f"{site_name}:apt/InRelease is not armored signed metadata")
+        raise SystemExit(
+            f"{site_name}:apt/InRelease is not armored signed metadata; "
+            f"{SIGNATURE_FAILURE_GUARDS}"
+        )
 
 
 def validate_downloaded_bundle(version: str, members: dict[str, bytes]) -> None:
@@ -769,7 +783,9 @@ def validate_downloaded_bundle(version: str, members: dict[str, bytes]) -> None:
     if match.group(1).lower() != actual:
         raise SystemExit("downloaded hosted repository bundle checksum mismatch")
     if b"BEGIN PGP SIGNATURE" not in members[signature_path]:
-        raise SystemExit("downloaded hosted repository bundle signature is not armored")
+        raise SystemExit(
+            f"downloaded hosted repository bundle signature is not armored; {SIGNATURE_FAILURE_GUARDS}"
+        )
 
 
 def extract_members(output_dir: Path, members: dict[str, bytes]) -> None:

--- a/scripts/prepare-package-manager-submissions.py
+++ b/scripts/prepare-package-manager-submissions.py
@@ -32,6 +32,9 @@ MAX_CHECKSUM_BYTES = 4096
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
+SIGNATURE_FAILURE_GUARDS = "signatureContentsDisplayed=false keyMaterialDisplayed=false"
+KEY_FAILURE_GUARDS = "keyContentsDisplayed=false keyMaterialDisplayed=false"
+TEXT_FAILURE_GUARDS = "contentsDisplayed=false keyMaterialDisplayed=false"
 ZIP_TIMESTAMP = (2020, 1, 1, 0, 0, 0)
 DEBIAN_ARCHES = ("amd64", "arm64")
 RPM_ARCHES = ("x86_64", "aarch64")
@@ -535,16 +538,18 @@ def validate_signature_source(source: Path, label: str, dist: Path) -> None:
     )
     text = read_ascii_text(source, label)
     if "BEGIN PGP SIGNATURE" not in text or "END PGP SIGNATURE" not in text:
-        raise SystemExit(f"{label} is not an armored detached PGP signature")
+        raise SystemExit(
+            f"{label} is not an armored detached PGP signature; {SIGNATURE_FAILURE_GUARDS}"
+        )
     assert_safe_text(text, label, Path())
 
 
 def validate_public_key_source(source: Path, label: str) -> None:
     text = read_ascii_text(source, label)
     if "BEGIN PGP PUBLIC KEY BLOCK" not in text or "END PGP PUBLIC KEY BLOCK" not in text:
-        raise SystemExit(f"{label} is not an armored PGP public key")
+        raise SystemExit(f"{label} is not an armored PGP public key; {KEY_FAILURE_GUARDS}")
     if "PRIVATE KEY BLOCK" in text:
-        raise SystemExit(f"{label} contains private key material")
+        raise SystemExit(f"{label} contains private key material; {KEY_FAILURE_GUARDS}")
     assert_safe_text(text, label, Path())
 
 
@@ -552,7 +557,7 @@ def assert_safe_text(text: str, label: str, dist: Path) -> None:
     normalized = text.replace("\\", "/")
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
-            raise SystemExit(f"{label} contains forbidden literal: {forbidden}")
+            raise SystemExit(f"{label} contains forbidden literal; {TEXT_FAILURE_GUARDS}")
     if dist != Path():
         resolved_dist = str(dist.resolve()).replace("\\", "/")
         if resolved_dist and resolved_dist in normalized:


### PR DESCRIPTION
## **User description**
## Summary
- Add explicit signature/key display guards to malformed detached-signature and public-key diagnostics in hosted repository and package-submission release helpers.
- Stop package-submission forbidden-text failures from echoing the exact token/key-looking marker that triggered the rejection.
- Require those guards in focused hosted repository, hosted site, Pages, and package-manager submission regressions.

## Validation
- python scripts\\check-hosted-linux-repositories.py
- python scripts\\check-hosted-linux-repository-site.py
- python scripts\\check-hosted-linux-repository-pages.py
- python scripts\\check-package-manager-submissions.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- git diff --check

Fixes #1073


___

## **CodeAnt-AI Description**
**Hide signature and key details in hosted repository and submission error messages**

### What Changed
- Error messages for invalid signatures and public keys now avoid exposing the file contents that triggered the failure.
- Hosted repository, hosted site, Pages, and package submission checks now include explicit guards when rejecting non-ASCII, non-armored, or private-key-containing signature/key files.
- Regression checks were updated to confirm the sensitive text is not shown in these failure cases.

### Impact
`✅ Fewer secret leaks in validation errors`
`✅ Safer handling of malformed signatures and keys`
`✅ Clearer rejection messages without exposing token or key material`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Security**
  * Enhanced error messaging throughout the system to ensure sensitive cryptographic material (private keys, signatures) is never displayed in failure outputs. Error messages now include explicit indicators when sensitive content has been redacted for security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->