### PR TITLE
Guard release hosting forbidden text diagnostics

### DIFF
--- a/scripts/check-hosted-linux-repository-pages.py
+++ b/scripts/check-hosted-linux-repository-pages.py
@@ -398,11 +398,19 @@ def main() -> int:
         shutil.copytree(dist, forbidden)
         rewrite_site_zip(forbidden / SITE_BUNDLE, {"install/README.txt": b"NPM_TOKEN\n"})
         sign_site(forbidden / SITE_BUNDLE)
-        expect_failure(
+        output = expect_failure(
             "forbidden site text",
             forbidden / SITE_BUNDLE,
             temp / "forbidden-pages",
             "forbidden Pages deployment text",
+        )
+        assert_not_displayed(output, "forbidden site text", "NPM_TOKEN")
+        assert_display_guards(
+            output,
+            "forbidden site text",
+            "contentsDisplayed=false",
+            "tokenDisplayed=false",
+            "keyMaterialDisplayed=false",
         )
 
         unexpected_download = temp / "unexpected-download"

--- a/scripts/check-hosted-linux-repository-site.py
+++ b/scripts/check-hosted-linux-repository-site.py
@@ -520,6 +520,29 @@ def main() -> int:
             "apt/Packages",
         )
 
+        forbidden_bundle = temp / "forbidden-bundle"
+        shutil.copytree(dist, forbidden_bundle)
+        rewrite_hosted_bundle(
+            forbidden_bundle / HOSTED_BUNDLE,
+            {"apt/README.txt": b"NPM_TOKEN\n"},
+        )
+        write_checksum(forbidden_bundle / HOSTED_BUNDLE)
+        write_signature(forbidden_bundle / HOSTED_BUNDLE)
+        output = expect_failure(
+            "forbidden hosted bundle text",
+            forbidden_bundle,
+            BASE_URL,
+            "forbidden release-site text",
+        )
+        assert_not_displayed(output, "forbidden hosted bundle text", "NPM_TOKEN")
+        assert_display_guards(
+            output,
+            "forbidden hosted bundle text",
+            "contentsDisplayed=false",
+            "tokenDisplayed=false",
+            "keyMaterialDisplayed=false",
+        )
+
         expect_failure(
             "insecure base URL",
             dist,
@@ -926,6 +949,14 @@ def is_text_member(name: str) -> bool:
 def read_zip_members(path: Path) -> dict[str, bytes]:
     with zipfile.ZipFile(path) as archive:
         return {name: archive.read(name) for name in archive.namelist()}
+
+
+def rewrite_hosted_bundle(path: Path, replacements: dict[str, bytes]) -> None:
+    members = read_zip_members(path)
+    members.update(replacements)
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+        for name in sorted(members):
+            write_zip_bytes(archive, name, members[name])
 
 
 def write_signature(path: Path) -> None:

--- a/scripts/check-release-update-policy.py
+++ b/scripts/check-release-update-policy.py
@@ -355,6 +355,12 @@ def main() -> int:
             "forbidden generated text",
             forbidden_text,
             "forbidden text",
+            forbidden=("do-not-print-this-secret-value",),
+            required=(
+                "contentsDisplayed=false",
+                "tokenDisplayed=false",
+                "keyMaterialDisplayed=false",
+            ),
         )
 
     print("Release update policy regression checks passed")

--- a/scripts/generate-hosted-linux-repository-site.py
+++ b/scripts/generate-hosted-linux-repository-site.py
@@ -98,6 +98,9 @@ FORBIDDEN_TEXT = (
     "payloadHex",
     "ciphertext_body",
 )
+TEXT_FAILURE_GUARDS = (
+    "contentsDisplayed=false tokenDisplayed=false keyMaterialDisplayed=false"
+)
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 OPEN_BINARY = getattr(os, "O_BINARY", 0)
 
@@ -726,7 +729,9 @@ def assert_no_forbidden_text(data: bytes, label: str) -> None:
         raise SystemExit(f"{label} is not UTF-8 text") from exc
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
-            raise SystemExit(f"{label} contains forbidden release-site text: {forbidden}")
+            raise SystemExit(
+                f"{label} contains forbidden release-site text; {TEXT_FAILURE_GUARDS}"
+            )
 
 
 def is_text_member(name: str) -> bool:

