### PR TITLE
Add npm archive content display guards

### DIFF
--- a/packaging/npm/conu-cli/lib/archive-preflight.js
+++ b/packaging/npm/conu-cli/lib/archive-preflight.js
@@ -38,7 +38,9 @@ function validateArchiveMembers(archivePath) {
 
 function assertSafeArchiveMemberList(members, archiveLabel = "archive") {
   if (!Array.isArray(members) || members.length === 0) {
-    throw new Error(`${archiveLabel} did not contain any extractable members`);
+    throw new Error(
+      `${archiveLabel} did not contain any extractable members; pathDisplayed=false contentsDisplayed=false`
+    );
   }
   if (members.length > MAX_ARCHIVE_MEMBERS) {
     throw archiveMemberPathError(
@@ -131,7 +133,7 @@ function listArchiveMembers(archivePath, archiveLabel) {
   }
 
   throw new Error(
-    `could not inspect archive members before extraction: ${archiveLabel}; pathDisplayed=false`
+    `could not inspect archive members before extraction: ${archiveLabel}; pathDisplayed=false contentsDisplayed=false`
   );
 }
 
@@ -144,7 +146,7 @@ function listArchiveMembersWithTar(archivePath, archiveLabel) {
   const verbose = runTool("tar", ["-tvf", archivePath]);
   if (verbose.status !== 0) {
     throw new Error(
-      `could not inspect archive member types before extraction: ${archiveLabel}; pathDisplayed=false`
+      `could not inspect archive member types before extraction: ${archiveLabel}; pathDisplayed=false contentsDisplayed=false`
     );
   }
 
@@ -307,7 +309,7 @@ function zipMemberType(name, flags, externalAttributes) {
 
 function zipInspectionError(archiveLabel) {
   const error = new Error(
-    `could not inspect zip archive members before extraction: ${archiveLabel}; pathDisplayed=false`
+    `could not inspect zip archive members before extraction: ${archiveLabel}; pathDisplayed=false contentsDisplayed=false`
   );
   error.zipInspectionError = true;
   return error;

--- a/packaging/npm/conu-cli/scripts/check-archive-preflight.js
+++ b/packaging/npm/conu-cli/scripts/check-archive-preflight.js
@@ -266,6 +266,12 @@ function expectArchiveInspectionPathRedacted() {
     try {
       validateArchiveMembers(archive);
     } catch (error) {
+      if (!error.message.includes("pathDisplayed=false")) {
+        throw new Error(`expected path display guard, got: ${error.message}`);
+      }
+      if (!error.message.includes("contentsDisplayed=false")) {
+        throw new Error(`expected contents display guard, got: ${error.message}`);
+      }
       if (!error.message.includes(path.basename(archive))) {
         throw new Error(`expected archive filename in error, got: ${error.message}`);
       }
@@ -290,6 +296,9 @@ function expectArchiveInspectionFailurePathGuard() {
     } catch (error) {
       if (!error.message.includes("pathDisplayed=false")) {
         throw new Error(`expected path display guard, got: ${error.message}`);
+      }
+      if (!error.message.includes("contentsDisplayed=false")) {
+        throw new Error(`expected contents display guard, got: ${error.message}`);
       }
       if (!error.message.includes(path.basename(archive))) {
         throw new Error(`expected archive filename in error, got: ${error.message}`);

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -203,7 +203,9 @@ function extractArchive(archivePath, destination, publicAssetName) {
     }
   }
 
-  throw new Error(`failed to extract ${publicAssetName}; pathDisplayed=false`);
+  throw new Error(
+    `failed to extract ${publicAssetName}; pathDisplayed=false contentsDisplayed=false`
+  );
 }
 
 function downloadOptionalText(url, maxBytes, timeoutMs) {


### PR DESCRIPTION
## Summary
- add `contentsDisplayed=false` to npm archive inspection and extraction failure messages that already carried path display guards
- cover empty, corrupt, and uninspectable archive failure paths consistently
- extend archive preflight regressions to require both path and content display guards

## Validation
- node packaging/npm/conu-cli/scripts/check-archive-preflight.js
- node packaging/npm/conu-cli/scripts/check-install-output-privacy.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

Closes #1111

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `contentsDisplayed=false` to all npm archive inspection and extraction errors to prevent leaking archive contents. Tests now enforce both content and path redaction across empty, corrupt, and uninspectable archives.

- **Bug Fixes**
  - Add `contentsDisplayed=false` to errors in `packaging/npm/conu-cli/lib/archive-preflight.js` and `packaging/npm/conu-cli/scripts/install.js`.
  - Update `packaging/npm/conu-cli/scripts/check-archive-preflight.js` to require both `pathDisplayed=false` and `contentsDisplayed=false`.
  - Keep archive filename visible while redacting paths and contents.

<sup>Written for commit 22ce9f21dd653eefef6656a610139cc7559de55d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages during archive inspection to provide more consistent and detailed feedback when operations fail.
  * Improved error message formatting for extraction failures.

* **Tests**
  * Expanded test coverage to verify error message consistency and ensure security safeguards are properly enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->