### PR TITLE
Guard workflow permission diagnostics

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -897,6 +897,8 @@ def assert_safe_report(report) -> dict[str, object]:
         "contentsDisplayed",
         "workflowCommandDisplayed",
         "secretValuesDisplayed",
+        "unexpectedPermissionKeyDisplayed",
+        "rawPermissionValueDisplayed",
     ):
         if parsed.get(field) is not False:
             raise AssertionError(f"expected {field}=false")
@@ -2283,8 +2285,52 @@ def run_expected_job_permission_tests(module) -> None:
     )
     if report.ready:
         raise AssertionError("extra release job permission should fail")
-    if "release.yml:github-release has extra permission actions=read" not in json.dumps(assert_safe_report(report)):
+    if "release.yml:github-release has extra permission actions;" not in json.dumps(
+        assert_safe_report(report)
+    ):
         raise AssertionError("extra expected permission issue was not reported")
+
+    sensitive_value_report = with_fixture(
+        module,
+        None,
+        replace_job_text(
+            ready_release(),
+            "github-release",
+            "      contents: write\n",
+            f"      contents: {SENSITIVE_SENTINEL}\n",
+        ),
+    )
+    if sensitive_value_report.ready:
+        raise AssertionError("sensitive permission value should fail")
+    sensitive_value_rendered = json.dumps(assert_safe_report(sensitive_value_report))
+    if (
+        "release.yml:github-release uses unexpected permission value for contents;"
+        not in sensitive_value_rendered
+    ):
+        raise AssertionError("sensitive permission value issue was not reported")
+    if module.PERMISSION_DIAGNOSTIC_GUARD not in sensitive_value_rendered:
+        raise AssertionError("permission diagnostic guard was not reported")
+
+    sensitive_key_report = with_fixture(
+        module,
+        None,
+        replace_job_text(
+            ready_release(),
+            "github-release",
+            "      contents: write\n",
+            f"      contents: write\n      {SENSITIVE_SENTINEL}: read\n",
+        ),
+    )
+    if sensitive_key_report.ready:
+        raise AssertionError("sensitive permission key should fail")
+    sensitive_key_rendered = json.dumps(assert_safe_report(sensitive_key_report))
+    if (
+        "release.yml:github-release uses unexpected permission key;"
+        not in sensitive_key_rendered
+    ):
+        raise AssertionError("sensitive permission key issue was not reported")
+    if module.PERMISSION_DIAGNOSTIC_GUARD not in sensitive_key_rendered:
+        raise AssertionError("permission diagnostic guard was not reported")
 
 
 def run_required_release_preflight_tests(module) -> None:

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -309,6 +309,10 @@ WORKFLOW_COMMAND_DIAGNOSTIC_GUARD = (
     "workflowCommandDisplayed=false contentsDisplayed=false "
     "tokenDisplayed=false secretValuesDisplayed=false"
 )
+PERMISSION_DIAGNOSTIC_GUARD = (
+    "unexpectedPermissionKeyDisplayed=false rawPermissionValueDisplayed=false "
+    "contentsDisplayed=false tokenDisplayed=false secretValuesDisplayed=false"
+)
 ALLOWED_PERMISSION_KEYS = (
     "actions",
     "attestations",
@@ -317,6 +321,7 @@ ALLOWED_PERMISSION_KEYS = (
     "pages",
     "security-events",
 )
+ALLOWED_PERMISSION_VALUES = {"read", "write", "none"}
 TOP_LEVEL_PERMISSIONS = {
     "contents": "read",
 }
@@ -2010,6 +2015,8 @@ class WorkflowPermissionsReadiness:
             "contentsDisplayed": False,
             "workflowCommandDisplayed": False,
             "secretValuesDisplayed": False,
+            "unexpectedPermissionKeyDisplayed": False,
+            "rawPermissionValueDisplayed": False,
         }
 
 
@@ -2889,6 +2896,24 @@ def mapping_contains_write(permissions: dict[str, str]) -> bool:
     return any(value == "write" for value in permissions.values())
 
 
+def format_permission_diagnostic_suffix() -> str:
+    return f"; {PERMISSION_DIAGNOSTIC_GUARD}"
+
+
+def describe_permission_key(key: str) -> str:
+    if key in ALLOWED_PERMISSION_KEYS:
+        return key
+    return "unrecognized key"
+
+
+def describe_actual_permission_value(value: str | None) -> str:
+    if value is None:
+        return "unset"
+    if value in ALLOWED_PERMISSION_VALUES:
+        return "nonmatching value"
+    return "invalid value"
+
+
 def audit_mapping(
     *,
     permissions: dict[str, str],
@@ -2897,23 +2922,33 @@ def audit_mapping(
     allow_write: bool,
 ) -> list[str]:
     issues: list[str] = []
-    allowed_values = {"read", "write", "none"}
     for key, value in permissions.items():
         if key not in ALLOWED_PERMISSION_KEYS:
-            issues.append(f"{scope} uses unexpected permission key: {key}")
-        if value not in allowed_values:
-            issues.append(f"{scope} uses unexpected permission value for {key}: {value}")
+            issues.append(
+                f"{scope} uses unexpected permission key"
+                f"{format_permission_diagnostic_suffix()}"
+            )
+        if value not in ALLOWED_PERMISSION_VALUES:
+            issues.append(
+                f"{scope} uses unexpected permission value for "
+                f"{describe_permission_key(key)}{format_permission_diagnostic_suffix()}"
+            )
         if value == "write" and not allow_write:
             issues.append(f"{scope} must not request write permission for {key}")
     for key, expected_value in expected.items():
         actual_value = permissions.get(key)
         if actual_value != expected_value:
             issues.append(
-                f"{scope} must set {key}={expected_value}; found {actual_value or 'unset'}"
+                f"{scope} must set {key}={expected_value}; found "
+                f"{describe_actual_permission_value(actual_value)}"
+                f"{format_permission_diagnostic_suffix()}"
             )
     for key, value in permissions.items():
         if key not in expected:
-            issues.append(f"{scope} has extra permission {key}={value}")
+            issues.append(
+                f"{scope} has extra permission {describe_permission_key(key)}"
+                f"{format_permission_diagnostic_suffix()}"
+            )
     return issues
 
 


### PR DESCRIPTION
## **User description**
## Summary
- Stops workflow permission diagnostics from echoing raw unexpected permission keys or raw invalid values.
- Adds explicit report flags for unexpected permission key and raw permission value display state.
- Adds sentinel regressions for sensitive permission key/value inputs.

Closes #1089.

## Validation
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened workflow permission diagnostics to avoid leaking raw permission keys and values. Adds guard flags and regression tests to keep outputs private and predictable.

- **Bug Fixes**
  - Suppress raw unexpected keys/values in messages; use neutral descriptors and append a guarded suffix (`PERMISSION_DIAGNOSTIC_GUARD`).
  - Add `unexpectedPermissionKeyDisplayed` and `rawPermissionValueDisplayed` fields to reports (default false).
  - Add sentinel regression tests to block sensitive key/value exposure in outputs.

<sup>Written for commit fb8eb8a97d0fa83c3c5ff96375da79203634bdf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide raw permission keys and values in workflow permission warnings**

### What Changed
- Workflow permission warnings now avoid printing the exact permission key or value when something is unexpected or missing.
- These warnings use neutral wording and add a guard marker so sensitive details are not exposed in the output.
- Regression coverage now checks that sensitive permission keys and values stay hidden in reports.

### Impact
`✅ Safer workflow permission diagnostics`
`✅ Fewer leaked secret-like values in reports`
`✅ Clearer privacy checks for permission validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