--- a/scripts/generate-release-update-policy.py
+++ b/scripts/generate-release-update-policy.py
@@ -65,6 +65,9 @@ FORBIDDEN_TEXT = (
     "ciphertext_body",
     "do-not-print-this-secret-value",
 )
+TEXT_FAILURE_GUARDS = (
+    "contentsDisplayed=false tokenDisplayed=false keyMaterialDisplayed=false"
+)
 
 
 @dataclass(frozen=True)
@@ -799,7 +802,9 @@ def assert_output_safe(text: str) -> None:
         raise SystemExit("release update policy must be ASCII JSON") from exc
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
-            raise SystemExit(f"release update policy contains forbidden text: {forbidden}")
+            raise SystemExit(
+                f"release update policy contains forbidden text; {TEXT_FAILURE_GUARDS}"
+            )
     if "\\" in text:
         raise SystemExit("release update policy must not contain local path separators")
 
@@ -825,7 +830,7 @@ def assert_open_file_text_safe(
         raise SystemExit(f"{label} is not UTF-8 text") from exc
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
-            raise SystemExit(f"{label} contains forbidden text: {forbidden}")
+            raise SystemExit(f"{label} contains forbidden text; {TEXT_FAILURE_GUARDS}")
     validate_open_regular_file(handle, label, max_bytes=max_bytes)
     handle.seek(0)
 

--- a/scripts/prepare-hosted-linux-repository-pages.py
+++ b/scripts/prepare-hosted-linux-repository-pages.py
@@ -108,6 +108,9 @@ FORBIDDEN_TEXT = (
     "payload_hex",
     "ciphertext_body",
 )
+TEXT_FAILURE_GUARDS = (
+    "contentsDisplayed=false tokenDisplayed=false keyMaterialDisplayed=false"
+)
 TEXT_SUFFIXES = (".txt", ".json", ".html", ".list", ".repo", ".asc", ".sha256")
 TEXT_MEMBER_NAMES = {"_headers"}
 OPEN_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
@@ -811,7 +814,9 @@ def assert_no_forbidden_text(data: bytes, label: str) -> None:
         raise SystemExit(f"{label} is not UTF-8 text") from exc
     for forbidden in FORBIDDEN_TEXT:
         if forbidden in text:
-            raise SystemExit(f"{label} contains forbidden Pages deployment text: {forbidden}")
+            raise SystemExit(
+                f"{label} contains forbidden Pages deployment text; {TEXT_FAILURE_GUARDS}"
+            )
 
 
 def is_text_member(name: str) -> bool:


### PR DESCRIPTION
## **User description**
Summary:
- Stop hosted repository site, Pages deployment prep, and release update-policy generators from echoing exact forbidden token/key/payload markers.
- Add explicit display-guard diagnostics for those forbidden-text failures.
- Extend regressions to prove forbidden marker values are not displayed while guard booleans remain visible.

Validation:
- python scripts\check-hosted-linux-repository-site.py
- python scripts\check-hosted-linux-repository-pages.py
- python scripts\check-release-update-policy.py
- python scripts\check-python-script-compile.py
- python scripts\check-production-readiness-toolchain.py
- python scripts\check-smoke-output-privacy.py
- git diff --check

Fixes #1079

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaking tokens/keys in release hosting and update-policy diagnostics by replacing forbidden values with guarded flags, and adds tests to enforce this behavior. Fixes #1079.

- **Bug Fixes**
  - Stop echoing forbidden markers in hosted site generation, Pages prep, and release update-policy generators; diagnostics now show "contentsDisplayed=false tokenDisplayed=false keyMaterialDisplayed=false".
  - Update check scripts to assert secrets are not printed and that guard flags are present for site bundles, Pages deployments, and release policy output.
  - Add a small helper to rewrite hosted bundle members in tests to simulate forbidden content.

<sup>Written for commit ba0ca4eea48e58bb9eed6ae4907009488f262b31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide forbidden text from release and hosting failure messages**

### What Changed
- Failure messages no longer repeat secret-like text such as token names or key material markers when hosted site, Pages, or release update policy checks reject content.
- The same guard wording now appears in these failures so users see a consistent redaction-safe message instead of the forbidden text itself.
- Regression checks were expanded to verify the secret text stays hidden while the guard details remain visible.

### Impact
`✅ Fewer secret leaks in build and release errors`
`✅ Safer hosted site and Pages diagnostics`
`✅ Clearer rejection messages for release policy checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
