### PR TITLE
Guard workflow command diagnostics

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -895,6 +895,8 @@ def assert_safe_report(report) -> dict[str, object]:
         "tokenHashDisplayed",
         "keyMaterialDisplayed",
         "contentsDisplayed",
+        "workflowCommandDisplayed",
+        "secretValuesDisplayed",
     ):
         if parsed.get(field) is not False:
             raise AssertionError(f"expected {field}=false")
@@ -1101,6 +1103,28 @@ def run_forbidden_workflow_command_tests(module) -> None:
         raise AssertionError("direct NPM marker workflow write was not reported")
     if not marker_write_parsed["forbiddenWorkflowCommands"]:
         raise AssertionError("direct marker write finding was not listed")
+
+    sensitive_marker_write_report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "      - name: Validate NPM token rotation marker\n",
+            "      - name: Unsafe direct NPM marker variable write with secret value\n"
+            "        run: gh variable set CONU_NPM_TOKEN_ROTATED_AFTER "
+            f"--body {SENSITIVE_SENTINEL}\n"
+            "      - name: Validate NPM token rotation marker\n",
+        ),
+    )
+    if sensitive_marker_write_report.ready:
+        raise AssertionError(
+            "direct NPM marker workflow write with secret value should fail"
+        )
+    sensitive_marker_write_parsed = assert_safe_report(sensitive_marker_write_report)
+    sensitive_marker_write_rendered = json.dumps(sensitive_marker_write_parsed)
+    if module.WORKFLOW_COMMAND_DIAGNOSTIC_GUARD not in sensitive_marker_write_rendered:
+        raise AssertionError("forbidden workflow command guard was not reported")
+    if not sensitive_marker_write_parsed["forbiddenWorkflowCommands"]:
+        raise AssertionError("direct marker write secret-value finding was not listed")
 
     dynamic_variable_write_report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -305,6 +305,10 @@ FORBIDDEN_WORKFLOW_BLOCK_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] 
         "scripted GitHub Actions secret workflow write",
     ),
 )
+WORKFLOW_COMMAND_DIAGNOSTIC_GUARD = (
+    "workflowCommandDisplayed=false contentsDisplayed=false "
+    "tokenDisplayed=false secretValuesDisplayed=false"
+)
 ALLOWED_PERMISSION_KEYS = (
     "actions",
     "attestations",
@@ -2004,6 +2008,8 @@ class WorkflowPermissionsReadiness:
             "tokenHashDisplayed": False,
             "keyMaterialDisplayed": False,
             "contentsDisplayed": False,
+            "workflowCommandDisplayed": False,
+            "secretValuesDisplayed": False,
         }
 
 
@@ -2355,6 +2361,15 @@ def audit_checkout_credential_persistence(path: Path) -> tuple[str, ...]:
     return tuple(issues)
 
 
+def format_forbidden_workflow_command_issue(
+    path: Path, location: str, description: str, command_signature: str
+) -> str:
+    return (
+        f"{path.name}{location} must not use {description}: {command_signature}; "
+        f"{WORKFLOW_COMMAND_DIAGNOSTIC_GUARD}"
+    )
+
+
 def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
     try:
         text = path.read_text(encoding="utf-8")
@@ -2367,17 +2382,15 @@ def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
     for line_number, line in enumerate(text.splitlines(), start=1):
         for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
             if fragment in line:
