### PR TITLE
Add simple launch release secret setup

### DIFF
--- a/scripts/set-github-release-secrets-regression.py
+++ b/scripts/set-github-release-secrets-regression.py
@@ -90,6 +90,12 @@ def write_required_env_file(path: Path, module, value: str) -> None:
     secure_write_text(path, "\n".join(lines) + "\n")
 
 
+def write_named_env_file(path: Path, names: tuple[str, ...], value: str) -> None:
+    lines = ["# local release secrets for regression"]
+    lines.extend(f"{name}={value}" for name in names)
+    secure_write_text(path, "\n".join(lines) + "\n")
+
+
 def run_env_template_tests(module) -> None:
     template = module.render_env_template(module.REQUIRED_RELEASE_SECRETS)
     if SENSITIVE_SENTINEL in template:
@@ -462,6 +468,30 @@ def run_value_preflight_tests(module) -> None:
         if kwargs.get("env", {}).get("NPM_TOKEN") != SENSITIVE_SENTINEL:
             raise AssertionError("value preflight did not receive env-file values via env")
 
+    calls = []
+    module.subprocess.run = fake_run
+    try:
+        module.run_value_preflights(
+            require_openssl=False,
+            values={"NPM_TOKEN": SENSITIVE_SENTINEL},
+            python_executable="python",
+            simple_launch=True,
+        )
+    finally:
+        module.subprocess.run = original_run
+
+    if len(calls) != 1:
+        raise AssertionError(f"expected one simple-launch preflight call, got {len(calls)}")
+    rendered = "\n".join(" ".join(args) for args, _kwargs in calls)
+    if "check-npm-publish-preflight.py" not in rendered:
+        raise AssertionError("simple-launch preflight did not call npm token auth")
+    if "check-platform-signing-secrets-preflight.py" in rendered:
+        raise AssertionError("simple-launch preflight should not call platform signing checks")
+    if "check-linux-signing-secrets-preflight.py" in rendered:
+        raise AssertionError("simple-launch preflight should not call Linux signing checks")
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("simple-launch preflight leaked secret value in arguments")
+
     def failed_run(_args, **_kwargs):
         return SimpleNamespace(returncode=7, stdout=SENSITIVE_SENTINEL, stderr=SENSITIVE_SENTINEL)
 
@@ -520,6 +550,17 @@ def run_dry_run_tests(module) -> None:
         if calls:
             raise AssertionError("dry run must not call gh secret set")
 
+        simple_values = {module.NPM_TOKEN_SECRET_NAME: SENSITIVE_SENTINEL}
+        configured_simple = module.configure_release_secrets(
+            "owner/repo",
+            "gh",
+            simple_values,
+            dry_run=True,
+            required_names=module.SIMPLE_LAUNCH_REQUIRED_SECRETS,
+        )
+        if configured_simple != module.SIMPLE_LAUNCH_REQUIRED_SECRETS:
+            raise AssertionError("simple-launch dry run should report only NPM_TOKEN")
+
         assert_raises(
             lambda: module.require_npm_rotation_marker_for_token_write(
                 values=values,
@@ -546,6 +587,162 @@ def run_dry_run_tests(module) -> None:
             ),
             module.NPM_TOKEN_ROTATION_MARKER_VAR,
         )
