### PR TITLE
Guard npm package verifier path diagnostics

### DIFF
--- a/scripts/verify-npm-package-contents-regression.py
+++ b/scripts/verify-npm-package-contents-regression.py
@@ -31,6 +31,8 @@ def assert_raises(func, pattern: str) -> None:
     try:
         func()
     except ValueError as exc:
+        if SENSITIVE_SENTINEL in str(exc):
+            raise AssertionError("npm package verifier error leaked a sensitive path value") from exc
         if pattern not in str(exc):
             raise AssertionError(f"expected {pattern!r} in {exc!r}") from exc
         return
@@ -66,6 +68,13 @@ def run_public_metadata_tests(module) -> None:
     assert_raises(
         lambda: module.validate_manifest_public_surface(cli_rule, broken_files),
         "files changed",
+    )
+
+    sensitive_files = copy.deepcopy(cli_manifest)
+    sensitive_files["files"].append(f"lib/{SENSITIVE_SENTINEL}.js")
+    assert_raises(
+        lambda: module.validate_manifest_public_surface(cli_rule, sensitive_files),
+        "pathDisplayed=false",
     )
 
     duplicate_files = copy.deepcopy(cli_manifest)
@@ -166,11 +175,77 @@ def run_npm_pack_privacy_tests(module) -> None:
         raise AssertionError("npm pack failure printed raw npm stderr")
 
 
+def run_pack_path_display_guard_tests(module) -> None:
+    assert_raises(
+        lambda: module.normalize_pack_path(f"lib\\{SENSITIVE_SENTINEL}.js"),
+        "pathDisplayed=false",
+    )
+    assert_raises(
+        lambda: module.normalize_pack_path(f"/{SENSITIVE_SENTINEL}/index.js"),
+        "pathDisplayed=false",
+    )
+    assert_raises(
+        lambda: module.reject_forbidden_path(f"lib/{SENSITIVE_SENTINEL}.token"),
+        "pathDisplayed=false",
+    )
+
+    cli_rule = rule_by_name(module, "@conu/cli")
+    cli_manifest = manifest_for(module, cli_rule)
+    version = cli_manifest["version"]
+    base_files = [
+        {"path": path, "size": 10}
+        for path in sorted(cli_rule.allowed_files)
+    ]
+
+    original_run_npm_pack = module.run_npm_pack
+    try:
+        module.run_npm_pack = lambda _npm, _package_dir: {
+            "name": cli_rule.name,
+            "version": version,
+            "id": f"{cli_rule.name}@{version}",
+            "filename": "conu-cli-0.1.0.tgz",
+            "size": 100,
+            "unpackedSize": 100,
+            "bundled": [],
+            "files": [
+                *base_files,
+                {"path": f"lib/{SENSITIVE_SENTINEL}.js", "size": 10},
+            ],
+            "entryCount": len(base_files) + 1,
+        }
+        assert_raises(
+            lambda: module.validate_package(Path(__file__).resolve().parents[1], "npm", cli_rule),
+            "pathDisplayed=false",
+        )
+
+        module.run_npm_pack = lambda _npm, _package_dir: {
+            "name": cli_rule.name,
+            "version": version,
+            "id": f"{cli_rule.name}@{version}",
+            "filename": "conu-cli-0.1.0.tgz",
+            "size": 100,
+            "unpackedSize": 100,
+            "bundled": [],
+            "files": [
+                *base_files,
+                {"path": f"lib/{SENSITIVE_SENTINEL}.js", "size": module.MAX_ENTRY_BYTES + 1},
+            ],
+            "entryCount": len(base_files) + 1,
+        }
+        assert_raises(
+            lambda: module.validate_package(Path(__file__).resolve().parents[1], "npm", cli_rule),
+            "pathDisplayed=false",
+        )
+    finally:
+        module.run_npm_pack = original_run_npm_pack
+
+
 def main() -> int:
     module = load_module()
     run_public_metadata_tests(module)
     run_json_duplicate_key_tests(module)
     run_npm_pack_privacy_tests(module)
+    run_pack_path_display_guard_tests(module)
     print("npm package content regression checks passed")
     return 0
 

--- a/scripts/verify-npm-package-contents.py
+++ b/scripts/verify-npm-package-contents.py
@@ -17,6 +17,7 @@ from json_safety import load_json_object, loads_json
 
 MAX_ENTRY_BYTES = 1_000_000
 MAX_PACKAGE_BYTES = 1_000_000
