### PR TITLE
Redact npm checksum read failures

### DIFF
--- a/packaging/npm/conu-cli/lib/checksum.js
+++ b/packaging/npm/conu-cli/lib/checksum.js
@@ -29,8 +29,10 @@ function parseSha256Checksum(checksumText, expectedArchiveName) {
 function sha256File(filePath) {
   const digest = crypto.createHash("sha256");
   const buffer = Buffer.allocUnsafe(HASH_CHUNK_BYTES);
-  const fd = fs.openSync(filePath, "r");
+  let fd = null;
+  let readFailed = false;
   try {
+    fd = fs.openSync(filePath, "r");
     while (true) {
       const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
       if (bytesRead === 0) {
@@ -38,8 +40,19 @@ function sha256File(filePath) {
       }
       digest.update(buffer.subarray(0, bytesRead));
     }
+  } catch (error) {
+    readFailed = true;
+    throw checksumTargetReadError(error);
   } finally {
-    fs.closeSync(fd);
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch (error) {
+        if (!readFailed) {
+          throw checksumTargetReadError(error);
+        }
+      }
+    }
   }
   return digest.digest("hex");
 }
@@ -50,6 +63,20 @@ function verifySha256File(filePath, checksumText, expectedArchiveName = path.bas
   if (actual !== expected) {
     throw new Error(`checksum mismatch for ${expectedArchiveName}`);
   }
+}
+
+function checksumTargetReadError(error) {
+  return new Error(
+    `checksum target could not be read; errorCode=${runtimeErrorCode(error)} pathDisplayed=false contentsDisplayed=false`
+  );
+}
+
+function runtimeErrorCode(error) {
+  const code = error && typeof error.code === "string" ? error.code : "";
+  if (/^[A-Z0-9_]+$/.test(code)) {
+    return code;
+  }
+  return "UNKNOWN";
 }
 
 module.exports = {

--- a/packaging/npm/conu-cli/scripts/check-checksum-verification.js
+++ b/packaging/npm/conu-cli/scripts/check-checksum-verification.js
@@ -7,6 +7,7 @@ const path = require("node:path");
 
 const {
   parseSha256Checksum,
+  sha256File,
   verifySha256File
 } = require("../lib/checksum");
 
@@ -58,6 +59,25 @@ function main() {
         "checksum mismatch",
         "mismatched digest"
       );
+      const missingSecretPath = path.join(tempDir, "secret-checksum-target-path.zip");
+      expectHashFailure(
+        () => sha256File(missingSecretPath),
+        "checksum target could not be read",
+        "direct checksum target read failure",
+        {
+          forbidden: [tempDir, missingSecretPath, "secret-checksum-target-path"],
+          required: ["errorCode=ENOENT", "pathDisplayed=false", "contentsDisplayed=false"]
+        }
+      );
+      expectHashFailure(
+        () => verifySha256File(missingSecretPath, `${digest}  ${ARCHIVE_NAME}\n`, ARCHIVE_NAME),
+        "checksum target could not be read",
+        "verify checksum target read failure",
+        {
+          forbidden: [tempDir, missingSecretPath, "secret-checksum-target-path"],
+          required: ["errorCode=ENOENT", "pathDisplayed=false", "contentsDisplayed=false"]
+        }
+      );
     } finally {
       fs.readFileSync = originalReadFileSync;
     }
@@ -70,6 +90,28 @@ function main() {
 function expectFailure(checksumText, expectedMessage, label, options = {}) {
   try {
     parseSha256Checksum(checksumText, ARCHIVE_NAME);
+  } catch (error) {
+    if (!error.message.includes(expectedMessage)) {
+      throw new Error(`expected ${label} to fail with ${expectedMessage}, got: ${error.message}`);
+    }
+    for (const value of options.required || []) {
+      if (!error.message.includes(value)) {
+        throw new Error(`expected ${label} failure to include ${value}, got: ${error.message}`);
+      }
+    }
+    for (const value of options.forbidden || []) {
+      if (error.message.includes(value)) {
+        throw new Error(`expected ${label} failure to redact ${value}, got: ${error.message}`);
+      }
+    }
+    return;
+  }
+  throw new Error(`expected ${label} to fail`);
+}
+
+function expectHashFailure(callback, expectedMessage, label, options = {}) {
+  try {
+    callback();
   } catch (error) {
     if (!error.message.includes(expectedMessage)) {
       throw new Error(`expected ${label} to fail with ${expectedMessage}, got: ${error.message}`);


### PR DESCRIPTION
## Summary
- Redact filesystem open/read/close failures while hashing npm checksum targets.
- Preserve checksum format and mismatch behavior while reporting only sanitized error codes for target-read failures.
- Add regressions for direct hashing and installer-style verification against a secret local path.

## Validation
- node packaging/npm/conu-cli/scripts/check-checksum-verification.js
- node packaging/npm/conu-cli/scripts/check-install-output-privacy.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

Closes #1115

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts filesystem read failures during checksum hashing/verification so errors never reveal local paths or contents. Keeps checksum format and mismatch behavior unchanged.

- **Bug Fixes**
  - Sanitize open/read/close failures in `sha256File` and `verifySha256File`, emitting: "checksum target could not be read; errorCode=<CODE> pathDisplayed=false contentsDisplayed=false".
  - Add tests for direct hashing and installer-style verification against a missing secret path to ensure redaction and behavior remain correct.

<sup>Written for commit ae274da39ab1d8fece2592deae1bace23ecc019c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