-                issue = (
-                    f"{path.name}:line {line_number} must not use {description}: "
-                    f"{fragment}"
+                issue = format_forbidden_workflow_command_issue(
+                    path, f":line {line_number}", description, fragment
                 )
                 seen_fragments.add(fragment)
                 issues.append(issue)
         for command, pattern, description in FORBIDDEN_WORKFLOW_COMMAND_PATTERNS:
             if pattern.search(line):
-                issue = (
-                    f"{path.name}:line {line_number} must not use {description}: "
-                    f"{command}"
+                issue = format_forbidden_workflow_command_issue(
+                    path, f":line {line_number}", description, command
                 )
                 seen_patterns.add(command)
                 issues.append(issue)
@@ -2385,35 +2398,51 @@ def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
     for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
         if fragment in seen_fragments or fragment not in continuation_normalized:
             continue
-        issues.append(f"{path.name} must not use {description}: {fragment}")
+        issues.append(
+            format_forbidden_workflow_command_issue(path, "", description, fragment)
+        )
     for command, pattern, description in FORBIDDEN_WORKFLOW_COMMAND_PATTERNS:
         if command in seen_patterns or not pattern.search(continuation_normalized):
             continue
-        issues.append(f"{path.name} must not use {description}: {command}")
+        issues.append(
+            format_forbidden_workflow_command_issue(path, "", description, command)
+        )
     for line_number, block in extract_folded_run_blocks(text):
         for fragment, description in FORBIDDEN_WORKFLOW_COMMAND_FRAGMENTS:
             if fragment in seen_fragments or fragment not in block:
                 continue
             seen_fragments.add(fragment)
             issues.append(
-                f"{path.name}:folded run block at line {line_number} must not use "
-                f"{description}: {fragment}"
+                format_forbidden_workflow_command_issue(
+                    path,
+                    f":folded run block at line {line_number}",
+                    description,
+                    fragment,
+                )
             )
         for command, pattern, description in FORBIDDEN_WORKFLOW_COMMAND_PATTERNS:
             if command in seen_patterns or not pattern.search(block):
                 continue
             seen_patterns.add(command)
             issues.append(
-                f"{path.name}:folded run block at line {line_number} must not use "
-                f"{description}: {command}"
+                format_forbidden_workflow_command_issue(
+                    path,
+                    f":folded run block at line {line_number}",
+                    description,
+                    command,
+                )
             )
         for command, pattern, description in FORBIDDEN_WORKFLOW_BLOCK_PATTERNS:
             if command in seen_patterns or not pattern.search(block):
                 continue
             seen_patterns.add(command)
             issues.append(
-                f"{path.name}:folded run block at line {line_number} must not use "
-                f"{description}: {command}"
+                format_forbidden_workflow_command_issue(
+                    path,
+                    f":folded run block at line {line_number}",
+                    description,
+                    command,
+                )
             )
     for line_number, block in extract_literal_run_blocks(text):
         for command, pattern, description in FORBIDDEN_WORKFLOW_BLOCK_PATTERNS:
@@ -2421,8 +2450,12 @@ def audit_forbidden_workflow_commands(path: Path) -> tuple[str, ...]:
                 continue
             seen_patterns.add(command)
             issues.append(
-                f"{path.name}:literal run block at line {line_number} must not use "
-                f"{description}: {command}"
+                format_forbidden_workflow_command_issue(
+                    path,
+                    f":literal run block at line {line_number}",
+                    description,
+                    command,
+                )
             )
     return tuple(issues)
 


### PR DESCRIPTION
## **User description**
## Summary
- Adds explicit non-display guard markers to forbidden workflow-command diagnostics.
- Adds JSON safety flags for raw workflow command and secret value display state.
- Adds a regression that injects a secret-looking command argument and verifies the report does not expose it.

Closes #1087.

## Validation
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened forbidden workflow-command diagnostics to prevent secret exposure in logs and reports. Adds explicit non-display guards and safety flags, plus a regression test to verify nothing sensitive is rendered.

- **Bug Fixes**
  - Append `WORKFLOW_COMMAND_DIAGNOSTIC_GUARD` to all forbidden workflow-command findings so logs state `workflowCommandDisplayed=false contentsDisplayed=false tokenDisplayed=false secretValuesDisplayed=false`.
  - Extend JSON report with `workflowCommandDisplayed` and `secretValuesDisplayed` flags, both defaulting to false.
  - Add regression that injects a secret-looking value into a forbidden command and verifies the report hides it and includes the guard.

- **Refactors**
  - Centralize issue formatting in `format_forbidden_workflow_command_issue(...)` to apply guards consistently across line, folded, and literal run blocks.

<sup>Written for commit aca581505471c4a8501cd398befe3aa6dba893e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide sensitive details in forbidden workflow-command reports**

### What Changed
- Forbidden workflow-command findings now include a fixed guard message instead of exposing command contents or secret-like values.
- The JSON report now marks workflow-command and secret-value display as disabled.
- A regression check now covers a forbidden command that includes a secret-looking value and verifies the report still hides it.

### Impact
`✅ Fewer secret leaks in workflow permission reports`
`✅ Safer CI logs for blocked workflow commands`
`✅ Clearer security findings without exposing command contents`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
