### PR TITLE
Redact npm download URL paths

### DIFF
--- a/packaging/npm/conu-cli/lib/download-policy.js
+++ b/packaging/npm/conu-cli/lib/download-policy.js
@@ -113,7 +113,7 @@ function validateResolvedDownloadAddress(rawUrl, address) {
 function formatDownloadUrlForError(rawUrl) {
   try {
     const parsed = new URL(rawUrl);
-    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+    return `${parsed.protocol}//${parsed.host}/[path redacted]; urlPathDisplayed=false queryDisplayed=false fragmentDisplayed=false`;
   } catch (_error) {
     return "<invalid download URL>";
   }

--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -145,7 +145,7 @@ async function expectArchiveLimitFailure() {
   }, async (baseUrl) => {
     const result = await runInstall({
       CONU_NPM_ALLOW_UNVERIFIED: "1",
-      CONU_NPM_DIST_BASE: `${baseUrl}/release?token=secret`,
+      CONU_NPM_DIST_BASE: `${baseUrl}/secret-download-path?token=secret`,
       CONU_NPM_MAX_ARCHIVE_BYTES: "8"
     });
     expectFailedWith(result, "archive download exceeded maximum size");
@@ -156,7 +156,7 @@ async function expectArchiveLimitFailure() {
 async function expectUnverifiedPublicBaseFailure() {
   const result = await runInstall({
     CONU_NPM_ALLOW_UNVERIFIED: "1",
-    CONU_NPM_DIST_BASE: "https://example.com/conu?token=secret"
+    CONU_NPM_DIST_BASE: "https://example.com/secret-download-path?token=secret"
   });
   expectFailedWith(result, "only allowed for loopback testing downloads");
   expectNoSecretDisplay(result);
@@ -169,7 +169,7 @@ async function expectLoopbackRedirectToPublicFailure() {
   }, async (baseUrl) => {
     const result = await runInstall({
       CONU_NPM_ALLOW_UNVERIFIED: "1",
-      CONU_NPM_DIST_BASE: `${baseUrl}/release?token=secret`,
+      CONU_NPM_DIST_BASE: `${baseUrl}/secret-download-path?token=secret`,
       CONU_NPM_MAX_ARCHIVE_BYTES: "1024"
     });
     expectFailedWith(result, "download redirect must not cross public and loopback boundaries");
@@ -188,7 +188,7 @@ async function expectChecksumLimitFailure() {
     response.end("tiny");
   }, async (baseUrl) => {
     const result = await runInstall({
-      CONU_NPM_DIST_BASE: `${baseUrl}/release?token=secret`,
+      CONU_NPM_DIST_BASE: `${baseUrl}/secret-download-path?token=secret`,
       CONU_NPM_MAX_ARCHIVE_BYTES: "1024",
       CONU_NPM_MAX_CHECKSUM_BYTES: "8"
     });
@@ -210,7 +210,7 @@ async function expectChecksumArchiveNameFailure() {
     response.end(body);
   }, async (baseUrl) => {
     const result = await runInstall({
-      CONU_NPM_DIST_BASE: `${baseUrl}/release?token=secret`,
+      CONU_NPM_DIST_BASE: `${baseUrl}/secret-download-path?token=secret`,
       CONU_NPM_MAX_ARCHIVE_BYTES: "1024"
     });
     expectFailedWith(result, "names wrong archive");
@@ -244,7 +244,7 @@ async function expectTimeoutFailure() {
   await withServer((_request, _response) => {}, async (baseUrl) => {
     const result = await runInstall({
       CONU_NPM_ALLOW_UNVERIFIED: "1",
-      CONU_NPM_DIST_BASE: `${baseUrl}/release?token=secret`,
+      CONU_NPM_DIST_BASE: `${baseUrl}/secret-download-path?token=secret`,
       CONU_NPM_DOWNLOAD_TIMEOUT_MS: "100",
       CONU_NPM_MAX_ARCHIVE_BYTES: "1024"
     });
@@ -314,6 +314,9 @@ function expectNoSecretDisplay(result) {
   const output = `${result.stdout || ""}${result.stderr || ""}`;
   if (output.includes("token=secret")) {
     throw new Error(`installer output displayed URL query material: ${output}`);
+  }
+  if (output.includes("secret-download-path")) {
+    throw new Error(`installer output displayed URL path material: ${output}`);
   }
 }
 

--- a/packaging/npm/conu-cli/scripts/check-download-policy.js
+++ b/packaging/npm/conu-cli/scripts/check-download-policy.js
@@ -83,7 +83,11 @@ function main() {
     "https://user:pass@example.com/conu.zip",
     "embedded credentials"
   );
-  expectDisplayUrl("https://example.com/conu.zip?token=secret#fragment", "https://example.com/conu.zip");
+  expectDisplayUrl(
+    "https://example.com/secret-token-path/conu.zip?token=secret#secret-fragment",
+    "https://example.com/[path redacted]; urlPathDisplayed=false queryDisplayed=false fragmentDisplayed=false",
+    ["secret-token-path", "conu.zip", "token=secret", "secret-fragment"]
+  );
   console.log("download URL policy check passed");
 }
 
@@ -204,10 +208,15 @@ function expectRedirectFail(fromUrl, toUrl, expectedMessage) {
   throw new Error(`expected download redirect policy failure: ${expectedMessage}`);
 }
 
-function expectDisplayUrl(url, expected) {
+function expectDisplayUrl(url, expected, forbiddenValues = []) {
   const actual = formatDownloadUrlForError(url);
   if (actual !== expected) {
     throw new Error(`expected sanitized display URL ${expected}, got ${actual}`);
+  }
+  for (const value of forbiddenValues) {
+    if (actual.includes(value)) {
+      throw new Error(`sanitized display URL leaked ${value}: ${actual}`);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #1103

## Summary
- redact URL path, query, and fragment display in npm download error formatting
- keep protocol and host metadata for operator context
- add unit and installer-level regressions for secret-looking URL path segments

## Validation
- node packaging/npm/conu-cli/scripts/check-download-policy.js
- node packaging/npm/conu-cli/scripts/check-download-limits.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts npm download URL path, query, and fragment in error messages to prevent leaking secrets while keeping protocol and host for context. Adds tests to lock this behavior in.

- **Bug Fixes**
  - Sanitize error display to `${protocol}//${host}/[path redacted]; urlPathDisplayed=false queryDisplayed=false fragmentDisplayed=false`.
  - Add installer and unit checks to ensure path, query, and fragment values (e.g., "secret-download-path", "token=secret") never appear in output.
  - Update test URLs and assertions across download limit, timeout, and policy checks to exercise redaction.

<sup>Written for commit 862778455e117c3e69ae784b8d98da4b203515a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

