### PR TITLE
Clarify tagged release readiness failures

### DIFF
--- a/scripts/check-tagged-release-readiness-regression.py
+++ b/scripts/check-tagged-release-readiness-regression.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import sys
@@ -735,6 +737,63 @@ def run_secret_rotation_marker_tests(module) -> None:
         raise AssertionError("invalid rotation marker issue was not reported")
 
 
+def run_text_report_guidance_tests(module) -> None:
+    secret_names = all_release_secrets(module)
+    missing_name = "CONU_WINDOWS_SIGN_CERT_PFX_BASE64"
+    if missing_name not in secret_names:
+        raise AssertionError("expected Windows signing certificate secret in release secret set")
+    secret_names.remove(missing_name)
+
+    report = module.audit_tagged_release_readiness(
+        repo="owner/repo",
+        tag=TAG,
+        version=VERSION,
+        secret_names=secret_names,
+        variable_values={
+            module.NPM_TOKEN_ROTATION_MARKER_VAR: "2026-06-04T13:11:57Z",
+        },
+        pages_payload=pages_payload(),
+        release_payload=None,
+        npm_registry_check=False,
+        secret_updated_at={
+            module.NPM_TOKEN_SECRET_NAME: "2026-06-04T13:05:47Z",
+        },
+        secret_rotation_requirements=module.default_secret_rotation_requirements(),
+        secret_rotation_marker_requirements=module.default_secret_rotation_marker_requirements(),
+        **ready_governance_kwargs(),
+    )
+    if report.ready:
+        raise AssertionError("missing secret and stale npm rotation metadata should fail")
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        module.print_text_report(report)
+    rendered = stdout.getvalue() + stderr.getvalue()
+
+    for expected in (
+        "status: release secrets 1/",
+        "NPM_TOKEN updatedAt not ready",
+        f"{module.NPM_TOKEN_ROTATION_MARKER_VAR} not ready",
+        "Linux repository ready",
+        "GitHub Release clobber ready",
+        "npm registry ready",
+        "CI ready",
+        "release branch ready",
+        "workflow permissions ready",
+        "main branch protection ready",
+        "Actions permissions ready",
+        "repository security ready",
+        "configure the missing release signing/publishing secret names",
+        "rotate NPM_TOKEN in GitHub Secrets",
+        "python scripts\\set-github-release-secrets.py --repo owner/repo --simple-launch",
+    ):
+        if expected not in rendered:
+            raise AssertionError(f"text readiness guidance was missing: {expected}")
+    if SENSITIVE_SENTINEL in rendered:
+        raise AssertionError("text readiness guidance leaked unrelated sensitive text")
+
+
 def run_custom_repository_tests(module) -> None:
     report = module.audit_tagged_release_readiness(
         repo="owner/repo",
@@ -1321,6 +1380,7 @@ def main() -> int:
     run_repo_version_json_duplicate_tests(module)
     run_secret_rotation_tests(module)
     run_secret_rotation_marker_tests(module)
+    run_text_report_guidance_tests(module)
     run_custom_repository_tests(module)
     run_variable_loader_tests(module)
     run_safe_failure_tests(module)

--- a/scripts/check-tagged-release-readiness.py
+++ b/scripts/check-tagged-release-readiness.py
@@ -1222,12 +1222,53 @@ def print_text_report(report: TaggedReleaseReadiness) -> None:
         )
         return
 
+    def status(ready: bool) -> str:
+        return "ready" if ready else "not ready"
+
+    release_secret_status = (
+        "ready"
+        if report.release_secrets.ready
+        else f"{len(report.release_secrets.missing)}/{len(report.release_secrets.required)} missing"
+    )
     print(
         f"Tagged release readiness failed for {report.repo}@{report.tag}",
         file=sys.stderr,
     )
+    print(
+        "status: "
+        f"release secrets {release_secret_status}; "
+        f"{NPM_TOKEN_SECRET_NAME} updatedAt {status(report.secret_rotation.ready)}; "
+        f"{NPM_TOKEN_ROTATION_MARKER_VAR} {status(report.secret_rotation_markers.ready)}; "
+        f"Linux repository {status(report.linux_repository.ready)}; "
+        f"GitHub Release clobber {status(report.release_clobber.ready)}; "
+        f"npm registry {status(report.npm_registry.ready)}; "
+        f"CI {status(report.ci.ready)}; "
+        f"release branch {status(report.release_branch.ready)}; "
+        f"workflow permissions {status(report.workflow_permissions.ready)}; "
+        f"main branch protection {status(report.main_branch_protection.ready)}; "
+        f"Actions permissions {status(report.actions_permissions.ready)}; "
+        f"repository security {status(report.repository_security.ready)}",
+        file=sys.stderr,
+    )
     for issue in report.issues:
         print(f"issue: {issue}", file=sys.stderr)
+    if report.release_secrets.missing:
+        print(
+            "next: configure the missing release signing/publishing secret names before creating a tag",
+            file=sys.stderr,
+        )
+    if not report.secret_rotation.ready or not report.secret_rotation_markers.ready:
+        print(
+            "next: rotate NPM_TOKEN in GitHub Secrets, then run:",
+            file=sys.stderr,
+        )
+        print(
+            "python scripts\\set-github-release-secrets.py "
+            f"--repo {report.repo} --simple-launch "
+            "--set-npm-token-rotation-marker-from-secret-updated-at "
+            "--confirm-npm-token-rotated",
+            file=sys.stderr,
+        )
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## **User description**
## Summary
- add a tagged-release failure status summary showing which gates are ready or blocked
- print safe next steps for missing release secrets and stale npm rotation metadata
- cover the text report with a regression that checks guidance and sentinel redaction

Fixes #1136.

## Validation
- `python -m py_compile scripts\check-tagged-release-readiness.py scripts\check-tagged-release-readiness-regression.py`
- `python scripts\check-tagged-release-readiness-regression.py`
- `python scripts\check-github-release-secret-readiness-regression.py`
- `python scripts\check-production-readiness-toolchain.py -SkipRust -SkipSmokes -CheckGitHubWorkflowPermissions`
- `python scripts\check-github-workflow-permissions.py`
- `git diff --check`
- `python scripts\check-tagged-release-readiness.py --repo imthegoodboy/conU --tag v0.1.0 --npm-registry-check --require-ci --require-default-branch-head` exits 1 only for known maintainer-owned release secret and npm rotation metadata blockers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies tagged release readiness failures by printing a concise status summary and actionable next steps. Helps maintainers quickly see which gates are ready or blocked and how to fix common issues. Fixes #1136.

- **New Features**
  - Add one-line status summary covering release secrets, `NPM_TOKEN` updatedAt, rotation marker, Linux repo, GitHub Release clobber, npm registry, CI, release branch, workflow permissions, main branch protection, Actions permissions, and repository security.
  - Print safe guidance for missing release secrets and stale npm rotation metadata, including the `scripts/set-github-release-secrets.py` command.
  - Add regression tests for the text report, including guidance coverage and sensitive sentinel redaction.

<sup>Written for commit b3e803d5f0f28e095c37f7827eb5e1b2fdb3048b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imthegoodboy/conU/pull/1137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Clarify tagged release readiness failures**

### What Changed
- Failed tagged-release checks now show a single status line that spells out which release gates are ready or blocked.
- When release secrets are missing or NPM_TOKEN rotation data is stale, the report now gives direct next steps and the command to run.
- Regression coverage now checks that this guidance appears in the text report and that unrelated sensitive values are not exposed.

### Impact
`✅ Clearer release-blocker messages`
`✅ Faster tagged release fixes`
`✅ Less back-and-forth for missing secrets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
