### PR TITLE
Avoid pycache writes in Python readiness compile

### DIFF
--- a/scripts/check-python-script-compile.py
+++ b/scripts/check-python-script-compile.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
-import py_compile
 import sys
+import tokenize
 from pathlib import Path
 
 
@@ -22,13 +22,19 @@ def main() -> int:
         if not targets:
             raise ValueError("no Python sources found")
         for target in targets:
-            py_compile.compile(str(target), doraise=True)
-    except (OSError, py_compile.PyCompileError, ValueError) as exc:
+            compile_source(target)
+    except (OSError, SyntaxError, ValueError) as exc:
         print(f"Python script compile check failed: {exc}", file=sys.stderr)
         return 1
 
     print(f"Python script compile check passed: {len(targets)} file(s)")
     return 0
+
+
+def compile_source(path: Path) -> None:
+    with tokenize.open(path) as source_file:
+        source = source_file.read()
+    compile(source, str(path), "exec", dont_inherit=True)
 
 
 def discover_python_sources() -> tuple[Path, ...]:


### PR DESCRIPTION
## What changed
- Updated the Python compile readiness checker to parse and compile sources in memory instead of writing shared .pyc files under __pycache__.
- This avoids Windows access-denied races when readiness scripts run at the same time as other Python checks.

## Validation
- python scripts\\check-python-script-compile.py
- two concurrent python compile checker runs
- python scripts\\check-release-artifact-verifier.py
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check
- staged token scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compile Python readiness check sources in memory instead of writing `.pyc` files to `__pycache__`. This prevents Windows access-denied races during concurrent runs.

- **Bug Fixes**
  - Replace `py_compile` with `tokenize.open` + built-in `compile(...)` to avoid `.pyc` writes.
  - Catch `SyntaxError` instead of `py_compile.PyCompileError`; CLI output and exit codes stay the same.

<sup>Written for commit 97157767b716a67b00f9973a699642eb6c4bad92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal Python compilation verification tooling to use native compilation methods for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->