+    finally:
+        restore_env(original)
+
+
+def run_simple_launch_main_tests(module) -> None:
+    original = {name: os.environ.get(name) for name in module.REQUIRED_RELEASE_SECRETS}
+    try:
+        for name in module.REQUIRED_RELEASE_SECRETS:
+            os.environ.pop(name, None)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_file = Path(temp_dir) / "simple.env"
+            write_named_env_file(env_file, module.SIMPLE_LAUNCH_REQUIRED_SECRETS, SENSITIVE_SENTINEL)
+
+            exit_code, rendered = call_main(
+                module,
+                [
+                    "set-github-release-secrets.py",
+                    "--env-file",
+                    str(env_file),
+                    "--check-env-file",
+                    "--simple-launch",
+                ],
+            )
+            if exit_code != 0:
+                raise AssertionError(f"expected simple-launch env-file check to pass: {rendered}")
+            if "1 required secret names" not in rendered:
+                raise AssertionError("simple-launch env-file check should report one required name")
+            if "present: NPM_TOKEN" not in rendered:
+                raise AssertionError("simple-launch env-file check omitted NPM_TOKEN")
+            if "CONU_WINDOWS_SIGN_CERT_PFX_BASE64" in rendered:
+                raise AssertionError("simple-launch env-file check should not mention signing secrets")
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("simple-launch env-file check leaked a secret value")
+
+            exit_code, rendered = call_main(
+                module,
+                [
+                    "set-github-release-secrets.py",
+                    "--repo",
+                    "owner/repo",
+                    "--gh",
+                    "gh",
+                    "--env-file",
+                    str(env_file),
+                    "--env-file-only",
+                    "--simple-launch",
+                    "--dry-run",
+                    "--set-npm-token-rotation-marker-from-secret-updated-at",
+                    "--confirm-npm-token-rotated",
+                ],
+            )
+            if exit_code != 0:
+                raise AssertionError(f"expected simple-launch dry run to pass: {rendered}")
+            if "would configure 1 required secret names" not in rendered:
+                raise AssertionError("simple-launch dry run should configure one secret")
+            if module.DRY_RUN_NPM_TOKEN_ROTATION_MARKER_FROM_UPDATED_AT not in rendered:
+                raise AssertionError("simple-launch dry run omitted deferred marker metadata text")
+            if "CONU_WINDOWS_SIGN_CERT_PFX_BASE64" in rendered:
+                raise AssertionError("simple-launch dry run should not mention signing secrets")
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("simple-launch dry run leaked a secret value")
+
+            calls: list[tuple[str, str]] = []
+
+            def fake_set_secret(_gh, _repo, name, value):
+                calls.append(("secret", name))
+                if name != module.NPM_TOKEN_SECRET_NAME:
+                    raise AssertionError(f"simple-launch tried to set unexpected secret {name}")
+                if value != SENSITIVE_SENTINEL:
+                    raise AssertionError("simple-launch setup did not pass NPM_TOKEN value")
+
+            def fake_set_variable(_gh, _repo, name, value):
+                calls.append(("variable", name))
+                if name != module.NPM_TOKEN_ROTATION_MARKER_VAR:
+                    raise AssertionError(f"simple-launch tried to set unexpected variable {name}")
+                if value != "2026-06-05T00:00:05Z":
+                    raise AssertionError("simple-launch marker did not use secret updatedAt")
+
+            original_set_secret = module.set_secret
+            original_set_variable = module.set_variable
+            original_loader = module.load_secret_metadata
+            module.set_secret = fake_set_secret
+            module.set_variable = fake_set_variable
+            module.load_secret_metadata = lambda _repo, _gh: {
+                module.NPM_TOKEN_SECRET_NAME: SimpleNamespace(updated_at="2026-06-05T00:00:05Z")
+            }
+            try:
+                exit_code, rendered = call_main(
+                    module,
+                    [
+                        "set-github-release-secrets.py",
+                        "--repo",
+                        "owner/repo",
+                        "--gh",
+                        "gh",
+                        "--env-file",
+                        str(env_file),
+                        "--env-file-only",
+                        "--simple-launch",
+                        "--set-npm-token-rotation-marker-from-secret-updated-at",
+                        "--confirm-npm-token-rotated",
+                    ],
+                )
+            finally:
+                module.set_secret = original_set_secret
+                module.set_variable = original_set_variable
+                module.load_secret_metadata = original_loader
+            if exit_code != 0:
+                raise AssertionError(f"expected simple-launch setup to pass: {rendered}")
+            if calls != [
+                ("secret", module.NPM_TOKEN_SECRET_NAME),
+                ("variable", module.NPM_TOKEN_ROTATION_MARKER_VAR),
+            ]:
+                raise AssertionError(f"simple-launch setup used unexpected GitHub writes: {calls}")
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("simple-launch setup output leaked a secret value")
+
+            unsupported = Path(temp_dir) / "unsupported.env"
+            write_named_env_file(
+                unsupported,
+                (module.NPM_TOKEN_SECRET_NAME, "CONU_WINDOWS_SIGN_CERT_PFX_BASE64"),
+                SENSITIVE_SENTINEL,
+            )
+            exit_code, rendered = call_main(
+                module,
+                [
+                    "set-github-release-secrets.py",
+                    "--env-file",
+                    str(unsupported),
+                    "--check-env-file",
+                    "--simple-launch",
+                ],
+            )
+            if exit_code == 0 or "unsupported key" not in rendered:
+                raise AssertionError(
+                    f"expected simple-launch env-file to reject signing keys: {rendered}"
+                )
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("simple-launch unsupported-key error leaked a secret value")
+
+            exit_code, rendered = call_main(
+                module,
+                [
+                    "set-github-release-secrets.py",
+                    "--simple-launch",
+                    "--preflight-values",
+                    "--require-openssl",
+                    "--dry-run",
+                ],
+            )
+            if exit_code == 0 or "cannot be combined with --simple-launch" not in rendered:
+                raise AssertionError(
+                    f"expected simple-launch OpenSSL argument guard to fail: {rendered}"
+                )
+            if SENSITIVE_SENTINEL in rendered:
+                raise AssertionError("simple-launch OpenSSL argument error leaked a secret value")
     finally:
         restore_env(original)
 
