### PR TITLE
Redact toolchain regression output

### DIFF
--- a/scripts/check-production-readiness-toolchain.py
+++ b/scripts/check-production-readiness-toolchain.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from command_output_redaction import redact_command_output
+
 
 HELPER = Path(__file__).with_name("production-readiness-toolchain.ps1")
 
@@ -34,13 +36,35 @@ def run_powershell(script: str) -> None:
         stderr=subprocess.PIPE,
     )
     if completed.returncode != 0:
-        raise AssertionError(
-            "production-readiness toolchain regression failed: "
-            f"exit={completed.returncode}\nstdout={completed.stdout}\nstderr={completed.stderr}"
-        )
+        raise AssertionError(format_powershell_failure(completed))
+
+
+def format_powershell_failure(completed: subprocess.CompletedProcess) -> str:
+    stdout = redact_command_output(completed.stdout)
+    stderr = redact_command_output(completed.stderr)
+    return (
+        "production-readiness toolchain regression failed: "
+        f"exit={completed.returncode}\nstdout={stdout}\nstderr={stderr}"
+    )
+
+
+def assert_failure_output_redacts() -> None:
+    sentinel = "do-not-print-this-secret-value"
+    completed = subprocess.CompletedProcess(
+        args=["powershell"],
+        returncode=1,
+        stdout=f"NPM_TOKEN={sentinel}\n",
+        stderr=f"AWS_SESSION_TOKEN='{sentinel} with spaces'\n",
+    )
+    message = format_powershell_failure(completed)
+    if sentinel in message or "with spaces" in message:
+        raise AssertionError("toolchain failure formatter leaked a secret value")
+    if message.count("[redacted]") < 2:
+        raise AssertionError("toolchain failure formatter did not mark redacted output")
 
 
 def main() -> int:
+    assert_failure_output_redacts()
     helper = str(HELPER.resolve()).replace("'", "''")
     script = f"""
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
## **User description**
Closes #1097.\n\nChanges:\n- Redact captured PowerShell stdout/stderr before formatting production-readiness toolchain regression failures.\n- Add an assertion that token-shaped and quoted secret assignment output is redacted by the formatter.\n\nLocal validation:\n- python scripts\\check-production-readiness-toolchain.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-smoke-output-privacy.py\n- git diff --check\n\nSecurity review:\n- payload exposure risk: no payload handling changed.\n- trust/permission risk: no trust or permission behavior changed.\n- storage/logging risk: lowers CI failure-output secret exposure risk.\n- relay/network risk: no relay or network behavior changed.\n- required fixes: wait for CI before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts PowerShell stdout/stderr in the production-readiness toolchain regression script to prevent secret leakage in CI logs. Adds a guard to ensure token-shaped and quoted secrets are redacted.

- **Bug Fixes**
  - Apply `redact_command_output` to stdout/stderr in a new `format_powershell_failure`.
  - Add `assert_failure_output_redacts()` to verify `[redacted]` for `NPM_TOKEN=` and quoted `AWS_SESSION_TOKEN`.
  - No behavior changes to the toolchain; only safer failure output.

<sup>Written for commit 00143f400db55b5e57e09ab1416610a69eedeee2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Redact toolchain regression output to prevent secret leaks in CI logs**

### What Changed
- Failure output from the production-readiness toolchain regression check is now scrubbed before being shown.
- The check now verifies that token-like values and quoted secret strings are hidden in the failure message.
- A failed PowerShell run still reports the exit code and output, but sensitive values are replaced with redacted text.

### Impact
`✅ Fewer secret leaks in CI logs`
`✅ Safer toolchain failure reports`
`✅ Clearer regression output without exposing tokens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
