### PR TITLE
Upload release artifacts before attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,16 +380,16 @@ jobs:
         run: python scripts/smoke-npm-launcher-local.py dist
       - name: Smoke npm launcher download install
         run: python scripts/smoke-npm-launcher-download.py dist
-      - name: Attest release artifact provenance
-        uses: actions/attest@v4.1.0
-        with:
-          subject-path: ${{ matrix.artifact }}
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:
           name: conu-${{ matrix.name }}
           path: ${{ matrix.artifact }}
           if-no-files-found: error
+      - name: Attest release artifact provenance
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: ${{ matrix.artifact }}
 
   manual-preview-release:
     name: Publish Unsigned Preview Release

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -489,16 +489,16 @@ jobs:
         run: python scripts/smoke-npm-launcher-local.py dist
       - name: Smoke npm launcher download install
         run: python scripts/smoke-npm-launcher-download.py dist
-      - name: Attest release artifact provenance
-        uses: actions/attest@v4.1.0
-        with:
-          subject-path: ${{ matrix.artifact }}
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:
           name: conu-${{ matrix.name }}
           path: ${{ matrix.artifact }}
           if-no-files-found: error
+      - name: Attest release artifact provenance
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: ${{ matrix.artifact }}
   manual-preview-release:
     needs: build
     if: github.event_name == 'workflow_dispatch' && inputs.publish_preview_release == 'true'
@@ -2905,6 +2905,41 @@ def run_required_build_job_tests(module) -> None:
         "attestation subject path"
     ) not in json.dumps(assert_safe_report(report)):
         raise AssertionError("missing matrix attestation subject was not reported")
+
+    upload_before_attest = """      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: conu-${{ matrix.name }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
+      - name: Attest release artifact provenance
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: ${{ matrix.artifact }}
+"""
+    attest_before_upload = """      - name: Attest release artifact provenance
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: ${{ matrix.artifact }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: conu-${{ matrix.name }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
+"""
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(upload_before_attest, attest_before_upload, 1),
+    )
+    if report.ready:
+        raise AssertionError("build job that attests before upload should fail")
+    if (
+        "release.yml:build must upload artifacts before attestation"
+        not in json.dumps(assert_safe_report(report))
+    ):
+        raise AssertionError("build upload-before-attest order was not reported")
 
     report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -1320,14 +1320,6 @@ BUILD_REQUIRED_STEPS: tuple[
         ),
     ),
     (
-        "Attest release artifact provenance",
-        "attest release artifact provenance",
-        (
-            ("artifact attestation action", "uses: actions/attest@v4.1.0"),
-            ("attestation subject path", "subject-path: ${{ matrix.artifact }}"),
-        ),
-    ),
-    (
         "Upload artifact",
         "upload release artifact",
         (
@@ -1335,6 +1327,14 @@ BUILD_REQUIRED_STEPS: tuple[
             ("matrix artifact name", "name: conu-${{ matrix.name }}"),
             ("matrix artifact path", "path: ${{ matrix.artifact }}"),
             ("missing artifact failure", "if-no-files-found: error"),
+        ),
+    ),
+    (
+        "Attest release artifact provenance",
+        "attest release artifact provenance",
+        (
+            ("artifact attestation action", "uses: actions/attest@v4.1.0"),
+            ("attestation subject path", "subject-path: ${{ matrix.artifact }}"),
         ),
     ),
 )
@@ -2254,6 +2254,13 @@ def extract_named_step_block(job_block: str, step_name: str) -> str:
     return "\n".join(block)
 
 
+def find_named_step_line(job_block: str, step_name: str) -> int | None:
+    for index, line in enumerate(job_block.splitlines(), start=1):
+        if line.strip() == f"- name: {step_name}":
+            return index
+    return None
+
+
 def extract_uses_step_blocks(text: str, action: str) -> tuple[tuple[int, str], ...]:
     lines = text.splitlines()
     blocks: list[tuple[int, str]] = []
@@ -2674,6 +2681,13 @@ def audit_required_build_job(path: Path) -> tuple[str, ...]:
         for label, snippet in required_snippets:
             if snippet not in step:
                 issues.append(f"release.yml:build {description} is missing {label}")
+    upload_line = find_named_step_line(block, "Upload artifact")
+    attest_line = find_named_step_line(block, "Attest release artifact provenance")
+    if upload_line is not None and attest_line is not None and upload_line > attest_line:
+        issues.append(
+            "release.yml:build must upload artifacts before attestation to avoid "
+            "Windows artifact file lock races"
+        )
     return tuple(issues)
 
 


### PR DESCRIPTION
## What changed
- Reordered the release build job so matrix artifacts upload before provenance attestation.
- Added a workflow-permission audit guard that fails if the build job attests before uploading artifacts.
- Added a regression fixture for the old order.

## Why
- Manual unsigned preview run 27036598136 passed Windows build, verification, release artifact smoke, npm launcher local smoke, npm launcher download smoke, and attestation, then failed during Windows artifact upload.
- Uploading before attestation avoids Windows post-read artifact lock races while still keeping attestation as a required build step.

## Validation
- python scripts\\check-python-script-compile.py
- python scripts\\check-unsigned-preview-release-assets-regression.py
- python scripts\\check-github-workflow-permissions.py
- python scripts\\check-github-workflow-permissions-regression.py
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\verify-production-readiness.ps1 -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check
- staged token scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the release workflow to upload artifacts before provenance attestation, removing Windows file-lock upload failures while keeping attestation required. Adds a CI audit to enforce this order.

- **Bug Fixes**
  - Upload with `actions/upload-artifact@v7.0.1` now runs before attestation with `actions/attest@v4.1.0` in the matrix build to avoid Windows artifact lock races.

- **New Features**
  - Workflow-permission audit in `scripts/check-github-workflow-permissions.py` (with a regression fixture) that fails if attestation runs before upload.

<sup>Written for commit a9300a804d21f98ae047d017d7acf2449d121aeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

