### PR TITLE
Redact npm temporary install target allocation failures

### DIFF
--- a/packaging/npm/conu-cli/lib/install-target.js
+++ b/packaging/npm/conu-cli/lib/install-target.js
@@ -194,7 +194,9 @@ function temporarySiblingPath(target) {
       return candidate;
     }
   }
-  throw new Error(`${base} temporary install target could not be allocated`);
+  throw new Error(
+    `${base} temporary install target could not be allocated; pathDisplayed=false contentsDisplayed=false`
+  );
 }
 
 function lstatRequired(target, label) {

--- a/packaging/npm/conu-cli/scripts/check-install-target.js
+++ b/packaging/npm/conu-cli/scripts/check-install-target.js
@@ -138,6 +138,34 @@ function main() {
   withFixture((root) => {
     const source = writeSource(root, "conu");
     const target = path.join(root, "vendor", "linux-x64", "conu");
+    const originalLstatSync = fs.lstatSync;
+    withPatchedFs(
+      {
+        lstatSync: (candidate) => {
+          if (path.basename(String(candidate)).startsWith(".conu.")) {
+            return {
+              isDirectory: () => false,
+              isFile: () => true,
+              isSymbolicLink: () => false
+            };
+          }
+          return originalLstatSync(candidate);
+        }
+      },
+      () => {
+        expectRedactedFailure(
+          () => install(root, source, target),
+          "temporary install target could not be allocated",
+          root,
+          "redacted temporary target allocation failure"
+        );
+      }
+    );
+  });
+
+  withFixture((root) => {
+    const source = writeSource(root, "conu");
+    const target = path.join(root, "vendor", "linux-x64", "conu");
     withPatchedFs(
       {
         renameSync: () => failWithPath(root),


### PR DESCRIPTION
Summary
- Add explicit path/content display guards to the npm installer temporary target allocation failure.
- Add regression coverage that forces temporary sibling names to be occupied and verifies local paths stay hidden.

Validation
- node packaging\npm\conu-cli\scripts\check-install-target.js
- node packaging\npm\conu-cli\scripts\check-install-output-privacy.js
- npm --prefix packaging\npm\conu-cli run check
- git diff --check

Closes #1119

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts local paths from `npm` temporary install target allocation errors in `conu-cli`, preventing path leakage in failure output. Adds a regression test to ensure errors stay redacted when all temporary sibling candidates are occupied.

- **Bug Fixes**
  - Added explicit guards to the allocation failure error in `packaging/npm/conu-cli/lib/install-target.js` to mark `pathDisplayed=false contentsDisplayed=false`.
  - Introduced a test in `packaging/npm/conu-cli/scripts/check-install-target.js` that simulates occupied `.conu.*` siblings and verifies redacted output.

<sup>Written for commit d2653348ed5c9d72c93410b8d7896ffcc8ddf9d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

