### PR TITLE
Guard workflow write permission diagnostics

### DIFF
--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -2160,6 +2160,28 @@ def run_unexpected_job_write_tests(module) -> None:
     if "ci.yml:packages must not request write permission for contents" not in rendered:
         raise AssertionError("unexpected write issue was not reported")
 
+    sensitive_key_report = with_fixture(
+        module,
+        ready_ci().replace(
+            "    runs-on: ubuntu-latest\n",
+            "    permissions:\n"
+            f"      {SENSITIVE_SENTINEL}: write\n"
+            "    runs-on: ubuntu-latest\n",
+            1,
+        ),
+        None,
+    )
+    if sensitive_key_report.ready:
+        raise AssertionError("sensitive write permission key should fail")
+    sensitive_key_rendered = json.dumps(assert_safe_report(sensitive_key_report))
+    if (
+        "ci.yml:packages must not request write permission for unrecognized key;"
+        not in sensitive_key_rendered
+    ):
+        raise AssertionError("sensitive write permission key issue was not reported")
+    if module.PERMISSION_DIAGNOSTIC_GUARD not in sensitive_key_rendered:
+        raise AssertionError("permission diagnostic guard was not reported")
+
 
 def run_required_ci_package_checks_job_tests(module) -> None:
     report = with_fixture(

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -2934,7 +2934,10 @@ def audit_mapping(
                 f"{describe_permission_key(key)}{format_permission_diagnostic_suffix()}"
             )
         if value == "write" and not allow_write:
-            issues.append(f"{scope} must not request write permission for {key}")
+            issues.append(
+                f"{scope} must not request write permission for "
+                f"{describe_permission_key(key)}{format_permission_diagnostic_suffix()}"
+            )
     for key, expected_value in expected.items():
         actual_value = permissions.get(key)
         if actual_value != expected_value:


### PR DESCRIPTION
## **User description**
## Summary
- Stops workflow write-permission diagnostics from echoing raw unknown permission keys.
- Reuses the existing safe permission key descriptor and diagnostic guard markers.
- Adds a sentinel regression for an unknown permission key with write access.

Closes #1091.

## Validation
- python scripts\\check-github-workflow-permissions-regression.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-python-script-compile.py
- python scripts\\check-production-readiness-toolchain.py
- python scripts\\check-smoke-output-privacy.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents diagnostics from echoing raw, unrecognized GitHub Actions permission keys by using the safe key descriptor and guard marker. Adds a regression test to ensure write access on unknown keys is flagged without exposing the key (closes #1091).

- **Bug Fixes**
  - Update `audit_mapping` to format write-permission errors with `describe_permission_key(...)` plus the diagnostic suffix, avoiding raw keys.
  - Add regression in `scripts/check-github-workflow-permissions-regression.py` to fail on unknown write keys and assert the diagnostic guard is present.

<sup>Written for commit f628d307641837010ab5333794d5398ebd0145d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Hide unknown workflow permission keys in write-permission errors**

### What Changed
- Write-permission errors for unrecognized workflow keys now use a safe label instead of showing the raw key
- Added a regression check that confirms unknown write permissions fail and that the warning stays redacted

### Impact
`✅ Fewer leaked internal permission names`
`✅ Safer workflow permission diagnostics`
`✅ Clearer write-permission failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