@@ -1270,6 +1467,7 @@ def main() -> int:
     run_rotation_marker_setup_tests(module)
     run_value_preflight_tests(module)
     run_dry_run_tests(module)
+    run_simple_launch_main_tests(module)
     run_env_file_main_tests(module)
     run_rotation_marker_main_tests(module)
     run_env_template_main_tests(module)

--- a/scripts/set-github-release-secrets.py
+++ b/scripts/set-github-release-secrets.py
@@ -33,6 +33,7 @@ POSIX_ENV_FILE_FORBIDDEN_MODE = stat.S_IRWXG | stat.S_IRWXO
 DRY_RUN_NPM_TOKEN_ROTATION_MARKER_FROM_UPDATED_AT = (
     "from NPM_TOKEN updatedAt after upload"
 )
+SIMPLE_LAUNCH_REQUIRED_SECRETS = (NPM_TOKEN_SECRET_NAME,)
 
 
 def render_env_template(names: tuple[str, ...]) -> str:
@@ -273,6 +274,7 @@ def run_value_preflights(
     require_openssl: bool,
     values: Mapping[str, str] | None = None,
     python_executable: str = sys.executable,
+    simple_launch: bool = False,
 ) -> None:
     platform_command = [
         python_executable,
@@ -281,29 +283,34 @@ def run_value_preflights(
     if require_openssl:
         platform_command.append("--require-openssl")
 
-    preflights: list[tuple[str, list[str]]] = [
-        (
-            "platform signing secret value preflight",
-            platform_command,
-        ),
-        (
-            "Linux signing secret preflight",
-            [
-                python_executable,
-                str(SCRIPT_DIR / "check-linux-signing-secrets-preflight.py"),
-            ],
-        ),
-        (
-            "npm token authentication preflight",
-            [
-                python_executable,
-                str(SCRIPT_DIR / "check-npm-publish-preflight.py"),
-                "--require-token-env",
-                "NPM_TOKEN",
-                "--token-auth-check",
-            ],
-        ),
-    ]
+    npm_token_preflight = (
+        "npm token authentication preflight",
+        [
+            python_executable,
+            str(SCRIPT_DIR / "check-npm-publish-preflight.py"),
+            "--require-token-env",
+            "NPM_TOKEN",
+            "--token-auth-check",
+        ],
+    )
+    preflights: list[tuple[str, list[str]]] = (
+        [npm_token_preflight]
+        if simple_launch
+        else [
+            (
+                "platform signing secret value preflight",
+                platform_command,
+            ),
+            (
+                "Linux signing secret preflight",
+                [
+                    python_executable,
+                    str(SCRIPT_DIR / "check-linux-signing-secrets-preflight.py"),
+                ],
+            ),
+            npm_token_preflight,
+        ]
+    )
     env = None
     if values is not None:
         env = os.environ.copy()
@@ -331,12 +338,13 @@ def configure_release_secrets(
     gh: str,
     values: dict[str, str],
     dry_run: bool,
+    required_names: tuple[str, ...] = REQUIRED_RELEASE_SECRETS,
 ) -> tuple[str, ...]:
-    missing = missing_required_values(values, REQUIRED_RELEASE_SECRETS)
+    missing = missing_required_values(values, required_names)
     if missing:
         raise ValueError("missing local release secret values: " + ", ".join(missing))
 
-    names = tuple(name for name in REQUIRED_RELEASE_SECRETS if name in values)
+    names = tuple(name for name in required_names if name in values)
     if dry_run:
         return names
 
@@ -407,6 +415,15 @@ def parse_args() -> argparse.Namespace:
         help=(
             "validate --env-file contains every required release secret name with "
             "a non-empty value, then exit without GitHub CLI access"
+        ),
+    )
+    parser.add_argument(
+        "--simple-launch",
+        action="store_true",
+        help=(
+            "configure only the unpaid simple launch/testing secret gate: "
+            "NPM_TOKEN plus its non-secret rotation marker; full tagged releases "
+            "still require all signing secrets"
         ),
     )
     parser.add_argument(
@@ -507,6 +524,8 @@ def main() -> int:
                 or args.set_npm_token_rotation_marker_from_secret_updated_at
             ):
                 raise ValueError("--check-env-file cannot be combined with setup options")
+        if args.simple_launch and args.require_openssl:
+            raise ValueError("--require-openssl cannot be combined with --simple-launch")
         if args.require_openssl and not args.preflight_values:
             raise ValueError("--require-openssl requires --preflight-values")
         if args.env_file_only and not args.env_file:
@@ -549,17 +568,32 @@ def main() -> int:
                 "NPM token rotation marker setup requires --confirm-npm-token-rotated"
             )
         if args.print_env_template:
