### PR TITLE
Guard npm installer metadata failures

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
+++ b/packaging/npm/conu-cli/scripts/check-install-output-privacy.js
@@ -66,6 +66,8 @@ function main() {
   expectNoLocalPath(checkOnly, vendorDir(), "check-only vendor dir");
   expectIncludes(checkOnly, "pathDisplayed=false", "check-only path display guard");
 
+  expectInstallMetadataFailureIsRedacted();
+
   withFixture((root) => {
     const packageCopy = path.join(root, "package");
     const binaryDir = path.join(root, "override-binaries");
@@ -189,6 +191,32 @@ function expectChildEnvScrubsWrapperSelector() {
   if (!("CONU_NPM_BINARY_DIR" in sourceEnv)) {
     throw new Error("launcher child env builder mutated installer env source");
   }
+}
+
+function expectInstallMetadataFailureIsRedacted() {
+  withFixture((root) => {
+    const packageCopy = path.join(root, "package");
+    copyPackage(packageRoot, packageCopy);
+    fs.rmSync(path.join(packageCopy, "package.json"), { force: true });
+
+    const output = runNodeFailure([path.join(packageCopy, "scripts", "install.js")], {
+      CONU_NPM_BINARY_DIR: "",
+      CONU_NPM_SKIP_DOWNLOAD: "",
+      CONU_NPM_DIST_BASE: "",
+      CONU_NPM_ALLOW_UNVERIFIED: ""
+    }, packageCopy);
+
+    expectNoLocalPath(output, root, "installer metadata failure temp root");
+    expectNoLocalPath(output, packageCopy, "installer metadata failure package root");
+    expectIncludes(
+      output,
+      "failed to read conU npm package metadata",
+      "installer metadata failure reason"
+    );
+    expectIncludes(output, "pathDisplayed=false", "installer metadata path display guard");
+    expectIncludes(output, "contentsDisplayed=false", "installer metadata content display guard");
+    expectNotIncludes(output, " at ", "installer metadata stack frame guard");
+  });
 }
 
 function expectLocalBinaryDirFailureIsRedacted() {

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -39,11 +39,6 @@ const checkOnly = process.argv.includes("--check-only");
 const skipDownload = process.env.CONU_NPM_SKIP_DOWNLOAD === "1";
 const allowUnverified = process.env.CONU_NPM_ALLOW_UNVERIFIED === "1";
 const localBinaryDir = process.env.CONU_NPM_BINARY_DIR;
-const version = packageVersion();
-const asset = assetName(version);
-const releaseBase =
-  process.env.CONU_NPM_DIST_BASE ||
-  `https://github.com/imthegoodboy/conU/releases/download/v${version}`;
 
 main().catch((error) => {
   console.error(`conU install failed: ${error.message}`);
@@ -51,6 +46,8 @@ main().catch((error) => {
 });
 
 async function main() {
+  const { version, asset, releaseBase } = loadInstallContext();
+
   if (checkOnly) {
     console.log(`conU npm package ${version}`);
     console.log(`platform asset: ${asset}`);
@@ -103,13 +100,38 @@ async function main() {
 
     const extractDir = path.join(tempDir, "extract");
     createExtractDir(extractDir);
-    extractArchive(archivePath, extractDir);
-    installFromExtractedArchive(extractDir);
+    extractArchive(archivePath, extractDir, asset);
+    installFromExtractedArchive(extractDir, asset);
   } catch (error) {
     installFailed = true;
     throw error;
   } finally {
     removeTempInstallDir(tempDir, { preserveFailure: installFailed });
+  }
+}
+
+function loadInstallContext() {
+  const version = readPackageVersionForInstall();
+  return {
+    version,
+    asset: assetName(version),
+    releaseBase:
+      process.env.CONU_NPM_DIST_BASE ||
+      `https://github.com/imthegoodboy/conU/releases/download/v${version}`
+  };
+}
+
+function readPackageVersionForInstall() {
+  try {
+    const version = packageVersion();
+    if (typeof version !== "string" || !version.trim()) {
+      throw new Error("missing package version");
+    }
+    return version;
+  } catch (_error) {
+    throw new Error(
+      "failed to read conU npm package metadata; pathDisplayed=false contentsDisplayed=false"
+    );
   }
 }
 
@@ -134,19 +156,19 @@ function installFromLocalDir(sourceDir) {
   console.log("installed conU binaries from local override; sourcePathDisplayed=false");
 }
 
-function installFromExtractedArchive(root) {
+function installFromExtractedArchive(root, publicAssetName) {
   const binaries = resolveExtractedBinaries(root, {
-    archiveName: asset,
+    archiveName: publicAssetName,
     binaryNames: BINARIES,
     binarySuffix: binarySuffix()
   });
   for (const name of BINARIES) {
     installBinary(binaries[name], name);
   }
-  console.log(`installed conU native binaries for ${asset}`);
+  console.log(`installed conU native binaries for ${publicAssetName}`);
 }
 
-function extractArchive(archivePath, destination) {
+function extractArchive(archivePath, destination, publicAssetName) {
   validateArchiveMembers(archivePath);
 
   const tar = spawnSync("tar", ["-xf", archivePath, "-C", destination], {
@@ -181,7 +203,7 @@ function extractArchive(archivePath, destination) {
     }
   }
 
-  throw new Error(`failed to extract ${asset}; pathDisplayed=false`);
+  throw new Error(`failed to extract ${publicAssetName}; pathDisplayed=false`);
 }
 
 function downloadOptionalText(url, maxBytes, timeoutMs) {


### PR DESCRIPTION
## Summary
- move npm installer package metadata and asset resolution inside the guarded `main()` execution path
- redact package metadata read/version failures as controlled installer errors
- add a privacy regression for missing package metadata so local paths and stack frames stay out of npm install output

## Validation
- node packaging/npm/conu-cli/scripts/check-install-output-privacy.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

Closes #1109

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `conu-cli` npm installer metadata failures to prevent leaking local paths, contents, and stack frames. Metadata and asset resolution now happen inside the protected execution path with clear, redacted errors.

- **Bug Fixes**
  - Redact package metadata read/version errors; hide paths, contents, and stack traces.
  - Ensure extraction/install messages use the public asset name and keep `pathDisplayed=false`.
  - Add a privacy regression test to verify metadata failure output stays redacted.

- **Refactors**
  - Load install context inside `main()` via `loadInstallContext()` (version, asset, release base).
  - Pass the asset name to `extractArchive` and `installFromExtractedArchive` for accurate, safe logging.

<sup>Written for commit 174c4bc0bbde6a973f50941ef7716d6dbe675f15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

