### PR TITLE
Guard release asset forbidden diagnostics

### DIFF
--- a/scripts/check-github-release-assets-published-regression.py
+++ b/scripts/check-github-release-assets-published-regression.py
@@ -77,6 +77,16 @@ def assert_not_ready(report, pattern: str) -> None:
         raise AssertionError(f"expected {pattern!r} in report: {rendered}")
 
 
+def assert_forbidden_asset_guarded(report, forbidden_name: str) -> None:
+    rendered = json.dumps(report.as_json())
+    for value in (SENSITIVE_SENTINEL, forbidden_name, "runtime"):
+        if value in rendered:
+            raise AssertionError(f"release asset report leaked forbidden value: {value}")
+    for guard in ("assetNameDisplayed=false", "markerDisplayed=false", "contentsDisplayed=false"):
+        if guard not in rendered:
+            raise AssertionError(f"release asset report missed forbidden asset guard: {guard}")
+
+
 def run_expected_name_tests(module) -> None:
     names = module.expected_release_asset_names(TEST_VERSION)
     if len(names) != len(set(names)):
@@ -206,19 +216,19 @@ def run_audit_tests(module) -> None:
         "digest must be sha256 metadata",
     )
 
+    forbidden_name = "conu-0.1.0-runtime-secret.zip"
     forbidden_payload = ready_payload(module)
     forbidden_payload["assets"].append(
         {
-            "name": "conu-0.1.0-runtime-secret.zip",
+            "name": forbidden_name,
             "size": 100,
             "state": "uploaded",
             "digest": f"sha256:{999:064x}",
         }
     )
-    assert_not_ready(
-        module.audit_release_assets("owner/repo", TEST_TAG, forbidden_payload),
-        "forbiddenAssets",
-    )
+    forbidden_report = module.audit_release_assets("owner/repo", TEST_TAG, forbidden_payload)
+    assert_not_ready(forbidden_report, "forbiddenAssets")
+    assert_forbidden_asset_guarded(forbidden_report, forbidden_name)
 
     whitespace_payload = ready_payload(module)
     whitespace_payload["assets"][0]["name"] = f"{whitespace_payload['assets'][0]['name']} "

--- a/scripts/check-github-release-assets-published.py
+++ b/scripts/check-github-release-assets-published.py
@@ -38,6 +38,7 @@ FORBIDDEN_ASSET_MARKERS = (
     "token",
     "trust.toml",
 )
+FORBIDDEN_ASSET_FAILURE_GUARDS = "assetNameDisplayed=false markerDisplayed=false contentsDisplayed=false"
 DEBIAN_ARCHES = {
     "linux-x64": "amd64",
     "linux-arm64": "arm64",
@@ -90,6 +91,14 @@ class ReleaseAssetReadiness:
             "forbiddenAssets": list(self.forbidden_assets),
             "unexpectedAssets": list(self.unexpected_assets),
             "issues": list(self.issues),
+            "payloadDisplayed": False,
+            "tokenDisplayed": False,
+            "tokenHashDisplayed": False,
+            "keyMaterialDisplayed": False,
+            "contentsDisplayed": False,
+            "secretValuesDisplayed": False,
+            "forbiddenAssetNameDisplayed": False,
+            "forbiddenAssetMarkerDisplayed": False,
         }
 
 
@@ -207,12 +216,14 @@ def asset_state_issue(asset: dict[str, Any], name: str) -> str | None:
     return None
 
 
-def asset_local_issue(asset: dict[str, Any], name: str) -> str | None:
+def asset_local_issue(asset: dict[str, Any], name: str, *, include_detail: bool = True) -> str | None:
     value = asset.get("localInvalidReason")
     if value is None:
         return None
     if not isinstance(value, str) or not value.strip():
         return f"{name}: local invalid reason must be a non-empty string"
+    if not include_detail:
+        return f"{name}: local invalid reason was provided"
     return f"{name}: {value.strip()}"
 
 
@@ -233,6 +244,16 @@ def forbidden_asset_marker(name: str) -> str | None:
         if marker in lower:
             return marker
     return None