-            print(render_env_template(REQUIRED_RELEASE_SECRETS), end="")
+            required_secret_names = (
+                SIMPLE_LAUNCH_REQUIRED_SECRETS
+                if args.simple_launch
+                else REQUIRED_RELEASE_SECRETS
+            )
+            print(render_env_template(required_secret_names), end="")
             return 0
         if args.write_env_template:
-            write_env_template(Path(args.write_env_template).expanduser(), REQUIRED_RELEASE_SECRETS)
+            required_secret_names = (
+                SIMPLE_LAUNCH_REQUIRED_SECRETS
+                if args.simple_launch
+                else REQUIRED_RELEASE_SECRETS
+            )
+            write_env_template(Path(args.write_env_template).expanduser(), required_secret_names)
             print(f"GitHub release secret env template written: {args.write_env_template}")
             return 0
+        required_secret_names = (
+            SIMPLE_LAUNCH_REQUIRED_SECRETS
+            if args.simple_launch
+            else REQUIRED_RELEASE_SECRETS
+        )
         if args.check_env_file:
             values = load_env_file_values(
-                Path(args.env_file).expanduser(), REQUIRED_RELEASE_SECRETS
+                Path(args.env_file).expanduser(), required_secret_names
             )
-            missing = missing_required_values(values, REQUIRED_RELEASE_SECRETS)
+            missing = missing_required_values(values, required_secret_names)
             if missing:
                 print_secret_names(
                     "GitHub release secret env file check failed: missing required env-file values:",
@@ -569,9 +603,9 @@ def main() -> int:
                 return 1
             print(
                 "GitHub release secret env file check passed: "
-                f"{len(REQUIRED_RELEASE_SECRETS)} required secret names have non-empty values"
+                f"{len(required_secret_names)} required secret names have non-empty values"
             )
-            for name in REQUIRED_RELEASE_SECRETS:
+            for name in required_secret_names:
                 print(f"present: {name}")
             return 0
 
@@ -593,12 +627,12 @@ def main() -> int:
             if args.env_file_only:
                 values = {}
             else:
-                values, _missing = collect_env_values(REQUIRED_RELEASE_SECRETS)
+                values, _missing = collect_env_values(required_secret_names)
             if args.env_file:
                 values.update(
-                    load_env_file_values(Path(args.env_file).expanduser(), REQUIRED_RELEASE_SECRETS)
+                    load_env_file_values(Path(args.env_file).expanduser(), required_secret_names)
                 )
-            missing = missing_required_values(values, REQUIRED_RELEASE_SECRETS)
+            missing = missing_required_values(values, required_secret_names)
             if missing:
                 print_secret_names(
                     "GitHub release secret setup failed: missing local release secret values:",
@@ -613,14 +647,24 @@ def main() -> int:
             )
 
             if args.preflight_values:
-                run_value_preflights(require_openssl=args.require_openssl, values=values)
+                run_value_preflights(
+                    require_openssl=args.require_openssl,
+                    values=values,
+                    simple_launch=args.simple_launch,
+                )
         else:
             values = {}
 
         gh = args.gh or find_gh()
         repo = normalize_repo(args.repo.strip() or infer_repo(gh))
         if secret_setup_requested:
-            configured = configure_release_secrets(repo, gh, values, args.dry_run)
+            configured = configure_release_secrets(
+                repo,
+                gh,
+                values,
+                args.dry_run,
+                required_secret_names,
+            )
         if marker_requested:
             if args.set_npm_token_rotation_marker_from_secret_updated_at:
                 if should_defer_npm_rotation_marker_updated_at(

--- a/user.md
+++ b/user.md
@@ -22,11 +22,10 @@ gh secret set NPM_TOKEN --repo imthegoodboy/conU
 
 For simple testing, there is nothing else you need to paste or configure for npm right now.
 
-Before any real npm publish, rotate `NPM_TOKEN` because a token value was pasted in chat. After rotating it, set the non-secret rotation marker:
+Before any real npm publish, rotate `NPM_TOKEN` because a token value was pasted in chat. After rotating it, set the non-secret rotation marker from GitHub's secret metadata:
 
 ```powershell
-$rotatedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-gh variable set CONU_NPM_TOKEN_ROTATED_AFTER --repo imthegoodboy/conU --body $rotatedAt
+python scripts\set-github-release-secrets.py --repo imthegoodboy/conU --simple-launch --set-npm-token-rotation-marker-from-secret-updated-at --confirm-npm-token-rotated
 ```
 
 Only run the marker command after the new rotated token has been uploaded to GitHub Secrets.


### PR DESCRIPTION
## **User description**
Closes #1132.

What changed:
- Added a --simple-launch profile to scripts/set-github-release-secrets.py so the no-paid-cert path can configure only NPM_TOKEN plus the non-secret rotation marker.
- Kept full tagged-release secret setup as the default path.
- Narrowed --preflight-values --simple-launch to npm token auth only, so paid Windows/macOS/Linux signing checks are not required for simple launch.
- Updated user.md to use the metadata-derived marker command instead of a hand-written timestamp.
- Added regressions proving simple launch writes only NPM_TOKEN and CONU_NPM_TOKEN_ROTATED_AFTER, rejects signing keys in the simple env file, and does not leak token values.

Validation run:
- python -m py_compile scripts/set-github-release-secrets.py scripts/set-github-release-secrets-regression.py
- python scripts/set-github-release-secrets-regression.py
- python scripts/check-github-release-secret-readiness-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-production-readiness-toolchain.py -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- python scripts/set-github-release-secrets.py --repo imthegoodboy/conU --simple-launch --set-npm-token-rotation-marker-from-secret-updated-at --confirm-npm-token-rotated --dry-run
- git diff --check

Live note:
- The dry-run marker command correctly fails until the GitHub NPM_TOKEN.updatedAt metadata is after 2026-06-05T00:00:00Z.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a --simple-launch mode to the release secret setup that configures only the npm token and a non-secret rotation marker, skipping paid signing secrets. The full tagged-release setup stays the default.

- **New Features**
  - New `--simple-launch` profile: sets `NPM_TOKEN` and `CONU_NPM_TOKEN_ROTATED_AFTER` only.
  - Simple-launch preflight runs npm token auth only; skips Windows/macOS/Linux signing checks.
  - Env template, env-file check, setup, and dry-run honor simple-launch’s single required name.
  - Guard added: `--require-openssl` cannot be used with `--simple-launch`.
  - Updated docs to set the rotation marker from GitHub secret metadata via the script, not a manual timestamp.
  - Added regressions to ensure only the intended keys are written, signing keys are rejected in simple mode, and secrets never print.

<sup>Written for commit b604f45384cf717388554e7a201a02dcaf83421c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add a simple launch mode for release secret setup**

### What Changed
- Adds a simple launch path that sets only `NPM_TOKEN` and its non-secret rotation marker, while skipping paid signing secrets.
- Simple launch checks and templates now mention only the required npm secret, and reject signing keys in the simple setup file.
- The npm token rotation marker can now be set from GitHub’s secret metadata during simple launch, instead of using a manually typed timestamp.
- The tool now blocks `--simple-launch` from being combined with OpenSSL signing checks.

### Impact
`✅ Shorter setup for simple npm launches`
`✅ Fewer required secrets for test releases`
`✅ Clearer marker setup after token rotation` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
