### PR TITLE
Redact quoted secret assignments

### DIFF
--- a/scripts/check-smoke-output-privacy.py
+++ b/scripts/check-smoke-output-privacy.py
@@ -106,11 +106,17 @@ def check_command_output_redaction(issues: list[str]) -> None:
         f"tool --target conu --secret {sentinel} --mode dry-run",
         f"AWS_ACCESS_KEY_ID={sentinel}",
         f"CONU_API_KEY:{sentinel}",
+        f"AWS_SESSION_TOKEN='{sentinel} with spaces'",
+        f'CONU_SIGNING_PASSWORD="{sentinel} with spaces"',
     )
     for value in cases:
         redacted = redact_command_output(value)
         if sentinel in redacted:
             issues.append(f"command output redaction leaked secret flag value from {value!r}")
+        if "with spaces" in redacted:
+            issues.append(
+                f"command output redaction leaked quoted secret suffix from {value!r}"
+            )
         if "[redacted]" not in redacted:
             issues.append(f"command output redaction did not mark secret flag value from {value!r}")
 

--- a/scripts/command_output_redaction.py
+++ b/scripts/command_output_redaction.py
@@ -11,16 +11,17 @@ SECRET_NAME_PATTERN = (
     r"PRIVATE[_-]?KEY|ACCESS[_-]?KEY|SECRET[_-]?KEY|API[_-]?KEY|"
     r"SECURITY[_-]?TOKEN|SESSION[_-]?TOKEN"
 )
+SECRET_VALUE_PATTERN = r"(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s;&|]+)"
 SECRET_ASSIGNMENT_RE = re.compile(
     rf"\b([A-Z0-9_.-]*(?:{SECRET_NAME_PATTERN})"
-    rf"[A-Z0-9_.-]*)\s*([=:])\s*([^\s;&|]+)",
+    rf"[A-Z0-9_.-]*)\s*([=:])\s*{SECRET_VALUE_PATTERN}",
     re.IGNORECASE,
 )
 AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
 SECRET_FLAG_RE = re.compile(
     rf"(?<!\w)(-{{1,2}}[A-Z0-9_.-]*(?:{SECRET_NAME_PATTERN})"
     r"[A-Z0-9_.-]*)(\s*=\s*|\s+)"
-    r"(\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s;&|]+)",
+    rf"{SECRET_VALUE_PATTERN}",
     re.IGNORECASE,
 )
 NPM_TOKEN_RE = re.compile(r"\bnpm_[A-Za-z0-9]{10,}\b")


### PR DESCRIPTION
## **User description**
Closes #1095.\n\nChanges:\n- Redact full quoted secret assignment values, including values with spaces.\n- Reuse the same secret value pattern for assignment and flag redaction.\n- Add smoke privacy regression cases for quoted AWS session token and signing password assignment output.\n\nLocal validation:\n- direct redaction probe for quoted assignments and safe display guards\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- git diff --check\n\nSecurity review:\n- payload exposure risk: lowers risk by redacting full quoted secret values.\n- trust/permission risk: no trust or permission behavior changed.\n- storage/logging risk: lowers subprocess failure-output leakage risk.\n- relay/network risk: no relay or network behavior changed.\n- required fixes: wait for CI before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts entire quoted secret values in command output, including values with spaces, for both env var assignments and secret flags. This closes a gap where quoted assignments could leak suffixes and reduces log leakage risk.

- **Bug Fixes**
  - Use one value pattern for assignments and flags to handle quoted values and spaces.
  - Add smoke privacy checks for quoted `AWS_SESSION_TOKEN` and `CONU_SIGNING_PASSWORD` to ensure full redaction.

<sup>Written for commit cdc59f8f8204627f40fe1da5e4eff249118461a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Redact quoted secret values in command output

### What Changed
- Secret values in command output are now fully hidden even when they are wrapped in quotes or include spaces
- Secret assignments and secret flags use the same redaction behavior, so quoted values are treated consistently
- Privacy checks now cover quoted session tokens and signing passwords to catch leaks of secret suffixes

### Impact
`✅ Fewer secret leaks in logs`
`✅ Safer handling of quoted credentials`
`✅ Clearer privacy checks for command output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
