### PR TITLE
Redact npm download URL parser failures

### DIFF
--- a/packaging/npm/conu-cli/lib/download-policy.js
+++ b/packaging/npm/conu-cli/lib/download-policy.js
@@ -24,7 +24,9 @@ function validateDownloadUrl(rawUrl) {
     throw new Error("download URL must use HTTPS unless it points at a loopback test server");
   }
 
-  throw new Error(`unsupported download URL protocol: ${parsed.protocol}`);
+  throw new Error(
+    "unsupported download URL protocol; protocolDisplayed=false contentsDisplayed=false"
+  );
 }
 
 function validateUnverifiedDownloadBase(rawUrl) {
@@ -122,8 +124,8 @@ function formatDownloadUrlForError(rawUrl) {
 function parseDownloadUrl(rawUrl) {
   try {
     return new URL(rawUrl);
-  } catch (error) {
-    throw new Error(`invalid download URL: ${error.message}`);
+  } catch (_error) {
+    throw new Error("invalid download URL; urlDisplayed=false contentsDisplayed=false");
   }
 }
 

--- a/packaging/npm/conu-cli/scripts/check-download-policy.js
+++ b/packaging/npm/conu-cli/scripts/check-download-policy.js
@@ -17,6 +17,13 @@ function main() {
   expectPass("http://[::1]:50123/conu.zip");
   expectFail("http://example.com/conu.zip", "download URL must use HTTPS");
   expectFail("ftp://example.com/conu.zip", "unsupported download URL protocol");
+  expectRedactedDownloadUrlFailure(
+    "npmsecretprotocolvalue://example.com/secret-download-path?token=secret",
+    "unsupported download URL protocol",
+    ["npmsecretprotocolvalue", "secret-download-path", "token=secret"],
+    ["protocolDisplayed=false", "contentsDisplayed=false"],
+    "unsupported protocol redaction"
+  );
   expectFail("https://user:pass@example.com/conu.zip", "embedded credentials");
   expectFail("https://10.0.0.1/conu.zip", "host must be public or loopback");
   expectFail("https://169.254.169.254/conu.zip", "host must be public or loopback");
@@ -31,6 +38,13 @@ function main() {
   expectFail("https://release.local/conu.zip", "host must be public or loopback");
   expectFail("http://localhost.evil.test/conu.zip", "download URL must use HTTPS");
   expectFail("not a url", "invalid download URL");
+  expectRedactedDownloadUrlFailure(
+    "https://[::1/secret-download-path?token=secret",
+    "invalid download URL",
+    ["secret-download-path", "token=secret"],
+    ["urlDisplayed=false", "contentsDisplayed=false"],
+    "invalid URL redaction"
+  );
   expectResolvedPass("https://example.com/conu.zip", "93.184.216.34");
   expectResolvedPass("https://example.com/conu.zip", "2001:4860:4860::8888");
   expectResolvedPass("http://localhost:50123/conu.zip", "127.0.0.1");
@@ -105,6 +119,34 @@ function expectFail(url, expectedMessage) {
     throw new Error(`expected ${expectedMessage}, got: ${error.message}`);
   }
   throw new Error(`expected download URL policy failure: ${expectedMessage}`);
+}
+
+function expectRedactedDownloadUrlFailure(
+  url,
+  expectedMessage,
+  forbiddenValues,
+  requiredValues,
+  label
+) {
+  try {
+    validateDownloadUrl(url);
+  } catch (error) {
+    if (!error.message.includes(expectedMessage)) {
+      throw new Error(`${label}: expected ${expectedMessage}, got: ${error.message}`);
+    }
+    for (const value of requiredValues) {
+      if (!error.message.includes(value)) {
+        throw new Error(`${label}: expected ${value}, got: ${error.message}`);
+      }
+    }
+    for (const value of forbiddenValues) {
+      if (error.message.includes(value)) {
+        throw new Error(`${label}: leaked ${value}: ${error.message}`);
+      }
+    }
+    return;
+  }
+  throw new Error(`${label}: expected download URL policy failure`);
 }
 
 function expectResolvedPass(url, address) {


### PR DESCRIPTION
Summary
- Stop echoing unsupported npm download URL protocols and URL parser details in install failures.
- Add regression coverage for secret-looking protocol, path, and query inputs.

Validation
- node packaging\\npm\\conu-cli\\scripts\\check-download-policy.js
- node packaging\\npm\\conu-cli\\scripts\\check-download-limits.js
- npm --prefix packaging\\npm\\conu-cli run check
- git diff --check

Closes #1121

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacted sensitive details from download URL validation errors to avoid leaking protocol, path, or query values in logs. Added regression tests to enforce redaction for unsupported protocols and invalid URLs.

- **Bug Fixes**
  - Replace error messages that echoed parsed protocol and URL parser output with constant, redacted strings.
  - Include explicit redaction flags in errors (e.g., protocolDisplayed=false, contentsDisplayed=false).
  - Add tests to ensure secret-like protocol/path/query values never appear in error messages and required redaction flags are present.

<sup>Written for commit e41dc775400f18a1e58df0d1bd5ce04c82c3de98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Download URL validation error messages now redact sensitive information, preventing exposure of protocol values and parser exceptions.

* **Tests**
  * Added test coverage to verify error message sanitization during URL validation failures, ensuring sensitive data is not leaked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->