### PR TITLE
Separate simple-launch release secret readiness

### DIFF
--- a/scripts/check-github-release-secret-readiness-regression.py
+++ b/scripts/check-github-release-secret-readiness-regression.py
@@ -118,6 +118,53 @@ def run_rotation_marker_tests(module) -> None:
         raise AssertionError("invalid marker issue was not reported")
 
 
+def run_simple_launch_tests(module) -> None:
+    configured = {module.NPM_TOKEN_SECRET_NAME}
+    ready = module.audit_release_secret_readiness(
+        "owner/repo",
+        configured,
+        {module.NPM_TOKEN_ROTATION_MARKER_VAR: "2026-06-05T00:00:01Z"},
+        simple_launch=True,
+    )
+    if not ready.ready:
+        raise AssertionError(f"simple launch readiness should pass: {ready.as_json()!r}")
+    parsed_ready = assert_safe_report(ready)
+    if parsed_ready["profile"] != module.SIMPLE_LAUNCH_PROFILE:
+        raise AssertionError("simple launch report omitted its profile")
+    if parsed_ready["releaseSecrets"]["required"] != [module.NPM_TOKEN_SECRET_NAME]:
+        raise AssertionError("simple launch mode should require only NPM_TOKEN")
+    if any(
+        "SIGN" in name or "MACOS" in name or "GPG" in name
+        for name in parsed_ready["releaseSecrets"]["required"]
+    ):
+        raise AssertionError("simple launch mode must not require signing secrets")
+
+    full_release = module.audit_release_secret_readiness(
+        "owner/repo",
+        configured,
+        {module.NPM_TOKEN_ROTATION_MARKER_VAR: "2026-06-05T00:00:01Z"},
+    )
+    if full_release.ready:
+        raise AssertionError("full release readiness should still require signing secrets")
+    parsed_full = assert_safe_report(full_release)
+    if parsed_full["profile"] != module.FULL_RELEASE_PROFILE:
+        raise AssertionError("full release report omitted its profile")
+    if "CONU_WINDOWS_SIGN_CERT_PFX_BASE64" not in parsed_full["releaseSecrets"]["missing"]:
+        raise AssertionError("full release mode no longer reports missing signing secrets")
+
+    missing_token = module.audit_release_secret_readiness(
+        "owner/repo",
+        set(),
+        {module.NPM_TOKEN_ROTATION_MARKER_VAR: "2026-06-05T00:00:01Z"},
+        simple_launch=True,
+    )
+    if missing_token.ready:
+        raise AssertionError("simple launch should fail without NPM_TOKEN")
+    parsed_missing = assert_safe_report(missing_token)
+    if parsed_missing["releaseSecrets"]["missing"] != [module.NPM_TOKEN_SECRET_NAME]:
+        raise AssertionError("simple launch missing report should only mention NPM_TOKEN")
+
+
 def run_repo_normalization_tests(module) -> None:
     helper = sys.modules["github_release_secrets"]
 
@@ -373,11 +420,85 @@ def run_main_tests(module) -> None:
     if SENSITIVE_SENTINEL in rendered:
         raise AssertionError("invalid repository failure leaked a secret value")
 
+    def fake_simple_launch_gh(args, **_kwargs):
+        if args[1:4] == ["secret", "list", "--repo"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"name": module.NPM_TOKEN_SECRET_NAME}]),
+                stderr="",
+            )
+        if args[1:] == [
+            "variable",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name",
+        ]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"name": module.NPM_TOKEN_ROTATION_MARKER_VAR}]),
+                stderr="",
+            )
+        if args[1:] == [
+            "variable",
+            "get",
+            module.NPM_TOKEN_ROTATION_MARKER_VAR,
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name,value",
+        ]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
+                        "value": "2026-06-05T00:00:01Z",
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected gh args: {args!r}")
+
+    sys.argv = [
+        "check-github-release-secret-readiness.py",
+        "--repo",
+        "owner/repo",
+        "--gh",
+        "gh",
+        "--simple-launch",
+        "--json",
+    ]
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    helper.subprocess.run = fake_simple_launch_gh
+    try:
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = module.main()
+    finally:
+        helper.subprocess.run = original_run
+        sys.argv = original_argv
+
+    rendered = stdout.getvalue() + stderr.getvalue()
+    if exit_code != 0:
+        raise AssertionError(
+            f"expected simple-launch main() to pass, got {exit_code}: {rendered}"
+        )
+    parsed = json.loads(stdout.getvalue())
+    if parsed["profile"] != module.SIMPLE_LAUNCH_PROFILE:
+        raise AssertionError("simple-launch main() JSON omitted the profile")
+    if parsed["releaseSecrets"]["required"] != [module.NPM_TOKEN_SECRET_NAME]:
+        raise AssertionError("simple-launch main() should not require signing secrets")
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("simple-launch main() leaked a secret or variable value")
+
 
 def main() -> int:
     module = load_module()
     run_audit_tests(module)
     run_rotation_marker_tests(module)
