### PR TITLE
Handle invalid npm redirect URLs safely

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -29,6 +29,7 @@ async function main() {
   expectContentLengthParsing();
   await expectUnverifiedPublicBaseFailure();
   await expectLoopbackRedirectToPublicFailure();
+  await expectInvalidRedirectUrlFailure();
   await expectArchiveLimitFailure();
   await expectChecksumLimitFailure();
   await expectChecksumArchiveNameFailure();
@@ -173,6 +174,23 @@ async function expectLoopbackRedirectToPublicFailure() {
       CONU_NPM_MAX_ARCHIVE_BYTES: "1024"
     });
     expectFailedWith(result, "download redirect must not cross public and loopback boundaries");
+    expectNoSecretDisplay(result);
+  });
+}
+
+async function expectInvalidRedirectUrlFailure() {
+  await withServer((_request, response) => {
+    response.writeHead(302, { Location: "https://[::1" });
+    response.end();
+  }, async (baseUrl) => {
+    const result = await runInstall({
+      CONU_NPM_ALLOW_UNVERIFIED: "1",
+      CONU_NPM_DIST_BASE: `${baseUrl}/secret-download-path?token=secret`,
+      CONU_NPM_MAX_ARCHIVE_BYTES: "1024"
+    });
+    expectFailedWith(result, "download redirect URL is invalid");
+    expectFailedWith(result, "urlDisplayed=false");
+    expectFailedWith(result, "contentsDisplayed=false");
     expectNoSecretDisplay(result);
   });
 }

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -385,7 +385,11 @@ function request(url, onError, handler, redirects = 0) {
         redirects < 5
       ) {
         response.resume();
-        const redirectUrl = new URL(response.headers.location, url).toString();
+        const redirectUrl = resolveRedirectUrl(response.headers.location, url);
+        if (redirectUrl === null) {
+          onError(invalidRedirectUrlError());
+          return;
+        }
         try {
           validateDownloadRedirect(url, redirectUrl);
         } catch (error) {
@@ -407,4 +411,18 @@ function request(url, onError, handler, redirects = 0) {
     );
   });
   return requestHandle;
+}
+
+function resolveRedirectUrl(location, baseUrl) {
+  try {
+    return new URL(location, baseUrl).toString();
+  } catch (_error) {
+    return null;
+  }
+}
+
+function invalidRedirectUrlError() {
+  return new Error(
+    "download redirect URL is invalid; urlDisplayed=false contentsDisplayed=false"
+  );
 }


### PR DESCRIPTION
Closes #1105

## Summary
- catch malformed npm download redirect Location values before redirect validation
- return a controlled redacted installer error instead of letting URL parsing escape from the response callback
- add an installer regression covering malformed redirects with secret-looking request path/query material

## Validation
- node packaging/npm/conu-cli/scripts/check-download-limits.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely handle malformed download redirect URLs in the `packaging/npm/conu-cli` installer to prevent crashes and avoid leaking secret-looking data. When a bad `Location` header is returned, we emit a controlled, redacted error. Closes #1105.

- **Bug Fixes**
  - Guard redirect URL parsing; if invalid, return a redacted "download redirect URL is invalid" error instead of throwing.
  - Add regression test `expectInvalidRedirectUrlFailure` in `scripts/check-download-limits.js` to cover malformed redirects and assert no secret exposure.

<sup>Written for commit 73f8be165d8ab76e85dde8c7cc12d662e5085751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