+
+
+def forbidden_asset_issue() -> str:
+    return f"release asset name matched forbidden marker; {FORBIDDEN_ASSET_FAILURE_GUARDS}"
+
+
+def report_asset_name(name: str) -> str:
+    if forbidden_asset_marker(name) is not None:
+        return f"release asset; {FORBIDDEN_ASSET_FAILURE_GUARDS}"
+    return name
 
 
 def audit_release_assets(
@@ -260,31 +281,32 @@ def audit_release_assets(
         if not isinstance(asset, dict):
             raise ValueError("GitHub Release assets must be JSON objects")
         name = asset_name(asset)
+        marker = forbidden_asset_marker(name)
+        display_name = report_asset_name(name)
         names.append(name)
 
-        size_issue = asset_size_issue(asset, name)
+        size_issue = asset_size_issue(asset, display_name)
         if size_issue:
             invalid.append(size_issue)
-        state_issue = asset_state_issue(asset, name)
+        state_issue = asset_state_issue(asset, display_name)
         if state_issue:
             invalid.append(state_issue)
-        local_issue = asset_local_issue(asset, name)
+        local_issue = asset_local_issue(asset, display_name, include_detail=marker is None)
         if local_issue:
             invalid.append(local_issue)
-        digest_issue = asset_digest_issue(repo, asset, name)
+        digest_issue = asset_digest_issue(repo, asset, display_name)
         if digest_issue:
             invalid.append(digest_issue)
 
-        marker = forbidden_asset_marker(name)
         if marker:
-            forbidden.append(f"{name}: matched forbidden marker {marker}")
+            forbidden.append(forbidden_asset_issue())
 
     counts = Counter(names)
     present_set = set(names)
     missing = tuple(name for name in required_assets if name not in present_set)
-    duplicates = tuple(sorted(name for name, count in counts.items() if count > 1))
+    duplicates = tuple(sorted(report_asset_name(name) for name, count in counts.items() if count > 1))
     present = tuple(name for name in required_assets if name in present_set)
-    unexpected = tuple(sorted(name for name in present_set - required_set))
+    unexpected = tuple(sorted(report_asset_name(name) for name in present_set - required_set))
     draft = release_bool(payload, "draft", "isDraft")
     prerelease = release_bool(payload, "prerelease", "isPrerelease")
 

--- a/scripts/check-unsigned-preview-release-assets-regression.py
+++ b/scripts/check-unsigned-preview-release-assets-regression.py
@@ -42,6 +42,8 @@ def assert_safe_report(report) -> dict:
         "do-not-print-this-token-or-payload",
         "BEGIN PGP PRIVATE KEY BLOCK",
         "private message contents",
+        f"conu-{VERSION}-runtime-secret.zip",
+        "runtime",
     )
     for value in forbidden:
         if value in rendered:
@@ -64,6 +66,13 @@ def assert_issue(report, expected: str, label: str) -> None:
     rendered = json.dumps(assert_safe_report(report))
     if expected not in rendered:
         raise AssertionError(f"{label} did not report expected issue: {expected}")
+
+
+def assert_forbidden_asset_guarded(report, label: str) -> None:
+    rendered = json.dumps(assert_safe_report(report))
+    for guard in ("assetNameDisplayed=false", "markerDisplayed=false", "contentsDisplayed=false"):
+        if guard not in rendered:
+            raise AssertionError(f"{label} did not include forbidden asset guard: {guard}")
 
 
 def run_dist_tests(module) -> None:
@@ -99,6 +108,14 @@ def run_dist_tests(module) -> None:
         payload = module.load_dist_metadata(TAG, dist)
         report = module.audit_preview_assets("local/dist", TAG, payload)
         assert_issue(report, "contains forbidden asset names", "preview update policy asset")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        dist = Path(tmp) / "dist"
+        write_preview_dist(dist, module, extra=f"conu-{VERSION}-runtime-secret.zip")
+        payload = module.load_dist_metadata(TAG, dist)
+        report = module.audit_preview_assets("local/dist", TAG, payload)
+        assert_issue(report, "contains forbidden asset names", "preview secret runtime asset")
+        assert_forbidden_asset_guarded(report, "preview secret runtime asset")
 
 
 def run_metadata_tests(module) -> None:

--- a/scripts/check-unsigned-preview-release-assets.py
+++ b/scripts/check-unsigned-preview-release-assets.py
@@ -61,6 +61,7 @@ FORBIDDEN_ASSET_MARKERS = (
     "trust.toml",
     "update-policy",
 )
+FORBIDDEN_ASSET_FAILURE_GUARDS = "assetNameDisplayed=false markerDisplayed=false contentsDisplayed=false"
 
 
 @dataclass(frozen=True)
@@ -106,6 +107,8 @@ class UnsignedPreviewAssetReadiness:
             "keyMaterialDisplayed": False,
             "contentsDisplayed": False,
             "secretValuesDisplayed": False,
+            "forbiddenAssetNameDisplayed": False,
+            "forbiddenAssetMarkerDisplayed": False,
         }
 
 
@@ -170,12 +173,14 @@ def asset_state_issue(asset: dict[str, Any], name: str) -> str | None:
     return None
 
 
-def asset_local_issue(asset: dict[str, Any], name: str) -> str | None:
+def asset_local_issue(asset: dict[str, Any], name: str, *, include_detail: bool = True) -> str | None:
     value = asset.get("localInvalidReason")
     if value is None:
         return None
     if not isinstance(value, str) or not value.strip():
         return f"{name}: local invalid reason must be a non-empty string"
