### PR TITLE
Redact npm extract close failures

### DIFF
--- a/packaging/npm/conu-cli/lib/extract-selection.js
+++ b/packaging/npm/conu-cli/lib/extract-selection.js
@@ -86,6 +86,7 @@ function collectBinaryMatches(root, fileNames, archiveName, limits) {
 
 function visit(root, archiveName, limits, onEntry, depth = 0, state = { entries: 0 }) {
   const dir = openExtractedTreeDirectory(root, archiveName);
+  let visitFailed = false;
   try {
     let entry = readExtractedTreeDirectory(dir, archiveName);
     while (entry !== null) {
@@ -110,8 +111,17 @@ function visit(root, archiveName, limits, onEntry, depth = 0, state = { entries:
       }
       entry = readExtractedTreeDirectory(dir, archiveName);
     }
+  } catch (error) {
+    visitFailed = true;
+    throw error;
   } finally {
-    dir.closeSync();
+    try {
+      dir.closeSync();
+    } catch (_error) {
+      if (!visitFailed) {
+        throw extractedTreeInspectionError(archiveName);
+      }
+    }
   }
 }
 

--- a/packaging/npm/conu-cli/scripts/check-extract-selection.js
+++ b/packaging/npm/conu-cli/scripts/check-extract-selection.js
@@ -95,6 +95,26 @@ function main() {
 
   withFixture((root) => {
     writeReleaseLayout(root);
+    withPatchedFs(
+      {
+        opendirSync: () => ({
+          readSync: () => null,
+          closeSync: () => failWithPath(root)
+        })
+      },
+      () => {
+        expectRedactedFailure(
+          root,
+          "failed to inspect extracted tree",
+          root,
+          "redacted extracted directory close failure"
+        );
+      }
+    );
+  });
+
+  withFixture((root) => {
+    writeReleaseLayout(root);
     expectFailure(
       root,
       "exceeds maximum entry count",


### PR DESCRIPTION
## Summary
- Redact directory close failures while scanning extracted npm release trees.
- Preserve earlier extraction failures if one is already being thrown.
- Add a regression for close failures that carry a secret local path.

## Validation
- node packaging/npm/conu-cli/scripts/check-extract-selection.js
- node packaging/npm/conu-cli/scripts/check-install-output-privacy.js
- npm --prefix packaging/npm/conu-cli run check
- git diff --check

Closes #1117

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts directory close errors during extracted npm tree scans in `packaging/npm/conu-cli` to prevent local path leaks. If a scan error already occurred, it is kept and not overwritten by a close error.

- **Bug Fixes**
  - Redact `closeSync` failures to a generic inspection error only when no prior error occurred.
  - Preserve the original scan error when present.
  - Add a regression test in `scripts/check-extract-selection.js` to ensure close failure paths are redacted.

<sup>Written for commit fe8464eab2ba361b14fd5f9a4282e2335d729355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

