### PR TITLE
Clarify simple launch readiness failures

### DIFF
--- a/scripts/check-github-release-secret-readiness-regression.py
+++ b/scripts/check-github-release-secret-readiness-regression.py
@@ -567,6 +567,89 @@ def run_main_tests(module) -> None:
     if SENSITIVE_SENTINEL in rendered:
         raise AssertionError("simple-launch main() leaked a secret or variable value")
 
+    def fake_stale_simple_launch_gh(args, **_kwargs):
+        if args[1:4] == ["secret", "list", "--repo"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "name": module.NPM_TOKEN_SECRET_NAME,
+                            "updatedAt": "2026-06-04T13:05:47Z",
+                            "value": SENSITIVE_SENTINEL,
+                        }
+                    ]
+                ),
+                stderr="",
+            )
+        if args[1:] == [
+            "variable",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name",
+        ]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"name": module.NPM_TOKEN_ROTATION_MARKER_VAR}]),
+                stderr="",
+            )
+        if args[1:] == [
+            "variable",
+            "get",
+            module.NPM_TOKEN_ROTATION_MARKER_VAR,
+            "--repo",
+            "owner/repo",
+            "--json",
+            "name,value",
+        ]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "name": module.NPM_TOKEN_ROTATION_MARKER_VAR,
+                        "value": "2026-06-04T13:11:57Z",
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected gh args: {args!r}")
+
+    sys.argv = [
+        "check-github-release-secret-readiness.py",
+        "--repo",
+        "owner/repo",
+        "--gh",
+        "gh",
+        "--simple-launch",
+    ]
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    helper.subprocess.run = fake_stale_simple_launch_gh
+    try:
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = module.main()
+    finally:
+        helper.subprocess.run = original_run
+        sys.argv = original_argv
+
+    rendered = stdout.getvalue() + stderr.getvalue()
+    if exit_code == 0:
+        raise AssertionError("stale simple-launch readiness should fail")
+    if "secret names ready" not in rendered:
+        raise AssertionError("stale simple-launch text should show secret names are ready")
+    if "NPM_TOKEN updatedAt not ready" not in rendered:
+        raise AssertionError("stale simple-launch text omitted updatedAt status")
+    if f"{module.NPM_TOKEN_ROTATION_MARKER_VAR} not ready" not in rendered:
+        raise AssertionError("stale simple-launch text omitted marker status")
+    if "set-github-release-secrets.py --repo owner/repo --simple-launch" not in rendered:
+        raise AssertionError("stale simple-launch text omitted safe repair command")
+    if "0/1 required secret names missing" in rendered:
+        raise AssertionError("stale simple-launch text kept the misleading missing-secret summary")
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("stale simple-launch text leaked a secret or variable value")
+
 
 def main() -> int:
     module = load_module()

--- a/scripts/check-github-release-secret-readiness.py
+++ b/scripts/check-github-release-secret-readiness.py
@@ -233,9 +233,18 @@ def print_text_report(report: ReleaseSecretReadiness) -> None:
         )
         return
 
+    secret_name_status = (
+        "ready"
+        if report.secrets.ready
+        else f"{len(report.secrets.missing)}/{len(report.secrets.required)} missing"
+    )
+    updated_at_status = "ready" if report.npm_token_secret_updated_at.ready else "not ready"
+    marker_status = "ready" if report.npm_rotation_marker.ready else "not ready"
     print(
         "GitHub release secret readiness failed: "
-        f"{len(report.secrets.missing)}/{len(report.secrets.required)} required secret names missing "
+        f"secret names {secret_name_status}; "
+        f"{NPM_TOKEN_SECRET_NAME} updatedAt {updated_at_status}; "
+        f"{NPM_TOKEN_ROTATION_MARKER_VAR} {marker_status} "
         f"for {report.repo} ({report.profile})",
         file=sys.stderr,
     )
@@ -245,6 +254,25 @@ def print_text_report(report: ReleaseSecretReadiness) -> None:
         print(f"secret: {issue}", file=sys.stderr)
     for issue in report.npm_rotation_marker.issues:
         print(f"marker: {issue}", file=sys.stderr)
+    if (
+        report.profile == SIMPLE_LAUNCH_PROFILE
+        and report.secrets.ready
+        and (
+            not report.npm_token_secret_updated_at.ready
+            or not report.npm_rotation_marker.ready
+        )
+    ):
+        print(
+            "next: rotate NPM_TOKEN in GitHub Secrets, then run:",
+            file=sys.stderr,
+        )
+        print(
+            "python scripts\\set-github-release-secrets.py "
+            f"--repo {report.repo} --simple-launch "
+            "--set-npm-token-rotation-marker-from-secret-updated-at "
+            "--confirm-npm-token-rotated",
+            file=sys.stderr,
+        )
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## **User description**
Closes #1134.

What changed:
- Changed failed text output from a missing-secret-only summary to separate gate statuses for secret names, NPM_TOKEN.updatedAt, and CONU_NPM_TOKEN_ROTATED_AFTER.
- Added the safe simple-launch repair command when NPM_TOKEN exists but rotation metadata/marker are stale.
- Added regression coverage for stale simple-launch text mode and token-value redaction.

Validation run:
- python -m py_compile scripts/check-github-release-secret-readiness.py scripts/check-github-release-secret-readiness-regression.py
- python scripts/check-github-release-secret-readiness-regression.py
- python scripts/check-github-release-secret-readiness.py --repo imthegoodboy/conU --simple-launch
- python scripts/set-github-release-secrets-regression.py
- python scripts/check-tagged-release-readiness-regression.py
- python scripts/check-github-workflow-permissions.py
- python scripts/check-production-readiness-toolchain.py -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions
- git diff --check

Live note:
- The live simple-launch readiness command still fails as expected until NPM_TOKEN is rotated after 2026-06-05T00:00:00Z.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified simple-launch readiness failures by showing separate statuses for secret names, `NPM_TOKEN` updatedAt, and `CONU_NPM_TOKEN_ROTATED_AFTER`. When the token exists but rotation info is stale, the script now suggests a safe repair command, and tests cover stale text output and secret redaction.

<sup>Written for commit dccda04b435a01a18ddeaed85ec18ae0403ad2ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Clarify simple-launch readiness failures and show the next fix**

### What Changed
- Failed readiness checks now spell out which part is not ready: secret names, `NPM_TOKEN` update time, and the rotation marker.
- For simple-launch checks, when the token exists but the rotation info is stale, the output now includes a safe command to rotate the token and repair the marker.
- Added coverage for stale simple-launch output and for keeping secret values hidden in error text.

### Impact
`✅ Clearer readiness failures`
`✅ Faster simple-launch recovery`
`✅ Fewer confusing secret-status errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
