### PR TITLE
Redact extracted binary paths in npm installer

### DIFF
--- a/packaging/npm/conu-cli/lib/extract-selection.js
+++ b/packaging/npm/conu-cli/lib/extract-selection.js
@@ -43,10 +43,7 @@ function resolveExtractedBinaries(
     const unexpected = matches.get(fileName).filter((candidate) => !samePath(candidate, expectedPath));
     if (unexpected.length > 0) {
       throw new Error(
-        `archive ${archiveName} contains unexpected ${fileName} path: ${relativePath(
-          extractDir,
-          unexpected[0]
-        )}`
+        `archive ${archiveName} contains unexpected ${fileName} path; pathDisplayed=false contentsDisplayed=false`
       );
     }
 
@@ -165,10 +162,6 @@ function samePath(left, right) {
     return leftResolved.toLowerCase() === rightResolved.toLowerCase();
   }
   return leftResolved === rightResolved;
-}
-
-function relativePath(root, target) {
-  return path.relative(root, target).replace(/\\/g, "/");
 }
 
 module.exports = {

--- a/packaging/npm/conu-cli/scripts/check-extract-selection.js
+++ b/packaging/npm/conu-cli/scripts/check-extract-selection.js
@@ -59,8 +59,14 @@ function main() {
 
   withFixture((root) => {
     writeReleaseLayout(root);
-    writeFile(path.join(root, "docs", "conu"), "duplicate");
-    expectFailure(root, "unexpected conu path", "duplicate binary outside expected bin");
+    const secretPath = path.join(root, "docs", "secret-token-fragment", "conu");
+    writeFile(secretPath, "duplicate");
+    expectRedactedFailure(
+      root,
+      "unexpected conu path",
+      "docs/secret-token-fragment/conu",
+      "duplicate binary outside expected bin"
+    );
   });
 
   withFixture((root) => {


### PR DESCRIPTION
Closes #1101

## Summary
- redact unexpected extracted binary paths from npm installer selection failures
- add a regression that uses a secret-looking duplicate binary path and requires path/content display guards

## Validation
- node packaging/npm/conu-cli/scripts/check-extract-selection.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts unexpected extracted binary paths in the `conu-cli` npm installer so errors don’t leak filesystem paths or contents. Adds a regression test with a secret-looking duplicate binary to verify redaction.

- Bug Fixes
  - Replace detailed path in selection failure with a constant message: "pathDisplayed=false contentsDisplayed=false".
  - Update extraction check to expect redacted failures for duplicate binaries.

<sup>Written for commit f2f0ea15e45f10809509496e55b8b5ac4a792887. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by redacting file paths from error messages when unexpected binaries are encountered.

* **Tests**
  * Updated test fixture to validate redacted error message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->