### PR TITLE
Guard hosted repository forbidden text diagnostics

### DIFF
--- a/scripts/check-hosted-linux-repository-endpoint-regression.py
+++ b/scripts/check-hosted-linux-repository-endpoint-regression.py
@@ -233,6 +233,33 @@ def main() -> int:
                 VERSION,
             )
 
+        forbidden_text = temp / "forbidden-text"
+        shutil.copytree(site_root, forbidden_text)
+        repository_path = forbidden_text / "repository.json"
+        repository = json.loads(repository_path.read_text(encoding="ascii"))
+        repository["forbiddenMarker"] = "NPM_TOKEN"
+        repository_path.write_text(
+            json.dumps(repository, indent=2, sort_keys=True) + "\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        with serve_site(forbidden_text, mode="good") as base_url:
+            rewrite_base_url(forbidden_text, PLACEHOLDER_BASE_URL, base_url)
+            output = run_checker_expect_failure(
+                base_url,
+                "forbidden hosted repository text",
+                "--expected-version",
+                VERSION,
+            )
+            assert_no_forbidden_literal(output, "endpoint forbidden text output", "NPM_TOKEN")
+            for guard in (
+                "contentsDisplayed=false",
+                "tokenDisplayed=false",
+                "keyMaterialDisplayed=false",
+            ):
+                if guard not in output:
+                    raise AssertionError(f"endpoint forbidden text output missed {guard}")
+
         escaped_dot_download_url = temp / "escaped-dot-download-url"
         shutil.copytree(site_root, escaped_dot_download_url)
         with serve_site(escaped_dot_download_url, mode="good") as base_url:
@@ -446,6 +473,11 @@ def run_checker_expect_failure(
 def assert_no_sentinel(output: str, label: str) -> None:
     if SENSITIVE_SENTINEL in output:
         raise AssertionError(f"{label} leaked duplicate-key shadow value")
+
+
+def assert_no_forbidden_literal(output: str, label: str, literal: str) -> None:
+    if literal in output:
+        raise AssertionError(f"{label} leaked forbidden literal {literal!r}")
 
 
 if __name__ == "__main__":

--- a/scripts/check-hosted-linux-repository-endpoint.py
+++ b/scripts/check-hosted-linux-repository-endpoint.py
@@ -35,6 +35,9 @@ FORBIDDEN_TEXT = (
     "payload_hex",
     "ciphertext_body",
 )
+TEXT_FAILURE_GUARDS = (
+    "contentsDisplayed=false tokenDisplayed=false keyMaterialDisplayed=false"
+)
 FORBIDDEN_PATH_SEGMENTS = {
     ".conu",
     ".git",
@@ -416,7 +419,9 @@ def decode_ascii(data: bytes, label: str) -> str:
 def assert_no_forbidden_text(text: str, label: str) -> None:
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
-            raise EndpointReadinessError(f"{label} contains forbidden hosted repository text: {forbidden}")
+            raise EndpointReadinessError(
+                f"{label} contains forbidden hosted repository text; {TEXT_FAILURE_GUARDS}"
+            )
 
 
 def validate_repository_json(base_url: str, repository: dict[str, Any]) -> str:

--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -259,8 +259,23 @@ def main() -> int:
         forbidden = temp / "forbidden-site"
         shutil.copytree(site_dir, forbidden)
         (forbidden / "README.txt").write_text("NPM_TOKEN\n", encoding="ascii")
-        forbidden_result = run_publisher_raw(forbidden, "--dry-run")
+        forbidden_result = run_publisher_raw(forbidden, "--dry-run", "--json")
         assert_failure("forbidden text", forbidden_result, "forbidden repository publication text")
+        assert_no_forbidden_literal(
+            forbidden_result.stdout,
+            "forbidden repository publication text",
+            "NPM_TOKEN",
+        )
+        forbidden_report = json.loads(forbidden_result.stdout)
+        assert_publication_display_guards(forbidden_report, "forbidden repository publication text")
+        rendered_forbidden_report = json.dumps(forbidden_report)
+        for guard in (
+            "contentsDisplayed=false",
+            "tokenDisplayed=false",
+            "keyMaterialDisplayed=false",
+        ):
+            if guard not in rendered_forbidden_report:
+                raise AssertionError(f"forbidden repository publication text missed {guard}")
 
         uncovered = temp / "uncovered-site"
         shutil.copytree(site_dir, uncovered)
@@ -589,9 +604,7 @@ def assert_publication_report(report: dict, *, published: bool) -> None:
         raise AssertionError("publication report file count was too low")
     if report["totalBytes"] <= 0:
         raise AssertionError("publication report total bytes was empty")
-    for guard in ("payloadDisplayed", "tokenDisplayed", "keyMaterialDisplayed"):
-        if report[guard] is not False:
-            raise AssertionError(f"publication report expected {guard}=false")
+    assert_publication_display_guards(report, "publication report")
     cache_classes = set(report["cacheClasses"])
     expected_classes = {
         "no-cache",
@@ -708,6 +721,11 @@ def assert_no_sentinel(output: str, label: str) -> None:
         raise AssertionError(f"{label} leaked duplicate-key shadow value")
 
 
+def assert_no_forbidden_literal(output: str, label: str, literal: str) -> None:
+    if literal in output:
+        raise AssertionError(f"{label} leaked forbidden literal {literal!r}")
+
+
 def assert_failed_publication_redacts(
     result: subprocess.CompletedProcess[str],
     fake_aws: str,
@@ -721,11 +739,20 @@ def assert_failed_publication_redacts(
     report = json.loads(result.stdout)
     if report["published"] is not False or report["endpointChecked"] is not False:
         raise AssertionError("failed publication report claimed work completed")
-    for guard in ("payloadDisplayed", "tokenDisplayed", "keyMaterialDisplayed"):
-        if report[guard] is not False:
-            raise AssertionError(f"failed publication report expected {guard}=false")
+    assert_publication_display_guards(report, "failed publication report")
     if "[redacted]" not in json.dumps(report):
         raise AssertionError("failed publication report did not include redacted command output")
+
+
+def assert_publication_display_guards(report: dict, label: str) -> None:
+    for guard in (
+        "payloadDisplayed",
+        "contentsDisplayed",
+        "tokenDisplayed",
+        "keyMaterialDisplayed",
+    ):
+        if report[guard] is not False:
+            raise AssertionError(f"{label} expected {guard}=false")
 
 
 def assert_aws_cli_wrapper_guard(publisher, fake_aws: str) -> None:

--- a/scripts/check-smoke-output-privacy.py
+++ b/scripts/check-smoke-output-privacy.py
@@ -110,6 +110,23 @@ def check_command_output_redaction(issues: list[str]) -> None:
         if "[redacted]" not in redacted:
             issues.append(f"command output redaction did not mark secret flag value from {value!r}")
 
+    safe_guards = (
+        "contentsDisplayed=false tokenDisplayed=false keyMaterialDisplayed=false"
+    )
+    if redact_command_output(safe_guards) != safe_guards:
+        issues.append("command output redaction changed safe display guard booleans")
+
+    unsafe_guard_assignments = (
+        f"tokenDisplayed={sentinel}",
+        f"keyMaterialDisplayed={sentinel}",
+    )
+    for value in unsafe_guard_assignments:
+        redacted = redact_command_output(value)
+        if sentinel in redacted:
+            issues.append(f"command output redaction leaked guarded secret value from {value!r}")
+        if "[redacted]" not in redacted:
+            issues.append(f"command output redaction did not mark guarded secret value from {value!r}")
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/command_output_redaction.py
+++ b/scripts/command_output_redaction.py
@@ -33,14 +33,59 @@ URL_SECRET_QUERY_RE = re.compile(
     r")=)([^&#\s]+)",
     re.IGNORECASE,
 )
+SAFE_BOOLEAN_GUARD_ASSIGNMENTS = (
+    "alertBodiesDisplayed=false",
+    "checksumTargetDisplayed=false",
+    "ciphertextDisplayed=false",
+    "commandOutputDisplayed=false",
+    "contentsDisplayed=false",
+    "endpointDisplayed=false",
+    "keyContentsDisplayed=false",
+    "keyMaterialDisplayed=false",
+    "pathDisplayed=false",
+    "payloadDisplayed=false",
+    "secretValuesDisplayed=false",
+    "sessionIdDisplayed=false",
+    "signatureContentsDisplayed=false",
+    "statePathDisplayed=false",
+    "tokenDisplayed=false",
+    "tokenHashDisplayed=false",
+)
+DISPLAY_GUARD_NAMES = tuple(
+    assignment.removesuffix("=false") for assignment in SAFE_BOOLEAN_GUARD_ASSIGNMENTS
+)
+DISPLAY_GUARD_ASSIGNMENT_RE = re.compile(
+    r"\b("
+    + "|".join(re.escape(name) for name in DISPLAY_GUARD_NAMES)
+    + r")\s*([=:])\s*([^\s;&|]+)"
+)
 
 
 def redact_command_output(value: str) -> str:
+    value, protected_guards = protect_safe_boolean_guards(value)
     value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
     value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
     value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)
     value = SECRET_FLAG_RE.sub(r"\1\2[redacted]", value)
     value = NPM_TOKEN_RE.sub(REDACTED, value)
     value = GITHUB_TOKEN_RE.sub(REDACTED, value)
+    value = DISPLAY_GUARD_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
     value = SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", value)
+    value = restore_safe_boolean_guards(value, protected_guards)
+    return value
+
+
+def protect_safe_boolean_guards(value: str) -> tuple[str, dict[str, str]]:
+    replacements: dict[str, str] = {}
+    for index, assignment in enumerate(SAFE_BOOLEAN_GUARD_ASSIGNMENTS):
+        placeholder = f"__CONU_SAFE_GUARD_{index}__"
+        if assignment in value:
+            value = value.replace(assignment, placeholder)
+            replacements[placeholder] = assignment
+    return value, replacements
+
+
+def restore_safe_boolean_guards(value: str, replacements: dict[str, str]) -> str:
+    for placeholder, assignment in replacements.items():
+        value = value.replace(placeholder, assignment)
     return value

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -93,6 +93,9 @@ FORBIDDEN_TEXT = (
     "payload_hex",
     "ciphertext_body",
 )
+TEXT_FAILURE_GUARDS = (
+    "contentsDisplayed=false tokenDisplayed=false keyMaterialDisplayed=false"
+)
 TEXT_SUFFIXES = (".txt", ".json", ".html", ".list", ".repo", ".asc", ".sha256")
 TEXT_MEMBER_NAMES = {"_headers", ".nojekyll"}
 
@@ -139,6 +142,7 @@ class PublishPlan:
             "totalBytes": sum(file.size for file in self.files),
             "cacheClasses": cache_classes,
             "payloadDisplayed": False,
+            "contentsDisplayed": False,
             "tokenDisplayed": False,
             "keyMaterialDisplayed": False,
         }
@@ -167,6 +171,7 @@ def main() -> int:
                         "endpointChecked": False,
                         "issues": [error_message],
                         "payloadDisplayed": False,
+                        "contentsDisplayed": False,
                         "tokenDisplayed": False,
                         "keyMaterialDisplayed": False,
                     },
@@ -782,7 +787,9 @@ def is_text_member(relative_path: str) -> bool:
 def assert_no_forbidden_text(text: str, label: str) -> None:
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
-            raise PublicationError(f"{label} contains forbidden repository publication text: {forbidden}")
+            raise PublicationError(
+                f"{label} contains forbidden repository publication text; {TEXT_FAILURE_GUARDS}"
+            )
 
 
 def validate_cache_control_value(value: str, label: str) -> None:


### PR DESCRIPTION
## **User description**
Summary:
- Stop hosted repository endpoint and S3 publication validators from echoing exact forbidden text markers.
- Add explicit display-guard diagnostics and JSON contentsDisplayed=false guards.
- Keep command output redaction strict while preserving exact safe display guard booleans.

Validation:
- python scripts\check-hosted-linux-repository-endpoint-regression.py
- python scripts\check-hosted-linux-repository-s3-publication.py
- python scripts\check-smoke-output-privacy.py
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- git diff --check

Fixes #1077

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened hosted repository diagnostics to stop echoing forbidden text markers and added clear display-guard flags in errors and JSON to prevent leaks. Redaction stays strict while preserving safe guard booleans. Fixes #1077.

- **Bug Fixes**
  - Endpoint and S3 validators no longer print the forbidden literal; they return a generic failure with contentsDisplayed=false tokenDisplayed=false keyMaterialDisplayed=false.
  - JSON reports now include contentsDisplayed=false alongside existing payload/token/keyMaterial guards; failures still show [redacted] output where needed.
  - Redactor preserves known safe guard booleans and redacts any guarded assignments; continues to redact tokens, headers, URLs, and secret flags/assignments.
  - Tests now assert no forbidden literals appear and verify guard booleans in both text output and JSON.

<sup>Written for commit b8185a455348687dd836aa1d961d4cf04e6db653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Stop forbidden repository text from appearing in failure output**

### What Changed
- Failure messages for hosted repository endpoint and S3 publication checks now avoid echoing exact forbidden text markers.
- JSON and text error output now include explicit display-status fields, including `contentsDisplayed=false`, alongside the existing token and key material flags.
- Safe boolean guard values are preserved in redacted command output, while unsafe guarded values are still hidden.
- Added checks to confirm forbidden markers do not appear in failure output and that the new display-status fields are present.

### Impact
`✅ Fewer secret text leaks in repository checks`
`✅ Clearer failure reports with display-status flags`
`✅ Safer output when validation fails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive regression tests validating that sensitive tokens and credentials are properly redacted from command output and error messages.
  * Enhanced endpoint and S3 publication checks with stricter validation of display guard flags.

* **Bug Fixes**
  * Improved output redaction logic to better prevent accidental exposure of sensitive credentials and tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->