+PATH_FAILURE_GUARDS = "pathDisplayed=false contentsDisplayed=false tokenDisplayed=false"
 FORBIDDEN_PARTS = frozenset(
     {
         ".conu",
@@ -164,12 +165,12 @@ def normalize_pack_path(raw_path: Any) -> str:
     if not isinstance(raw_path, str) or not raw_path:
         raise ValueError("npm pack reported an empty or non-string file path")
     if "\\" in raw_path:
-        raise ValueError(f"npm pack path uses backslash separators: {raw_path}")
+        raise ValueError(f"npm pack path uses backslash separators; {PATH_FAILURE_GUARDS}")
     path = PurePosixPath(raw_path)
     if path.is_absolute():
-        raise ValueError(f"npm pack path is absolute: {raw_path}")
+        raise ValueError(f"npm pack path is absolute; {PATH_FAILURE_GUARDS}")
     if any(part in ("", ".", "..") for part in path.parts):
-        raise ValueError(f"npm pack path is not normalized: {raw_path}")
+        raise ValueError(f"npm pack path is not normalized; {PATH_FAILURE_GUARDS}")
     return "/".join(path.parts)
 
 
@@ -178,13 +179,13 @@ def reject_forbidden_path(path: str) -> None:
     lower_parts = {part.lower() for part in parts}
     forbidden_parts = sorted(lower_parts & FORBIDDEN_PARTS)
     if forbidden_parts:
-        raise ValueError(f"{path} contains forbidden package path component {forbidden_parts[0]}")
+        raise ValueError(f"npm pack path contains forbidden package path component; {PATH_FAILURE_GUARDS}")
 
     name = parts[-1].lower()
     if name in FORBIDDEN_NAMES or name.startswith(".env."):
-        raise ValueError(f"{path} contains forbidden package file name")
+        raise ValueError(f"npm pack path contains forbidden package file name; {PATH_FAILURE_GUARDS}")
     if name.endswith(FORBIDDEN_SUFFIXES):
-        raise ValueError(f"{path} contains forbidden package file suffix")
+        raise ValueError(f"npm pack path contains forbidden package file suffix; {PATH_FAILURE_GUARDS}")
 
 
 def run_npm_pack(npm: str, package_dir: Path) -> dict[str, Any]:
@@ -240,7 +241,7 @@ def validate_manifest_string_set(
         if missing:
             details.append("missing " + ", ".join(missing))
         if extra:
-            details.append("unexpected " + ", ".join(extra))
+            details.append(f"unexpected {len(extra)} entries; {PATH_FAILURE_GUARDS}")
         raise ValueError(f"{context} {field} changed: {'; '.join(details)}")
 
 
@@ -332,7 +333,12 @@ def validate_package(repo: Path, npm: str, rule: PackageRule) -> int:
             raise ValueError(f"{rule.name} npm pack reported a non-object file entry")
         path = normalize_pack_path(entry.get("path"))
         reject_forbidden_path(path)
-        validate_size("file size", entry.get("size"), MAX_ENTRY_BYTES, f"{rule.name}:{path}")
+        validate_size(
+            "file size",
+            entry.get("size"),
+            MAX_ENTRY_BYTES,
+            f"{rule.name}:npm pack file; {PATH_FAILURE_GUARDS}",
+        )
         actual_files.add(path)
 
     if len(actual_files) != len(files):
@@ -348,7 +354,7 @@ def validate_package(repo: Path, npm: str, rule: PackageRule) -> int:
         if missing:
             details.append("missing " + ", ".join(missing))
         if extra:
-            details.append("unexpected " + ", ".join(extra))
+            details.append(f"unexpected {len(extra)} file(s); {PATH_FAILURE_GUARDS}")
         raise ValueError(f"{rule.name} npm package contents changed: {'; '.join(details)}")
 
     print(f"{rule.name} package contents verified: {len(actual_files)} files")


### PR DESCRIPTION
## **User description**
## Summary
- Stop echoing malformed, forbidden, oversized, or unexpected npm pack paths in verifier failures.
- Add path display guards to package file and package.json files-list diagnostics.
- Add regression coverage for token-looking path values in npm pack and package metadata failures.

## Validation
- python scripts\\verify-npm-package-contents-regression.py
- python scripts\\verify-npm-package-contents.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- python scripts\\check-npm-publish-preflight-regression.py
- git diff --check

Fixes #1085

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the npm package verifier to avoid leaking sensitive path values in error messages, preventing secrets from appearing in CI logs. Fixes #1085.

- **Bug Fixes**
  - Hide raw `npm pack` paths in errors (backslashes, absolute, malformed, forbidden); add guards: `pathDisplayed=false contentsDisplayed=false tokenDisplayed=false`.
  - Guard manifest/package diffs: report counts for unexpected entries, not values.
  - Sanitize file size error context to exclude paths.
  - Add regression tests that fail on any sensitive path echo in `npm pack` output or `package.json` `files` list.

<sup>Written for commit 406142e7c8e939cc517f4850b16733e3fbd7c199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide sensitive npm pack paths from verifier errors**

### What Changed
- Error messages for invalid npm pack paths no longer echo the path value when it is malformed, forbidden, or too large
- Package content checks now report only counts and privacy-safe markers when files are unexpected or changed
- Added regression coverage for path-related failures in npm pack output and package metadata checks

### Impact
`✅ Fewer leaked path values in publish checks`
`✅ Safer npm package verification failures`
`✅ Clearer privacy-safe error messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced regression test suite with additional validation checks for package contents
* **Chores**
  * Improved validation error messaging and consistency in npm package verification scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->