### PR TITLE
Redact access key command output

### DIFF
--- a/scripts/check-hosted-linux-repository-s3-publication.py
+++ b/scripts/check-hosted-linux-repository-s3-publication.py
@@ -661,6 +661,8 @@ def write_failing_fake_aws(temp: Path) -> str:
             [
                 "import sys",
                 f"print('NODE_AUTH_TOKEN={SENSITIVE_SENTINEL}', file=sys.stderr)",
+                f"print('AWS_ACCESS_KEY_ID={SENSITIVE_SENTINEL}', file=sys.stderr)",
+                f"print('CONU_API_KEY={SENSITIVE_SENTINEL}', file=sys.stderr)",
                 f"print('Authorization: Bearer {SENSITIVE_SENTINEL}', file=sys.stderr)",
                 f"print('https://user:{SENSITIVE_SENTINEL}@example.invalid/conu', file=sys.stderr)",
                 "print('https://s3.example.invalid/conu?"
@@ -774,7 +776,13 @@ def assert_aws_cli_wrapper_guard(publisher, fake_aws: str) -> None:
             f"env AWS_SECRET_ACCESS_KEY={SENSITIVE_SENTINEL} aws",
             "inline credentials or secrets",
         ),
+        (
+            f"env AWS_ACCESS_KEY_ID={SENSITIVE_SENTINEL} aws",
+            "inline credentials or secrets",
+        ),
         (f"aws --password {SENSITIVE_SENTINEL}", "inline credentials or secrets"),
+        (f"aws --access-key-id {SENSITIVE_SENTINEL}", "inline credentials or secrets"),
+        (f"aws --api-key={SENSITIVE_SENTINEL}", "inline credentials or secrets"),
         (
             f"aws https://user:{SENSITIVE_SENTINEL}@example.invalid",
             "inline credentials or secrets",

--- a/scripts/check-smoke-output-privacy.py
+++ b/scripts/check-smoke-output-privacy.py
@@ -100,8 +100,12 @@ def check_command_output_redaction(issues: list[str]) -> None:
         f"tool --token {sentinel}",
         f"tool --password='{sentinel} with spaces'",
         f"tool --security-token \"{sentinel} with spaces\"",
+        f"tool --access-key-id {sentinel}",
+        f"tool --api-key={sentinel}",
         f"tool -auth {sentinel}",
         f"tool --target conu --secret {sentinel} --mode dry-run",
+        f"AWS_ACCESS_KEY_ID={sentinel}",
+        f"CONU_API_KEY:{sentinel}",
     )
     for value in cases:
         redacted = redact_command_output(value)

--- a/scripts/command_output_redaction.py
+++ b/scripts/command_output_redaction.py
@@ -6,17 +6,20 @@ import re
 
 
 REDACTED = "[redacted]"
+SECRET_NAME_PATTERN = (
+    r"TOKEN|SECRET|PASSWORD|PASSWD|AUTH|"
+    r"PRIVATE[_-]?KEY|ACCESS[_-]?KEY|SECRET[_-]?KEY|API[_-]?KEY|"
+    r"SECURITY[_-]?TOKEN|SESSION[_-]?TOKEN"
+)
 SECRET_ASSIGNMENT_RE = re.compile(
-    r"\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH)"
-    r"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
+    rf"\b([A-Z0-9_.-]*(?:{SECRET_NAME_PATTERN})"
+    rf"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
     re.IGNORECASE,
 )
 AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
 SECRET_FLAG_RE = re.compile(
-    r"(?<!\w)(-{1,2}[A-Z0-9_.-]*(?:"
-    r"TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY|AUTH|"
-    r"ACCESS[_-]?KEY|SECRET[_-]?KEY|SECURITY[_-]?TOKEN|SESSION[_-]?TOKEN"
-    r")[A-Z0-9_.-]*)(\s*=\s*|\s+)"
+    rf"(?<!\w)(-{{1,2}}[A-Z0-9_.-]*(?:{SECRET_NAME_PATTERN})"
+    r"[A-Z0-9_.-]*)(\s*=\s*|\s+)"
     r"(\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s;&|]+)",
     re.IGNORECASE,
 )

--- a/scripts/publish-hosted-linux-repository-s3.py
+++ b/scripts/publish-hosted-linux-repository-s3.py
@@ -67,7 +67,11 @@ AWS_CLI_RESERVED_OPTIONS = {
     "--region",
 }
 AWS_CLI_SECRET_ARGUMENT_RE = re.compile(
-    r"(token|secret|password|passwd|private[_-]?key|auth)",
+    r"("
+    r"token|secret|password|passwd|auth|private[_-]?key|"
+    r"access[_-]?key|secret[_-]?key|api[_-]?key|"
+    r"security[_-]?token|session[_-]?token"
+    r")",
     re.IGNORECASE,
 )
 OPEN_BINARY = getattr(os, "O_BINARY", 0)


### PR DESCRIPTION
## **User description**
Closes #1093.\n\nChanges:\n- Redact access-key/API-key names in shared subprocess output redaction.\n- Reject custom AWS CLI wrapper arguments that pass access-key/API-key values inline.\n- Add fast smoke privacy coverage plus S3 publication regression cases.\n\nLocal validation:\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- AWS CLI wrapper guard probe\n- git diff --check\n\nNote: python scripts\\check-hosted-linux-repository-s3-publication.py timed out locally twice on Windows before focused checks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts access and API keys in command output and blocks inline credentials in the AWS CLI wrapper to prevent secret leaks. Adds smoke tests and S3 publication checks to verify privacy and guard behavior.

- **Bug Fixes**
  - Expanded redaction to catch `ACCESS_KEY`, `SECRET_KEY`, `API_KEY`, and session/security tokens in assignments, flags, and auth headers.
  - Strengthened AWS publisher guard to reject inline secret arguments and env vars (e.g., `--access-key-id`, `--api-key`, `AWS_ACCESS_KEY_ID`).
  - Added privacy smoke tests and S3 regression cases covering `AWS_ACCESS_KEY_ID` and `CONU_API_KEY`.

<sup>Written for commit 2cdf42f74ba5bda3637aa7f73088609b87799fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact access keys from command output and block them in AWS publish commands**

### What Changed
- Command output redaction now hides access key, API key, session token, and security token values when they appear in assignments, flags, or auth headers.
- The AWS publish command now rejects inline access key and API key values, including values passed through environment-style input.
- Privacy checks and S3 publish regression coverage now include access key and API key leak cases.

### Impact
`✅ Fewer secret leaks in command errors`
`✅ Safer AWS publish command usage`
`✅ Clearer privacy regression coverage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced secret detection and redaction to protect additional credential types including access keys, API keys, and security tokens in command output and environment variables.

* **Tests**
  * Expanded test coverage for secret redaction validation across additional credential formats and flag variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->