### PR TITLE
Enforce npm token metadata release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,11 @@ jobs:
         env:
           CONU_NPM_TOKEN_ROTATED_AFTER: ${{ vars.CONU_NPM_TOKEN_ROTATED_AFTER }}
         run: python scripts/check-release-secret-rotation-gate.py --secret-name NPM_TOKEN --rotated-after-env CONU_NPM_TOKEN_ROTATED_AFTER --required-after 2026-06-05T00:00:00Z
+      - name: Validate NPM token metadata rotation
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/check-github-release-secret-readiness.py --repo "$GITHUB_REPOSITORY" --simple-launch
       - name: Validate npm token authentication and registry availability
         if: startsWith(github.ref, 'refs/tags/v')
         env:

--- a/scripts/check-github-workflow-permissions-regression.py
+++ b/scripts/check-github-workflow-permissions-regression.py
@@ -245,6 +245,11 @@ jobs:
         env:
           CONU_NPM_TOKEN_ROTATED_AFTER: ${{ vars.CONU_NPM_TOKEN_ROTATED_AFTER }}
         run: python scripts/check-release-secret-rotation-gate.py --secret-name NPM_TOKEN --rotated-after-env CONU_NPM_TOKEN_ROTATED_AFTER --required-after 2026-06-05T00:00:00Z
+      - name: Validate NPM token metadata rotation
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/check-github-release-secret-readiness.py --repo "$GITHUB_REPOSITORY" --simple-launch
       - name: Validate npm token authentication and registry availability
         if: startsWith(github.ref, 'refs/tags/v')
         env:
@@ -2534,6 +2539,38 @@ def run_required_release_preflight_tests(module) -> None:
         "is missing rotation marker command"
     ) not in json.dumps(assert_safe_report(report)):
         raise AssertionError("missing NPM token rotation marker preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            '        run: python scripts/check-github-release-secret-readiness.py --repo "$GITHUB_REPOSITORY" --simple-launch\n',
+            "        run: echo skipped-npm-token-metadata-rotation\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("missing NPM token metadata rotation preflight should fail")
+    if (
+        "release.yml:release-preflight validate NPM token metadata rotation "
+        "is missing NPM token metadata command"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing NPM token metadata rotation preflight was not reported")
+
+    report = with_fixture(
+        module,
+        None,
+        ready_release().replace(
+            "          GH_TOKEN: ${{ github.token }}\n        run: python scripts/check-github-release-secret-readiness.py --repo \"$GITHUB_REPOSITORY\" --simple-launch\n",
+            "        run: python scripts/check-github-release-secret-readiness.py --repo \"$GITHUB_REPOSITORY\" --simple-launch\n",
+        ),
+    )
+    if report.ready:
+        raise AssertionError("NPM token metadata rotation preflight without GitHub token should fail")
+    if (
+        "release.yml:release-preflight validate NPM token metadata rotation "
+        "is missing GitHub token env"
+    ) not in json.dumps(assert_safe_report(report)):
+        raise AssertionError("missing NPM token metadata GitHub token issue was not reported")
 
     report = with_fixture(
         module,

--- a/scripts/check-github-workflow-permissions.py
+++ b/scripts/check-github-workflow-permissions.py
@@ -352,6 +352,10 @@ RELEASE_PREFLIGHT_NPM_AUTH_COMMAND = (
     "python scripts/check-npm-publish-preflight.py "
     "--registry-check --require-token-env NODE_AUTH_TOKEN --token-auth-check"
 )
+RELEASE_PREFLIGHT_NPM_METADATA_COMMAND = (
+    'python scripts/check-github-release-secret-readiness.py --repo "$GITHUB_REPOSITORY" '
+    "--simple-launch"
+)
 RELEASE_PREFLIGHT_JOB_SNIPPETS: tuple[tuple[str, str], ...] = (
     ("Ubuntu runner", "runs-on: ubuntu-latest"),
     (
@@ -506,6 +510,18 @@ RELEASE_PREFLIGHT_REQUIRED_STEPS: tuple[
                 "python scripts/check-release-secret-rotation-gate.py --secret-name "
                 "NPM_TOKEN --rotated-after-env CONU_NPM_TOKEN_ROTATED_AFTER "
                 "--required-after 2026-06-05T00:00:00Z",
+            ),
+        ),
+    ),
+    (
+        "Validate NPM token metadata rotation",
+        "validate NPM token metadata rotation",
+        (
+            ("tag gate", "if: startsWith(github.ref, 'refs/tags/v')"),
+            ("GitHub token env", "GH_TOKEN: ${{ github.token }}"),
+            (
+                "NPM token metadata command",
+                RELEASE_PREFLIGHT_NPM_METADATA_COMMAND,
             ),
         ),
     ),


### PR DESCRIPTION
## **User description**
Closes #1130.\n\nWhat changed:\n- Added a tag-gated release-preflight step that checks live GitHub metadata for NPM_TOKEN using the existing simple-launch release-secret readiness helper.\n- Updated the workflow-permission guard so removing or weakening that metadata check fails.\n- Added regression coverage for the metadata command and required GH_TOKEN env.\n\nValidation run:\n- python -m py_compile scripts/check-github-workflow-permissions.py scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-github-workflow-permissions-regression.py\n- python scripts/check-github-workflow-permissions.py\n- python scripts/check-tagged-release-readiness-regression.py\n- python scripts/check-github-release-secret-readiness-regression.py\n- python scripts/check-production-readiness-toolchain.py -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions\n- git diff --check\n\nLive note:\n- The simple-launch readiness check is still expected to fail until NPM_TOKEN is rotated after 2026-06-05T00:00:00Z and CONU_NPM_TOKEN_ROTATED_AFTER is updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tag-gated release preflight that verifies NPM token metadata via live GitHub checks and blocks tagged releases if the gate is missing or misconfigured. Updates the workflow-permissions guard and adds regression tests to lock this gate in place.

- **New Features**
  - Release workflow: new “Validate NPM token metadata rotation” step for tags using the simple-launch readiness helper and `GH_TOKEN`.
  - Guard: `check-github-workflow-permissions.py` now requires the tag gate, `GH_TOKEN`, and the metadata command.
  - Tests: regression checks fail if the command or `GH_TOKEN` is removed; preserves rotation-marker coverage.

- **Migration**
  - Tagged releases will fail until the NPM token is rotated after 2026-06-05 and `CONU_NPM_TOKEN_ROTATED_AFTER` is updated.

<sup>Written for commit a2dd366bd1736890483d9f70e8c66c6a650e9da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Require GitHub metadata checks before tagged npm releases**

### What Changed
- Tagged releases now include a new check that verifies the npm token’s GitHub metadata before the release continues
- The release safety check now rejects workflows if this metadata step is missing or if the GitHub token is not provided
- Coverage was added so the release guard fails when the new check is removed or misconfigured

### Impact
`✅ Safer tagged releases`
`✅ Fewer broken npm publishes`
`✅ Earlier detection of misconfigured release secrets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
