### PR TITLE
Redact private key command output

### DIFF
--- a/scripts/check-smoke-output-privacy.py
+++ b/scripts/check-smoke-output-privacy.py
@@ -126,6 +126,27 @@ def check_command_output_redaction(issues: list[str]) -> None:
     if redact_command_output(safe_guards) != safe_guards:
         issues.append("command output redaction changed safe display guard booleans")
 
+    private_key_blocks = (
+        (
+            "PEM private key",
+            "-----BEGIN PRIVATE KEY-----\n"
+            f"{sentinel}\n"
+            "-----END PRIVATE KEY-----",
+        ),
+        (
+            "PGP private key",
+            "-----BEGIN PGP PRIVATE KEY BLOCK-----\n"
+            f"{sentinel}\n"
+            "-----END PGP PRIVATE KEY BLOCK-----",
+        ),
+    )
+    for label, value in private_key_blocks:
+        redacted = redact_command_output(value)
+        if sentinel in redacted or "PRIVATE KEY" in redacted:
+            issues.append(f"command output redaction leaked {label}")
+        if redacted != "[redacted]":
+            issues.append(f"command output redaction did not collapse {label}")
+
     unsafe_guard_assignments = (
         f"tokenDisplayed={sentinel}",
         f"keyMaterialDisplayed={sentinel}",

--- a/scripts/command_output_redaction.py
+++ b/scripts/command_output_redaction.py
@@ -18,6 +18,12 @@ SECRET_ASSIGNMENT_RE = re.compile(
     re.IGNORECASE,
 )
 AUTH_HEADER_RE = re.compile(r"\b(Bearer|Basic)\s+([A-Za-z0-9._~+/\-=]{8,})", re.IGNORECASE)
+PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 _-]*PRIVATE KEY(?: BLOCK)?-----"
+    r".*?"
+    r"-----END [A-Z0-9 _-]*PRIVATE KEY(?: BLOCK)?-----",
+    re.IGNORECASE | re.DOTALL,
+)
 SECRET_FLAG_RE = re.compile(
     rf"(?<!\w)(-{{1,2}}[A-Z0-9_.-]*(?:{SECRET_NAME_PATTERN})"
     r"[A-Z0-9_.-]*)(\s*=\s*|\s+)"
@@ -67,6 +73,7 @@ DISPLAY_GUARD_ASSIGNMENT_RE = re.compile(
 
 def redact_command_output(value: str) -> str:
     value, protected_guards = protect_safe_boolean_guards(value)
+    value = PRIVATE_KEY_BLOCK_RE.sub(REDACTED, value)
     value = URL_CREDENTIAL_RE.sub(r"\1\2:[redacted]@", value)
     value = URL_SECRET_QUERY_RE.sub(r"\1[redacted]", value)
     value = AUTH_HEADER_RE.sub(r"\1 [redacted]", value)


### PR DESCRIPTION
## **User description**
Closes #1099.\n\nChanges:\n- Collapse multiline private-key armor blocks in shared subprocess command-output redaction.\n- Cover PEM and PGP private-key blocks in the fast smoke privacy regression.\n\nLocal validation:\n- direct redaction probe for PEM, PGP, and OpenSSH private-key blocks\n- python scripts\\check-smoke-output-privacy.py\n- python scripts\\check-python-script-compile.py\n- python scripts\\check-production-readiness-toolchain.py\n- git diff --check\n\nSecurity review:\n- payload exposure risk: no payload handling changed; lowers accidental key-material exposure in failure output.\n- trust/permission risk: no trust or permission behavior changed.\n- storage/logging risk: lowers subprocess/CI failure-output key-material exposure risk.\n- relay/network risk: no relay or network behavior changed.\n- required fixes: wait for CI before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts private-key blocks in subprocess command output to prevent accidental exposure in logs. Adds privacy checks to ensure PEM and PGP blocks are fully removed.

- **Bug Fixes**
  - Added `PRIVATE_KEY_BLOCK_RE` to collapse any "BEGIN/END … PRIVATE KEY" block to "[redacted]" in `redact_command_output`.
  - Extended `scripts/check-smoke-output-privacy.py` to verify no leakage and that PEM/PGP blocks collapse to a single "[redacted]".

<sup>Written for commit 3643b48fa31d862dc59c8c46867a3b6bed0e7b37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Redact private key blocks from command output before they reach logs

### What Changed
- Private key blocks in command output are now replaced with a single `[redacted]` marker, including PEM and PGP private key blocks
- The privacy check now verifies that these key blocks are fully removed and do not leave any private-key text behind

### Impact
`✅ Fewer secret leaks in failure logs`
`✅ Safer CI output for private keys`
`✅ Clearer redaction of PEM and PGP key material`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
