### PR TITLE
Redact npm network failure output

### DIFF
--- a/packaging/npm/conu-cli/scripts/check-download-limits.js
+++ b/packaging/npm/conu-cli/scripts/check-download-limits.js
@@ -35,6 +35,7 @@ async function main() {
   await expectChecksumLimitFailure();
   await expectChecksumArchiveNameFailure();
   await expectInvalidArchiveUsesNeutralTempLabel();
+  await expectNetworkFailureIsRedacted();
   await expectTimeoutFailure();
   console.log("download limit check passed");
 }
@@ -267,6 +268,24 @@ async function expectInvalidArchiveUsesNeutralTempLabel() {
     });
     expectFailedWith(result, "conu-native-archive");
     expectFailedWithout(result, assetName());
+    expectNoSecretDisplay(result);
+  });
+}
+
+async function expectNetworkFailureIsRedacted() {
+  await withServer((request, _response) => {
+    request.socket.destroy();
+  }, async (baseUrl) => {
+    const result = await runInstall({
+      CONU_NPM_ALLOW_UNVERIFIED: "1",
+      CONU_NPM_DIST_BASE: `${baseUrl}/secret-download-path?token=secret`,
+      CONU_NPM_MAX_ARCHIVE_BYTES: "1024"
+    });
+    expectFailedWith(result, "download request failed");
+    expectFailedWith(result, "errorCode=");
+    expectFailedWith(result, "pathDisplayed=false");
+    expectFailedWith(result, "contentsDisplayed=false");
+    expectFailedWithout(result, "socket hang up");
     expectNoSecretDisplay(result);
   });
 }

--- a/packaging/npm/conu-cli/scripts/install.js
+++ b/packaging/npm/conu-cli/scripts/install.js
@@ -262,7 +262,7 @@ function downloadOptionalText(url, maxBytes, timeoutMs) {
         }
       });
       response.on("error", fail);
-    }, 0, timeoutMs).on("error", reject);
+    }, 0, timeoutMs);
   });
 }
 
@@ -331,7 +331,6 @@ function downloadFile(url, target, maxBytes, timeoutMs) {
       response.on("error", fail);
       file.on("drain", () => response.resume());
     }, 0, timeoutMs);
-    activeRequest.on("error", fail);
   });
 }
 
@@ -426,21 +425,47 @@ function request(url, onError, handler, redirects, timeoutMs) {
           onError(error);
           return;
         }
-        request(redirectUrl, onError, handler, redirects + 1, timeoutMs).on("error", onError);
+        request(redirectUrl, onError, handler, redirects + 1, timeoutMs);
         return;
       }
 
       handler(response);
     }
   );
+  requestHandle.on("error", (error) => {
+    onError(downloadRequestError(url, error));
+  });
   requestHandle.setTimeout(timeoutMs, () => {
     requestHandle.destroy(
-      new Error(
+      taggedDownloadError(
         `download timed out after ${timeoutMs} ms: ${formatDownloadUrlForError(url)}`
       )
     );
   });
   return requestHandle;
+}
+
+function downloadRequestError(url, error) {
+  if (error && error.conuDownloadError === true) {
+    return error;
+  }
+  return taggedDownloadError(
+    `download request failed ${formatDownloadUrlForError(url)}; errorCode=${runtimeErrorCode(error)} pathDisplayed=false contentsDisplayed=false`
+  );
+}
+
+function taggedDownloadError(message) {
+  const error = new Error(message);
+  error.conuDownloadError = true;
+  return error;
+}
+
+function runtimeErrorCode(error) {
+  const code = error && typeof error.code === "string" ? error.code : "";
+  if (/^[A-Z0-9_]+$/.test(code)) {
+    return code;
+  }
+  return "UNKNOWN";
 }
 
 function resolveRedirectUrl(location, baseUrl) {


### PR DESCRIPTION
## Summary
- Wrap npm installer request errors in a controlled redacted failure message.
- Preserve explicit timeout wording while keeping URL paths, queries, fragments, and raw network text out of output.
- Add a regression for socket failure against a secret path/query download URL.

## Validation
- node packaging/npm/conu-cli/scripts/check-download-limits.js
- node packaging/npm/conu-cli/scripts/check-install-output-privacy.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

Closes #1113

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacted `npm` install network error output to prevent leaking URL paths, queries, and raw socket messages while keeping clear timeout info. Centralized error handling and added tests to ensure secrets never appear in logs.

- **Bug Fixes**
  - Wrap request errors in a controlled message with `errorCode`, and mark `pathDisplayed=false contentsDisplayed=false`.
  - Preserve explicit timeout wording without exposing raw network text (e.g., no “socket hang up”).
  - Add a regression test for secret path/query URLs to confirm no secrets are printed.

<sup>Written for commit 97208f93239b846252a06ef000d9882cf99f827c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