+    run_simple_launch_tests(module)
     run_repo_normalization_tests(module)
     run_gh_payload_tests(module)
     run_error_tests(module)

--- a/scripts/check-github-release-secret-readiness.py
+++ b/scripts/check-github-release-secret-readiness.py
@@ -28,11 +28,15 @@ from github_release_secrets import (
 
 
 REQUIRED_VARIABLE_VALUES = (NPM_TOKEN_ROTATION_MARKER_VAR,)
+FULL_RELEASE_PROFILE = "tagged-release"
+SIMPLE_LAUNCH_PROFILE = "simple-launch"
+SIMPLE_LAUNCH_REQUIRED_SECRETS = (NPM_TOKEN_SECRET_NAME,)
 
 
 @dataclass(frozen=True)
 class ReleaseSecretReadiness:
     repo: str
+    profile: str
     secrets: SecretReadiness
     npm_rotation_marker: Any
 
@@ -44,6 +48,7 @@ class ReleaseSecretReadiness:
         return {
             "schema": "conu.githubReleaseSecretReadiness.v1",
             "repo": self.repo,
+            "profile": self.profile,
             "ready": self.ready,
             "releaseSecrets": self.secrets.as_json(),
             "npmTokenRotationMarker": self.npm_rotation_marker.as_json(),
@@ -67,13 +72,36 @@ def load_script_module(filename: str, module_name: str):
     return module
 
 
+def audit_secret_names_for_required(
+    repo: str,
+    configured_names: set[str],
+    required_names: tuple[str, ...],
+) -> SecretReadiness:
+    repo = normalize_repo(repo)
+    present = tuple(name for name in required_names if name in configured_names)
+    missing = tuple(name for name in required_names if name not in configured_names)
+    return SecretReadiness(
+        repo=repo,
+        required=required_names,
+        present=present,
+        missing=missing,
+    )
+
+
 def audit_release_secret_readiness(
     repo: str,
     secret_names: set[str],
     variable_values: dict[str, str],
+    *,
+    simple_launch: bool = False,
 ) -> ReleaseSecretReadiness:
     repo = normalize_repo(repo)
-    secrets = audit_secret_names(repo, secret_names)
+    profile = SIMPLE_LAUNCH_PROFILE if simple_launch else FULL_RELEASE_PROFILE
+    secrets = (
+        audit_secret_names_for_required(repo, secret_names, SIMPLE_LAUNCH_REQUIRED_SECRETS)
+        if simple_launch
+        else audit_secret_names(repo, secret_names)
+    )
     gate_module = load_script_module(
         "check-release-secret-rotation-gate.py",
         "check_release_secret_rotation_gate_for_secret_readiness",
@@ -86,6 +114,7 @@ def audit_release_secret_readiness(
     )
     return ReleaseSecretReadiness(
         repo=repo,
+        profile=profile,
         secrets=secrets,
         npm_rotation_marker=npm_rotation_marker,
     )
@@ -97,14 +126,14 @@ def print_text_report(report: ReleaseSecretReadiness) -> None:
             "GitHub release secret readiness passed: "
             f"{len(report.secrets.present)}/{len(report.secrets.required)} required secret names "
             f"and {report.npm_rotation_marker.marker_env} configured "
-            f"for {report.repo}"
+            f"for {report.repo} ({report.profile})"
         )
         return
 
     print(
         "GitHub release secret readiness failed: "
         f"{len(report.secrets.missing)}/{len(report.secrets.required)} required secret names missing "
-        f"for {report.repo}",
+        f"for {report.repo} ({report.profile})",
         file=sys.stderr,
     )
     for name in report.secrets.missing:
@@ -126,6 +155,14 @@ def parse_args() -> argparse.Namespace:
         help="print a machine-readable report containing secret names and non-secret marker status",
     )
     parser.add_argument(
+        "--simple-launch",
+        action="store_true",
+        help=(
+            "check only the unpaid simple launch/testing secret gate: NPM_TOKEN plus "
+            "its non-secret rotation marker; full tagged releases still require all signing secrets"
+        ),
+    )
+    parser.add_argument(
         "--gh",
         default="",
         help=argparse.SUPPRESS,
@@ -145,6 +182,7 @@ def main() -> int:
             repo,
             load_secret_names(repo, gh),
             load_variable_values(repo, gh, REQUIRED_VARIABLE_VALUES),
+            simple_launch=args.simple_launch,
         )
     except (OSError, ValueError) as exc:
         print(f"GitHub release secret readiness failed: {exc}", file=sys.stderr)

--- a/user.md
+++ b/user.md
@@ -52,7 +52,7 @@ Official npm token guide: `https://docs.npmjs.com/creating-and-viewing-access-to
 After the secret and marker are set, validate:
 
 ```powershell
-python scripts\check-github-release-secret-readiness.py --repo imthegoodboy/conU --json
+python scripts\check-github-release-secret-readiness.py --repo imthegoodboy/conU --simple-launch --json
 ```
 
 ## What You Can Skip For Now


### PR DESCRIPTION
## **User description**
## Summary
- add a `--simple-launch` profile to `scripts/check-github-release-secret-readiness.py`
- make simple-launch readiness require only `NPM_TOKEN` plus `CONU_NPM_TOKEN_ROTATED_AFTER`
- preserve the full tagged-release profile so Windows/macOS signing, Linux GPG, notary, and npm secrets remain required for public tags
- update `user.md` to use the simple-launch command for the unpaid testing path

Closes #1126.

## Security review
- payload exposure risk: no payload or secret values are read into reports; output remains name/status metadata only
- trust/permission risk: no trust, auth, or permission behavior changes
- storage/logging risk: no new persistence or logging; regression checks prevent sentinel secret leakage
- relay/network risk: no relay or network behavior changes
- required fixes: none identified before PR

## Validation
- `python -m py_compile scripts\check-github-release-secret-readiness.py scripts\check-github-release-secret-readiness-regression.py`
- `python scripts\check-github-release-secret-readiness-regression.py`
- `git diff --check`
- `python scripts\check-github-release-secret-readiness.py --repo imthegoodboy/conU --simple-launch --json` (expected live failure: `NPM_TOKEN` marker is stale; signing secrets are not required in this profile)
- `python scripts\check-github-release-secret-readiness.py --repo imthegoodboy/conU --json` (expected live failure: full profile still requires signing/GPG/notary secrets plus fresh npm marker)
- `python scripts\verify-release-versions.py`
- `npm run check --prefix packaging/npm/conu-cli`
- `python scripts\check-production-readiness-toolchain.py -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`
- `python scripts\check-release-secret-rotation-gate-regression.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a simple-launch profile to the GitHub release secret readiness check so unpaid test releases only need an npm token and rotation marker. Keeps the full tagged-release gate unchanged and updates tests and docs accordingly.

- **New Features**
  - Add `--simple-launch` to `scripts/check-github-release-secret-readiness.py` requiring only `NPM_TOKEN` and `CONU_NPM_TOKEN_ROTATED_AFTER`.
  - Preserve full `tagged-release` profile (signing/GPG/notary/npm still required).
  - Include `profile` in JSON and text reports.
  - Expand regression tests for simple-launch and update `user.md` to use the simple-launch command for the unpaid testing path.

<sup>Written for commit e68e5a128e5dfa6e5f2f20bd9e535edcf0149714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add a simple-launch release check for the unpaid testing path**

### What Changed
- Added a new check mode that only requires `NPM_TOKEN` and its rotation marker for simple-launch testing
- Kept the full tagged-release check intact for public releases, where signing, GPG, notary, and other release secrets are still required
- Included the release profile in the report so the output clearly shows which readiness path was checked
- Updated the setup guide to use the simple-launch command for the unpaid validation flow
- Added regression coverage for both the new simple-launch path and the unchanged full-release path

### Impact
`✅ Shorter pre-release validation for simple-launch testing`
`✅ Clearer release readiness results`
`✅ Fewer false failures when signing secrets are not needed`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simple-launch audit mode for validating GitHub Actions secrets with minimal requirements (NPM token and rotation marker only).
  * New `--simple-launch` CLI flag to activate the simplified audit profile alongside existing validation.

* **Documentation**
  * Updated secret validation instructions to include the new `--simple-launch` flag for readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->