### PR TITLE
Guard package manifest literal diagnostics

### DIFF
--- a/scripts/check-package-manager-manifests.py
+++ b/scripts/check-package-manager-manifests.py
@@ -1014,14 +1014,25 @@ def main() -> int:
         finally:
             generator.open_regular_file = original_open_regular_file
 
-        for literal in ("PRIVATE KEY BLOCK", "BEGIN OPENSSH PRIVATE KEY"):
-            expect_failure(
+        for literal in ("NPM_TOKEN", "PRIVATE KEY BLOCK", "BEGIN OPENSSH PRIVATE KEY"):
+            message = expect_failure(
                 f"forbidden package-manager manifest literal {literal}",
                 lambda literal=literal: generator.assert_output_safe(
                     f"public manifest text\n{literal}\n",
                     rootless_dist,
                 ),
-                f"forbidden literal: {literal}",
+                "generated package-manager manifests contain forbidden literal",
+            )
+            assert_not_displayed(
+                message,
+                f"forbidden package-manager manifest literal {literal}",
+                literal,
+            )
+            assert_display_guards(
+                message,
+                f"forbidden package-manager manifest literal {literal}",
+                "contentsDisplayed=false",
+                "keyMaterialDisplayed=false",
             )
 
         expect_failure_with_limit(

--- a/scripts/generate-package-manager-manifests.py
+++ b/scripts/generate-package-manager-manifests.py
@@ -57,6 +57,7 @@ MAX_RELEASE_MEMBER_BYTES = 512_000_000
 MAX_RELEASE_MEMBER_COUNT = 10_000
 MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES = 2_000_000_000
 MEMBER_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false"
+TEXT_FAILURE_GUARDS = "contentsDisplayed=false keyMaterialDisplayed=false"
 MAX_PACKAGE_BINARY_BYTES = MAX_RELEASE_MEMBER_BYTES
 MAX_GENERATED_OUTPUT_BYTES = MAX_RELEASE_TOTAL_UNCOMPRESSED_BYTES
 
@@ -1797,7 +1798,10 @@ def assert_output_safe(text: str, dist: Path) -> None:
     ]
     for literal in forbidden_literals:
         if literal in text:
-            raise SystemExit(f"generated package-manager manifests contain forbidden literal: {literal}")
+            raise SystemExit(
+                "generated package-manager manifests contain forbidden literal; "
+                f"{TEXT_FAILURE_GUARDS}"
+            )
     resolved_dist = str(dist.resolve()).replace("\\", "/")
     if resolved_dist and resolved_dist in text.replace("\\", "/"):
         raise SystemExit("generated package-manager manifests contain local dist path")


### PR DESCRIPTION
## **User description**
## Summary
- stop package-manager manifest safety failures from echoing the exact forbidden literal
- add display guards for generated-manifest forbidden-text diagnostics
- extend manifest regressions to prove NPM/private-key markers are not displayed

## Validation
- python scripts/check-package-manager-manifests.py
- python scripts/check-python-script-compile.py
- python scripts/check-production-readiness-toolchain.py
- python scripts/check-github-workflow-permissions.py --json
- git diff --check
- python scripts/check-github-release-secret-readiness.py --repo imthegoodboy/conU --json (expected failure: remaining #274 signing/notarization/GPG secrets missing; no values displayed)

Fixes #1075

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened package-manager manifest diagnostics to avoid leaking sensitive literals and added display guards for forbidden text. Extended checks to cover `NPM_TOKEN` and private key markers so they never appear in error output. Fixes #1075.

- **Bug Fixes**
  - Do not echo forbidden literals in errors; emit a generic message with guards.
  - Added `TEXT_FAILURE_GUARDS` (`contentsDisplayed=false keyMaterialDisplayed=false`) and applied it in `assert_output_safe`.
  - Expanded forbidden literal set to include `NPM_TOKEN`, and asserted both non-display and guard flags in tests.

<sup>Written for commit 96618b81b3a476c56f46aa3c742be2cef96eb916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Stop package-manifest errors from revealing sensitive text**

### What Changed
- Package-manifest validation now reports a generic forbidden-text error instead of echoing the exact secret-like value it found
- The error output now includes explicit safety guards that confirm sensitive content is not shown
- Tests now cover `NPM_TOKEN` as well as private key markers and verify those values stay out of error messages

### Impact
`✅ Safer manifest checks`
`✅ Fewer secret leaks in build logs`
`✅ Clearer validation failures without exposing sensitive values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
