### PR TITLE
Handle invalid npm download limits safely

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -27,6 +27,7 @@ async function main() {
   expectInvalidLimit("CONU_NPM_MAX_CHECKSUM_BYTES", "-1");
   expectInvalidLimit("CONU_NPM_DOWNLOAD_TIMEOUT_MS", "1.5");
   expectContentLengthParsing();
+  await expectInvalidLimitInstallFailure();
   await expectUnverifiedPublicBaseFailure();
   await expectLoopbackRedirectToPublicFailure();
   await expectInvalidRedirectUrlFailure();
@@ -152,6 +153,18 @@ async function expectArchiveLimitFailure() {
     expectFailedWith(result, "archive download exceeded maximum size");
     expectNoSecretDisplay(result);
   });
+}
+
+async function expectInvalidLimitInstallFailure() {
+  const result = await runInstall({
+    CONU_NPM_DIST_BASE: "https://example.com/secret-download-path?token=secret",
+    CONU_NPM_MAX_ARCHIVE_BYTES: "secret-limit-value"
+  });
+  expectFailedWith(result, "CONU_NPM_MAX_ARCHIVE_BYTES must be a positive integer");
+  expectFailedWithout(result, "secret-limit-value");
+  expectFailedWithout(result, "at ");
+  expectFailedWithout(result, packageRoot);
+  expectNoSecretDisplay(result);
 }
 
 async function expectUnverifiedPublicBaseFailure() {

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -39,7 +39,6 @@ const checkOnly = process.argv.includes("--check-only");
 const skipDownload = process.env.CONU_NPM_SKIP_DOWNLOAD === "1";
 const allowUnverified = process.env.CONU_NPM_ALLOW_UNVERIFIED === "1";
 const localBinaryDir = process.env.CONU_NPM_BINARY_DIR;
-const downloadLimits = getDownloadLimits();
 const version = packageVersion();
 const asset = assetName(version);
 const releaseBase =
@@ -73,16 +72,23 @@ async function main() {
     validateUnverifiedDownloadBase(releaseBase);
   }
 
+  const downloadLimits = getDownloadLimits();
   const tempDir = createTempInstallDir();
   let installFailed = false;
   try {
     const archivePath = path.join(tempDir, tempArchiveFileName(asset));
     const checksumPath = `${archivePath}.sha256`;
-    await downloadFile(`${releaseBase}/${asset}`, archivePath, downloadLimits.maxArchiveBytes);
+    await downloadFile(
+      `${releaseBase}/${asset}`,
+      archivePath,
+      downloadLimits.maxArchiveBytes,
+      downloadLimits.timeoutMs
+    );
 
     const checksum = await downloadOptionalText(
       `${releaseBase}/${asset}.sha256`,
-      downloadLimits.maxChecksumBytes
+      downloadLimits.maxChecksumBytes,
+      downloadLimits.timeoutMs
     );
     if (checksum) {
       writeChecksumArtifact(checksumPath, checksum);
@@ -178,7 +184,7 @@ function extractArchive(archivePath, destination) {
   throw new Error(`failed to extract ${asset}; pathDisplayed=false`);
 }
 
-function downloadOptionalText(url, maxBytes) {
+function downloadOptionalText(url, maxBytes, timeoutMs) {
   return new Promise((resolve, reject) => {
     request(url, reject, (response) => {
       if (response.statusCode === 404) {
@@ -232,11 +238,11 @@ function downloadOptionalText(url, maxBytes) {
         }
       });
       response.on("error", fail);
-    }).on("error", reject);
+    }, 0, timeoutMs).on("error", reject);
   });
 }
 
-function downloadFile(url, target, maxBytes) {
+function downloadFile(url, target, maxBytes, timeoutMs) {
   return new Promise((resolve, reject) => {
     let file = null;
     let activeRequest = null;
@@ -300,7 +306,7 @@ function downloadFile(url, target, maxBytes) {
       });
       response.on("error", fail);
       file.on("drain", () => response.resume());
-    });
+    }, 0, timeoutMs);
     activeRequest.on("error", fail);
   });
 }
@@ -371,7 +377,7 @@ function downloadArtifactWriteError(kind) {
   );
 }
 
-function request(url, onError, handler, redirects = 0) {
+function request(url, onError, handler, redirects, timeoutMs) {
   const parsedUrl = validateDownloadUrl(url);
   const client = parsedUrl.protocol === "https:" ? https : http;
   const requestHandle = client.get(
@@ -396,17 +402,17 @@ function request(url, onError, handler, redirects = 0) {
           onError(error);
           return;
         }
-        request(redirectUrl, onError, handler, redirects + 1).on("error", onError);
+        request(redirectUrl, onError, handler, redirects + 1, timeoutMs).on("error", onError);
         return;
       }
 
       handler(response);
     }
   );
-  requestHandle.setTimeout(downloadLimits.timeoutMs, () => {
+  requestHandle.setTimeout(timeoutMs, () => {
     requestHandle.destroy(
       new Error(
-        `download timed out after ${downloadLimits.timeoutMs} ms: ${formatDownloadUrlForError(url)}`
+        `download timed out after ${timeoutMs} ms: ${formatDownloadUrlForError(url)}`
       )
     );
   });


### PR DESCRIPTION
## Summary
- defer npm download limit parsing until installer execution is inside the top-level failure handler
- pass timeout configuration through download helpers instead of reading module-level state
- add a regression that invalid limit env values fail without leaking env contents, URL paths, stack frames, or local package paths

## Validation
- node packaging/npm/conu-cli/scripts/check-download-limits.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

Closes #1107

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the npm installer to safely handle invalid download limit env values and to pass timeout configuration through all download helpers. Failures now avoid leaking env contents, URL paths, stack traces, and local paths.

- **Bug Fixes**
  - Defer parsing of download limit env vars until inside the top-level failure handler.
  - Pass `timeoutMs` through `downloadFile`, `downloadOptionalText`, and `request` instead of reading module-level state.
  - Added a regression test to ensure invalid limits fail with a clear message and no secret leakage.

<sup>Written for commit 053582431eeceb3933d43d3a226ae920b044d9ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