+    if not include_detail:
+        return f"{name}: local invalid reason was provided"
     return f"{name}: {value.strip()}"
 
 
@@ -196,6 +201,16 @@ def forbidden_asset_marker(name: str) -> str | None:
         if marker in lower:
             return marker
     return None
+
+
+def forbidden_asset_issue() -> str:
+    return f"release asset name contains forbidden marker; {FORBIDDEN_ASSET_FAILURE_GUARDS}"
+
+
+def report_asset_name(name: str) -> str:
+    if forbidden_asset_marker(name) is not None:
+        return f"release asset; {FORBIDDEN_ASSET_FAILURE_GUARDS}"
+    return name
 
 
 def infer_preview_version(names: tuple[str, ...]) -> tuple[str, tuple[str, ...]]:
@@ -245,24 +260,25 @@ def audit_preview_assets(
         if not isinstance(asset, dict):
             raise ValueError("GitHub Release assets must be JSON objects")
         name = asset_name(asset)
+        marker = forbidden_asset_marker(name)
+        display_name = report_asset_name(name)
         names.append(name)
 
-        size_issue = asset_size_issue(asset, name)
+        size_issue = asset_size_issue(asset, display_name)
         if size_issue:
             invalid.append(size_issue)
-        state_issue = asset_state_issue(asset, name)
+        state_issue = asset_state_issue(asset, display_name)
         if state_issue:
             invalid.append(state_issue)
-        local_issue = asset_local_issue(asset, name)
+        local_issue = asset_local_issue(asset, display_name, include_detail=marker is None)
         if local_issue:
             invalid.append(local_issue)
-        digest_issue = asset_digest_issue(repo, asset, name)
+        digest_issue = asset_digest_issue(repo, asset, display_name)
         if digest_issue:
             invalid.append(digest_issue)
 
-        marker = forbidden_asset_marker(name)
         if marker is not None:
-            forbidden.append(f"{name}: contains forbidden marker {marker}")
+            forbidden.append(forbidden_asset_issue())
 
     name_tuple = tuple(names)
     version, version_issues = infer_preview_version(name_tuple)
@@ -272,8 +288,8 @@ def audit_preview_assets(
     present_set = set(names)
     missing = tuple(name for name in required if name not in present_set)
     present = tuple(name for name in required if name in present_set)
-    duplicates = tuple(sorted(name for name, count in Counter(names).items() if count > 1))
-    unexpected = tuple(name for name in names if name not in required_set)
+    duplicates = tuple(sorted(report_asset_name(name) for name, count in Counter(names).items() if count > 1))
+    unexpected = tuple(report_asset_name(name) for name in names if name not in required_set)
 
     draft = release_bool(payload, "draft", "isDraft")
     prerelease = release_bool(payload, "prerelease", "isPrerelease")


### PR DESCRIPTION
## **User description**
## Summary
- Sanitize forbidden release asset diagnostics so exact forbidden asset names and matched marker strings are not displayed.
- Apply the same guard to unsigned preview release asset readiness output.
- Add regression coverage for secret/runtime-looking asset names.

## Validation
- python scripts\\check-unsigned-preview-release-assets-regression.py
- python scripts\\check-github-release-assets-published-regression.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- git diff --check

Fixes #1081

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaking forbidden release asset names, markers, and contents in diagnostics. Also applies the same guards to unsigned preview checks and adds regression tests. Fixes #1081.

- **Bug Fixes**
  - Mask forbidden asset details in reports; emit guards: `assetNameDisplayed=false markerDisplayed=false contentsDisplayed=false`.
  - Obfuscate names in duplicates/unexpected lists when they match forbidden markers.
  - Suppress detailed local invalid reasons for forbidden assets.
  - Add non-sensitive JSON flags (e.g., `forbiddenAssetNameDisplayed`, `forbiddenAssetMarkerDisplayed`) to show what was hidden.
  - Add regression tests to ensure no secret/runtime-like values leak and guards are present.

<sup>Written for commit 9880f27621aca798d4b76b7141b0ff7a65a50437. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide forbidden release asset details from readiness checks**

### What Changed
- Forbidden asset names are no longer shown directly in release and preview asset reports; they now use guarded wording instead of exposing the full name or marker.
- Reports now include explicit flags showing that asset names, markers, and contents were withheld.
- Local invalid reasons are also reduced to a generic message when the asset is forbidden, so sensitive details are not echoed back.
- Regression checks now cover secret-like runtime asset names and confirm the guarded output is present.

### Impact
`✅ Fewer leaked secret names in release checks`
`✅ Safer preview asset diagnostics`
`✅ No sensitive asset details in failure reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
